### PR TITLE
Gjør radio-panel mer fleksibel ved å tillate children.

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
@@ -7,7 +7,7 @@ import { skjemaelementFeilmeldingShape } from './skjemaelement-feilmelding';
 import 'nav-frontend-skjema-style';
 
 export interface RadioProps {
-    label: string;
+    label?: string;
     value: string;
     disabled?: boolean;
     inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
@@ -27,6 +27,7 @@ export interface RadioPanelGruppeProps {
 }
 
 export interface RadioPanelProps extends RadioProps {
+    children?: React.ReactChildren;
     checked: boolean;
     name: string;
     onChange: (event: React.SyntheticEvent<EventTarget>) => void;
@@ -57,6 +58,12 @@ export class RadioPanel extends React.Component<RadioPanelProps, RadioPanelState
             'inputPanel--disabled': disabled === true
         });
 
+        const content = this.props.children ? (
+            <div className="inputPanel__label">{this.props.children}</div>
+        ) : (
+            <span className="inputPanel__label">{label}</span>
+        );
+
         return (
             <label className={cls}>
                 <input
@@ -70,7 +77,7 @@ export class RadioPanel extends React.Component<RadioPanelProps, RadioPanelState
                     onBlur={() => this.toggleOutline()}
                     onChange={(event: React.SyntheticEvent<EventTarget>) => onChange(event)}
                 />
-                <span className="inputPanel__label">{label}</span>
+                {content}
             </label>
         );
     }


### PR DESCRIPTION
I mitt prosjekt har vi behov for å legge til en Hjelpetekst i en RadioPanel. Vi kom frem til at den letteste måten å gjøre det på var å sende med children til panelet.