### PR TITLE
Checkbox bgColor bugfix

### DIFF
--- a/packages/node_modules/nav-frontend-skjema-style/src/checkbox.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/checkbox.less
@@ -37,7 +37,7 @@
   }
 
   &:disabled + .skjemaelement__label:before {
-    background-color: @navLysGra;
+    background-color: @navGra20;
     border-color: @navGra40;
     box-shadow: none;
   }
@@ -67,7 +67,7 @@
     &:disabled {
       + .skjemaelement__label:before {
         border-color: @navGra40;
-        background-color: @navLysGra;
+        background-color: @navGra20;
         border-width: 1px;
 
       }


### PR DESCRIPTION
Checkbox in disabled state currently has background-color set to #e7e9e9. This should according
to sketches in Zeplin, be #c6c2bf (navGra20). This commit sets the correct background-color.

Link til Zeplin:
https://zpl.io/amB1xEv