### PR TITLE
BekreftCheckboksPanel bugfixes

### DIFF
--- a/packages/node_modules/nav-frontend-skjema-style/src/bekreft-checkboks-panel.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/bekreft-checkboks-panel.less
@@ -42,9 +42,9 @@
 
         &:before {
             position: absolute;
-            left: 0px;
+            top: 0.5rem;
+            left: 0;
             border-radius: 4px;
-            top: auto;
             background-color: @orangeFocusLighten80;
             border-color: @orangeFocus;
         }

--- a/packages/node_modules/nav-frontend-skjema/src/bekreft-checkboks-panel.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/bekreft-checkboks-panel.tsx
@@ -31,12 +31,6 @@ export class BekreftCheckboksPanel extends React.Component<Props, State> {
         return () => this.setState({ hasFocus: !this.state.hasFocus });
     }
 
-    onKeyDown(event: React.KeyboardEvent<EventTarget>) {
-        if (event.key === 'Enter') {
-            this.props.onChange(event);
-        }
-    }
-
     renderChildren() {
         const children = this.props.children;
         return children ? <div className="bekreftCheckboksPanel-innhold" id={this.childrenId}>{children}</div> : null;
@@ -54,10 +48,7 @@ export class BekreftCheckboksPanel extends React.Component<Props, State> {
         return (
             <div className={cls}>
                 {this.renderChildren()}
-                <label
-                    className="inputPanel__label"
-                    onKeyDown={(event) => this.onKeyDown(event)}
-                >
+                <label className="inputPanel__label">
                     <input
                         {...inputProps}
                         className="inputPanel__field"


### PR DESCRIPTION
Fixes two issues in BekreftCheckboksPanel-component of nav-frontend-skjema:
- A styling issue that resulted in checkbox and label not becoming correctly
aligned in Firefox. Verified that it now works correctly on FF, Safari and Chrome.
- Remove custom 'Enter'-button key event handler when BekreftCheckboksPanel
has focus.