### PR TITLE
Fikser at legend i Fieldset får samme fontstørrelse som SkjemaGruppe tittel

### DIFF
--- a/packages/node_modules/nav-frontend-skjema-style/src/index.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/index.less
@@ -16,7 +16,7 @@
 }
 
 .skjema__legend {
-  .typo-undertittel-mixin();
+  .typo-element-mixin();
   margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
Fikser dette:
<img width="242" alt="screen shot 2018-06-27 at 12 17 58" src="https://user-images.githubusercontent.com/74510/41968374-8676ad56-7a04-11e8-91ed-b67438a1627a.png">
Til dette:
<img width="230" alt="screen shot 2018-06-27 at 12 18 55" src="https://user-images.githubusercontent.com/74510/41968379-8b3d3dbe-7a04-11e8-93ed-d190205947af.png">
