### PR TITLE
Gjør aria-label optional og deprecated på Lukknapp + style fix

### DIFF
--- a/packages/node_modules/nav-frontend-lukknapp-style/src/lukknapp-style.less
+++ b/packages/node_modules/nav-frontend-lukknapp-style/src/lukknapp-style.less
@@ -50,24 +50,28 @@
     box-shadow: 0 0 0 3px @orangeFocus;
   }
 
-}
-
-  .lukknapp--bla {
+  &--bla {
     color: @navBla;
   }
 
-  .lukknapp--hvit {
+  &--hvit {
     color: @white;
 
     &:hover {
       background-color: @navLysBla;
       border-color: @navLysBla;
       color: @navGra60;
+
+      &:before,
+      &:after {
+        background-color: @navMorkGra;
+      }
     }
   }
 
-  .lukknapp--overstHjorne {
+  &--overstHjorne {
     position: absolute;
     top: 1rem;
     right: 1rem;
   }
+}

--- a/packages/node_modules/nav-frontend-lukknapp/src/lukknapp.tsx
+++ b/packages/node_modules/nav-frontend-lukknapp/src/lukknapp.tsx
@@ -17,11 +17,11 @@ const cls = (bla, hvit, hjorne, className) =>
 
 export interface LukknappProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     /**
-     * Bruk blå som standard farge i stedet for grå
+     * Blå variant
      */
     bla?: boolean;
     /**
-     * Bruk hvit som standard farge i stedet for grå
+     * Hvit variant
      */
     hvit?: boolean;
     /**
@@ -30,19 +30,26 @@ export interface LukknappProps extends React.ButtonHTMLAttributes<HTMLButtonElem
      */
     overstHjorne?: boolean;
     /**
-     * -
+     * Egendefinert klassenavn
      */
     className?: string;
     /**
-     * -
+     * @deprecated Bruk children i stedet.
      */
-    ariaLabel: string;
+    ariaLabel?: string;
 }
 
 /**
  * Lukknapp
  */
 class Lukknapp extends React.Component<LukknappProps, {}> {
+    static defaultProps: Partial<LukknappProps> = {
+        children: 'Lukk',
+        bla: false,
+        hvit: false,
+        overstHjorne: false
+    };
+
     buttonRef: HTMLButtonElement;
 
     constructor(props) {
@@ -77,9 +84,7 @@ class Lukknapp extends React.Component<LukknappProps, {}> {
     children: 'Lukk',
     bla: false,
     hvit: false,
-    overstHjorne: false,
-    className: '',
-    ariaLabel: 'Lukk'
+    overstHjorne: false
 };
 
 (Lukknapp as any).propTypes = {
@@ -88,17 +93,26 @@ class Lukknapp extends React.Component<LukknappProps, {}> {
      */
     children: PT.string,
     /**
-     * Bruk blå som standard farge i stedet for grå
+     * Blå variant
      */
     bla: PT.bool,
+    /**
+     * Hvit variant
+     */
     hvit: PT.bool,
     /**
      * Plasser knappen øverst i høyre hjørne.
      * Knappen er absolut possisjonert og trenger derfor litt hjelp med å legge seg riktig sted.
      */
     overstHjorne: PT.bool,
+    /**
+     * Egendefinert klassenavn
+     */
     className: PT.string,
-    ariaLabel: PT.string.isRequired
+    /**
+     * @deprecated Bruk children i stedet.
+     */
+    ariaLabel: PT.string
 };
 
 export default Lukknapp;


### PR DESCRIPTION
Påkrevd `aria-label` blir litt unødvendig på denne komponenten ettersom `children` kan brukes uten problemer. Det kan også være litt uheldig å legge opp til å bruke begge da `aria-label` vanligvis overstyrer verdien av children, eller i verste fall skape støy hvis både `aria-label` og `children` blir lest opp.

Fikser også styling fra dette:

<img width="411" alt="screen shot 2018-06-27 at 09 26 28" src="https://user-images.githubusercontent.com/74510/41959055-3edb63b4-79ec-11e8-841c-026effcc8d18.png">

Til dette:

<img width="407" alt="screen shot 2018-06-27 at 09 26 38" src="https://user-images.githubusercontent.com/74510/41959069-440dd7e0-79ec-11e8-9dd9-5ec1dd07f0cd.png">
