### PR TITLE
(TypeScript) Endre type på staten til Knapp(er): void --> {}

### DIFF
--- a/packages/node_modules/nav-frontend-knapper/types/index.d.ts
+++ b/packages/node_modules/nav-frontend-knapper/types/index.d.ts
@@ -4,7 +4,7 @@ declare module 'nav-frontend-knapper' {
     type KnappTypes = "standard" | "hoved" | "fare";
     type HtmlTypes = "submit" | "button" | "reset";
 
-    interface KnappProps {
+    interface KnappProps extends React.HTMLProps<HTMLButtonElement> {
         className?: string;
         disabled?: boolean;
         spinner?: boolean;

--- a/packages/node_modules/nav-frontend-knapper/types/index.d.ts
+++ b/packages/node_modules/nav-frontend-knapper/types/index.d.ts
@@ -19,8 +19,8 @@ declare module 'nav-frontend-knapper' {
         htmlType?: HtmlTypes
     }
 
-    export class Knapp extends React.Component<BaseknappProps, void> {}
-    export class Hovedknapp extends React.Component<KnappProps, void> {}
-    export class Fareknapp extends React.Component<KnappProps, void> {}
+    export class Knapp extends React.Component<BaseknappProps, {}> {}
+    export class Hovedknapp extends React.Component<KnappProps, {}> {}
+    export class Fareknapp extends React.Component<KnappProps, {}> {}
     export default Knapp;
 }


### PR DESCRIPTION
Per nå fungerer det ikke å bruke Knapp uten å overstyre dette i typedeklarasjonen.