### PR TITLE
Fragment bugfix

### DIFF
--- a/packages/node_modules/nav-frontend-tekstomrade/src/fragments.tsx
+++ b/packages/node_modules/nav-frontend-tekstomrade/src/fragments.tsx
@@ -4,27 +4,37 @@ import Lenke from "nav-frontend-lenker";
 
 const httpRegex = /^(https?):\/\/.*$/;
 
-export const SpanFragment: React.StatelessComponent<{ children: string }> = ({
-  children,
-  ...props
-}) => {
-  if (!children || children.length === 0) {
-    return null;
-  }
-  return <span {...props}>{children}</span>;
-};
+export interface SpanFragmentProps {
+  children: string;
+}
 
-export const LenkeFragment: React.StatelessComponent<{ href: string }> = ({
-  href,
-  ...props
-}) => {
-  if (!href || href.length === 0) {
-    return null;
+export class SpanFragment extends React.Component<SpanFragmentProps> {
+  render() {
+      const { children } = this.props;
+
+      if (!children || children.length === 0) {
+          return null;
+      }
+      return <span {...this.props}>{children}</span>;
   }
-  const matched = href.match(httpRegex) ? href : `http://${href}`;
-  return (
-    <Lenke target="_blank" href={matched} {...props}>
-      {matched}
-    </Lenke>
-  );
+}
+
+export interface LenkeFragmentProps {
+    href: string;
+}
+
+export class LenkeFragment extends React.Component<LenkeFragmentProps> {
+    render() {
+        const { href } = this.props;
+
+        if (!href || href.length === 0) {
+            return null;
+        }
+        const matched = href.match(httpRegex) ? href : `http://${href}`;
+            return (
+            <Lenke target="_blank" href={matched} {...this.props}>
+              {matched}
+            </Lenke>
+        );
+    }
 };


### PR DESCRIPTION
Rewrite fragment components in tekstomrade-component to be implemented as classes instead of
function constants, because compilation of the constants for some reason results in runtime errors
on fragments being undefined (which also broke the guideline-app).