### PR TITLE
Oppdaterer Guideline-siden med nye tabs, og endel små design-tweaks

### DIFF
--- a/guideline-app/app/assets/styles/core.less
+++ b/guideline-app/app/assets/styles/core.less
@@ -1,2 +1,1 @@
 @import './../../../../node_modules/nav-frontend-core/less/core.less';
-

--- a/guideline-app/app/ui/components/color-sample/styles.less
+++ b/guideline-app/app/ui/components/color-sample/styles.less
@@ -5,7 +5,6 @@
   height: 200px;
   width: 188px;
   padding: @GL_BASE_UNIT * 2;
-  cursor: pointer;
   border-radius: 2px;
 
   &__colorInfo {

--- a/guideline-app/app/ui/components/color-sample/styles.less
+++ b/guideline-app/app/ui/components/color-sample/styles.less
@@ -5,13 +5,8 @@
   height: 200px;
   width: 188px;
   padding: @GL_BASE_UNIT * 2;
-  opacity: 0.9;
   cursor: pointer;
   border-radius: 2px;
-
-  &:hover {
-    opacity: 1;
-  }
 
   &__colorInfo {
     vertical-align: middle;

--- a/guideline-app/app/ui/components/expandable-list/ExpandableList.js
+++ b/guideline-app/app/ui/components/expandable-list/ExpandableList.js
@@ -102,7 +102,6 @@ class ExpandableListItem extends Component { // eslint-disable-line react/no-mul
                     { item.title }
                     { this.renderChevron() }
                 </Link>
-                <hr className="expandableList__item__line" />
                 { this.renderChildren() }
             </li>
         );

--- a/guideline-app/app/ui/components/expandable-list/styles.less
+++ b/guideline-app/app/ui/components/expandable-list/styles.less
@@ -1,19 +1,32 @@
+@import '../../../assets/styles/main';
+
 .expandableList {
   list-style: none;
   padding: 0;
 
   &__item, &__item--active {
-    padding: 8px 4px 8px 4px;
     font-weight: normal;
+    border-bottom:1px solid #C6C2BF;
 
     .link {
       display: block;
       text-decoration: none;
+      padding: 12px 4px 12px 4px;
 
       .nav-frontend-chevron {
         float: right;
         top: 8px;
         right: 4px;
+      }
+    }
+
+    .expandableListWrapper {
+      border-top:1px solid #C6C2BF;
+
+      .expandableList__item, .expandableList__item--active {
+        &:last-child {
+          border:0;
+        }
       }
     }
 
@@ -23,10 +36,6 @@
 
     ul li:last-child {
       padding-bottom: 0;
-    }
-
-    ul li:first-child {
-      padding-top: 16px;
     }
 
     &__line {

--- a/guideline-app/app/ui/components/header/styles.less
+++ b/guideline-app/app/ui/components/header/styles.less
@@ -3,9 +3,7 @@
 .header {
   background-color: @GL_WRAPPER_BACKGROUND_COLOR;
   padding: 48px 64px 32px 64px;
-  margin-left:-64px;
-  margin-right:-32px;
-  margin-bottom:40px;
+  margin:0px -64px 40px -64px;
 
   &__content {
     position:relative;

--- a/guideline-app/app/ui/components/left-navigation/LeftNavigation.js
+++ b/guideline-app/app/ui/components/left-navigation/LeftNavigation.js
@@ -43,7 +43,6 @@ class LeftNavigation extends React.Component {
                 <a className="leftNavigation__logoSection" href="https://navikt.github.io/nav-frontend-moduler/#/">
                     <NAVLogo />
                     <Normaltekst>NAV Designsystem</Normaltekst>
-                    <hr className="line" />
                 </a>
                 <div className="leftNavigation__expandableListWrapper">
                     <ExpandableList items={routeConfig} />

--- a/guideline-app/app/ui/components/left-navigation/styles.less
+++ b/guideline-app/app/ui/components/left-navigation/styles.less
@@ -65,8 +65,10 @@
     .lukknapp {
       display:block;
       position:absolute;
-      top:15px;
-      right:15px;
+      top:20px;
+      right:20px;
+      width:45px;
+      height:40px;
     }
 
     &__logoSection {

--- a/guideline-app/app/ui/components/md-content/styles.less
+++ b/guideline-app/app/ui/components/md-content/styles.less
@@ -12,7 +12,6 @@
 
     h1, h2, h3, h4, h5, h6 {
       .typo-element-mixin();
-      // padding: 8px 8px 0px 8px !important;
       margin: 8px 0;
     }
 

--- a/guideline-app/app/ui/components/md-content/styles.less
+++ b/guideline-app/app/ui/components/md-content/styles.less
@@ -7,13 +7,13 @@
   &--normal {
     p {
       .typo-normal-mixin();
-      margin: 0;
+      margin: 8px 0;
     }
 
     h1, h2, h3, h4, h5, h6 {
       .typo-element-mixin();
-      padding: 8px 8px 0px 8px !important;
-      margin: 0;
+      // padding: 8px 8px 0px 8px !important;
+      margin: 8px 0;
     }
 
     a {

--- a/guideline-app/app/ui/components/prop-type-table/styles.less
+++ b/guideline-app/app/ui/components/prop-type-table/styles.less
@@ -1,6 +1,8 @@
+@import '../../../assets/styles/core.less';
+
 .propTypeTableWrapperOuter {
   position:relative;
-  margin:0 8px;
+  margin:1rem 0;
 
   &--overflowLeft {
     &:before {
@@ -32,23 +34,26 @@
   overflow:scroll;
 
   table {
-    border: 1px solid #e7e7e9;
-    border-radius: 4px;
     width:100%;
-    min-width: 50%;
-    text-align: left;
+    border-spacing: 0;
+    border-collapse: collapse;
+
+    th, td {
+      padding:8px;
+    }
 
     th {
-      border-bottom: 1px solid #e7e9e9;
+      text-align:left;
+      border-bottom:1px solid @navGra20;
     }
 
-    tr:nth-child(even):not(:first-child) {
-      background-color: #e7e9e9;
+    td {
+      border-bottom:1px solid #eee;
     }
 
-    tr {
-      &:hover {
-        background-color: #f8f8f8 !important;
+    tr:nth-child(2n+1){
+      td {
+        background:#fafafa;
       }
     }
   }

--- a/guideline-app/app/ui/components/section-title/SectionTitle.js
+++ b/guideline-app/app/ui/components/section-title/SectionTitle.js
@@ -11,12 +11,7 @@ const SectionTitle = (props) => (
 );
 
 SectionTitle.propTypes = {
-    title: PropTypes.string.isRequired,
-    noHr: PropTypes.bool
-};
-
-SectionTitle.defaultProps = {
-    noHr: false
+    title: PropTypes.string.isRequired
 };
 
 export default SectionTitle;

--- a/guideline-app/app/ui/components/section-title/SectionTitle.js
+++ b/guideline-app/app/ui/components/section-title/SectionTitle.js
@@ -7,7 +7,6 @@ import './styles.less';
 const SectionTitle = (props) => (
     <div className="sectionTitle">
         <Sidetittel>{ props.title }</Sidetittel>
-        { !props.noHr && <hr /> }
     </div>
 );
 

--- a/guideline-app/app/ui/containers/about/AboutPage.js
+++ b/guideline-app/app/ui/containers/about/AboutPage.js
@@ -85,7 +85,7 @@ const AboutPage = () => (
                     <li>Interaksjonsdesign - Thea Steen Hellebust</li>
                     <li>Kommunikasjon - Mathilde Skjelbostad</li>
                     <li>Utvikling - Erlend Vige, Eirik Lillebo</li>
-                    <li>Visuelt design - Sergio Haisch.</li>
+                    <li>Visuelt design - Sergio Haisch, Chris Arnesen</li>
                 </ul>
 
                 <Normaltekst>

--- a/guideline-app/app/ui/containers/about/styles.less
+++ b/guideline-app/app/ui/containers/about/styles.less
@@ -23,7 +23,7 @@
   }
 
   &__header {
-    margin: -179px -32px 0 -64px;
+    margin: -179px -64px 0 -64px;
     position: relative;
     z-index: 999;
     text-align:center;

--- a/guideline-app/app/ui/containers/app/mixins.less
+++ b/guideline-app/app/ui/containers/app/mixins.less
@@ -4,8 +4,8 @@
     flex-direction: row;
     justify-content: flex-start;
     align-items: flex-start;
-    margin: -179px -32px 0 -64px;
-    padding: 32px 32px 0 64px;
+    margin: -179px -64px 0 -64px;
+    padding: 32px 64px;
     background: white;
     position:relative;
     z-index:10;

--- a/guideline-app/app/ui/containers/app/styles.less
+++ b/guideline-app/app/ui/containers/app/styles.less
@@ -8,11 +8,14 @@ body {
     min-height: 100%;
     overflow: hidden;
 
+    hr {
+      border:0;
+      border-bottom:1px solid #C6C2BF;
+    }
+
     .contentWrapper {
       background-color: @GL_CONTENT_BACKGROUND_COLOR;
-      padding-left: 64px;
-      padding-right: 32px;
-      padding-bottom: 32px;
+      padding: 0px 64px;
       margin-left: 304px;
 
       @media screen and (max-width: 1000px) {

--- a/guideline-app/app/ui/containers/app/styles.less
+++ b/guideline-app/app/ui/containers/app/styles.less
@@ -35,8 +35,8 @@ body {
     .mobileMenuToggleButton {
       display:none;
       position:fixed;
-      bottom:32px;
-      right:32px;
+      top:20px;
+      right:20px;
       border:none;
       background:white;
       padding:10px;
@@ -67,7 +67,7 @@ body {
         background:@navBla;
         cursor:pointer;
 
-        &__hamburger-icon {
+        .mobileMenuToggleButton__hamburger-icon {
           &::before {
             border-top:12px double white;
             border-bottom:4px solid white; 
@@ -77,6 +77,11 @@ body {
 
       @media screen and (max-width: 1000px) {
         display:block;
+      }
+
+      @media screen and (max-width: 430px) {
+        top:16px;
+        right:16px;
       }
     }
   }

--- a/guideline-app/app/ui/containers/color/ColorPage.js
+++ b/guideline-app/app/ui/containers/color/ColorPage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import SectionTitle from './../../components/section-title/SectionTitle';
+import { Innholdstittel } from './../../../../../packages/node_modules/nav-frontend-typografi';
 import {
     ColorPaletteSection,
     ColorContrastSection
@@ -12,12 +13,16 @@ const ColorPage = () => (
     <div className="colorPage">
         <div className="section">
             <SectionTitle title="Fargepaletten" />
-            <ColorPaletteSection />
+            <div className="section">
+                <ColorPaletteSection />
+            </div>
         </div>
 
         <div className="section">
-            <SectionTitle title="Fargekontrast mellom tekst og bakgrunn" />
-            <ColorContrastSection />
+            <Innholdstittel>Fargekontrast mellom tekst og bakgrunn</Innholdstittel>
+            <div className="section">
+                <ColorContrastSection />
+            </div>
         </div>
     </div>
 );

--- a/guideline-app/app/ui/containers/color/sections/ContrastSection.js
+++ b/guideline-app/app/ui/containers/color/sections/ContrastSection.js
@@ -14,7 +14,7 @@ export default function ColorContrastSection() {
             <br />
             <Ingress>Fargene som skal brukes er vist under:</Ingress>
 
-            <div className="colorPage__content__contrastSamples" style={{ width: '100%' }}>
+            <div className="section colorPage__content__contrastSamples" style={{ width: '100%' }}>
                 <ColorContrastSample color={c.navMorkGra} contrast={c.navMorkGra.contrastColors.hvit} />
                 <ColorContrastSample color={c.hvit} contrast={c.hvit.contrastColors.navMorkGra} />
                 <ColorContrastSample color={c.navBla} contrast={c.navBla.contrastColors.hvit} />

--- a/guideline-app/app/ui/containers/component/guidelines/ComponentGuidelinePage.js
+++ b/guideline-app/app/ui/containers/component/guidelines/ComponentGuidelinePage.js
@@ -4,7 +4,7 @@ import {
     Ingress
 } from './../../../../../../packages/node_modules/nav-frontend-typografi';
 import Sample from './common/Sample';
-import Tabbar from './../../../components/tabbar/Tabbar';
+import Tabs from './../../../../../../packages/node_modules/nav-frontend-tabs';
 import GuidelineContentForDesigners from './designers/GuidelineContent.designers';
 import GuidelineContentForDevelopers from './developers/GuidelineContent.developers';
 import MdContent from './../../../components/md-content/MdContent';
@@ -13,15 +13,15 @@ import './styles.less';
 class ComponentGuidelinePage extends React.Component {
 
     componentWillMount() {
-        this.tabbarItems = [
-            { label: 'Retnings&shy;linjer for design', content: GuidelineContentForDesigners, defaultActive: true },
-            { label: 'Utvikler&shy;dokumentasjon', content: GuidelineContentForDevelopers }
+        this.tabContent = [
+            GuidelineContentForDesigners,
+            GuidelineContentForDevelopers
         ];
 
         if (this.hasDeveloperGuidelinesOnly()) {
-            this.setState({ activeContent: this.tabbarItems[1].content });
+            this.setState({ activeContent: this.tabContent[1] });
         } else {
-            this.setState({ activeContent: this.tabbarItems[0].content });
+            this.setState({ activeContent: this.tabContent[0] });
         }
     }
 
@@ -29,8 +29,8 @@ class ComponentGuidelinePage extends React.Component {
         return !this.props.textData;
     }
 
-    updateActiveContent(item) {
-        this.setState({ activeContent: item.content });
+    updateActiveContent = (e, index) => {
+        this.setState({ activeContent: this.tabContent[index] });
     }
 
     renderIngress() {
@@ -46,10 +46,10 @@ class ComponentGuidelinePage extends React.Component {
                 </div>
 
                 <div className="section componentGuidelinePage__tabbarContainer">
-                    <Tabbar
-                        items={this.tabbarItems}
-                        onActiveItemChange={(item) => this.updateActiveContent(item)}
-                    />
+                    <Tabs onChange={this.updateActiveContent}>
+                        { !this.hasDeveloperGuidelinesOnly() && <Tabs.Tab>Retnings&shy;linjer for design</Tabs.Tab> }
+                        <Tabs.Tab>Utvikler&shy;dokumentasjon</Tabs.Tab>
+                    </Tabs>
                 </div>
 
                 <div className="section">

--- a/guideline-app/app/ui/containers/component/guidelines/ComponentGuidelinePage.js
+++ b/guideline-app/app/ui/containers/component/guidelines/ComponentGuidelinePage.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PT from 'prop-types';
 import {
-    Ingress,
-    Undertittel
+    Ingress
 } from './../../../../../../packages/node_modules/nav-frontend-typografi';
 import Sample from './common/Sample';
 import Tabs from './../../../../../../packages/node_modules/nav-frontend-tabs';

--- a/guideline-app/app/ui/containers/component/guidelines/ComponentGuidelinePage.js
+++ b/guideline-app/app/ui/containers/component/guidelines/ComponentGuidelinePage.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PT from 'prop-types';
 import {
-    Ingress
+    Ingress,
+    Undertittel
 } from './../../../../../../packages/node_modules/nav-frontend-typografi';
 import Sample from './common/Sample';
 import Tabs from './../../../../../../packages/node_modules/nav-frontend-tabs';

--- a/guideline-app/app/ui/containers/component/guidelines/common/styles.less
+++ b/guideline-app/app/ui/containers/component/guidelines/common/styles.less
@@ -1,12 +1,13 @@
+@import '../../../../../assets/styles/main';
+
 .sampleWrapper {
   max-width: 640px;
 
   .sample {
     background-color: #e7e9e9;
-    padding: 4px 16px 16px 16px;
+    padding: 0.5rem 1rem;
     border-radius: 4px;
     min-width: 40%;
-    margin: 24px 24px 24px 12px;
 
     .hjelpetekst__tekst {
       .typo-normal {
@@ -17,17 +18,13 @@
     .componentSample {
       margin: 16px;
     }
-
-    @media screen and (max-width: 1000px) {
-      margin:12px;
-    }
   }
 
   .sampleEditor {
     border: 1px solid #e7e9e9;
-    padding: 4px 16px 16px 16px;
+    padding: 0.5rem 1rem;
     border-radius: 4px;
-    margin: 12px 24px 12px 12px;
+    margin-top:12px;
     min-width: 28%;
 
     &__form {
@@ -41,10 +38,6 @@
       .modifiers {
         width: 50%;
       }
-    }
-
-    @media screen and (max-width: 1000px) {
-      margin:12px;
     }
   }
 }

--- a/guideline-app/app/ui/containers/component/guidelines/designers/GuidelineContent.designers.js
+++ b/guideline-app/app/ui/containers/component/guidelines/designers/GuidelineContent.designers.js
@@ -4,6 +4,7 @@ import PT from 'prop-types';
 import { Undertittel } from './../../../../../../../packages/node_modules/nav-frontend-typografi';
 
 import MdContent from './../../../../components/md-content/MdContent';
+import './styles.less';
 
 class GuidelineContentForDesigners extends Component {
 

--- a/guideline-app/app/ui/containers/component/guidelines/designers/styles.less
+++ b/guideline-app/app/ui/containers/component/guidelines/designers/styles.less
@@ -1,0 +1,8 @@
+.designerGuidelineSection {
+  .typo-undertittel {
+    margin: 24px 0px 12px 0px;
+  }
+  .typo-element {
+    padding: 12px 0px 0px 0px;
+  }
+}

--- a/guideline-app/app/ui/containers/component/guidelines/developers/code-example/CodeExample.js
+++ b/guideline-app/app/ui/containers/component/guidelines/developers/code-example/CodeExample.js
@@ -14,6 +14,7 @@ class CodeExample extends Component {
 
     componentWillMount() {
         this.tabbarItems = this.getTabbarItems();
+        console.log(this.tabbarItems);
         this.setState({
             activeTabbarItem:
             this.tabbarItems.find((item) => item.defaultActive) ||
@@ -77,7 +78,7 @@ class CodeExample extends Component {
             <div className="codeExample">
                 <Tabs 
                     onChange={this.changeActiveContent}
-                    defaultAktiv={this.tabbarItems.findIndex((item) => item.defaultActive)}
+                    defaultAktiv={Math.max(0, this.tabbarItems.findIndex((item) => item.defaultActive))}
                     kompakt
                 >
                     {this.tabbarItems.map((item) => <Tabs.Tab key={item.label}>{item.label}</Tabs.Tab>)}

--- a/guideline-app/app/ui/containers/component/guidelines/developers/code-example/CodeExample.js
+++ b/guideline-app/app/ui/containers/component/guidelines/developers/code-example/CodeExample.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PT from 'prop-types';
 import { connect } from 'react-redux';
 import hljs from 'highlight.js';
-import Tabbar from './../../../../../components/tabbar/Tabbar';
+import Tabs from './../../../../../../../../packages/node_modules/nav-frontend-tabs';
 import {
     getHtmlCodeForComponent,
     getReactCodeForComponent,
@@ -68,17 +68,20 @@ class CodeExample extends Component {
     }
 
 
-    changeActiveCodeOption(activeTabbarItem) {
-        this.setState({ activeTabbarItem });
+    changeActiveContent = (e, index) => {
+        this.setState({ activeTabbarItem: this.tabbarItems[index] });
     }
 
     render() {
         return (
             <div className="codeExample">
-                <Tabbar
-                    items={this.tabbarItems}
-                    onActiveItemChange={(item) => this.changeActiveCodeOption(item)}
-                />
+                <Tabs 
+                    onChange={this.changeActiveContent}
+                    defaultAktiv={this.tabbarItems.findIndex((item) => item.defaultActive)}
+                    kompakt
+                >
+                    {this.tabbarItems.map((item) => <Tabs.Tab key={item.label}>{item.label}</Tabs.Tab>)}
+                </Tabs>
                 <pre>
                     <code
                         className="hljs"

--- a/guideline-app/app/ui/containers/component/guidelines/developers/code-example/CodeExample.js
+++ b/guideline-app/app/ui/containers/component/guidelines/developers/code-example/CodeExample.js
@@ -76,7 +76,7 @@ class CodeExample extends Component {
     render() {
         return (
             <div className="codeExample">
-                <Tabs 
+                <Tabs
                     onChange={this.changeActiveContent}
                     defaultAktiv={Math.max(0, this.tabbarItems.findIndex((item) => item.defaultActive))}
                     kompakt

--- a/guideline-app/app/ui/containers/component/guidelines/developers/code-example/styles.less
+++ b/guideline-app/app/ui/containers/component/guidelines/developers/code-example/styles.less
@@ -2,20 +2,10 @@
 
 .codeExample {
   padding: 12px;
-  margin: 12px;
 
   &__centeredText {
     cursor: pointer;
     text-align: center;
-  }
-
-  pre {
-    cursor: pointer;
-    opacity: 0.8;
-
-    &:hover {
-      opacity: 1;
-    }
   }
   
   .tabbar {

--- a/guideline-app/app/ui/containers/component/guidelines/developers/styles.less
+++ b/guideline-app/app/ui/containers/component/guidelines/developers/styles.less
@@ -10,12 +10,11 @@
   overflow-x: hidden;
 
   pre {
-    cursor: pointer;
     white-space: pre-wrap;
-    opacity: 0.8;
 
-    &:hover {
-      opacity: 1;
+    code {
+      background:#222;
+      color:white;
     }
   }
 }

--- a/guideline-app/app/ui/containers/component/guidelines/styles.less
+++ b/guideline-app/app/ui/containers/component/guidelines/styles.less
@@ -1,14 +1,28 @@
 .componentGuidelinePage {
   &__tabbarContainer {
-    margin:32px -32px 0px -64px;
+    margin:32px -64px;
 
     .nav-frontend-tabs {
-      padding-left:64px;
+      padding:0px 64px;
+
+      .typo-undertittel {
+        padding:0;
+      }
     }
 
-    .designerGuidelineSection {
-      .typo-element {
-        padding: 12px 0px 0px 0px;
+    @media screen and (max-width: 600px) {
+      margin: 32px -40px;
+
+      .nav-frontend-tabs {
+        padding:0px 40px;
+      }
+    }
+
+    @media screen and (max-width: 480px) {
+      margin: 32px -20px;
+
+      .nav-frontend-tabs {
+        padding:0px 20px;
       }
     }
   }

--- a/guideline-app/app/ui/containers/component/guidelines/styles.less
+++ b/guideline-app/app/ui/containers/component/guidelines/styles.less
@@ -1,30 +1,9 @@
 .componentGuidelinePage {
   &__tabbarContainer {
-    max-width: 640px;
+    margin:32px -32px 0px -64px;
 
-    .tabbar {
-      margin-left: 16px;
-      margin-right: 16px;
-
-      &__item {
-        background-color: #0067C5;
-        border: 1px solid white;
-        border-radius: 4px;
-        color: white;
-        opacity: 0.5;
-
-        &--active {
-          opacity: 1;
-        }
-
-        &:hover:not(.tabbar__item--active) {
-          opacity: 0.6;
-        }
-      }
-
-      &__item:nth-child(even), &__item:nth-child(odd):not(:first-child) {
-        border-left: none;
-      }
+    .nav-frontend-tabs {
+      padding-left:64px;
     }
 
     .designerGuidelineSection {

--- a/guideline-app/app/ui/containers/component/main/styles.less
+++ b/guideline-app/app/ui/containers/component/main/styles.less
@@ -1,10 +1,5 @@
 @import './../../app/mixins';
 
 .componentMainPage {
-
-  p:not([class]),h1,h2,h3 {
-    padding: 8px;
-  }
-
   .genericSubsectionFrontpage();
 }

--- a/guideline-app/app/ui/containers/typography/sections/_TypographyHierarchySection.js
+++ b/guideline-app/app/ui/containers/typography/sections/_TypographyHierarchySection.js
@@ -7,7 +7,6 @@ import {
 } from './../../../../../../packages/node_modules/nav-frontend-typografi';
 
 import { TypographyHierarchyData as samples } from '../../../../data/index';
-import SectionTitle from './../../../components/section-title/SectionTitle';
 
 const TypographyHierarchySection = (props) => {
     const renderDescription = () => (
@@ -39,7 +38,7 @@ const TypographyHierarchySection = (props) => {
     return (
         <div {... props} className="typographyHierarchySection wrapper">
             <Innholdstittel>Typografisk Hierarki</Innholdstittel>
-            <hr/>
+            <hr />
 
             { renderDescription() }
 

--- a/guideline-app/app/ui/containers/typography/sections/_TypographyHierarchySection.js
+++ b/guideline-app/app/ui/containers/typography/sections/_TypographyHierarchySection.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PT from 'prop-types';
 
 import {
-    Normaltekst
+    Normaltekst,
+    Innholdstittel
 } from './../../../../../../packages/node_modules/nav-frontend-typografi';
 
 import { TypographyHierarchyData as samples } from '../../../../data/index';
@@ -37,7 +38,8 @@ const TypographyHierarchySection = (props) => {
 
     return (
         <div {... props} className="typographyHierarchySection wrapper">
-            <SectionTitle title="Typografisk Hierarki" />
+            <Innholdstittel>Typografisk Hierarki</Innholdstittel>
+            <hr/>
 
             { renderDescription() }
 

--- a/guideline-app/app/ui/containers/typography/sections/_WeightCombinationsSection.js
+++ b/guideline-app/app/ui/containers/typography/sections/_WeightCombinationsSection.js
@@ -15,7 +15,8 @@ import SectionTitle from './../../../components/section-title/SectionTitle';
 
 const WeightCombinationsSection = (props) => (
     <div className="weightCombinationsSection" {... props}>
-        <SectionTitle title="Vektkombinasjoner" />
+        <Innholdstittel>Vektkombinasjoner</Innholdstittel>
+        <hr/>
 
         <Row className="weightCombinationsSection__example">
             <Column xs="12">

--- a/guideline-app/app/ui/containers/typography/sections/_WeightCombinationsSection.js
+++ b/guideline-app/app/ui/containers/typography/sections/_WeightCombinationsSection.js
@@ -11,12 +11,10 @@ import {
     Column
 } from './../../../../../../packages/node_modules/nav-frontend-grid';
 
-import SectionTitle from './../../../components/section-title/SectionTitle';
-
 const WeightCombinationsSection = (props) => (
     <div className="weightCombinationsSection" {... props}>
         <Innholdstittel>Vektkombinasjoner</Innholdstittel>
-        <hr/>
+        <hr />
 
         <Row className="weightCombinationsSection__example">
             <Column xs="12">


### PR DESCRIPTION
Nevneverdig:
- Nye tabs på komponent-sidene for "Retningslinjer for design" og "Utviklerdokumentasjon"
- Mobil-meny-knappen er flyttet til toppen av siden slik at den er der lukk-knappen ender opp
- Lukk-knappen er gjort bittelitt større
- Farge-paletten har ikke lengre default `opacity:0.9` styling, fjernet også hover-effekten her

Forhåndsvisning: http://archivedworks.com/dev/nav/guideline