### PR TITLE
Fix/tekstomrade error

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "react-test-renderer": "^15.4.2 || ^16.0.0",
     "redux": "^3.7.1",
     "redux-logger": "^3.0.6",
-    "sanitize-html": "^1.13.0",
     "semver": "^5.4.1",
     "specificity": "^0.3.1",
     "style-loader": "^0.18.1",

--- a/packages/node_modules/nav-frontend-tekstomrade/README.md
+++ b/packages/node_modules/nav-frontend-tekstomrade/README.md
@@ -7,7 +7,7 @@ Tekstområde som:
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-tekstomrade nav-frontend-typografi classnames nav-frontend-core nav-frontend-typografi-style prop-types react sanitize-html --save
+npm install nav-frontend-tekstomrade nav-frontend-typografi classnames nav-frontend-core nav-frontend-typografi-style prop-types react --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 

--- a/packages/node_modules/nav-frontend-tekstomrade/_tekstomrade.sample.js
+++ b/packages/node_modules/nav-frontend-tekstomrade/_tekstomrade.sample.js
@@ -1,0 +1,11 @@
+import Tekstomrade from './';
+import generateSample from '../../../guideline-app/app/utils/sampling/sampleDataGenerator';
+
+const lengreTekst = `En komponent som tar ansvar for å brekke opp tekst i avsnitt, og legge til lenker.
+Vi kan f.eks lenke til www.nav.no, og ha flere lenker på samme linje. (Les mer her; https://nav.no)`;
+
+export default generateSample({
+    baseType: Tekstomrade,
+    modifierNames: ['ingenFormattering'],
+    children: lengreTekst
+});

--- a/packages/node_modules/nav-frontend-tekstomrade/package.json
+++ b/packages/node_modules/nav-frontend-tekstomrade/package.json
@@ -15,13 +15,11 @@
   "peerDependencies": {
     "nav-frontend-typografi": "^1.0.12",
     "prop-types": "^15.5.10",
-    "react": "^15.4.2 || ^16.0.0",
-    "sanitize-html": "^1.13.0"
+    "react": "^15.4.2 || ^16.0.0"
   },
   "devDependencies": {
     "nav-frontend-typografi": "^1.0.12",
     "prop-types": "^15.5.10",
-    "react": "^15.4.2 || ^16.0.0",
-    "sanitize-html": "^1.13.0"
+    "react": "^15.4.2 || ^16.0.0"
   }
 }

