### PR TITLE
Fjerner margin/padding på lenker. 

### DIFF
--- a/packages/node_modules/nav-frontend-alertstriper/package.json
+++ b/packages/node_modules/nav-frontend-alertstriper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-alertstriper",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "lib/alertstripe.js",
   "jsnext:main": "src/alertstripe.js",
   "license": "MIT",

--- a/packages/node_modules/nav-frontend-lenker-style/src/lenker-mixins.less
+++ b/packages/node_modules/nav-frontend-lenker-style/src/lenker-mixins.less
@@ -2,8 +2,6 @@
 
 .lenke-mixin() {
   color: @navBla;
-  border: 0;
-  padding: 0;
   background: none;
   text-decoration: none;
   border-bottom: solid 1px @navGra40;


### PR DESCRIPTION
Hvis mixin skal brukes på en knapp, må margin: 0/padding: 0 settes i tillegg lokalt i appen.

Dagens løsning gir uønskede konsekvenser som er uheldig. 