### PR TITLE
className for Input-komponent

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/input.js
+++ b/packages/node_modules/nav-frontend-skjema/src/input.js
@@ -4,24 +4,27 @@ import { guid } from 'nav-frontend-js-utils';
 import 'nav-frontend-skjema-style'; // eslint-disable-line import/extensions
 import classNames from 'classnames';
 
+const inputClass = (width, className) => classNames('skjemaelement__input', className, `input--${width}`);
+const skjemaElementClass = (harFeil, className) => classNames(
+    'skjemaelement',
+    className,
+    { 'skjemaelement--harFeil': harFeil }
+);
+
 /**
  * Standard inputfelt med mulighet for å sette bredde
  */
 class Input extends Component { // eslint-disable-line react/prefer-stateless-function
-
     render() {
-        const { label, bredde, feil, id, name, inputRef, ...other } = this.props;
-
+        const { label, bredde, feil, id, name, inputRef, className, inputClassName, ...other } = this.props;
         const inputId = id || name || guid();
-        const inputClass = (width) => classNames('skjemaelement__input', `input--${width}`);
-        // eslint-disable-next-line quote-props
-        const skjemaElementClass = (harFeil) => classNames('skjemaelement', { 'skjemaelement--harFeil': harFeil });
+
         return (
-            <div className={skjemaElementClass(!!feil)}>
+            <div className={skjemaElementClass(!!feil, className)}>
                 <label className="skjemaelement__label" htmlFor={inputId}>{label}</label>
                 <input
                     type="text"
-                    className={inputClass(bredde)}
+                    className={inputClass(bredde, inputClassName)}
                     id={inputId}
                     {...other}
                     ref={inputRef}
@@ -60,7 +63,15 @@ Input.propTypes = {
     /**
      * Referanse til selve inputfeltet. Brukes for eksempel til å sette fokus
      */
-    inputRef: PT.func
+    inputRef: PT.func,
+    /**
+     * Classname som blir satt på komponentwrapperen
+     */
+    className: PT.string,
+    /**
+     * Classname som blir satt på input-elementet
+     */
+    inputClassName: PT.string
 };
 
 Input.defaultProps = {
@@ -68,7 +79,9 @@ Input.defaultProps = {
     feil: undefined,
     id: undefined,
     name: undefined,
-    inputRef: undefined
+    inputRef: undefined,
+    className: undefined,
+    inputClassName: undefined
 };
 
 export default Input;

--- a/packages/node_modules/nav-frontend-skjema/stories.js
+++ b/packages/node_modules/nav-frontend-skjema/stories.js
@@ -64,7 +64,7 @@ storiesOf('Skjema', module)
             <Input label="input--s label" bredde="s" />
             <Input label="input--s label" bredde="s" />
             <Input label="input--xs label" bredde="xs" />
-            <Input label="input--xxs label" bredde="xxs" />
+            <Input label="input--xxs label" bredde="xxs" className="testclass" inputClassName="inputclass" />
 
             <Input label="Inputfelt med feil label" feil={{ feilmelding: 'Dette er en feilmelding' }} />
 


### PR DESCRIPTION
La til støtte for `className` og `inputClassName` for å fikse opp #13