### PR TITLE
Legger til eksplisitt 'type="button"' på knapp i EkspanderbartpanelBasePure

### DIFF
--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
@@ -65,6 +65,7 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
                     onKeyDown={(event) => this.tabHandler(event)}
                     onClick={onClick}
                     aria-expanded={apen}
+                    type="button"
                 >
                     <div className="ekspanderbartPanel__flex-wrapper">
                         {heading}


### PR DESCRIPTION
For å forhindre at knappen får implisitt `type="submit"` når komponenten legges i skjemaer.