### PR TITLE
Eksportere ett RadioPanel + fjerne nivå på styling, tillate inputprops

### DIFF
--- a/packages/node_modules/nav-frontend-skjema-style/src/radio-panel-gruppe.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/radio-panel-gruppe.less
@@ -1,81 +1,81 @@
 .radioPanel {
-  background-color: @white;
-  border: 2px solid @navGra20;
-  border-radius: 8px;
-  display: block;
-  cursor: pointer;
-  height: 3.5rem;
-  padding: 1rem;
-  position: relative;
-
-  &__radio {
-    cursor: pointer;
-    position: absolute;
-    opacity: 0;
-
-    &:checked + .radioPanel__label:before {
-      border: 2px solid @navBla;
-      background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="evenodd"%3E%3Cpath fill="%230067C5" fill-rule="nonzero" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0zm5.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3Cpath stroke="%23FFF" stroke-width="2" d="M17.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
-    }
-
-    &:disabled + .radioPanel__label:before {
-      background-color: @navLysGra;
-    }
-  }
-
-  &__label {
-    .typo-normal-mixin();
-    cursor: pointer;
-    padding-left: 2rem;
-    line-height: 20px;
-
-    &:before {
-      border: 2px solid @navGra20;
-      border-radius: 50%;
-      background-color: @white;
-      background-position: center center;
-      content: '';
-      height: 1.5rem;
-      width: 1.5rem;
-      position: absolute;
-      top: 1rem;
-      left: 1rem;
-    }
-  }
-
-  &--checked {
-    background-color: rgba(0, 103, 197, 0.2);
-    border: 2px solid transparent;
-  }
-
-  &--disabled {
-    background-color: @navLysGra;
+    background-color: @white;
     border: 2px solid @navGra20;
-    box-shadow: none;
-    cursor: default;
+    border-radius: 8px;
+    display: block;
+    cursor: pointer;
+    height: 3.5rem;
+    padding: 1rem;
+    position: relative;
 
-    .radioPanel__label {
-      cursor: default;
+    &__radio {
+        cursor: pointer;
+        position: absolute;
+        opacity: 0;
+
+        &:checked + .radioPanel__label:before {
+            border: 2px solid @navBla;
+            background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="evenodd"%3E%3Cpath fill="%230067C5" fill-rule="nonzero" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0zm5.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3Cpath stroke="%23FFF" stroke-width="2" d="M17.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
+        }
+
+        &:disabled + .radioPanel__label:before {
+            background-color: @navLysGra;
+        }
     }
-  }
 
-  &--focused {
-    box-shadow: 0 0 0 2px @orangeFocus;
-    border: 2px solid transparent;
-  }
+    &__label {
+        .typo-normal-mixin();
+        cursor: pointer;
+        padding-left: 2rem;
+        line-height: 20px;
 
-  &:hover:not(.radioPanel--disabled) {
-    border: 2px solid @navBla;
-    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
-
-    .radioPanel__radio + .radioPanel__label:before {
-      background-color: @navBlaLighten60;
-      border: 0;
+        &:before {
+            border: 2px solid @navGra20;
+            border-radius: 50%;
+            background-color: @white;
+            background-position: center center;
+            content: '';
+            height: 1.5rem;
+            width: 1.5rem;
+            position: absolute;
+            top: 1rem;
+            left: 1rem;
+        }
     }
 
-    .radioPanel__radio:checked + .radioPanel__label:before {
-      border: 2px solid transparent;
-      background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="nonzero"%3E%3Cpath fill="%2399C2E8" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0z"/%3E%3Cpath fill="%23FFF" d="M15.475 7.405a1.5 1.5 0 1 1 2.05 2.191L10.02 16.6a1.502 1.502 0 0 1-2.082-.038l-2.5-2.5A1.5 1.5 0 0 1 7.56 11.94l1.475 1.475 6.44-6.01z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
+    &--checked {
+        background-color: rgba(0, 103, 197, 0.2);
+        border: 2px solid transparent;
     }
-  }
+
+    &--disabled {
+        background-color: @navLysGra;
+        border: 2px solid @navGra20;
+        box-shadow: none;
+        cursor: default;
+
+        .radioPanel__label {
+            cursor: default;
+        }
+    }
+
+    &--focused {
+        box-shadow: 0 0 0 2px @orangeFocus;
+        border: 2px solid transparent;
+    }
+
+    &:hover:not(.radioPanel--disabled) {
+        border: 2px solid @navBla;
+        box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
+
+        .radioPanel__radio + .radioPanel__label:before {
+            background-color: @navBlaLighten60;
+            border: 0;
+        }
+
+        .radioPanel__radio:checked + .radioPanel__label:before {
+            border: 2px solid transparent;
+            background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="nonzero"%3E%3Cpath fill="%2399C2E8" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0z"/%3E%3Cpath fill="%23FFF" d="M15.475 7.405a1.5 1.5 0 1 1 2.05 2.191L10.02 16.6a1.502 1.502 0 0 1-2.082-.038l-2.5-2.5A1.5 1.5 0 0 1 7.56 11.94l1.475 1.475 6.44-6.01z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
+        }
+    }
 }

--- a/packages/node_modules/nav-frontend-skjema-style/src/radio-panel-gruppe.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/radio-panel-gruppe.less
@@ -1,83 +1,81 @@
-.radioPanelGruppe {
-  .radioPanel {
-    background-color: @white;
-    border: 2px solid @navGra20;
-    border-radius: 8px;
-    display: block;
-    cursor: pointer;
-    height: 3.5rem;
-    padding: 1rem;
-    position: relative;
+.radioPanel {
+	background-color: @white;
+	border: 2px solid @navGra20;
+	border-radius: 8px;
+	display: block;
+	cursor: pointer;
+	height: 3.5rem;
+	padding: 1rem;
+	position: relative;
 
-    &__radio {
-      cursor: pointer;
-      position: absolute;
-      opacity: 0;
+	&__radio {
+		cursor: pointer;
+		position: absolute;
+		opacity: 0;
 
-      &:checked + .radioPanel__label:before {
-        border: 2px solid @navBla;
-        background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="evenodd"%3E%3Cpath fill="%230067C5" fill-rule="nonzero" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0zm5.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3Cpath stroke="%23FFF" stroke-width="2" d="M17.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
-      }
+		&:checked + .radioPanel__label:before {
+			border: 2px solid @navBla;
+			background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="evenodd"%3E%3Cpath fill="%230067C5" fill-rule="nonzero" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0zm5.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3Cpath stroke="%23FFF" stroke-width="2" d="M17.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
+		}
 
-      &:disabled + .radioPanel__label:before {
-        background-color: @navLysGra;
-      }
-    }
+		&:disabled + .radioPanel__label:before {
+			background-color: @navLysGra;
+		}
+	}
 
-    &__label {
-      .typo-normal-mixin();
-      cursor: pointer;
-      padding-left: 2rem;
-      line-height: 20px;
+	&__label {
+		.typo-normal-mixin();
+		cursor: pointer;
+		padding-left: 2rem;
+		line-height: 20px;
 
-      &:before {
-        border: 2px solid @navGra20;
-        border-radius: 50%;
-        background-color: @white;
-        background-position: center center;
-        content: '';
-        height: 1.5rem;
-        width: 1.5rem;
-        position: absolute;
-        top: 1rem;
-        left: 1rem;
-      }
-    }
+		&:before {
+			border: 2px solid @navGra20;
+			border-radius: 50%;
+			background-color: @white;
+			background-position: center center;
+			content: '';
+			height: 1.5rem;
+			width: 1.5rem;
+			position: absolute;
+			top: 1rem;
+			left: 1rem;
+		}
+	}
 
-    &--checked {
-      background-color: rgba(0, 103, 197, 0.2);
-      border: 2px solid transparent;
-    }
+	&--checked {
+		background-color: rgba(0, 103, 197, 0.2);
+		border: 2px solid transparent;
+	}
 
-    &--disabled {
-      background-color: @navLysGra;
-      border: 2px solid @navGra20;
-      box-shadow: none;
-      cursor: default;
+	&--disabled {
+		background-color: @navLysGra;
+		border: 2px solid @navGra20;
+		box-shadow: none;
+		cursor: default;
 
-      .radioPanel__label {
-        cursor: default;
-      }
-    }
+		.radioPanel__label {
+			cursor: default;
+		}
+	}
 
-    &--focused {
-      box-shadow: 0 0 0 2px @orangeFocus;
-      border: 2px solid transparent;
-    }
+	&--focused {
+		box-shadow: 0 0 0 2px @orangeFocus;
+		border: 2px solid transparent;
+	}
 
-    &:hover:not(.radioPanel--disabled) {
-      border: 2px solid @navBla;
-      box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
+	&:hover:not(.radioPanel--disabled) {
+		border: 2px solid @navBla;
+		box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
 
-      .radioPanel__radio + .radioPanel__label:before {
-        background-color: @navBlaLighten60;
-        border: 0;
-      }
+		.radioPanel__radio + .radioPanel__label:before {
+			background-color: @navBlaLighten60;
+			border: 0;
+		}
 
-      .radioPanel__radio:checked + .radioPanel__label:before {
-        border: 2px solid transparent;
-        background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="nonzero"%3E%3Cpath fill="%2399C2E8" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0z"/%3E%3Cpath fill="%23FFF" d="M15.475 7.405a1.5 1.5 0 1 1 2.05 2.191L10.02 16.6a1.502 1.502 0 0 1-2.082-.038l-2.5-2.5A1.5 1.5 0 0 1 7.56 11.94l1.475 1.475 6.44-6.01z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
-      }
-    }
-  }
+		.radioPanel__radio:checked + .radioPanel__label:before {
+			border: 2px solid transparent;
+			background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="nonzero"%3E%3Cpath fill="%2399C2E8" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0z"/%3E%3Cpath fill="%23FFF" d="M15.475 7.405a1.5 1.5 0 1 1 2.05 2.191L10.02 16.6a1.502 1.502 0 0 1-2.082-.038l-2.5-2.5A1.5 1.5 0 0 1 7.56 11.94l1.475 1.475 6.44-6.01z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
+		}
+	}
 }

--- a/packages/node_modules/nav-frontend-skjema-style/src/radio-panel-gruppe.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/radio-panel-gruppe.less
@@ -1,81 +1,81 @@
 .radioPanel {
-    background-color: @white;
-    border: 2px solid @navGra20;
-    border-radius: 8px;
-    display: block;
+  background-color: @white;
+  border: 2px solid @navGra20;
+  border-radius: 8px;
+  display: block;
+  cursor: pointer;
+  height: 3.5rem;
+  padding: 1rem;
+  position: relative;
+
+  &__radio {
     cursor: pointer;
-    height: 3.5rem;
-    padding: 1rem;
-    position: relative;
+    position: absolute;
+    opacity: 0;
 
-    &__radio {
-        cursor: pointer;
-        position: absolute;
-        opacity: 0;
-
-        &:checked + .radioPanel__label:before {
-            border: 2px solid @navBla;
-            background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="evenodd"%3E%3Cpath fill="%230067C5" fill-rule="nonzero" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0zm5.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3Cpath stroke="%23FFF" stroke-width="2" d="M17.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
-        }
-
-        &:disabled + .radioPanel__label:before {
-            background-color: @navLysGra;
-        }
+    &:checked + .radioPanel__label:before {
+      border: 2px solid @navBla;
+      background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="evenodd"%3E%3Cpath fill="%230067C5" fill-rule="nonzero" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0zm5.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3Cpath stroke="%23FFF" stroke-width="2" d="M17.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
     }
 
-    &__label {
-        .typo-normal-mixin();
-        cursor: pointer;
-        padding-left: 2rem;
-        line-height: 20px;
+    &:disabled + .radioPanel__label:before {
+      background-color: @navLysGra;
+    }
+  }
 
-        &:before {
-            border: 2px solid @navGra20;
-            border-radius: 50%;
-            background-color: @white;
-            background-position: center center;
-            content: '';
-            height: 1.5rem;
-            width: 1.5rem;
-            position: absolute;
-            top: 1rem;
-            left: 1rem;
-        }
+  &__label {
+    .typo-normal-mixin();
+    cursor: pointer;
+    padding-left: 2rem;
+    line-height: 20px;
+
+    &:before {
+      border: 2px solid @navGra20;
+      border-radius: 50%;
+      background-color: @white;
+      background-position: center center;
+      content: '';
+      height: 1.5rem;
+      width: 1.5rem;
+      position: absolute;
+      top: 1rem;
+      left: 1rem;
+    }
+  }
+
+  &--checked {
+    background-color: rgba(0, 103, 197, 0.2);
+    border: 2px solid transparent;
+  }
+
+  &--disabled {
+    background-color: @navLysGra;
+    border: 2px solid @navGra20;
+    box-shadow: none;
+    cursor: default;
+
+    .radioPanel__label {
+      cursor: default;
+    }
+  }
+
+  &--focused {
+    box-shadow: 0 0 0 2px @orangeFocus;
+    border: 2px solid transparent;
+  }
+
+  &:hover:not(.radioPanel--disabled) {
+    border: 2px solid @navBla;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
+
+    .radioPanel__radio + .radioPanel__label:before {
+      background-color: @navBlaLighten60;
+      border: 0;
     }
 
-    &--checked {
-        background-color: rgba(0, 103, 197, 0.2);
-        border: 2px solid transparent;
+    .radioPanel__radio:checked + .radioPanel__label:before {
+      border: 2px solid transparent;
+      background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="nonzero"%3E%3Cpath fill="%2399C2E8" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0z"/%3E%3Cpath fill="%23FFF" d="M15.475 7.405a1.5 1.5 0 1 1 2.05 2.191L10.02 16.6a1.502 1.502 0 0 1-2.082-.038l-2.5-2.5A1.5 1.5 0 0 1 7.56 11.94l1.475 1.475 6.44-6.01z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
     }
-
-    &--disabled {
-        background-color: @navLysGra;
-        border: 2px solid @navGra20;
-        box-shadow: none;
-        cursor: default;
-
-        .radioPanel__label {
-            cursor: default;
-        }
-    }
-
-    &--focused {
-        box-shadow: 0 0 0 2px @orangeFocus;
-        border: 2px solid transparent;
-    }
-
-    &:hover:not(.radioPanel--disabled) {
-        border: 2px solid @navBla;
-        box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
-
-        .radioPanel__radio + .radioPanel__label:before {
-            background-color: @navBlaLighten60;
-            border: 0;
-        }
-
-        .radioPanel__radio:checked + .radioPanel__label:before {
-            border: 2px solid transparent;
-            background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="nonzero"%3E%3Cpath fill="%2399C2E8" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0z"/%3E%3Cpath fill="%23FFF" d="M15.475 7.405a1.5 1.5 0 1 1 2.05 2.191L10.02 16.6a1.502 1.502 0 0 1-2.082-.038l-2.5-2.5A1.5 1.5 0 0 1 7.56 11.94l1.475 1.475 6.44-6.01z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
-        }
-    }
+  }
 }

--- a/packages/node_modules/nav-frontend-skjema-style/src/radio-panel-gruppe.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/radio-panel-gruppe.less
@@ -1,81 +1,81 @@
 .radioPanel {
-	background-color: @white;
-	border: 2px solid @navGra20;
-	border-radius: 8px;
-	display: block;
-	cursor: pointer;
-	height: 3.5rem;
-	padding: 1rem;
-	position: relative;
+  background-color: @white;
+  border: 2px solid @navGra20;
+  border-radius: 8px;
+  display: block;
+  cursor: pointer;
+  height: 3.5rem;
+  padding: 1rem;
+  position: relative;
 
-	&__radio {
-		cursor: pointer;
-		position: absolute;
-		opacity: 0;
+  &__radio {
+    cursor: pointer;
+    position: absolute;
+    opacity: 0;
 
-		&:checked + .radioPanel__label:before {
-			border: 2px solid @navBla;
-			background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="evenodd"%3E%3Cpath fill="%230067C5" fill-rule="nonzero" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0zm5.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3Cpath stroke="%23FFF" stroke-width="2" d="M17.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
-		}
+    &:checked + .radioPanel__label:before {
+      border: 2px solid @navBla;
+      background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="evenodd"%3E%3Cpath fill="%230067C5" fill-rule="nonzero" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0zm5.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3Cpath stroke="%23FFF" stroke-width="2" d="M17.341 8.866l-7.5 7a.502.502 0 0 1-.695-.012l-2.5-2.5a.5.5 0 0 1 .707-.707l2.158 2.158 7.147-6.67a.5.5 0 1 1 .683.731z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
+    }
 
-		&:disabled + .radioPanel__label:before {
-			background-color: @navLysGra;
-		}
-	}
+    &:disabled + .radioPanel__label:before {
+      background-color: @navLysGra;
+    }
+  }
 
-	&__label {
-		.typo-normal-mixin();
-		cursor: pointer;
-		padding-left: 2rem;
-		line-height: 20px;
+  &__label {
+    .typo-normal-mixin();
+    cursor: pointer;
+    padding-left: 2rem;
+    line-height: 20px;
 
-		&:before {
-			border: 2px solid @navGra20;
-			border-radius: 50%;
-			background-color: @white;
-			background-position: center center;
-			content: '';
-			height: 1.5rem;
-			width: 1.5rem;
-			position: absolute;
-			top: 1rem;
-			left: 1rem;
-		}
-	}
+    &:before {
+      border: 2px solid @navGra20;
+      border-radius: 50%;
+      background-color: @white;
+      background-position: center center;
+      content: '';
+      height: 1.5rem;
+      width: 1.5rem;
+      position: absolute;
+      top: 1rem;
+      left: 1rem;
+    }
+  }
 
-	&--checked {
-		background-color: rgba(0, 103, 197, 0.2);
-		border: 2px solid transparent;
-	}
+  &--checked {
+    background-color: rgba(0, 103, 197, 0.2);
+    border: 2px solid transparent;
+  }
 
-	&--disabled {
-		background-color: @navLysGra;
-		border: 2px solid @navGra20;
-		box-shadow: none;
-		cursor: default;
+  &--disabled {
+    background-color: @navLysGra;
+    border: 2px solid @navGra20;
+    box-shadow: none;
+    cursor: default;
 
-		.radioPanel__label {
-			cursor: default;
-		}
-	}
+    .radioPanel__label {
+      cursor: default;
+    }
+  }
 
-	&--focused {
-		box-shadow: 0 0 0 2px @orangeFocus;
-		border: 2px solid transparent;
-	}
+  &--focused {
+    box-shadow: 0 0 0 2px @orangeFocus;
+    border: 2px solid transparent;
+  }
 
-	&:hover:not(.radioPanel--disabled) {
-		border: 2px solid @navBla;
-		box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
+  &:hover:not(.radioPanel--disabled) {
+    border: 2px solid @navBla;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
 
-		.radioPanel__radio + .radioPanel__label:before {
-			background-color: @navBlaLighten60;
-			border: 0;
-		}
+    .radioPanel__radio + .radioPanel__label:before {
+      background-color: @navBlaLighten60;
+      border: 0;
+    }
 
-		.radioPanel__radio:checked + .radioPanel__label:before {
-			border: 2px solid transparent;
-			background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="nonzero"%3E%3Cpath fill="%2399C2E8" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0z"/%3E%3Cpath fill="%23FFF" d="M15.475 7.405a1.5 1.5 0 1 1 2.05 2.191L10.02 16.6a1.502 1.502 0 0 1-2.082-.038l-2.5-2.5A1.5 1.5 0 0 1 7.56 11.94l1.475 1.475 6.44-6.01z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
-		}
-	}
+    .radioPanel__radio:checked + .radioPanel__label:before {
+      border: 2px solid transparent;
+      background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cg fill="none" fill-rule="nonzero"%3E%3Cpath fill="%2399C2E8" d="M12 0C5.383 0 0 5.384 0 12s5.383 12 12 12c6.616 0 12-5.384 12-12S18.616 0 12 0z"/%3E%3Cpath fill="%23FFF" d="M15.475 7.405a1.5 1.5 0 1 1 2.05 2.191L10.02 16.6a1.502 1.502 0 0 1-2.082-.038l-2.5-2.5A1.5 1.5 0 0 1 7.56 11.94l1.475 1.475 6.44-6.01z"/%3E%3C/g%3E%3C/svg%3E%0A'); // lesshint maxCharPerLine: false
+    }
+  }
 }

--- a/packages/node_modules/nav-frontend-skjema-style/src/radio-panel-gruppe.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/radio-panel-gruppe.less
@@ -1,11 +1,14 @@
+.radioPanelGruppe .radioPanel {
+  margin-bottom: 0.5rem;
+}
+
 .radioPanel {
   background-color: @white;
   border: 2px solid @navGra20;
   border-radius: 8px;
   display: block;
   cursor: pointer;
-  height: 3.5rem;
-  padding: 1rem;
+  padding: 1rem 1rem 1rem 3rem;
   position: relative;
 
   &__radio {
@@ -26,7 +29,6 @@
   &__label {
     .typo-normal-mixin();
     cursor: pointer;
-    padding-left: 2rem;
     line-height: 20px;
 
     &:before {

--- a/packages/node_modules/nav-frontend-skjema/src/index.js
+++ b/packages/node_modules/nav-frontend-skjema/src/index.js
@@ -9,4 +9,4 @@ export { default as SkjemaGruppe } from './skjema-gruppe';
 export { default as ToggleGruppe } from './toggle-gruppe';
 export { default as ToggleKnapp } from './toggle-knapp';
 // eslint-disable-next-line import/no-unresolved
-export { default as RadioPanelGruppe } from './radio-panel-gruppe';
+export { default as RadioPanelGruppe, RadioPanel } from './radio-panel-gruppe';

--- a/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
@@ -85,7 +85,6 @@ class RadioPanelGruppe extends React.Component<RadioPanelGruppeProps> {
                             key={`${name}-${radio.value}`}
                             checked={checked === radio.value}
                             onChange={(event: React.SyntheticEvent<EventTarget>) => onChange(event, radio.value)}
-                            id={radio.id}
                             {...radio}
                         />
                     ))}

--- a/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
@@ -4,96 +4,97 @@ import { SkjemaGruppe, Fieldset } from './';
 import 'nav-frontend-skjema-style';
 
 export interface RadioProps {
-    label: string;
-    value: string;
-    id?: string;
-    disabled?: boolean;
+	label: string;
+	value: string;
+	id?: string;
+	disabled?: boolean;
+	inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
 export interface FeilProps {
-    feilmelding: React.ReactNode | React.ReactChild | React.ReactChildren;
+	feilmelding: React.ReactNode | React.ReactChild | React.ReactChildren;
 }
 
 export interface RadioPanelGruppeProps {
-    radios: RadioProps[];
-    name: string;
-    legend: string;
-    onChange: (event: React.SyntheticEvent<EventTarget>, value: string) => void;
-    checked?: string;
-    feil?: FeilProps;
+	radios: RadioProps[];
+	name: string;
+	legend: string;
+	onChange: (event: React.SyntheticEvent<EventTarget>, value: string) => void;
+	checked?: string;
+	feil?: FeilProps;
 }
 
 export interface RadioPanelProps extends RadioProps {
-    checked: boolean;
-    name: string;
-    onChange: (event: React.SyntheticEvent<EventTarget>) => void;
+	checked: boolean;
+	name: string;
+	onChange: (event: React.SyntheticEvent<EventTarget>) => void;
+	inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
-interface RadioPanelState {
-    hasFocus: boolean;
+export interface RadioPanelState {
+	hasFocus: boolean;
 }
 
-class RadioPanel extends React.Component<RadioPanelProps, RadioPanelState> {
-    constructor(props: RadioPanelProps) {
-        super(props);
-        this.state = { hasFocus: false };
-    }
+export class RadioPanel extends React.Component<RadioPanelProps, RadioPanelState> {
+	constructor(props: RadioPanelProps) {
+		super(props);
+		this.state = { hasFocus: false };
+	}
 
-    toggleOutline() {
-        this.setState({ hasFocus: !this.state.hasFocus });
-    }
+	toggleOutline() {
+		this.setState({ hasFocus: !this.state.hasFocus });
+	}
 
-    render() {
-        const { checked, disabled, label, name, id, onChange } = this.props;
-        const { hasFocus } = this.state;
+	render() {
+		const { checked, disabled, label, name, id, onChange, inputProps } = this.props;
+		const { hasFocus } = this.state;
 
-        const cls = classNames('radioPanel', {
-            'radioPanel--checked': checked === true && !disabled,
-            'radioPanel--focused': hasFocus === true && !disabled,
-            'radioPanel--disabled': disabled === true
-        });
+		const cls = classNames('radioPanel', {
+			'radioPanel--checked': checked === true && !disabled,
+			'radioPanel--focused': hasFocus === true && !disabled,
+			'radioPanel--disabled': disabled === true
+		});
 
-        return (
-            <label className={cls}>
-                <input
-                    className="radioPanel__radio"
-                    type="radio"
-                    name={name}
-                    id={id}
-                    checked={checked}
-                    disabled={disabled}
-                    onFocus={() => this.toggleOutline()}
-                    onBlur={() => this.toggleOutline()}
-                    onChange={(event: React.SyntheticEvent<EventTarget>) => onChange(event)}
-                />
-                <span className="radioPanel__label">{label}</span>
-            </label>
-        );
-    }
+		return (
+			<label className={cls}>
+				<input
+					{...inputProps}
+					className="radioPanel__radio"
+					type="radio"
+					name={name}
+					id={id}
+					checked={checked}
+					disabled={disabled}
+					onFocus={() => this.toggleOutline()}
+					onBlur={() => this.toggleOutline()}
+					onChange={(event: React.SyntheticEvent<EventTarget>) => onChange(event)}
+				/>
+				<span className="radioPanel__label">{label}</span>
+			</label>
+		);
+	}
 }
 
 class RadioPanelGruppe extends React.Component<RadioPanelGruppeProps> {
-    render () {
-        const { radios, name, legend, feil, checked, onChange } = this.props;
-        return (
-            <SkjemaGruppe className="radioPanelGruppe" feil={feil}>
-                <Fieldset legend={legend}>
-                    {
-                        radios.map((radio: RadioProps) => (
-                            <RadioPanel
-                                name={name}
-                                key={`${name}-${radio.value}`}
-                                checked={checked === radio.value}
-                                onChange={(event: React.SyntheticEvent<EventTarget>) => onChange(event, radio.value)}
-                                id={radio.id}
-                                {...radio}
-                            />
-                        ))
-                    }
-                </Fieldset>
-            </SkjemaGruppe>
-        );
-    }
+	render() {
+		const { radios, name, legend, feil, checked, onChange } = this.props;
+		return (
+			<SkjemaGruppe className="radioPanelGruppe" feil={feil}>
+				<Fieldset legend={legend}>
+					{radios.map((radio: RadioProps) => (
+						<RadioPanel
+							name={name}
+							key={`${name}-${radio.value}`}
+							checked={checked === radio.value}
+							onChange={(event: React.SyntheticEvent<EventTarget>) => onChange(event, radio.value)}
+							id={radio.id}
+							{...radio}
+						/>
+					))}
+				</Fieldset>
+			</SkjemaGruppe>
+		);
+	}
 }
 
 export default RadioPanelGruppe;

--- a/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
@@ -6,7 +6,6 @@ import 'nav-frontend-skjema-style';
 export interface RadioProps {
     label: string;
     value: string;
-    id?: string;
     disabled?: boolean;
     inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
@@ -46,7 +45,7 @@ export class RadioPanel extends React.Component<RadioPanelProps, RadioPanelState
     }
 
     render() {
-        const { checked, disabled, label, name, id, onChange, inputProps } = this.props;
+        const { checked, disabled, label, name, onChange, inputProps } = this.props;
         const { hasFocus } = this.state;
 
         const cls = classNames('radioPanel', {
@@ -62,7 +61,6 @@ export class RadioPanel extends React.Component<RadioPanelProps, RadioPanelState
                     className="radioPanel__radio"
                     type="radio"
                     name={name}
-                    id={id}
                     checked={checked}
                     disabled={disabled}
                     onFocus={() => this.toggleOutline()}

--- a/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
@@ -4,97 +4,97 @@ import { SkjemaGruppe, Fieldset } from './';
 import 'nav-frontend-skjema-style';
 
 export interface RadioProps {
-	label: string;
-	value: string;
-	id?: string;
-	disabled?: boolean;
-	inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+    label: string;
+    value: string;
+    id?: string;
+    disabled?: boolean;
+    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
 export interface FeilProps {
-	feilmelding: React.ReactNode | React.ReactChild | React.ReactChildren;
+    feilmelding: React.ReactNode | React.ReactChild | React.ReactChildren;
 }
 
 export interface RadioPanelGruppeProps {
-	radios: RadioProps[];
-	name: string;
-	legend: string;
-	onChange: (event: React.SyntheticEvent<EventTarget>, value: string) => void;
-	checked?: string;
-	feil?: FeilProps;
+    radios: RadioProps[];
+    name: string;
+    legend: string;
+    onChange: (event: React.SyntheticEvent<EventTarget>, value: string) => void;
+    checked?: string;
+    feil?: FeilProps;
 }
 
 export interface RadioPanelProps extends RadioProps {
-	checked: boolean;
-	name: string;
-	onChange: (event: React.SyntheticEvent<EventTarget>) => void;
-	inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+    checked: boolean;
+    name: string;
+    onChange: (event: React.SyntheticEvent<EventTarget>) => void;
+    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
 }
 
 export interface RadioPanelState {
-	hasFocus: boolean;
+    hasFocus: boolean;
 }
 
 export class RadioPanel extends React.Component<RadioPanelProps, RadioPanelState> {
-	constructor(props: RadioPanelProps) {
-		super(props);
-		this.state = { hasFocus: false };
-	}
+    constructor(props: RadioPanelProps) {
+        super(props);
+        this.state = { hasFocus: false };
+    }
 
-	toggleOutline() {
-		this.setState({ hasFocus: !this.state.hasFocus });
-	}
+    toggleOutline() {
+        this.setState({ hasFocus: !this.state.hasFocus });
+    }
 
-	render() {
-		const { checked, disabled, label, name, id, onChange, inputProps } = this.props;
-		const { hasFocus } = this.state;
+    render() {
+        const { checked, disabled, label, name, id, onChange, inputProps } = this.props;
+        const { hasFocus } = this.state;
 
-		const cls = classNames('radioPanel', {
-			'radioPanel--checked': checked === true && !disabled,
-			'radioPanel--focused': hasFocus === true && !disabled,
-			'radioPanel--disabled': disabled === true
-		});
+        const cls = classNames('radioPanel', {
+            'radioPanel--checked': checked === true && !disabled,
+            'radioPanel--focused': hasFocus === true && !disabled,
+            'radioPanel--disabled': disabled === true
+        });
 
-		return (
-			<label className={cls}>
-				<input
-					{...inputProps}
-					className="radioPanel__radio"
-					type="radio"
-					name={name}
-					id={id}
-					checked={checked}
-					disabled={disabled}
-					onFocus={() => this.toggleOutline()}
-					onBlur={() => this.toggleOutline()}
-					onChange={(event: React.SyntheticEvent<EventTarget>) => onChange(event)}
-				/>
-				<span className="radioPanel__label">{label}</span>
-			</label>
-		);
-	}
+        return (
+            <label className={cls}>
+                <input
+                    {...inputProps}
+                    className="radioPanel__radio"
+                    type="radio"
+                    name={name}
+                    id={id}
+                    checked={checked}
+                    disabled={disabled}
+                    onFocus={() => this.toggleOutline()}
+                    onBlur={() => this.toggleOutline()}
+                    onChange={(event: React.SyntheticEvent<EventTarget>) => onChange(event)}
+                />
+                <span className="radioPanel__label">{label}</span>
+            </label>
+        );
+    }
 }
 
 class RadioPanelGruppe extends React.Component<RadioPanelGruppeProps> {
-	render() {
-		const { radios, name, legend, feil, checked, onChange } = this.props;
-		return (
-			<SkjemaGruppe className="radioPanelGruppe" feil={feil}>
-				<Fieldset legend={legend}>
-					{radios.map((radio: RadioProps) => (
-						<RadioPanel
-							name={name}
-							key={`${name}-${radio.value}`}
-							checked={checked === radio.value}
-							onChange={(event: React.SyntheticEvent<EventTarget>) => onChange(event, radio.value)}
-							id={radio.id}
-							{...radio}
-						/>
-					))}
-				</Fieldset>
-			</SkjemaGruppe>
-		);
-	}
+    render() {
+        const { radios, name, legend, feil, checked, onChange } = this.props;
+        return (
+            <SkjemaGruppe className="radioPanelGruppe" feil={feil}>
+                <Fieldset legend={legend}>
+                    {radios.map((radio: RadioProps) => (
+                        <RadioPanel
+                            name={name}
+                            key={`${name}-${radio.value}`}
+                            checked={checked === radio.value}
+                            onChange={(event: React.SyntheticEvent<EventTarget>) => onChange(event, radio.value)}
+                            id={radio.id}
+                            {...radio}
+                        />
+                    ))}
+                </Fieldset>
+            </SkjemaGruppe>
+        );
+    }
 }
 
 export default RadioPanelGruppe;


### PR DESCRIPTION
* For å gjøre komponenten mer fleksibel og samtidig ivareta utseendet, eksporteres RadioPanel komponenten i tillegg til RadioPanelGruppe
* Det er av og til behov for å sette på ekstra gyldige htmlinput props - har lagt til egen prop på RadioPanel for dette
* Jeg har fjernet nivået .radiopanelgruppe fra less-fila - denne inneholdt ikke noen styling, og medførte at ett RadioPanel ikke kunne stå alene
