### PR TITLE
SkjemaelementFeilmelding komponent - #72

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/checkbox.js
+++ b/packages/node_modules/nav-frontend-skjema/src/checkbox.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react';
 import { guid } from 'nav-frontend-js-utils';
 import 'nav-frontend-skjema-style'; // eslint-disable-line import/extensions
 import classNames from 'classnames';
+import SkjemaelementFeilmelding from './skjemaelement-feilmelding';
 
 const cls = (className) => classNames('skjemaelement skjemaelement--horisontal', className);
 const inputCls = (harFeil) => classNames('skjemaelement__input checkboks', {
@@ -28,9 +29,7 @@ class Checkbox extends Component {
                     {...other}
                 />
                 <label className="skjemaelement__label" htmlFor={inputId}>{label}</label>
-                <div role="alert" aria-live="assertive" className="skjemaelement__feilmelding">
-                    {feil ? feil.feilmelding : null}
-                </div>
+                <SkjemaelementFeilmelding feil={feil} />
             </div>
         );
     }

--- a/packages/node_modules/nav-frontend-skjema/src/input.js
+++ b/packages/node_modules/nav-frontend-skjema/src/input.js
@@ -3,6 +3,7 @@ import PT from 'prop-types';
 import { guid } from 'nav-frontend-js-utils';
 import 'nav-frontend-skjema-style'; // eslint-disable-line import/extensions
 import classNames from 'classnames';
+import SkjemaelementFeilmelding from './skjemaelement-feilmelding';
 
 const cls = (className) => classNames('skjemaelement', className);
 const inputClass = (width, className, harFeil) => classNames(
@@ -30,9 +31,7 @@ class Input extends Component { // eslint-disable-line react/prefer-stateless-fu
                     {...other}
                     ref={inputRef}
                 />
-                <div role="alert" aria-live="assertive" className="skjemaelement__feilmelding">
-                    {feil ? feil.feilmelding : null}
-                </div>
+                <SkjemaelementFeilmelding feil={feil} />
             </div>
         );
     }

--- a/packages/node_modules/nav-frontend-skjema/src/select.js
+++ b/packages/node_modules/nav-frontend-skjema/src/select.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react';
 import { guid } from 'nav-frontend-js-utils';
 import 'nav-frontend-skjema-style'; // eslint-disable-line import/extensions
 import classNames from 'classnames';
+import SkjemaelementFeilmelding from './skjemaelement-feilmelding';
 
 const cls = (className) => classNames('skjemaelement', className);
 const inputCls = (harFeil) => classNames('skjemaelement__input', {
@@ -34,9 +35,7 @@ class Select extends Component {
                         {children}
                     </select>
                 </div>
-                <div role="alert" aria-live="assertive" className="skjemaelement__feilmelding">
-                    {feil ? feil.feilmelding : null}
-                </div>
+                <SkjemaelementFeilmelding feil={feil} />
             </div>
         );
     }

--- a/packages/node_modules/nav-frontend-skjema/src/skjema-gruppe.js
+++ b/packages/node_modules/nav-frontend-skjema/src/skjema-gruppe.js
@@ -3,6 +3,7 @@ import PT from 'prop-types';
 import React, { Component } from 'react';
 import 'nav-frontend-skjema-style'; // eslint-disable-line import/extensions
 import classNames from 'classnames';
+import SkjemaelementFeilmelding from './skjemaelement-feilmelding';
 
 const cls = (className, harFeil) => classNames(className, {
     'skjema__feilomrade--harFeil': harFeil
@@ -22,9 +23,7 @@ class SkjemaGruppe extends Component {
             <div className={cls(className, feil)} {...other}>
                 { title && this.renderTitle() }
                 {children}
-                <div role="alert" aria-live="assertive" className="skjemaelement__feilmelding">
-                    {feil ? feil.feilmelding : null}
-                </div>
+                <SkjemaelementFeilmelding feil={feil} />
             </div>
         );
     }

--- a/packages/node_modules/nav-frontend-skjema/src/skjemaelement-feilmelding.js
+++ b/packages/node_modules/nav-frontend-skjema/src/skjemaelement-feilmelding.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import PT from 'prop-types';
+
+class SkjemaelementFeilmelding extends Component {
+
+    renderFeil() {
+        return (<div className="skjemaelement__feilmelding">{this.props.feil.feilmelding}</div>);
+    }
+
+    render() {
+        const { feil } = this.props;
+        return (
+            <div role="alert" aria-live="assertive">
+                {feil && this.renderFeil()}
+            </div>
+        );
+    }
+}
+
+SkjemaelementFeilmelding.propTypes = {
+  /**
+     * Hvis skjemaet har feil sender man inn et objekt med en feilmelding
+     */
+    feil: PT.shape({
+        feilmelding: PT.string.isRequired
+    })
+};
+
+SkjemaelementFeilmelding.defaultProps = {
+    feil: undefined
+};
+
+export default SkjemaelementFeilmelding;

--- a/packages/node_modules/nav-frontend-skjema/src/textarea.js
+++ b/packages/node_modules/nav-frontend-skjema/src/textarea.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { guid, autobind, requestAnimationFrame } from 'nav-frontend-js-utils';
 import 'nav-frontend-skjema-style'; // eslint-disable-line import/extensions
 import classNames from 'classnames';
+import SkjemaelementFeilmelding from './skjemaelement-feilmelding';
 
 const inputCls = (className, harFeil) => classNames(
     className,
@@ -63,9 +64,7 @@ class Textarea extends Component {
                 <p className="textarea--medMeta__teller">
                     { tellerTekst(antallTegn || 0, maxLength) }
                 </p>
-                <div role="alert" aria-live="assertive" className="skjemaelement__feilmelding">
-                    {feil ? feil.feilmelding : null}
-                </div>
+                <SkjemaelementFeilmelding feil={feil} />
                 <div
                     className="textareamirror"
                     ref={(mirror) => { this.mirror = mirror; }}


### PR DESCRIPTION
Har satt opp en egen komponent som viser skjemafeilmelding, og som beholder role="alert", men rendrer ikke div med feil dersom den ikke settes. Div med role rendres - tror den må være der for at endringer inne i den skal fanges opp. Dersom vi ønsker å fjerne den helt, kan vi kanskje sette klassen til invisible dersom feil er undefined.

Erstattet duplikat kode i de ulike skjema-komponentene med denne komponenten.