### PR TITLE
Plasser chevron til høyre i Safari på iOS og OSX

### DIFF
--- a/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
@@ -31,6 +31,14 @@
     padding-top: 0.5rem;
   }
 
+  .ekspanderbartPanel__indikator_wrapper {
+    position: absolute;
+    right: 1rem;
+    top: 0;
+    height: 100%;
+    display: flex;
+    align-items: center;
+  }
 
   &--lukket {
     .ekspanderbartPanel__indikator {

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-pure.js
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-pure.js
@@ -20,7 +20,9 @@ function EkspanderbartpanelPure(props) {
         <div className={cls(className, props)} {...renderProps}>
             <button className="ekspanderbartPanel__hode" onClick={onClick} aria-expanded={apen}>
                 {heading}
-                <span className="ekspanderbartPanel__indikator" />
+                <div className="ekspanderbartPanel__indikator_wrapper">
+                    <span className="ekspanderbartPanel__indikator" />
+                </div>
             </button>
             <Collapse isOpened={apen}>
                 <article aria-label={tittel} className="ekspanderbartPanel__innhold">{children}</article>


### PR DESCRIPTION
Fix for ekspandertbart panel i Safari på iOS og OSX. Siden css flex er implementert litt annerledes i disse nettleserne, vises chevronen rett etter tittelen og ikke helt til høyre i panelet som på andre nettlesere.

Løsningen er å wrappe chevronene i en div tag som plasseres til høyre med absolute posisjonering. Utseendemessig skal det ikke være noen forskjeller.