### PR TITLE
Fikser optional onClick prop for Ekspanderbartpanel

### DIFF
--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/index.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/index.tsx
@@ -15,7 +15,7 @@ export interface EkspanderbartpanelProps {
     /**
      * Callback funksjon for når knappen blir klikket på
      */
-    onClick: (event: React.SyntheticEvent<HTMLButtonElement>) => void;
+    onClick?: (event: React.SyntheticEvent<HTMLButtonElement>) => void;
     /**
      * Tittel/label-tekst
      */


### PR DESCRIPTION
Ble gjort påkrevd ved en feil i oversettelsen til Typescript.