### PR TITLE
Fikser 'name' attributt på input, textarea

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/input.js
+++ b/packages/node_modules/nav-frontend-skjema/src/input.js
@@ -28,6 +28,7 @@ class Input extends Component { // eslint-disable-line react/prefer-stateless-fu
                     type="text"
                     className={inputClass(bredde, inputClassName, feil)}
                     id={inputId}
+                    name={name}
                     {...other}
                     ref={inputRef}
                 />

--- a/packages/node_modules/nav-frontend-skjema/src/textarea.js
+++ b/packages/node_modules/nav-frontend-skjema/src/textarea.js
@@ -39,7 +39,7 @@ class Textarea extends Component {
         }
     }
 
-    renderTextareaElement(textareaRef, textareaClass, feil, textareaId, other) {
+    renderTextareaElement(textareaRef, textareaClass, feil, textareaId, name, other) {
         return (
             <textarea
                 ref={(textarea) => {
@@ -50,6 +50,7 @@ class Textarea extends Component {
                 className={inputCls(textareaClass, feil)}
                 type="text"
                 id={textareaId}
+                name={name}
                 style={{ height: '30px' }}
                 {...other}
             />
@@ -61,7 +62,7 @@ class Textarea extends Component {
             this.props;
         const textareaId = id || name || guid();
         const antallTegn = other.value.length;
-        const textareaEl = this.renderTextareaElement(textareaRef, textareaClass, feil, textareaId, other);
+        const textareaEl = this.renderTextareaElement(textareaRef, textareaClass, feil, textareaId, name, other);
 
         return (
             <div className="skjemaelement textarea__container">


### PR DESCRIPTION
Resolves #195

Lot være å gjøre noe med at `name` brukes som fallback-verdi til `id` hvis den ikke er gitt. Dette gjelder foreløpig kun for input og textarea, og kan sikkert legges til på select også? Men vil vel uansett bli vanskelig å få dette til å fungere likt på tvers av alle skjema-elementene ettersom radio og checkbox ikke vil ha noe nytte av det?