### PR TITLE
Fikser at children mangler på TS versjon av EkspanderbartPanel

### DIFF
--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/index.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/index.tsx
@@ -47,9 +47,9 @@ class Ekspanderbartpanel extends React.Component<EkspanderbartpanelProps, Ekspan
     }
 
     render() {
-        const {tittel, tittelProps } = this.props;
+        const {tittel, tittelProps, ...renderProps } = this.props;
         return (
-            <EkspanderbartpanelPure apen={this.state.apen} onClick={this.handleClick} tittel={tittel} tittelProps={tittelProps} />
+            <EkspanderbartpanelPure {...renderProps} apen={this.state.apen} onClick={this.handleClick} tittel={tittel} tittelProps={tittelProps} />
         );
     }
 }


### PR DESCRIPTION
Fikser en feil på nylig merget TS versjon av `EkspanderbartPanel` hvor props ikke ble spredt utover `EkspandertbartpanelPure` som gjorde at children uteble.