### PR TITLE
Fikser docgen, props-tabell på komponentene

### DIFF
--- a/guideline-app/app/ui/components/prop-type-table/PropTypeTable.js
+++ b/guideline-app/app/ui/components/prop-type-table/PropTypeTable.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PT from 'prop-types';
 import cn from 'classnames';
-import { omit } from './../../../../../packages/node_modules/nav-frontend-js-utils';
-import { Normaltekst, EtikettLiten } from './../../../../../packages/node_modules/nav-frontend-typografi';
+import { EtikettLiten } from './../../../../../packages/node_modules/nav-frontend-typografi';
 import './styles.less';
 
 class PropTypeTable extends React.Component {
@@ -50,6 +49,8 @@ class PropTypeTable extends React.Component {
             ...propTypes[key]
         }));
 
+        console.log(propTypeDocs);
+
         const headers = ['Property', 'Type', 'Required', 'Description', 'Default'];
         const cls = () => cn('propTypeTableWrapperOuter', {
             'propTypeTableWrapperOuter--overflowLeft': this.state.overflowLeft,
@@ -77,7 +78,9 @@ class PropTypeTable extends React.Component {
                         </thead>
                         <tbody>
                             {
-                                propTypeDocs.filter((item) => item.name.indexOf('aria-') !== 0).map((propTypeDoc, key) => (
+                                propTypeDocs.filter((item) =>
+                                    item.name.indexOf('aria-') !== 0
+                                ).map((propTypeDoc, key) => (
                                     <PropTypeTableRow
                                         val={{
                                             ...propTypeDoc,
@@ -120,32 +123,36 @@ PropTypeTableHeader.propTypes = {
     val: PT.string.isRequired
 };
 
-const PropTypeTableRow = (props) => {
-    return (
-        <tr>
-            <td><strong>{parsePropValue(props.val['name'])}</strong></td>
-            <td>{parsePropValue(props.val['type'])}</td>
-            <td>{parsePropValue(props.val['required'])}</td>
-            <td>{parsePropValue(props.val['description'])}</td>
-            <td>{parsePropValue(props.val['defaultValue'])}</td>
-        </tr>
-    );
-};
-
-PropTypeTableRow.propTypes = {
-    val: PT.shape({}).isRequired
-};
-
 const parsePropValue = (val) => {
     if (val && typeof val === 'object') {
         if (val.name === 'enum') {
-            val = val.value.map((x) => x.value).join(' | ');
-        } else {
-           val = val.name || val.value; 
-       }
+            return val.value.map((x) => x.value).join(' | ');
+        }
+        val = val.name || val.value; // eslint-disable-line no-param-reassign
     }
     if (val === null || typeof val === 'undefined' || val.length <= 0) {
-        val = '-';
+        return '-';
     }
     return val.toString();
+};
+
+const PropTypeTableRow = (props) => (
+    <tr>
+        <td><strong>{parsePropValue(props.val.name)}</strong></td>
+        <td>{parsePropValue(props.val.type)}</td>
+        <td>{parsePropValue(props.val.required)}</td>
+        <td>{parsePropValue(props.val.description)}</td>
+        <td>{parsePropValue(props.val.defaultValue)}</td>
+    </tr>
+);
+
+PropTypeTableRow.propTypes = {
+    val: PT.shape({
+        defaultValue: PT.any,
+        description: PT.string,
+        name: PT.string,
+        propName: PT.string,
+        required: PT.boolean,
+        type: PT.any
+    }).isRequired
 };

--- a/guideline-app/app/ui/components/prop-type-table/PropTypeTable.js
+++ b/guideline-app/app/ui/components/prop-type-table/PropTypeTable.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PT from 'prop-types';
 import cn from 'classnames';
+import { omit } from './../../../../../packages/node_modules/nav-frontend-js-utils';
 import { Normaltekst, EtikettLiten } from './../../../../../packages/node_modules/nav-frontend-typografi';
 import './styles.less';
 
@@ -76,7 +77,7 @@ class PropTypeTable extends React.Component {
                         </thead>
                         <tbody>
                             {
-                                propTypeDocs.map((propTypeDoc, key) => (
+                                propTypeDocs.filter((item) => item.name.indexOf('aria-') !== 0).map((propTypeDoc, key) => (
                                     <PropTypeTableRow
                                         val={{
                                             ...propTypeDoc,
@@ -120,18 +121,13 @@ PropTypeTableHeader.propTypes = {
 };
 
 const PropTypeTableRow = (props) => {
-    const keys = Object.keys(props.val);
-
     return (
         <tr>
-            {
-                keys.map((key, index) => (
-                    <PropTypeTableCell
-                        val={props.val[key]}
-                        key={index} // eslint-disable-line react/no-array-index-key
-                    />
-                ))
-            }
+            <td><strong>{parsePropValue(props.val['name'])}</strong></td>
+            <td>{parsePropValue(props.val['type'])}</td>
+            <td>{parsePropValue(props.val['required'])}</td>
+            <td>{parsePropValue(props.val['description'])}</td>
+            <td>{parsePropValue(props.val['defaultValue'])}</td>
         </tr>
     );
 };
@@ -140,27 +136,16 @@ PropTypeTableRow.propTypes = {
     val: PT.shape({}).isRequired
 };
 
-const PropTypeTableCell = (props) => {
-    let val = props.val;
-
+const parsePropValue = (val) => {
     if (val && typeof val === 'object') {
-        val = val.name || val.value;
+        if (val.name === 'enum') {
+            val = val.value.map((x) => x.value).join(' | ');
+        } else {
+           val = val.name || val.value; 
+       }
     }
-    if (!val || val.length <= 0) {
+    if (val === null || typeof val === 'undefined' || val.length <= 0) {
         val = '-';
     }
-
-    return (
-        <td>
-            <Normaltekst>{ val.toString() }</Normaltekst>
-        </td>
-    );
-};
-
-PropTypeTableCell.propTypes = {
-    val: PT.oneOfType([PT.string, PT.bool, PT.shape({}), PT.number])
-};
-
-PropTypeTableCell.defaultProps = {
-    val: undefined
+    return val.toString();
 };

--- a/guideline-app/app/ui/components/prop-type-table/PropTypeTable.js
+++ b/guideline-app/app/ui/components/prop-type-table/PropTypeTable.js
@@ -49,8 +49,6 @@ class PropTypeTable extends React.Component {
             ...propTypes[key]
         }));
 
-        console.log(propTypeDocs);
-
         const headers = ['Property', 'Type', 'Required', 'Description', 'Default'];
         const cls = () => cn('propTypeTableWrapperOuter', {
             'propTypeTableWrapperOuter--overflowLeft': this.state.overflowLeft,

--- a/guideline-app/app/ui/containers/component/guidelines/developers/code-example/CodeExample.js
+++ b/guideline-app/app/ui/containers/component/guidelines/developers/code-example/CodeExample.js
@@ -14,7 +14,6 @@ class CodeExample extends Component {
 
     componentWillMount() {
         this.tabbarItems = this.getTabbarItems();
-        console.log(this.tabbarItems);
         this.setState({
             activeTabbarItem:
             this.tabbarItems.find((item) => item.defaultActive) ||

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,10 @@ const fonts = './packages/node_modules/*/assets/**/*.woff';
 const dest = 'packages/node_modules';
 const tsProject = ts.createProject('tsconfig.json');
 
-const tsDocgen = require('react-docgen-typescript');
+const tsDocgen = require('react-docgen-typescript').withDefaultConfig({
+    propFilter: { skipPropsWithoutDoc: true }
+});
+
 const insert = require('gulp-insert');
 const fs = require('fs');
 

--- a/packages/node_modules/nav-frontend-alertstriper/src/alertstripe.tsx
+++ b/packages/node_modules/nav-frontend-alertstriper/src/alertstripe.tsx
@@ -29,13 +29,28 @@ const ikonKind = (type, solid): icons => {
 };
 
 export interface AlertStripeProps {
+    /**
+     * -
+     */
     children: React.ReactNode | React.ReactChild | React.ReactChildren;
+    /**
+     * Bestemmer om Alertstripen skal ha bakgrunnsfarge eller ikke
+     */
     solid?: boolean;
+    /**
+     * -
+     */
     size?: string | number;
+    /**
+     * -
+     */
     className?: string;
 }
 
 export interface AlertStripeBaseProps extends  AlertStripeProps {
+    /**
+     * Varianter å velge mellom
+     */
     type: 'suksess' | 'info' | 'advarsel' | 'nav-ansatt' | 'stopp';
 }
 

--- a/packages/node_modules/nav-frontend-chevron/src/chevron.tsx
+++ b/packages/node_modules/nav-frontend-chevron/src/chevron.tsx
@@ -27,8 +27,17 @@ const cls = (type?, stor?: boolean, className?: string) =>
  */
 
 export interface NavFrontendChevronProps {
+    /**
+     * Bestemmer hvilken vei Chevron skal peke
+     */
     type?: 'høyre' | 'venstre' | 'ned' | 'opp';
+    /**
+     * Sett denne proppen hvis chevron skal være stor
+     */
     stor?: boolean;
+    /**
+     * Klassenavn for chevron
+     */
     className?: string;
 }
 class NavFrontendChevron extends React.Component<NavFrontendChevronProps> {
@@ -46,7 +55,7 @@ class NavFrontendChevron extends React.Component<NavFrontendChevronProps> {
 
 (NavFrontendChevron as any).propTypes = {
     /**
-     * Retting chevron skal peke
+     * Bestemmer hvilken vei Chevron skal peke
      */
     type: PT.oneOf(['høyre', 'venstre', 'opp', 'ned']),
     /**

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/index.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/index.tsx
@@ -16,7 +16,13 @@ export interface EkspanderbartpanelProps {
      * Callback funksjon for når knappen blir klikket på
      */
     onClick: (event: React.SyntheticEvent<HTMLButtonElement>) => void;
+    /**
+     * Tittel/label-tekst
+     */
     tittel: string;
+    /**
+     * Må være en gyldig 'type' prop på Typografi-komponenten, se 'nav-frontend-typografi'
+     */
     tittelProps: string;
 }
 

--- a/packages/node_modules/nav-frontend-etiketter/src/index.tsx
+++ b/packages/node_modules/nav-frontend-etiketter/src/index.tsx
@@ -12,8 +12,17 @@ const cls = (type, className) => classNames('etikett', className, {
 });
 
 export interface EtikettProps {
+    /**
+     * Må være en gyldig 'type' prop på Typografi-komponenten, se 'nav-frontend-typografi'
+     */
     typo?: string;
+    /**
+     * -
+     */
     children: React.ReactNode | React.ReactChild | React.ReactChildren;
+    /**
+     * Klassenavn på etiketten
+     */
     className?: string;
 }
 /**
@@ -21,6 +30,9 @@ export interface EtikettProps {
  * om det er behov anbefales å lage en egen klasse hvor man kan legge til flere farger
  */
 export interface EtikettBaseProps extends  EtikettProps {
+    /**
+     * Predefinerte farger
+     */
     type: 'suksess' | 'info' | 'advarsel' | 'fokus';
 }
 

--- a/packages/node_modules/nav-frontend-hjelpetekst/src/hjelpetekst.tsx
+++ b/packages/node_modules/nav-frontend-hjelpetekst/src/hjelpetekst.tsx
@@ -30,11 +30,29 @@ const cls = (type, className) =>
     });
 
 export interface HjelpetekstProps {
+    /**
+     * -
+     */
     id: string;
+    /**
+     * Innholdet i hjelpetekst-vinduet
+     */
     children: React.ReactNode;
+    /**
+     * -
+     */
     className?: string;
+    /**
+     * Tekst som vises ved mouseover
+     */
     tittel?: string;
+    /**
+     * Posisjon på hjelpetekst-vinduet
+     */
     type?: 'auto' | 'over' | 'under' | 'venstre' | 'midt' | 'hoyre' | 'under-venstre' | 'under-hoyre';
+    /**
+     * -
+     */
     anchor?: any;
 }
 

--- a/packages/node_modules/nav-frontend-knapper/src/index.tsx
+++ b/packages/node_modules/nav-frontend-knapper/src/index.tsx
@@ -24,6 +24,9 @@ function skalVareDisabled(props) {
 }
 
 export interface KnappBaseProps extends KnappProps {
+    /**
+     * Varianter å velge mellom
+     */
     type: 'standard' | 'hoved' | 'fare' | 'flat';
 }
 

--- a/packages/node_modules/nav-frontend-knapper/src/knapp.tsx
+++ b/packages/node_modules/nav-frontend-knapper/src/knapp.tsx
@@ -3,10 +3,25 @@ import KnappBase from './index';
 import { CustomHTMLButtonAttributes } from './CustomHTMLButtonAttributes';
 
 export interface KnappProps extends CustomHTMLButtonAttributes {
+    /**
+     * Verdi for <button>-attributtet 'type', angir knappens default funksjon
+     */
     htmlType?: 'submit' | 'button' | 'reset';
+    /**
+     * Liten knapp
+     */
     mini?: boolean;
+    /**
+     * Knapp med spinner
+     */
     spinner?: boolean;
+    /**
+     * -
+     */
     autoDisableVedSpinner?: boolean;
+    /**
+     * -
+     */
     inaktivKlasseVedDisabled?: boolean;
 }
 

--- a/packages/node_modules/nav-frontend-lenkepanel/src/Lenkepanel-base.tsx
+++ b/packages/node_modules/nav-frontend-lenkepanel/src/Lenkepanel-base.tsx
@@ -6,9 +6,21 @@ import 'nav-frontend-lenkepanel-style';
 const cls = (className) => classNames('lenkepanel', className);
 
 export interface LenkepanelBaseProps {
+    /**
+     * Klassenavn
+     */
     className?: string;
+    /**
+     * Lenke (denne sendes som prop til linkCreator)
+     */
     href: string;
+    /**
+     * Tekstinnhold for lenkepanel
+     */
     children: React.ReactNode | React.ReactNode[];
+    /**
+     * Funksjon som brukes for å lage lenken. her kan du spessifisere din egen hvis du f.eks. bruker React Router
+     */
     linkCreator?: (props: React.HTMLProps<HTMLElement>) => React.ReactNode;
 }
 

--- a/packages/node_modules/nav-frontend-lenker/src/lenke.tsx
+++ b/packages/node_modules/nav-frontend-lenker/src/lenke.tsx
@@ -3,9 +3,21 @@ import * as classnames from 'classnames';
 import 'nav-frontend-lenker-style';
 
 export interface Props extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+    /**
+     * -
+     */
     href: string;
+    /**
+     * -
+     */
     target?: string;
+    /**
+     * -
+     */
     ariaLabel?: string;
+    /**
+     * -
+     */
     className?: string;
 }
 

--- a/packages/node_modules/nav-frontend-lukknapp/src/lukknapp.tsx
+++ b/packages/node_modules/nav-frontend-lukknapp/src/lukknapp.tsx
@@ -16,10 +16,26 @@ const cls = (bla, hvit, hjorne, className) =>
     );
 
 export interface LukknappProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    /**
+     * Bruk blå som standard farge i stedet for grå
+     */
     bla?: boolean;
+    /**
+     * Bruk hvit som standard farge i stedet for grå
+     */
     hvit?: boolean;
+    /**
+     * Plasser knappen øverst i høyre hjørne.
+     * Knappen er absolut possisjonert og trenger derfor litt hjelp med å legge seg riktig sted.
+     */
     overstHjorne?: boolean;
+    /**
+     * -
+     */
     className?: string;
+    /**
+     * -
+     */
     ariaLabel: string;
 }
 

--- a/packages/node_modules/nav-frontend-skjema/src/bekreft-checkboks-panel.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/bekreft-checkboks-panel.tsx
@@ -4,11 +4,29 @@ import * as PT from 'prop-types';
 import { guid } from 'nav-frontend-js-utils';
 
 export interface BekreftCheckboksPanelProps {
+    /**
+     * Callback-funksjon som blir kalt når checkboksen endrer state
+     */
     onChange: (event: React.SyntheticEvent<EventTarget>) => void;
+    /**
+     * Default checked state for checkboksen
+     */
     checked: boolean;
+    /**
+     * Tekst til høyre for checkboksen
+     */
     label: string;
+    /**
+     * Tekst over checkboksen
+     */
     children?: React.ReactNode | React.ReactChildren;
+    /**
+     * Øvrige custom props til <input>-elementet som ligger i bunn
+     */
     inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+    /**
+     * Klassenavn
+     */
     className?: string;
 }
 

--- a/packages/node_modules/nav-frontend-skjema/src/checkboks-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/checkboks-panel-gruppe.tsx
@@ -5,74 +5,25 @@ import { guid } from 'nav-frontend-js-utils';
 import 'nav-frontend-skjema-style';
 import { SkjemaGruppe, Fieldset } from './';
 import { SkjemaelementFeil, skjemaelementFeilmeldingShape } from './skjemaelement-feilmelding';
-
-export interface CheckboksProps {
-    checked: boolean;
-    label: string;
-    value?: string;
-    id?: string;
-    disabled?: boolean;
-    feil?: SkjemaelementFeil;
-    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-}
+import { CheckboksPanel, CheckboksProps } from './checkboks-panel';
 
 export interface CheckboksPanelGruppeProps {
+    /**
+     * Array av checkbokser, se 'checkboks-panel.tsx'
+     */
     checkboxes: CheckboksProps[];
+    /**
+     * Overskrift
+     */
     legend: string;
+    /**
+     * Callback-funksjon som blir kalt straks noen av checkboksene endrer state
+     */
     onChange: (event: React.SyntheticEvent<EventTarget>, value?: string) => void;
+    /**
+     * Objekt som beskriver skjema-feil, se 'skjemaelement-feilmelding.tsx'
+     */
     feil?: SkjemaelementFeil;
-}
-
-export interface CheckboksPanelProps extends CheckboksProps {
-    id?: string;
-    checked: boolean;
-    onChange: (event: React.SyntheticEvent<EventTarget>) => void;
-    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
-}
-
-export interface CheckboksPanelState {
-    hasFocus: boolean;
-}
-
-export class CheckboksPanel extends React.Component<CheckboksPanelProps, CheckboksPanelState> {
-    constructor(props: CheckboksPanelProps) {
-        super(props);
-        this.state = { hasFocus: false };
-    }
-
-    toggleOutline() {
-        this.setState({ hasFocus: !this.state.hasFocus });
-    }
-
-    render() {
-        const { id, checked, label, onChange, inputProps, disabled } = this.props;
-        const { hasFocus } = this.state;
-        const inputId = id || guid();
-
-        const cls = classNames('inputPanel checkboksPanel', {
-            'inputPanel--checked': checked && !disabled,
-            'inputPanel--focused': hasFocus && !disabled,
-            'inputPanel--disabled': disabled === true
-        });
-
-        return (
-            <label className={cls} htmlFor={inputId}>
-                <input
-                    {...inputProps}
-                    id={inputId}
-                    className="inputPanel__field"
-                    type="checkbox"
-                    checked={checked}
-                    aria-checked={checked}
-                    disabled={disabled}
-                    onFocus={() => this.toggleOutline()}
-                    onBlur={() => this.toggleOutline()}
-                    onChange={onChange}
-                />
-                <span className="inputPanel__label">{label}</span>
-            </label>
-        );
-    }
 }
 
 class CheckboksPanelGruppe extends React.Component<CheckboksPanelGruppeProps> {

--- a/packages/node_modules/nav-frontend-skjema/src/checkboks-panel.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/checkboks-panel.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import * as PT from 'prop-types';
+import * as classNames from 'classnames';
+import { guid } from 'nav-frontend-js-utils';
+import { SkjemaelementFeil } from './skjemaelement-feilmelding';
+import 'nav-frontend-skjema-style';
+
+export interface CheckboksProps {
+    checked: boolean;
+    label: string;
+    value?: string;
+    id?: string;
+    disabled?: boolean;
+    feil?: SkjemaelementFeil;
+    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+}
+
+export interface CheckboksPanelProps extends CheckboksProps {
+    id?: string;
+    checked: boolean;
+    onChange: (event: React.SyntheticEvent<EventTarget>) => void;
+    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+}
+
+export interface CheckboksPanelState {
+    hasFocus: boolean;
+}
+
+export class CheckboksPanel extends React.Component<CheckboksPanelProps, CheckboksPanelState> {
+    constructor(props: CheckboksPanelProps) {
+        super(props);
+        this.state = { hasFocus: false };
+    }
+
+    toggleOutline() {
+        this.setState({ hasFocus: !this.state.hasFocus });
+    }
+
+    render() {
+        const { id, checked, label, onChange, inputProps, disabled } = this.props;
+        const { hasFocus } = this.state;
+        const inputId = id || guid();
+
+        const cls = classNames('inputPanel checkboksPanel', {
+            'inputPanel--checked': checked && !disabled,
+            'inputPanel--focused': hasFocus && !disabled,
+            'inputPanel--disabled': disabled === true
+        });
+
+        return (
+            <label className={cls} htmlFor={inputId}>
+                <input
+                    {...inputProps}
+                    id={inputId}
+                    className="inputPanel__field"
+                    type="checkbox"
+                    checked={checked}
+                    aria-checked={checked}
+                    disabled={disabled}
+                    onFocus={() => this.toggleOutline()}
+                    onBlur={() => this.toggleOutline()}
+                    onChange={onChange}
+                />
+                <span className="inputPanel__label">{label}</span>
+            </label>
+        );
+    }
+}
+
+export default CheckboksPanel;

--- a/packages/node_modules/nav-frontend-skjema/src/checkbox.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/checkbox.tsx
@@ -12,10 +12,25 @@ const inputCls = (harFeil) => classNames('skjemaelement__input checkboks', {
 });
 
 export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    /**
+     * Klassenavn
+     */
     className?: string;
+    /**
+     * Label for checkbox
+     */
     label: React.ReactNode;
+    /**
+     * Id for checkbox, hvis id ikke er satt brukes en tilfeldig guid
+     */
     id?: string;
+    /**
+     * Hvis skjemaet har feil sender man inn et objekt med en feilmelding
+     */
     feil?: SkjemaelementFeil;
+    /**
+     * Referanse til selve checkboxen. Brukes for eksempel til å sette fokus
+     */
     checkboxRef?: () => any;
 }
 

--- a/packages/node_modules/nav-frontend-skjema/src/index.ts
+++ b/packages/node_modules/nav-frontend-skjema/src/index.ts
@@ -9,5 +9,6 @@ export { default as SkjemaGruppe, SkjemaGruppeProps } from './skjema-gruppe';
 export { default as ToggleGruppe, ToggleGruppeProps } from './toggle-gruppe';
 export { default as ToggleKnapp, ToggleKnappProps } from './toggle-knapp';
 export { default as RadioPanelGruppe, RadioPanel, RadioPanelGruppeProps, RadioPanelProps } from './radio-panel-gruppe';
-export { default as CheckboksPanelGruppe, CheckboksPanel, CheckboksPanelGruppeProps, CheckboksPanelProps } from './checkboks-panel-gruppe'; // tslint:disable-line:max-line-length
+export { default as CheckboksPanel, CheckboksPanelProps } from './checkboks-panel';
+export { default as CheckboksPanelGruppe, CheckboksPanelGruppeProps } from './checkboks-panel-gruppe';
 export { default as BekreftCheckboksPanel, BekreftCheckboksPanelProps  } from './bekreft-checkboks-panel';

--- a/packages/node_modules/nav-frontend-skjema/src/input.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/input.tsx
@@ -14,13 +14,37 @@ const inputClass = (width, className, harFeil) => classNames(
 );
 
 export interface NavFrontendInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    /**
+     * Bredden til inputfeltet
+     */
     bredde?: 'fullbredde' | 'XXL' | 'XL' | 'L' | 'M' | 'S' | 'XS' | 'XXS';
+    /**
+     * Classname som blir satt på komponentwrapperen
+     */
     className?: string;
+    /**
+     * Hvis skjemaet har feil sender man inn et objekt med en feilmelding
+     */
     feil?: SkjemaelementFeil;
+    /**
+     * Id for inputfelt, hvis id ikke er satt brukes name eller en tilfeldig guid
+     */
     id?: string;
+    /**
+     * Classname som blir satt på input-elementet
+     */
     inputClassName?: string;
+    /**
+     * Referanse til selve inputfeltet. Brukes for eksempel til å sette fokus
+     */
     inputRef?: () => any;
+    /**
+     * Label for tekstfeltet
+     */
     label: React.ReactNode;
+    /**
+     * Name for inputfelt, hvis name ikke er satt brukes id eller en tilfeldig guid
+     */
     name?: string;
 }
 

--- a/packages/node_modules/nav-frontend-skjema/src/radio.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/radio.tsx
@@ -7,10 +7,25 @@ import * as classNames from 'classnames';
 const cls = (className) => classNames('skjemaelement skjemaelement--horisontal', className);
 
 export interface RadioProps extends React.InputHTMLAttributes<HTMLInputElement>{
+    /**
+     * ClassName
+     */
     className?: string;
+    /**
+     * Label for radiobutton
+     */
     label: React.ReactNode;
+    /**
+     * Id for radiobutton, hvis id ikke er satt brukes en tilfeldig guid
+     */
     id?: string;
+    /**
+     * Name for radiobutton gruppe
+     */
     name: string;
+    /**
+     * Referanse til selve radioknappen. Brukes for eksempel til å sette fokus
+     */
     radioRef?: () => any;
 }
 

--- a/packages/node_modules/nav-frontend-skjema/src/select.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/select.tsx
@@ -12,14 +12,41 @@ const inputCls = (harFeil) => classNames('skjemaelement__input', {
 const selectCls = (bredde) => classNames('selectContainer', `input--${bredde}`);
 
 export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+    /**
+     * En eller flere select options
+     */
     children: React.ReactNode | React.ReactNode[];
+    /**
+     * ClassName
+     */
     className?: string;
+    /**
+     * Bredden på select-boksen
+     */
     bredde?: 'fullbredde' | 'xxl' | 'xl' | 'l' | 'm' | 's' | 'xs';
+    /**
+     * Label for select
+     */
     label: React.ReactNode;
+    /**
+     * Id for select, hvis id ikke er satt brukes en tilfeldig guid
+     */
     id?: string;
+    /**
+     * Hvis skjemaet har feil sender man inn et objekt med en feilmelding
+     */
     feil?: SkjemaelementFeil;
+    /**
+     * Referanse til selve selectfeltet. Brukes for eksempel til å sette fokus
+     */
     selectRef?: () => any;
+    /**
+     * -
+     */
     disabled?: boolean;
+    /**
+     * -
+     */
     selected?: string | number;
 }
 

--- a/packages/node_modules/nav-frontend-skjema/src/skjema-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/skjema-gruppe.tsx
@@ -9,9 +9,21 @@ const cls = (className, harFeil) => classNames(className, {
 });
 
 export interface SkjemaGruppeProps {
+    /**
+     * En eller flere children, oftest en eller flere .skjemaelement
+     */
     children: React.ReactNode | React.ReactNode[];
+    /**
+     * ClassName
+     */
     className?: string;
+    /**
+     * Tittel eller skjemaspørsmål for skjemagruppe
+     */
     title?: string;
+    /**
+     * Hvis skjemagruppen har feil sender man inn et objekt med en feilmelding
+     */
     feil?: SkjemaelementFeil;
 }
 

--- a/packages/node_modules/nav-frontend-skjema/src/textarea.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/textarea.tsx
@@ -12,13 +12,37 @@ const inputCls = (className, harFeil) => classNames(
 );
 
 export interface TextareaProps extends React.HTMLAttributes<HTMLTextAreaElement> {
+    /**
+     * Ledetekst for tekstområdet
+     */
     label: React.ReactNode;
+    /**
+     * Maks antal tegn som kan skrives inn i tekstområdet
+     */
     maxLength?: number;
+    /**
+     * Teksten som er skrevet inn i tekstområdet.
+     */
     value: string;
+    /**
+     * Klassenavn for tekstomnrådet
+     */
     textareaClass?: string;
+    /**
+     * Id for tekstområdet, settes til name eller random guid hvis prop ikke er satt
+     */
     id?: string;
+    /**
+     * Navn for tekstområdet, settes til id eller random guid hvis prop ikke er satt
+     */
     name?: string;
+    /**
+     * Optional onChange handler
+     */
     onChange: (event: React.SyntheticEvent<EventTarget>) => void;
+    /**
+     * Hvis skjemaet har feil sender man inn et objekt med en feilmelding
+     */
     feil?: SkjemaelementFeil;
     tellerTekst?: (antallTegn: number, maxLength: number) => React.ReactNode;
     textareaRef?: () => any;

--- a/packages/node_modules/nav-frontend-skjema/src/toggle-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/toggle-gruppe.tsx
@@ -4,9 +4,21 @@ import 'nav-frontend-skjema-style';
 import * as classNames from 'classnames';
 
 export interface ToggleGruppeProps {
+    /**
+     * Array av toggle knapper
+     */
     children: React.ReactElement<any>[];
+    /**
+     * Klassenavn
+     */
     className?: string;
+    /**
+     * Navn attributt til toggle knapper
+     */
     name: string;
+    /**
+     * Valgfri callback som blir kalt ved endring
+     */
     onChange?: (event: React.SyntheticEvent<EventTarget>) => void;
 }
 

--- a/packages/node_modules/nav-frontend-snakkeboble/src/snakkeboble.tsx
+++ b/packages/node_modules/nav-frontend-snakkeboble/src/snakkeboble.tsx
@@ -10,10 +10,25 @@ const snakkebobleCls = (hoyre) => classNames('snakkeboble', {
 });
 
 export interface SnakkebobleProps {
+    /**
+     * @Deprecated Dato for melding, bruk `topp`
+     */
     dato?: string;
+    /**
+     * Toppteksten (tittel) for meldingen
+     */
     topp?: string;
+    /**
+     * Tekst for melding
+     */
     children: React.ReactChildren | React.ReactChild | React.ReactNode;
+    /**
+     * Settes denne peker pilen til snakkeboblen mot høyre, og snakkeboblen og teksten i snakkeboblen flyter mot høyre.
+     */
     pilHoyre?: boolean;
+    /**
+     * Klasse som brukes på ikonet. Dette lar deg styre form, farge og illustrasjon.
+     */
     ikonClass?: string;
 }
 

--- a/packages/node_modules/nav-frontend-spinner/src/spinner.tsx
+++ b/packages/node_modules/nav-frontend-spinner/src/spinner.tsx
@@ -9,9 +9,21 @@ const cls = (className, storrelse) => classNames('spinner', className, {
 });
 
 export interface NavFrontendSpinnerProps {
+    /**
+     * -
+     */
     negativ?: boolean;
+    /**
+     * Border rundt spinneren
+     */
     stroke?: boolean;
+    /**
+     * Classname
+     */
     className?: string;
+    /**
+     * -
+     */
     'aria-label'?: string;
 }
 

--- a/packages/node_modules/nav-frontend-stegindikator/src/stegindikator.tsx
+++ b/packages/node_modules/nav-frontend-stegindikator/src/stegindikator.tsx
@@ -11,12 +11,34 @@ const cls = (state) => cn('stegindikator', {
 });
 
 export interface StegindikatorProps {
+    /**
+     * Array av steg, se `stegindikator-steg.tsx`
+     */
     steg: StegindikatorStegProps[];
+    /**
+     * Vise/skjule steg label
+     */
     visLabel: boolean;
+    /**
+     * Kompakt versjon som krever mye mindre plass
+     */
     kompakt: boolean;
+    /**
+     * Optional aktivt steg override. Kan brukes hvis det f.eks. er flere stegindikatorer på en side, hvor alle skal 
+     * oppdateres hvis den ene endrer seg.
+     */
     aktivtSteg?: number;
+    /**
+     * Valgfri callback som kjøres når state endrer seg etter click
+     */
     onChange?: (index: number) => void;
+    /**
+     * Valgfri callback som kjøres før `onChange`. Kan avbryte kall til `onChange` hvis den returnerer `false`
+     */
     onBeforeChange?: (index: number) => boolean;
+    /**
+     * Komponenten vil auto-justere seg selv avhengig av tilgjengelig konteiner-bredde, lytter på window `resize` event
+     */
     autoResponsiv: boolean;
 }
 

--- a/packages/node_modules/nav-frontend-tabs/src/tab.tsx
+++ b/packages/node_modules/nav-frontend-tabs/src/tab.tsx
@@ -10,14 +10,41 @@ const tabCls = (props) => cn('nav-frontend-tabs__tab-inner', props.className, {
 });
 
 export interface TabProps {
+    /**
+     * Innhold for label, kan være tekst eller HTML/JSX. Erstattes av `children` ved bruk av `<Tabs.Tab></Tabs.Tab>`
+     */
     label?: React.ReactNode | React.ReactChild | React.ReactChildren;
+    /**
+     * Vise som aktiv tab, kan brukes hvis man benytter pure versjon av Tabs-komponenten
+     */
     aktiv?: boolean;
+    /**
+     * Valgfri onClick callback
+     */
     onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    /**
+     * Brukes av TabsPure for å fasilitere tastatur-kontroll
+     */
     onKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
+    /**
+     * Brukes av TabsPure for å fasilitere tastatur-kontroll
+     */
     onFocus?: () => void;
+    /**
+     * Lar deg bestemme hvilket klikkbart HTML-element som brukes
+     */
     linkCreator?: Function;
+    /**
+     * Gjør tab utilgjengelig
+     */
     disabled?: boolean;
+    /**
+     * -
+     */
     tabIndex?: number;
+    /**
+     * Brukes av PureTabs for fokus-management
+     */
     linkRef?: Function;
 }
 

--- a/packages/node_modules/nav-frontend-tabs/src/tabs-pure.tsx
+++ b/packages/node_modules/nav-frontend-tabs/src/tabs-pure.tsx
@@ -9,9 +9,21 @@ const tabsCls = (props) => cn('nav-frontend-tabs', props.className, {
 });
 
 export interface TabsPureProps {
+    /**
+     * Array av tabs, se `tab.tsx`
+     */
     tabs: TabProps[];
+    /**
+     * Rendre mindre, sekundær versjon
+     */
     kompakt?: boolean;
+    /**
+     * Bestemmer om piltaster skal auto-switche aktiv tab eller om de bare flytter fokus
+     */
     arrowKeysAutoSwitchTabs?: boolean;
+    /**
+     * Valgfri callback som kjøres når state endrer seg etter click
+     */
     onChange?: (event: React.SyntheticEvent<EventTarget>, index: number) => void;
 }
 

--- a/packages/node_modules/nav-frontend-tabs/src/tabs.tsx
+++ b/packages/node_modules/nav-frontend-tabs/src/tabs.tsx
@@ -7,7 +7,13 @@ import TabsPure, { TabsPureProps } from './tabs-pure';
 import 'nav-frontend-tabs-style';
 
 export interface TabsProps extends TabsPureProps {
+    /**
+     * Påkrevd callback for når state endrer seg etter klikk
+     */
     onChange: (event: React.SyntheticEvent<EventTarget>, index: number) => void;
+    /**
+     * Default aktiv tab index
+     */
     defaultAktiv?: number;
 }
 

--- a/packages/node_modules/nav-frontend-tekstomrade/src/tekstomrade.tsx
+++ b/packages/node_modules/nav-frontend-tekstomrade/src/tekstomrade.tsx
@@ -36,7 +36,13 @@ function tilAvsnitt(avsnitt, index, list) {
 }
 
 export interface TekstomradeProps {
+    /**
+     * Ren tekst-innhold som skal formateres
+     */
     children: string;
+    /**
+     * Skru av/på formatering
+     */
     ingenFormattering?: boolean;
 }
 

--- a/packages/node_modules/nav-frontend-veileder/src/veileder.tsx
+++ b/packages/node_modules/nav-frontend-veileder/src/veileder.tsx
@@ -26,13 +26,39 @@ function getChatBubble(says, veilederSize) {
 }
 
 export interface VeilederProps {
+    /**
+     * Definerer størrelsen på Avataren. Kan angis helt fritt, og snakkeboblen vil posisjoneres
+     * og snakkeboble-pilen vil skalere basert på denne verdien.
+     */
     width?: number;
+    /**
+     * Custom SVG-element som illustrerer en figur, f.eks. en av disse:
+     * https://app.zeplin.io/project/59831e455850985791bdeb4d/screen/5a7c1fcc36781f9423ab6a0e
+     */
     children: React.ReactNode | React.ReactChild | React.ReactChildren;
+    /**
+     * Tekst eller HTML som rendres i en snakkeboble
+     */
     says?: React.ReactNode | React.ReactChild | React.ReactChildren;
+    /**
+     * Hex-fargecode som definerer bakgrunnsfarge, @navLysGra er default
+     */
     color?: string;
+    /**
+     * Skrur av bakgrunnsfargen
+     */
     transparent?: boolean;
+    /**
+     * Skrur av sirkulær maskering/cropping av children
+     */
     nomask?: boolean;
+    /**
+     * Skrur av 80% height på children, og rendrer i full høyde (hvis innholdet skal sentreres)
+     */
     center?: boolean;
+    /**
+     * Predefinerte nøkler for styling av snakkeboblen, avhengig av type budskap.
+     */
     type: 'normal' | 'suksess' | 'advarsel' | 'feilmelding';
 }
 


### PR DESCRIPTION
Resolves #239 

Har endret slik at `react-docgen-typescript` nå ignorerer alle props uten doc kommentarer i `gulpfile.js` (trengs for å ignorere alle props som blir arvet fra `HTMLAttributes` osv). Ref. https://github.com/styleguidist/react-docgen-typescript/issues/49

Det betyr at alle props vi definerer i interfaces fra nå av krever doc kommentarer for at de skal vises på Guideline-siden. Har lagt til docs på de komponentene vi allerede har.

De eneste propsene fra `HTMLAttributes` som kommer med docs er aria-attributter. La derfor inn et eget filter på disse i `PropTypeTable.js` for at heller ikke disse skal vises.

**Andre funn:**
- Docgen sliter med å håndtere flere klasser i samme fil (har foreløpig splittet `CheckboksPanelGruppe` og `CheckboksPanel` i egne filer)
- For at docgen skal plukke opp default-verdier må disse defineres som en `static defaultProps: Partial<MyProps>` på klassen (se f.eks. `Ekspanderbartpanel`)

**Proptable for Knapp etter fix:**
<img width="815" alt="screen shot 2018-05-28 at 10 08 39" src="https://user-images.githubusercontent.com/74510/40604421-3f801ee4-625f-11e8-8a1c-f27109d72a43.png">
**Proptable for Knapp før fix:**
<img width="1323" alt="screen shot 2018-05-28 at 10 09 09" src="https://user-images.githubusercontent.com/74510/40604429-44696b5e-625f-11e8-90ea-5939420f9428.png">
