### PR TITLE
Fjerner CSS-transisjoner og fikser litt på Stegindikator, Tabs

### DIFF
--- a/packages/node_modules/nav-frontend-stegindikator-style/src/index.less
+++ b/packages/node_modules/nav-frontend-stegindikator-style/src/index.less
@@ -162,7 +162,6 @@
     align-items: center;
     border-radius: 1rem;
     box-shadow: 0 0 0 1px @navGra20 inset;
-    transition: all linear 100ms;
     background: white;
   }
 

--- a/packages/node_modules/nav-frontend-stegindikator/_stegindikator.no-transpilation.js
+++ b/packages/node_modules/nav-frontend-stegindikator/_stegindikator.no-transpilation.js
@@ -1,36 +1,36 @@
-import React, { Component } from 'react';
-
+import React from 'react';
 import Stegindikator from './';
 
-export default class StegindikatorEksempel extends Component {
-    handleChange = (index) => {
-        console.log(`Aktivt steg er nå nr. ${index}`);
-    }
+/**
+ * Dette eksempelet er inkludert for å vise begge måtene man kan
+ * definere steg på:
+ *  a) Som props
+ *  b) Som children
+ */
 
-    render() {
-        return (
-            <div>
-                <h3>Eksempel med props</h3>
+const StegindikatorEksempel = () => (
+    <div>
+        <h3>Eksempel med props</h3>
 
-                <Stegindikator
-                    onChange={this.handleChange}
-                    steg={[
-                        { label: 'Dette steget først' },
-                        { label: 'Og så dette steget', aktiv: true },
-                        { label: 'Deretter må du gjøre dette' },
-                        { label: 'Konklusjonen', disabled: true }
-                    ]}
-                />
+        <Stegindikator
+            onChange={() => {}}
+            steg={[
+                { label: 'Dette steget først' },
+                { label: 'Og så dette steget', aktiv: true },
+                { label: 'Deretter må du gjøre dette' },
+                { label: 'Konklusjonen', disabled: true }
+            ]}
+        />
 
-                <h3>Eksempel med children</h3>
+        <h3>Eksempel med children</h3>
 
-                <Stegindikator onChange={this.handleChange}>
-                    <Stegindikator.Steg>Dette steget først</Stegindikator.Steg>
-                    <Stegindikator.Steg aktiv>Og så dette steget</Stegindikator.Steg>
-                    <Stegindikator.Steg>Deretter må du gjøre dette</Stegindikator.Steg>
-                    <Stegindikator.Steg disabled>Konklusjonen</Stegindikator.Steg>
-                </Stegindikator>
-            </div>
-        );
-    }
-}
+        <Stegindikator onChange={() => {}}>
+            <Stegindikator.Steg>Dette steget først</Stegindikator.Steg>
+            <Stegindikator.Steg aktiv>Og så dette steget</Stegindikator.Steg>
+            <Stegindikator.Steg>Deretter må du gjøre dette</Stegindikator.Steg>
+            <Stegindikator.Steg disabled>Konklusjonen</Stegindikator.Steg>
+        </Stegindikator>
+    </div>
+);
+
+export default StegindikatorEksempel;

--- a/packages/node_modules/nav-frontend-stegindikator/_stegindikator.sample.js
+++ b/packages/node_modules/nav-frontend-stegindikator/_stegindikator.sample.js
@@ -1,27 +1,24 @@
-import React from 'react';
 // eslint-disable-next-line
 import exampleCode from 'raw-loader!./_stegindikator.no-transpilation';
 import Stegindikator from './';
 import generateSample from '../../../guideline-app/app/utils/sampling/sampleDataGenerator';
 
-const steps = [
-    <Stegindikator.Steg key={'s0'}>Dette steget først</Stegindikator.Steg>,
-    <Stegindikator.Steg key={'s1'} aktiv>Og så dette steget</Stegindikator.Steg>,
-    <Stegindikator.Steg key={'s2'}>Deretter må du gjøre dette</Stegindikator.Steg>,
-    <Stegindikator.Steg key={'s3'} disabled>Konklusjonen</Stegindikator.Steg>
-];
-
 export default generateSample({
     baseType: Stegindikator,
-    children: steps,
     attrs: {
+        steg: [
+            { label: 'Dette steget først' },
+            { label: 'Og så dette steget', aktiv: true },
+            { label: 'Deretter må du gjøre dette' },
+            { label: 'Konklusjonen', disabled: true }
+        ],
         onChange: () => {}
     },
     modifierNames: ['visLabel', 'kompakt', 'autoResponsiv'],
     tabOptions: {
-        react: { show: false },
-        html: { show: false },
-        css: { show: false },
+        react: { show: true },
+        html: { show: true },
+        css: { show: true },
         js: { show: true, code: exampleCode }
     }
 });

