### PR TITLE
Bruker less import-reference

### DIFF
--- a/packages/node_modules/nav-frontend-alertstriper-style/src/index.less
+++ b/packages/node_modules/nav-frontend-alertstriper-style/src/index.less
@@ -1,5 +1,5 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import '@{nodeModulesPath}nav-frontend-paneler-style/src/mixins';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{nodeModulesPath}nav-frontend-paneler-style/src/mixins';
 
 .alertstripe {
   .panel-mixin();

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
@@ -1,6 +1,6 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import '@{nodeModulesPath}nav-frontend-chevron-style/src/mixins';
-@import '@{nodeModulesPath}nav-frontend-paneler-style/src/mixins';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{nodeModulesPath}nav-frontend-chevron-style/src/mixins';
+@import (reference) '@{nodeModulesPath}nav-frontend-paneler-style/src/mixins';
 
 .ekspanderbartPanel {
   &__hode {

--- a/packages/node_modules/nav-frontend-etiketter-style/src/index.less
+++ b/packages/node_modules/nav-frontend-etiketter-style/src/index.less
@@ -1,4 +1,4 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
 @import './_mixins';
 
 

--- a/packages/node_modules/nav-frontend-grid-style/src/index.less
+++ b/packages/node_modules/nav-frontend-grid-style/src/index.less
@@ -1,5 +1,5 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import '@{coreModulePath}nav-frontend-core/less/_mixins';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_mixins';
 @import './mixins';
 
 //

--- a/packages/node_modules/nav-frontend-hjelpetekst-style/src/hjelpetekst-style.less
+++ b/packages/node_modules/nav-frontend-hjelpetekst-style/src/hjelpetekst-style.less
@@ -1,9 +1,9 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import '@{coreModulePath}nav-frontend-core/less/_mixins';
-@import '@{coreModulePath}nav-frontend-core/less/scaffolding';
-@import '@{nodeModulesPath}nav-frontend-lukknapp-style/src/lukknapp-style';
-@import '@{nodeModulesPath}nav-frontend-typografi-style/src/index';
-@import '@{nodeModulesPath}nav-frontend-lenker-style/src/lenker-mixins';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_mixins';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/scaffolding';
+@import (reference) '@{nodeModulesPath}nav-frontend-lukknapp-style/src/lukknapp-style';
+@import (reference) '@{nodeModulesPath}nav-frontend-typografi-style/src/index';
+@import (reference) '@{nodeModulesPath}nav-frontend-lenker-style/src/lenker-mixins';
 
 @desktop: ~'only screen and (min-width: 480px)';
 
@@ -14,6 +14,7 @@
 }
 
 .hjelpetekst .lukknapp {
+    .lukknapp();
     position: absolute;
     top: 1rem;
     right: 1rem;

--- a/packages/node_modules/nav-frontend-hjelpetekst/src/hjelpetekst.tsx
+++ b/packages/node_modules/nav-frontend-hjelpetekst/src/hjelpetekst.tsx
@@ -218,7 +218,7 @@ class HjelpetekstBase extends React.Component<HjelpetekstProps, State> {
                     title={this.props.tittel}
                     aria-label={this.props.tittel}
                     aria-pressed={this.state.erSynlig}
-                    aria-describedby={this.state.erSynlig ? ariaId : null}
+                    aria-describedby={this.state.erSynlig ? ariaId : undefined}
                 >
                     <span className="sr-only">{this.props.tittel}</span>
                     <Anchor

--- a/packages/node_modules/nav-frontend-knapper-style/src/index.less
+++ b/packages/node_modules/nav-frontend-knapper-style/src/index.less
@@ -1,5 +1,5 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import '@{nodeModulesPath}nav-frontend-typografi-style/src/index';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{nodeModulesPath}nav-frontend-typografi-style/src/index';
 @import './mixins';
 
 .knapp {

--- a/packages/node_modules/nav-frontend-lenkepanel-style/src/index.less
+++ b/packages/node_modules/nav-frontend-lenkepanel-style/src/index.less
@@ -1,6 +1,6 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import '@{nodeModulesPath}nav-frontend-chevron-style/src/mixins';
-@import '@{nodeModulesPath}nav-frontend-paneler-style/src/mixins';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{nodeModulesPath}nav-frontend-chevron-style/src/mixins';
+@import (reference) '@{nodeModulesPath}nav-frontend-paneler-style/src/mixins';
 
 .lenkepanel {
   margin-bottom: 1rem;

--- a/packages/node_modules/nav-frontend-lenker-style/src/lenker-mixins.less
+++ b/packages/node_modules/nav-frontend-lenker-style/src/lenker-mixins.less
@@ -1,4 +1,4 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
 
 .lenke-mixin() {
   color: @navBla;

--- a/packages/node_modules/nav-frontend-lukknapp-style/src/lukknapp-style.less
+++ b/packages/node_modules/nav-frontend-lukknapp-style/src/lukknapp-style.less
@@ -1,5 +1,5 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import '@{coreModulePath}nav-frontend-core/less/hide-text';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/hide-text';
 
 .lukknapp {
   .hide-text();

--- a/packages/node_modules/nav-frontend-modal-style/src/index.less
+++ b/packages/node_modules/nav-frontend-modal-style/src/index.less
@@ -1,6 +1,6 @@
-@import '@{coreModulePath}nav-frontend-core/less/hide-text';
-@import '@{nodeModulesPath}nav-frontend-paneler-style/src/mixins';
-@import '@{nodeModulesPath}nav-frontend-lukknapp-style/src/lukknapp-style';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/hide-text';
+@import (reference) '@{nodeModulesPath}nav-frontend-paneler-style/src/mixins';
+@import (reference) '@{nodeModulesPath}nav-frontend-lukknapp-style/src/lukknapp-style';
 
 .ReactModal__Body--open {
   overflow: hidden;

--- a/packages/node_modules/nav-frontend-paneler-style/src/index.less
+++ b/packages/node_modules/nav-frontend-paneler-style/src/index.less
@@ -1,6 +1,6 @@
 // lesshint propertyOrdering: false
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import 'mixins';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) 'mixins';
 
 .panel {
   .panel-mixin();

--- a/packages/node_modules/nav-frontend-skjema-style/src/index.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/index.less
@@ -1,5 +1,5 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import '@{nodeModulesPath}nav-frontend-typografi-style/src/index';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{nodeModulesPath}nav-frontend-typografi-style/src/index';
 
 [autocomplete='off']::-webkit-contacts-auto-fill-button {
   visibility: hidden;

--- a/packages/node_modules/nav-frontend-skjema-style/src/toggle.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/toggle.less
@@ -1,5 +1,5 @@
-@import '@{coreModulePath}nav-frontend-core/less/core';
-@import '@{nodeModulesPath}nav-frontend-typografi-style/src/index';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/core';
+@import (reference) '@{nodeModulesPath}nav-frontend-typografi-style/src/index';
 
 .toggle {
   display: flex;

--- a/packages/node_modules/nav-frontend-snakkeboble-style/src/snakkeboble-style.less
+++ b/packages/node_modules/nav-frontend-snakkeboble-style/src/snakkeboble-style.less
@@ -1,7 +1,7 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import '@{coreModulePath}nav-frontend-core/less/_mixins';
-@import '@{coreModulePath}nav-frontend-core/less/utilities';
-@import '@{coreModulePath}nav-frontend-core/less/hide-text';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_mixins';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/utilities';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/hide-text';
 
 .snakkeboble {
   display: flex;

--- a/packages/node_modules/nav-frontend-stegindikator-style/src/index.less
+++ b/packages/node_modules/nav-frontend-stegindikator-style/src/index.less
@@ -1,4 +1,4 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
 
 @hvit: @white; //deprecated in core
 @aktivBlaa: @navDypBla;

--- a/packages/node_modules/nav-frontend-tabell-style/src/index.less
+++ b/packages/node_modules/nav-frontend-tabell-style/src/index.less
@@ -1,4 +1,4 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
 
 // troligen generelle ting
 //tr,

--- a/packages/node_modules/nav-frontend-tabs-style/src/tabs-style.less
+++ b/packages/node_modules/nav-frontend-tabs-style/src/tabs-style.less
@@ -1,4 +1,4 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
 
 .nav-frontend-tabs {
   border-bottom: 1px solid @navGra20;

--- a/packages/node_modules/nav-frontend-tabs/README.md
+++ b/packages/node_modules/nav-frontend-tabs/README.md
@@ -3,7 +3,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-tabs nav-frontend-tabs-style nav-frontend-core nav-frontend-js-utils lodash.throttle prop-types react --save
+npm install nav-frontend-tabs nav-frontend-js-utils lodash.throttle prop-types react nav-frontend-tabs-style nav-frontend-core --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 

--- a/packages/node_modules/nav-frontend-typografi-style/src/index.less
+++ b/packages/node_modules/nav-frontend-typografi-style/src/index.less
@@ -1,4 +1,4 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
 @import 'fontimports';
 @import 'mixins';
 

--- a/packages/node_modules/nav-frontend-veileder-style/src/index.less
+++ b/packages/node_modules/nav-frontend-veileder-style/src/index.less
@@ -1,4 +1,4 @@
-@import '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
 
 .nav-frontend-veileder {
   position: relative;


### PR DESCRIPTION
Flere som har opplevd duplikat-styling når man har brukt webpack og less-loader.
Dette skyldes at `nav-frontend-core` og `nav-frontend-typografi` blir importert
i stortsett alle modulene, og at less-loader kompilerer hver enkelt `require`
i sitt eget scope. Så det er derfor ikke mulig å oppdage duplikater vha plugins etc.

`@import (reference)` endrer på dette, slik at hver modul ikke drar med seg for mye styling.
Downside er at hvert prosjekt må i større grad passe på at stylingen fra `nav-frontend-core` og
`nav-frontend-typografi` har blitt riktig lastet inn.

Dokumentasjonen til LESS:
> Use @import (reference) to import external files, but without adding the imported styles to the compiled output unless referenced.
http://lesscss.org/features/