### PR TITLE
Setter text-align:center på Tabs label

### DIFF
--- a/packages/node_modules/nav-frontend-tabs-style/src/tabs-style.less
+++ b/packages/node_modules/nav-frontend-tabs-style/src/tabs-style.less
@@ -23,6 +23,7 @@
   &__tab-label {
     padding-bottom: 0.2rem;
     border: 1px solid transparent;
+    text-align: center;
   }
 
   &__tab-inner {


### PR DESCRIPTION
Fikser dette:
<img width="378" alt="screen shot 2018-06-20 at 08 53 29" src="https://user-images.githubusercontent.com/74510/41642085-9fb9f414-7467-11e8-9ebc-21a09acdf39f.png">
Til dette:
<img width="378" alt="screen shot 2018-06-20 at 08 54 46" src="https://user-images.githubusercontent.com/74510/41642092-a4be4b04-7467-11e8-8437-567240c2fbba.png">
