### PR TITLE
Legge på type=button på trigger button i hjelpetekst

### DIFF
--- a/packages/node_modules/nav-frontend-hjelpetekst/src/hjelpetekst.js
+++ b/packages/node_modules/nav-frontend-hjelpetekst/src/hjelpetekst.js
@@ -128,6 +128,7 @@ class HjelpetekstBase extends Component {
         return (
             <div className="hjelpetekst">
                 <button
+										type="button"
                     ref={(button) => { this.apneKnapp = button; }}
                     className="hjelpetekst__apneknapp"
                     onClick={this.toggleSynlighet}

--- a/packages/node_modules/nav-frontend-hjelpetekst/src/hjelpetekst.js
+++ b/packages/node_modules/nav-frontend-hjelpetekst/src/hjelpetekst.js
@@ -128,7 +128,7 @@ class HjelpetekstBase extends Component {
         return (
             <div className="hjelpetekst">
                 <button
-										type="button"
+                    type="button"
                     ref={(button) => { this.apneKnapp = button; }}
                     className="hjelpetekst__apneknapp"
                     onClick={this.toggleSynlighet}


### PR DESCRIPTION
Standard type på button er submit, og i og med type ikke var satt i Hjelpetekst komponenten, dukket hjelpeteksten opp dersom en var inne i et skjema og trykket enter på en checkbox (og sikkert andre elementer).
Har nå lagt inn type="button" i komponenten.