### PR TITLE
Fixed lerna automatic version bumping with --exact, causing build to …

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "npm run build",
     "lerna": "lerna",
     "gulp": "gulp",
-    "lernapublish": "(lerna updated && lerna publish --exact --cd-version patch --yes -m \"publish [ci skip]\") || echo \"Ingen endringer avslutter OK\"",
+    "lernapublish": "(lerna updated && lerna publish --cd-version patch --yes -m \"publish [ci skip]\") || echo \"Ingen endringer avslutter OK\"",
     "create": "node ./_scripts/scaffold.js",
     "new": "npm run create",
     "checkversions": "node ./_scripts/verifyPkgDependencies.js",

--- a/packages/node_modules/nav-frontend-alertstriper-style/package.json
+++ b/packages/node_modules/nav-frontend-alertstriper-style/package.json
@@ -11,12 +11,12 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "devDependencies": {
-    "nav-frontend-ikoner-assets": "0.2.19",
+    "nav-frontend-ikoner-assets": "^0.2.19",
     "nav-frontend-paneler-style": "^0.3.7",
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
-    "nav-frontend-ikoner-assets": "0.2.19",
+    "nav-frontend-ikoner-assets": "^0.2.19",
     "nav-frontend-paneler-style": "^0.3.7"
   }
 }

--- a/packages/node_modules/nav-frontend-alertstriper/package.json
+++ b/packages/node_modules/nav-frontend-alertstriper/package.json
@@ -15,15 +15,15 @@
   "peerDependencies": {
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",
-    "nav-frontend-alertstriper-style": "0.2.23",
-    "nav-frontend-ikoner-assets": "0.2.19",
+    "nav-frontend-alertstriper-style": "^0.2.23",
+    "nav-frontend-ikoner-assets": "^0.2.19",
     "nav-frontend-typografi": "^1.0.12",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   },
   "devDependencies": {
-    "nav-frontend-alertstriper-style": "0.2.23",
-    "nav-frontend-ikoner-assets": "0.2.19",
+    "nav-frontend-alertstriper-style": "^0.2.23",
+    "nav-frontend-ikoner-assets": "^0.2.19",
     "nav-frontend-typografi": "^1.0.12",
     "react": "^15.4.2 || ^16.0.0"
   }

--- a/packages/node_modules/nav-frontend-hjelpetekst/package.json
+++ b/packages/node_modules/nav-frontend-hjelpetekst/package.json
@@ -15,7 +15,7 @@
   "peerDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-hjelpetekst-style": "^0.3.8",
-    "nav-frontend-ikoner-assets": "0.2.19",
+    "nav-frontend-ikoner-assets": "^0.2.19",
     "nav-frontend-lukknapp": "^0.1.13",
     "nav-frontend-typografi": "^1.0.12",
     "prop-types": "^15.5.10",
@@ -24,7 +24,7 @@
   "devDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-hjelpetekst-style": "^0.3.8",
-    "nav-frontend-ikoner-assets": "0.2.19",
+    "nav-frontend-ikoner-assets": "^0.2.19",
     "nav-frontend-lukknapp": "^0.1.13",
     "nav-frontend-typografi": "^1.0.12",
     "prop-types": "^15.5.10",

--- a/packages/node_modules/nav-frontend-spinner/package.json
+++ b/packages/node_modules/nav-frontend-spinner/package.json
@@ -14,13 +14,13 @@
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-ikoner-assets": "0.2.19",
+    "nav-frontend-ikoner-assets": "^0.2.19",
     "nav-frontend-spinner-style": "^0.2.4",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   },
   "devDependencies": {
-    "nav-frontend-ikoner-assets": "0.2.19",
+    "nav-frontend-ikoner-assets": "^0.2.19",
     "nav-frontend-spinner-style": "^0.2.4",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"

--- a/packages/node_modules/nav-frontend-stegindikator-style/package.json
+++ b/packages/node_modules/nav-frontend-stegindikator-style/package.json
@@ -8,12 +8,12 @@
   ],
   "peerDependencies": {
     "nav-frontend-core": "^4.0.2",
-    "nav-frontend-ikoner-assets": "0.2.19",
+    "nav-frontend-ikoner-assets": "^0.2.19",
     "react": "^15.4.2 || ^16.0.0"
   },
   "devDependencies": {
     "nav-frontend-core": "^4.0.2",
-    "nav-frontend-ikoner-assets": "0.2.19",
+    "nav-frontend-ikoner-assets": "^0.2.19",
     "react": "^15.4.2 || ^16.0.0"
   }
 }


### PR DESCRIPTION
Sånn jeg tolker [denne dokumentasjonen](https://www.npmjs.com/package/lerna#commands) vil --exact fjerne ^, og istedet sette absolutt versjon. PR fjerner --exact fra lerna publish-kallet.