### PR TITLE
Fikser at Snakkeboble-sample bruker 'topp' i stedet for 'dato'

### DIFF
--- a/guideline-app/app/ui/containers/component/main/styles.less
+++ b/guideline-app/app/ui/containers/component/main/styles.less
@@ -2,7 +2,7 @@
 
 .componentMainPage {
 
-  p,h1,h2,h3 {
+  p:not([class]),h1,h2,h3 {
     padding: 8px;
   }
 

--- a/packages/node_modules/nav-frontend-snakkeboble/_snakkeboble.sample.js
+++ b/packages/node_modules/nav-frontend-snakkeboble/_snakkeboble.sample.js
@@ -4,6 +4,6 @@ import generateSample from '../../../guideline-app/app/utils/sampling/sampleData
 export default generateSample({
     baseType: Snakkeboble,
     modifierNames: ['pilHoyre'],
-    attrs: { dato: '14.07.2017 kl. 10:12' },
+    attrs: { topp: '14.07.2017 kl. 10:12' },
     children: 'Hei! Jeg lurer på en ting...'
 });

--- a/packages/node_modules/nav-frontend-veileder/package.json
+++ b/packages/node_modules/nav-frontend-veileder/package.json
@@ -10,7 +10,7 @@
   ],
   "peerDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-veileder-style": "^0.0.1",
+    "nav-frontend-veileder-style": "^0.0.2",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   },


### PR DESCRIPTION
Fikser slik at Guideline-siden ikke gir runtime-feil lokalt på Snakkeboble-komponenten. Fikser samtidig at default Guideline-styling ikke legger til 8px padding på alle `<p>` elementer.