### PR TITLE
Gjør enkelte typer optional i TS, likt proptypes

### DIFF
--- a/packages/node_modules/nav-frontend-etiketter/src/index.tsx
+++ b/packages/node_modules/nav-frontend-etiketter/src/index.tsx
@@ -12,7 +12,7 @@ const cls = (type, className) => classNames('etikett', className, {
 });
 
 export interface EtikettProps {
-    typo: string;
+    typo?: string;
     children: React.ReactNode | React.ReactChild | React.ReactChildren;
     className?: string;
 }

--- a/packages/node_modules/nav-frontend-spinner/src/spinner.tsx
+++ b/packages/node_modules/nav-frontend-spinner/src/spinner.tsx
@@ -17,7 +17,7 @@ export interface NavFrontendSpinnerProps {
 }
 
 export interface  NavFrontendSpinnerBaseProps extends  NavFrontendSpinnerProps {
-    type: 'XXS'|  'XS' | 'S'|  'M' |  'L'|  'XL'|  'XXL' |  'XXXL';
+    type?: 'XXS'|  'XS' | 'S'|  'M' |  'L'|  'XL'|  'XXL' |  'XXXL';
 }
 
 class NavFrontendSpinner extends React.Component<NavFrontendSpinnerBaseProps>{


### PR DESCRIPTION
Når jeg oppdaterte til ny versjon i forenklet-deploy oppdaget jeg at etiketter og spinneren hadde proptypes som skulle vært optional. Fikset disse :)

Versjonene som er releaset nå, er breaking om man brukte TS i prosjektet fra før. Så det blir vel en form for prodfix :) Anbefaler derfor å ikke vente så lenge med å release denne.