--- a/packages/node_modules/nav-frontend-stegindikator/src/stegindikator.tsx
+++ b/packages/node_modules/nav-frontend-stegindikator/src/stegindikator.tsx
@@ -12,9 +12,10 @@ const cls = (state) => cn('stegindikator', {
 
 export interface StegindikatorProps {
     /**
-     * Array av steg, se `stegindikator-steg.tsx`
+     * Array av steg, se `stegindikator-steg.tsx`. Merk at steg også kan defineres som children av typen 
+     * <Stegindikator.Steg />.
      */
-    steg: StegindikatorStegProps[];
+    steg?: StegindikatorStegProps[];
     /**
      * Vise/skjule steg label
      */
@@ -96,7 +97,7 @@ class Stegindikator extends React.Component<StegindikatorProps, StegindikatorSta
         if (nextProps.autoResponsiv) {
             this.setState({
                 visLabel: (this.canShowLabel()) ? nextProps.visLabel : false,
-                kompakt: nextProps.kompakt
+                kompakt: nextProps.kompakt || !this.canBeNormal()
             });
         } else {
             this.setState({
@@ -139,7 +140,7 @@ class Stegindikator extends React.Component<StegindikatorProps, StegindikatorSta
                 }
             });
         } else {
-            index = this.props.steg.findIndex((steg) => !!steg.aktiv);
+            index = this.props.steg!.findIndex((steg) => !!steg.aktiv);
         }
         return (index !== -1) ? index : 0 ;
     }
@@ -148,7 +149,7 @@ class Stegindikator extends React.Component<StegindikatorProps, StegindikatorSta
         if (this.props.children) {
             return React.Children.toArray(this.props.children).filter((child) => React.isValidElement(child)).length;
         }
-        return this.props.steg.length;
+        return this.props.steg!.length;
     }
 
     getDimensions() {
@@ -201,7 +202,7 @@ class Stegindikator extends React.Component<StegindikatorProps, StegindikatorSta
             });
         }
 
-        return this.props.steg.map((steg, i) => {
+        return this.props.steg!.map((steg, i) => {
 
             const stegDomProps = omit(
                 steg,

--- a/packages/node_modules/nav-frontend-tabs/_tabs.no-transpilation.js
+++ b/packages/node_modules/nav-frontend-tabs/_tabs.no-transpilation.js
@@ -1,34 +1,34 @@
-import React, { Component } from 'react';
-
+import React from 'react';
 import Tabs from './';
 
-export default class TabsEksempel extends Component {
-    handleChange = (index) => {
-        console.log(`Aktiv tab er nå nr. ${index}`);
-    }
+/**
+ * Dette eksempelet er inkludert for å vise begge måtene man kan
+ * definere steg på:
+ *  a) Som props
+ *  b) Som children
+ */
 
-    render() {
-        return (
-            <div>
-                <h3>Eksempel med props</h3>
+const TabsEksempel = () => (
+    <div>
+        <h3>Eksempel med props</h3>
 
-                <Tabs
-                    tabs={[
-                        { label: 'Første side' },
-                        { label: 'Andre side' },
-                        { label: 'Tredje side' }
-                    ]}
-                    onChange={this.handleChange}
-                />
+        <Tabs
+            tabs={[
+                { label: 'Første side' },
+                { label: 'Andre side' },
+                { label: 'Tredje side' }
+            ]}
+            onChange={() => {}}
+        />
 
-                <h3>Eksempel med children</h3>
+        <h3>Eksempel med children</h3>
 
-                <Tabs onChange={this.handleChange}>
-                    <Tabs.Tab>Første side</Tabs.Tab>
-                    <Tabs.Tab>Andre side</Tabs.Tab>
-                    <Tabs.Tab>Tredje side</Tabs.Tab>
-                </Tabs>
-            </div>
-        );
-    }
-}
+        <Tabs onChange={() => {}}>
+            <Tabs.Tab>Første side</Tabs.Tab>
+            <Tabs.Tab>Andre side</Tabs.Tab>
+            <Tabs.Tab>Tredje side</Tabs.Tab>
+        </Tabs>
+    </div>
+);
+
+export default TabsEksempel;

--- a/packages/node_modules/nav-frontend-tabs/_tabs.sample.js
+++ b/packages/node_modules/nav-frontend-tabs/_tabs.sample.js
@@ -15,7 +15,7 @@ export default generateSample({
     },
     modifierNames: ['kompakt'],
     tabOptions: {
-        react: { show: false },
+        react: { show: true },
         html: { show: true },
         css: { show: true },
         js: { show: true, code: exampleCode }


### PR DESCRIPTION
Resolves #323

- Fjerner CSS transisjoner på `stegindikator__steg-num`
- Fikser at `steg` prop blir optional i Stegindikator interface
- Fikser en bug på `autoResponsiv` hvor `kompakt` ikke ble re-sjekket i `componentWillReceiveProps`
- Forbedret samples på både Stegindikator og Tabs