### PR TITLE
Bugfixes on Radio and Checkbox

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/checkbox.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/checkbox.tsx
@@ -11,12 +11,12 @@ const inputCls = (harFeil) => classNames('skjemaelement__input checkboks', {
     'skjemaelement__input--harFeil': harFeil
 });
 
-export interface CheckboxProps extends React.HTMLAttributes<HTMLInputElement> {
+export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
     className?: string;
     label: React.ReactNode;
     id?: string;
     feil?: SkjemaelementFeil;
-    checkboxRef: () => any;
+    checkboxRef?: () => any;
 }
 
 /**

--- a/packages/node_modules/nav-frontend-skjema/src/radio.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/radio.tsx
@@ -6,12 +6,12 @@ import * as classNames from 'classnames';
 
 const cls = (className) => classNames('skjemaelement skjemaelement--horisontal', className);
 
-export interface RadioProps extends React.HTMLAttributes<HTMLInputElement>{
+export interface RadioProps extends React.InputHTMLAttributes<HTMLInputElement>{
     className?: string;
     label: React.ReactNode;
     id?: string;
     name: string;
-    radioRef: () => any;
+    radioRef?: () => any;
 }
 
 /**


### PR DESCRIPTION
Neither checkboxRef or radioRef should be required properties when using those components.
Also, "checked" is not currently being recognized on either of the two, which is the reason
for now extending React.InputHTMLAttributes instead of React.HTMLAttributes.