### PR TITLE
F17HL4-241 fikset bryting av tekst i textareamirror

### DIFF
--- a/packages/node_modules/nav-frontend-skjema-style/src/textarea.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/textarea.less
@@ -22,12 +22,17 @@
   }
 }
 
+// NB: viktig at denne styles slik at tekstbrytning blir identisk med textareaet
 .textareamirror {
   .skjemaelement__input;
   white-space: pre-wrap;
   display: inline-block;
   width: 100%;
-  word-break: break-all;
+  word-wrap: break-word;
   position: absolute;
   left: -99999px;
+}
+
+.textarea__container {
+  position: relative; // begrenser bredden til textareamirror, viktig for at tekstbryting blir riktig
 }

--- a/packages/node_modules/nav-frontend-skjema/src/textarea.js
+++ b/packages/node_modules/nav-frontend-skjema/src/textarea.js
@@ -45,7 +45,7 @@ class Textarea extends Component {
         const antallTegn = other.value.length;
 
         return (
-            <div className="skjemaelement">
+            <div className="skjemaelement textarea__container">
                 <label className="skjemaelement__label" htmlFor={textareaId}>
                     {label}
                 </label>

--- a/packages/node_modules/nav-frontend-skjema/stories.js
+++ b/packages/node_modules/nav-frontend-skjema/stories.js
@@ -129,6 +129,18 @@ storiesOf('Skjema', module)
                 maxLength={2000}
                 tellerTekst={(antall, maxLength) => `${maxLength - antall} tegn igjen`}
             />
+
+            <div style={{ width: '300px' }}>
+                <TextareaControlled
+                    label="tekstarea med innhold som er vanskelig å bryte riktig i textarea og mirror"
+                    defaultValue="asdf a asfasdfasdf as asdfasf asdfasdfasdfasdfadfasdf a asfasdfasdf as asdfasf
+                    asdfasdfasdfasdfadfasdf a asfasdfasdf as asdfasf asdfasdfasdfasdfadfasdf a asfasdfasdf as
+                    asdfasf asdfasdfasdfasdfadfasdf a asfasdfasdf as asdfasf asdfasdfasdfasdfadfasdf a asfasdfasdf
+                    as asdfasf veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+                    eeeeeeeeeeeeeldiglang sdfg sdgfsdfg
+                    sdfgsdfgs dfgsdfg sdfgsgsdfgsdfgsdfg"
+                />
+            </div>
         </div>
     ), JSDokumentasjon(pkg, readme, Textarea));
 


### PR DESCRIPTION
textareamirror må bryte teksten likt som textarea for at høyden til texareaet skal beregnes riktig.
 - word-break: break-all bryter midt i ord, ser ut som word-wrap: break-word er mer riktig
 - bredden til texareamirror må begrenses