### PR TITLE
Korrekt håndtering av marginer i tekstområdet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8206,9 +8206,9 @@
       "dev": true
     },
     "nav-frontend-core": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/nav-frontend-core/-/nav-frontend-core-4.0.2.tgz",
-      "integrity": "sha512-3yZ3yrIhahEBdGmXOi5QBEJ6g6MOskEAXZohNfI4r+oAB8dhfkk0uUsd/q1oICjHUXzw5HC9DE9D3x87D5mG2g==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/nav-frontend-core/-/nav-frontend-core-4.0.5.tgz",
+      "integrity": "sha1-MJyd5qUUbo6Ts/UtT8Qswwms3KE=",
       "dev": true
     },
     "negotiator": {

--- a/packages/node_modules/nav-frontend-tekstomrade/package.json
+++ b/packages/node_modules/nav-frontend-tekstomrade/package.json
@@ -13,12 +13,14 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "peerDependencies": {
+    "nav-frontend-typografi": "^1.0.2",
     "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "sanitize-html": "^1.13.0"
   },
   "devDependencies": {
     "@storybook/react": "3.0.0",
+    "nav-frontend-typografi": "^1.0.2",
     "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "sanitize-html": "^1.13.0"

--- a/packages/node_modules/nav-frontend-tekstomrade/src/tekstomrade.js
+++ b/packages/node_modules/nav-frontend-tekstomrade/src/tekstomrade.js
@@ -1,6 +1,7 @@
 import PT from 'prop-types';
 import React, { Component } from 'react';
 import sanitize from 'sanitize-html';
+import { Normaltekst } from 'nav-frontend-typografi';
 
 const leggTilLenkerTags = (innhold) => {
     const uriRegex = /(([\w-]+:\/\/?|www(?:-\w+)?\.)[^\s()<>]+\w)/g;
@@ -14,8 +15,12 @@ const leggTilLenkerTags = (innhold) => {
 
 const safeHtml = (content) => sanitize(content, { allowedTags: ['a'] });
 
-const tilAvsnitt = (avsnitt, index) => (
-    <p dangerouslySetInnerHTML={{ __html: safeHtml(avsnitt) }} key={index} /> // eslint-disable-line react/no-danger
+const tilAvsnitt = (avsnitt, index, list) => (
+    <Normaltekst
+        className={index < list.length - 1 ? 'blokk-xs' : ''}
+        dangerouslySetInnerHTML={{ __html: safeHtml(avsnitt) }} // eslint-disable-line react/no-danger
+        key={index}
+    />
 );
 
 class Tekstomrade extends Component { // eslint-disable-line react/prefer-stateless-function


### PR DESCRIPTION
Tekstområdet brukte ikke nav-frontend-typografi, og fikk derfor `p`-tagger med masse margins. 
Denne fikser slik at `Normaltekst` blir brukt med `blokk-xs` på alle paragrafer med unntak av siste paragraf.