--- a/packages/node_modules/nav-frontend-tekstomrade/package.json
+++ b/packages/node_modules/nav-frontend-tekstomrade/package.json
@@ -13,11 +13,13 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "peerDependencies": {
+    "nav-frontend-lenker": "^0.0.2",
     "nav-frontend-typografi": "^1.0.12",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   },
   "devDependencies": {
+    "nav-frontend-lenker": "^0.0.2",
     "nav-frontend-typografi": "^1.0.12",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"

--- a/packages/node_modules/nav-frontend-tekstomrade/src/fragments.js
+++ b/packages/node_modules/nav-frontend-tekstomrade/src/fragments.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PT from 'prop-types';
+
+const httpRegex = /^(https?):\/\/.*$/;
+
+export function SpanFragment({ children, ...props }) {
+    if (!children || children.length === 0) {
+        return null;
+    }
+    return (<span {...props}>{children}</span>);
+}
+SpanFragment.defaultProps = {
+    children: undefined
+};
+SpanFragment.propTypes = {
+    children: PT.string
+};
+
+export function LinkFragment({ href, ...props }) {
+    if (!href || href.length === 0) {
+        return null;
+    }
+    const matched = href.match(httpRegex) ? href : `http://${href}`;
+    return (<a target="_blank" rel="noreferrer" href={matched} {...props}>{matched}</a>);
+}
+LinkFragment.defaultProps = {
+    href: undefined
+};
+LinkFragment.propTypes = {
+    href: PT.string
+};

--- a/packages/node_modules/nav-frontend-tekstomrade/src/fragments.js
+++ b/packages/node_modules/nav-frontend-tekstomrade/src/fragments.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PT from 'prop-types';
+import Lenke from 'nav-frontend-lenker';
 
 const httpRegex = /^(https?):\/\/.*$/;
 
@@ -16,16 +17,16 @@ SpanFragment.propTypes = {
     children: PT.string
 };
 
-export function LinkFragment({ href, ...props }) {
+export function LenkeFragment({ href, ...props }) {
     if (!href || href.length === 0) {
         return null;
     }
     const matched = href.match(httpRegex) ? href : `http://${href}`;
-    return (<a target="_blank" rel="noreferrer" href={matched} {...props}>{matched}</a>);
+    return (<Lenke target="_blank" href={matched} {...props}>{href}</Lenke>);
 }
-LinkFragment.defaultProps = {
+LenkeFragment.defaultProps = {
     href: undefined
 };
-LinkFragment.propTypes = {
+LenkeFragment.propTypes = {
     href: PT.string
 };

--- a/packages/node_modules/nav-frontend-tekstomrade/src/fragments.js
+++ b/packages/node_modules/nav-frontend-tekstomrade/src/fragments.js
@@ -22,7 +22,7 @@ export function LenkeFragment({ href, ...props }) {
         return null;
     }
     const matched = href.match(httpRegex) ? href : `http://${href}`;
-    return (<Lenke target="_blank" href={matched} {...props}>{href}</Lenke>);
+    return (<Lenke target="_blank" href={matched} {...props}>{matched}</Lenke>);
 }
 LenkeFragment.defaultProps = {
     href: undefined

--- a/packages/node_modules/nav-frontend-tekstomrade/src/tekstomrade.js
+++ b/packages/node_modules/nav-frontend-tekstomrade/src/tekstomrade.js
@@ -1,27 +1,38 @@
 import PT from 'prop-types';
 import React, { Component } from 'react';
-import sanitize from 'sanitize-html';
 import { Normaltekst } from 'nav-frontend-typografi';
+import { SpanFragment, LinkFragment } from './fragments';
 
-const leggTilLenkerTags = (innhold) => {
-    const uriRegex = /(([\w-]+:\/\/?|www(?:-\w+)?\.)[^\s()<>]+\w)/g;
-    const httpRegex = /^(https?):\/\/.*$/;
+const uriRegex = /((?:[\w-]+:\/\/?|www(?:-\w+)?\.)[^\s()<>]+\w)/g;
+const notNull = (element) => element !== null;
 
-    return innhold.replace(uriRegex, (match) => {
-        const matched = match.match(httpRegex) ? match : `http://${match}`;
-        return `<a target="_blank" rel="noreferrer" href="${matched}">${matched}</a>`;
-    });
-};
+function tilJSXLenke(fragment, fragmentIndex) {
+    const urimatch = uriRegex.exec(fragment);
+    if (urimatch === null) {
+        return <SpanFragment key={fragmentIndex}>{fragment}</SpanFragment>;
+    }
+    return <LinkFragment key={fragmentIndex} href={urimatch[0]} />;
+}
 
-const safeHtml = (content) => sanitize(content, { allowedTags: ['a'] });
+function leggTilLenkerJSX(innhold) {
+    const fragments = innhold.split(uriRegex);
+    if (fragments.length === 1) {
+        const text = fragments[0];
+        if (!text || text.length === 0) {
+            return null;
+        }
+        return (<SpanFragment>{text}</SpanFragment>);
+    }
 
-const tilAvsnitt = (avsnitt, index, list) => (
-    <Normaltekst
-        className={index < list.length - 1 ? 'blokk-xs' : ''}
-        dangerouslySetInnerHTML={{ __html: safeHtml(avsnitt) }} // eslint-disable-line react/no-danger
-        key={index}
-    />
-);
+    return fragments
+        .map(tilJSXLenke)
+        .filter(notNull);
+}
+function tilAvsnitt(avsnitt, index, list) {
+    return (
+        <Normaltekst className={index < list.length - 1 ? 'blokk-xs' : ''} key={index}>{avsnitt}</Normaltekst>
+    );
+}
 
 class Tekstomrade extends Component { // eslint-disable-line react/prefer-stateless-function
     render() {
@@ -29,7 +40,8 @@ class Tekstomrade extends Component { // eslint-disable-line react/prefer-statel
 
         const tekst = children;
         const avsnitt = ingenFormattering ? tekst : tekst.split(/[\r\n]+/)
-            .map(leggTilLenkerTags)
+            .map(leggTilLenkerJSX)
+            .filter(notNull)
             .map(tilAvsnitt);
 
         return <div {...props}>{avsnitt}</div>;

--- a/packages/node_modules/nav-frontend-tekstomrade/src/tekstomrade.js
+++ b/packages/node_modules/nav-frontend-tekstomrade/src/tekstomrade.js
@@ -1,7 +1,7 @@
 import PT from 'prop-types';
 import React, { Component } from 'react';
 import { Normaltekst } from 'nav-frontend-typografi';
-import { SpanFragment, LinkFragment } from './fragments';
+import { SpanFragment, LenkeFragment } from './fragments';
 
 const uriRegex = /((?:[\w-]+:\/\/?|www(?:-\w+)?\.)[^\s()<>]+\w)/g;
 const notNull = (element) => element !== null;
@@ -11,7 +11,7 @@ function tilJSXLenke(fragment, fragmentIndex) {
     if (urimatch === null) {
         return <SpanFragment key={fragmentIndex}>{fragment}</SpanFragment>;
     }
-    return <LinkFragment key={fragmentIndex} href={urimatch[0]} />;
+    return <LenkeFragment key={fragmentIndex} href={urimatch[0]} />;
 }
 
 function leggTilLenkerJSX(innhold) {


### PR DESCRIPTION
Alle bruksmønstre for `Tekstområde` ga feil i consolen, da det
ble brukt `dangerouslySetInnerHTML` på en `Normaltekst` som forventer
`children`. Dette var nødvendig pga konverteringen til lenker.

Vi parser nå heller teksten selv, og generer react-komponenter (span/a)
for de ulike fragmentene vi finner.

Fjernet `sanitize-html` som avhengighet da den ikke er nødvendig mer.

Før:
![image](https://user-images.githubusercontent.com/1413417/35674233-471428ec-0744-11e8-8a1f-5e11a8b61cc1.png)
![image](https://user-images.githubusercontent.com/1413417/35674266-64f12e00-0744-11e8-9d43-b2a0d925b0cf.png)


Etter:
![image](https://user-images.githubusercontent.com/1413417/35674326-a0d8cba8-0744-11e8-8c58-402877b15510.png)
![image](https://user-images.githubusercontent.com/1413417/35674338-a8d5048e-0744-11e8-8b9f-646b195cde20.png)


