### PR TITLE
open-styling should just apply to current element

### DIFF
--- a/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
@@ -53,19 +53,18 @@
   }
 
   &--apen {
-
-    .ekspanderbartPanel__hode {
+    >.ekspanderbartPanel__hode {
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
     }
 
-    .ekspanderbartPanel__innhold {
+    >.ekspanderbartPanel__innhold {
       border-top-left-radius: 0;
       border-top-right-radius: 0;
     }
 
-    .ekspanderbartPanel__hode:hover:not(:focus),
-    .ekspanderbartPanel__hode--hover:not(.ekspanderbartPanel__hode--focus) {
+    >.ekspanderbartPanel__hode:hover:not(:focus),
+    >.ekspanderbartPanel__hode--hover:not(.ekspanderbartPanel__hode--focus) {
       box-shadow: none;
     }
 


### PR DESCRIPTION
Border-bottom-radius ble satt feil når man hadde nested ekspanderbare-paneler. 


![image](https://user-images.githubusercontent.com/1413417/41651368-b62514a4-7480-11e8-8c47-6c8383d4c9ff.png)
