### PR TITLE
Fixes #332 Global variables

### DIFF
--- a/development/conf/webpack.config.js
+++ b/development/conf/webpack.config.js
@@ -46,16 +46,7 @@ const GlobalWebpackConfig = {
                 use: [
                     { loader: 'style-loader' },
                     { loader: 'css-loader' },
-                    {
-                        loader: 'less-loader',
-                        options: {
-                            globalVars: {
-                                nodeModulesPath: '\'~\'',
-                                coreModulePath: '\'~\''
-                            },
-                            include: path.resolve(__dirname, '../')
-                        }
-                    }
+                    { loader: 'less-loader' }
                 ]
             }
         ]

--- a/examples/cra/less.json
+++ b/examples/cra/less.json
@@ -1,0 +1,5 @@
+{
+  "watchFolder": "src",
+  "outputFolder": "src",
+  "plugins": "npm-import=\"prefix=~\""
+}

--- a/examples/cra/package.json
+++ b/examples/cra/package.json
@@ -19,15 +19,17 @@
   "scripts": {
     "start:js": "react-scripts start",
     "build:js": "react-scripts build",
-    "start:css": "autoless src",
-    "build:css": "autoless --no-watch src",
+    "start:css": "less-watch-compiler --config less.json",
+    "build:css": "less-watch-compiler --run-once --config less.json",
     "start": "npm-run-all -p start:*",
     "build": "npm run build:css && npm run build:js",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
   "devDependencies": {
-    "autoless": "^0.1.7",
+    "less": "^3.5.2",
+    "less-plugin-npm-import": "^2.1.0",
+    "less-watch-compiler": "^1.11.3",
     "npm-run-all": "^4.0.2"
   }
 }

--- a/examples/cra/src/index.less
+++ b/examples/cra/src/index.less
@@ -1,16 +1,10 @@
-@coreModulePath: "./../node_modules/";
-@nodeModulesPath: "./../node_modules/";
-
-@frontendModuler: "@{nodeModulesPath}nav-frontend-";
-@indexFil: "-style/src/index";
-
 body {
   margin: 0;
   padding: 0;
   font-family: sans-serif;
 }
 
-@import "@{frontendModuler}typografi@{indexFil}";
-@import "@{frontendModuler}skjema@{indexFil}";
-@import "@{frontendModuler}knapper@{indexFil}";
+@import "~nav-frontend-typografi-style";
+@import "~nav-frontend-skjema-style";
+@import "~nav-frontend-knapper-style";
 

--- a/examples/legacy/package.json
+++ b/examples/legacy/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "clean": "rimraf out",
-    "build:less": "lessc src/index.less out/index.css",
+    "build:less": "lessc --npm-import=\"prefix=~\" src/index.less out/index.css",
     "build:js": "browserify src/index.js -o out/index.js -p [ browserify-file-filter -p \"\\.(?:css|less|scss|sass)$\" ]",
     "build:html": "copyfiles index.html out",
     "build": "npm run clean && npm run build:less && npm run build:js && npm run build:html"
@@ -17,20 +17,22 @@
     "browserify-file-filter": "^1.0.0",
     "copyfiles": "^1.2.0",
     "less": "^2.7.2",
+    "less-plugin-npm-import": "^2.1.0",
     "rimraf": "^2.6.1"
   },
   "dependencies": {
     "babel-polyfill": "^6.23.0",
     "babel-runtime": "^6.23.0",
     "classnames": "^2.2.5",
-    "nav-frontend-core": "^2.0.4",
-    "nav-frontend-etiketter": "0.0.2",
-    "nav-frontend-etiketter-style": "0.0.2",
-    "nav-frontend-ikoner-assets": "0.0.3",
-    "nav-frontend-paneler": "0.0.2",
-    "nav-frontend-paneler-style": "0.0.2",
-    "nav-frontend-typografi": "0.0.2",
-    "nav-frontend-typografi-style": "0.0.2",
+    "nav-frontend-core": "^4.0.5",
+    "nav-frontend-etiketter": "1.0.7",
+    "nav-frontend-etiketter-style": "0.3.5",
+    "nav-frontend-ikoner-assets": "0.2.27",
+    "nav-frontend-paneler": "1.0.7",
+    "nav-frontend-paneler-style": "0.3.9",
+    "nav-frontend-typografi": "2.0.5",
+    "nav-frontend-typografi-style": "1.0.9",
+    "prop-types": "15.5.10",
     "react": "^15.4.2",
     "react-dom": "^15.4.2"
   }

--- a/examples/legacy/src/index.less
+++ b/examples/legacy/src/index.less
@@ -1,6 +1,4 @@
-@nodeModulesPath: './../node_modules';
-@coreModulePath: './../node_modules';
-
-@import '@{nodeModulesPath}/nav-frontend-typografi-style/src/index';
-@import '@{nodeModulesPath}/nav-frontend-etiketter-style/src/index';
-@import '@{nodeModulesPath}/nav-frontend-paneler-style/src/index';
+@import '~nav-frontend-core/less/core';
+@import '~nav-frontend-typografi-style';
+@import '~nav-frontend-etiketter-style';
+@import '~nav-frontend-paneler-style';

--- a/examples/webpack/webpack.config.style.js
+++ b/examples/webpack/webpack.config.style.js
@@ -8,7 +8,7 @@ module.exports = {
     },
     module: {
         loaders: [
-            { test: /\.less$/, loader: ['style-loader', 'css-loader', 'less-loader?{"globalVars":{"nodeModulesPath":"\'~\'", "coreModulePath":"\'~\'"}}'] }
+            { test: /\.less$/, loader: ['style-loader', 'css-loader', 'less-loader'] }
         ]
     }
 };

--- a/guideline-app/conf/_webpack.global.js
+++ b/guideline-app/conf/_webpack.global.js
@@ -42,16 +42,7 @@ const GlobalWebpackConfig = {
                 use: [
                     { loader: 'style-loader' },
                     { loader: 'css-loader' },
-                    {
-                        loader: 'less-loader',
-                        options: {
-                            globalVars: {
-                                nodeModulesPath: '\'~\'',
-                                coreModulePath: '\'~\''
-                            },
-                            include: path.resolve(__dirname, '../')
-                        }
-                    }
+                    { loader: 'less-loader' }
                 ]
             },
             {

--- a/packages/node_modules/nav-frontend-alertstriper-style/src/index.less
+++ b/packages/node_modules/nav-frontend-alertstriper-style/src/index.less
@@ -1,5 +1,5 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import (reference) '@{nodeModulesPath}nav-frontend-paneler-style/src/mixins';
+@import (reference) '~nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-paneler-style/src/mixins';
 
 .alertstripe {
   .panel-mixin();

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
@@ -1,6 +1,6 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import (reference) '@{nodeModulesPath}nav-frontend-chevron-style/src/mixins';
-@import (reference) '@{nodeModulesPath}nav-frontend-paneler-style/src/mixins';
+@import (reference) '~nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-chevron-style/src/mixins';
+@import (reference) '~nav-frontend-paneler-style/src/mixins';
 
 .ekspanderbartPanel {
   &__hode {

--- a/packages/node_modules/nav-frontend-etiketter-style/src/index.less
+++ b/packages/node_modules/nav-frontend-etiketter-style/src/index.less
@@ -1,4 +1,4 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-core/less/_variabler';
 @import './_mixins';
 
 

--- a/packages/node_modules/nav-frontend-grid-style/src/index.less
+++ b/packages/node_modules/nav-frontend-grid-style/src/index.less
@@ -1,5 +1,5 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_mixins';
+@import (reference) '~nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-core/less/_mixins';
 @import './mixins';
 
 //

--- a/packages/node_modules/nav-frontend-hjelpetekst-style/src/hjelpetekst-style.less
+++ b/packages/node_modules/nav-frontend-hjelpetekst-style/src/hjelpetekst-style.less
@@ -1,9 +1,9 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_mixins';
-@import (reference) '@{coreModulePath}nav-frontend-core/less/scaffolding';
-@import (reference) '@{nodeModulesPath}nav-frontend-lukknapp-style/src/lukknapp-style';
-@import (reference) '@{nodeModulesPath}nav-frontend-typografi-style/src/index';
-@import (reference) '@{nodeModulesPath}nav-frontend-lenker-style/src/lenker-mixins';
+@import (reference) '~nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-core/less/_mixins';
+@import (reference) '~nav-frontend-core/less/scaffolding';
+@import (reference) '~nav-frontend-lukknapp-style/src/lukknapp-style';
+@import (reference) '~nav-frontend-typografi-style/src/index';
+@import (reference) '~nav-frontend-lenker-style/src/lenker-mixins';
 
 @desktop: ~'only screen and (min-width: 480px)';
 

--- a/packages/node_modules/nav-frontend-knapper-style/src/index.less
+++ b/packages/node_modules/nav-frontend-knapper-style/src/index.less
@@ -1,5 +1,5 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import (reference) '@{nodeModulesPath}nav-frontend-typografi-style/src/index';
+@import (reference) '~nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-typografi-style/src/index';
 @import './mixins';
 
 .knapp {

--- a/packages/node_modules/nav-frontend-lenkepanel-style/src/index.less
+++ b/packages/node_modules/nav-frontend-lenkepanel-style/src/index.less
@@ -1,6 +1,6 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import (reference) '@{nodeModulesPath}nav-frontend-chevron-style/src/mixins';
-@import (reference) '@{nodeModulesPath}nav-frontend-paneler-style/src/mixins';
+@import (reference) '~nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-chevron-style/src/mixins';
+@import (reference) '~nav-frontend-paneler-style/src/mixins';
 
 .lenkepanel {
   margin-bottom: 1rem;

--- a/packages/node_modules/nav-frontend-lenker-style/src/lenker-mixins.less
+++ b/packages/node_modules/nav-frontend-lenker-style/src/lenker-mixins.less
@@ -1,4 +1,4 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-core/less/_variabler';
 
 .lenke-mixin() {
   color: @navBla;

--- a/packages/node_modules/nav-frontend-lukknapp-style/src/lukknapp-style.less
+++ b/packages/node_modules/nav-frontend-lukknapp-style/src/lukknapp-style.less
@@ -1,5 +1,5 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import (reference) '@{coreModulePath}nav-frontend-core/less/hide-text';
+@import (reference) '~nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-core/less/hide-text';
 
 .lukknapp {
   .hide-text();

--- a/packages/node_modules/nav-frontend-modal-style/src/index.less
+++ b/packages/node_modules/nav-frontend-modal-style/src/index.less
@@ -1,6 +1,6 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/hide-text';
-@import (reference) '@{nodeModulesPath}nav-frontend-paneler-style/src/mixins';
-@import (reference) '@{nodeModulesPath}nav-frontend-lukknapp-style/src/lukknapp-style';
+@import (reference) '~nav-frontend-core/less/hide-text';
+@import (reference) '~nav-frontend-paneler-style/src/mixins';
+@import (reference) '~nav-frontend-lukknapp-style/src/lukknapp-style';
 
 .ReactModal__Body--open {
   overflow: hidden;

--- a/packages/node_modules/nav-frontend-paneler-style/src/index.less
+++ b/packages/node_modules/nav-frontend-paneler-style/src/index.less
@@ -1,5 +1,4 @@
-// lesshint propertyOrdering: false
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-core/less/_variabler';
 @import (reference) 'mixins';
 
 .panel {

--- a/packages/node_modules/nav-frontend-skjema-style/src/index.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/index.less
@@ -1,5 +1,5 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import (reference) '@{nodeModulesPath}nav-frontend-typografi-style/src/index';
+@import (reference) '~nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-typografi-style/src/index';
 
 [autocomplete='off']::-webkit-contacts-auto-fill-button {
   visibility: hidden;

--- a/packages/node_modules/nav-frontend-skjema-style/src/toggle.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/toggle.less
@@ -1,5 +1,5 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/core';
-@import (reference) '@{nodeModulesPath}nav-frontend-typografi-style/src/index';
+@import (reference) '~nav-frontend-core/less/core';
+@import (reference) '~nav-frontend-typografi-style/src/index';
 
 .toggle {
   display: flex;

--- a/packages/node_modules/nav-frontend-snakkeboble-style/src/snakkeboble-style.less
+++ b/packages/node_modules/nav-frontend-snakkeboble-style/src/snakkeboble-style.less
@@ -1,7 +1,7 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_mixins';
-@import (reference) '@{coreModulePath}nav-frontend-core/less/utilities';
-@import (reference) '@{coreModulePath}nav-frontend-core/less/hide-text';
+@import (reference) '~nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-core/less/_mixins';
+@import (reference) '~nav-frontend-core/less/utilities';
+@import (reference) '~nav-frontend-core/less/hide-text';
 
 .snakkeboble {
   display: flex;

--- a/packages/node_modules/nav-frontend-stegindikator-style/src/index.less
+++ b/packages/node_modules/nav-frontend-stegindikator-style/src/index.less
@@ -1,4 +1,4 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-core/less/_variabler';
 
 @hvit: @white; //deprecated in core
 @aktivBlaa: @navDypBla;

--- a/packages/node_modules/nav-frontend-tabell-style/src/index.less
+++ b/packages/node_modules/nav-frontend-tabell-style/src/index.less
@@ -1,46 +1,4 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
-
-// troligen generelle ting
-//tr,
-//img {
-//	page-break-inside: avoid;
-//}
-//
-//th,
-//td {
-//	vertical-align: top;
-//	line-height: 1.42857143;
-//	padding: 8px;
-//  text-align: center;
-//}
-//
-//td:first-child,
-//th {
-//  text-align: left;
-//}
-//
-//thead tr:first-child th {
-//	text-align: left;
-//}
-//
-//a {
-//  color: @navBla;
-//  text-decoration: none;
-//  border-bottom: 1px dashed @navBla;
-//
-//  &:hover {
-//    border-bottom-style: dashed;
-//  }
-//
-//  &:focus {
-//    background-color: @orangeFocus;
-//    outline: none;
-//  }
-//
-//  &:active {
-//    color: @navLilla;
-//  }
-//}
+@import (reference) '~nav-frontend-core/less/_variabler';
 
 // tabell-spesifike ting
 .tabell-enkel {

--- a/packages/node_modules/nav-frontend-tabs-style/src/tabs-style.less
+++ b/packages/node_modules/nav-frontend-tabs-style/src/tabs-style.less
@@ -1,4 +1,4 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-core/less/_variabler';
 
 .nav-frontend-tabs {
   border-bottom: 1px solid @navGra20;

--- a/packages/node_modules/nav-frontend-typografi-style/src/index.less
+++ b/packages/node_modules/nav-frontend-typografi-style/src/index.less
@@ -1,4 +1,4 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-core/less/_variabler';
 @import 'fontimports';
 @import 'mixins';
 

--- a/packages/node_modules/nav-frontend-veileder-style/src/index.less
+++ b/packages/node_modules/nav-frontend-veileder-style/src/index.less
@@ -1,4 +1,4 @@
-@import (reference) '@{coreModulePath}nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-core/less/_variabler';
 
 .nav-frontend-veileder {
   position: relative;


### PR DESCRIPTION
Removes all occurences of `nodeModulesPath` and `coreModulePath`, and replacing these with `~`.

Non-breaking for those who use `less-loader`.
Breaking for those who use `lessc`, `autoless` or similar. These needs a plugin `less-plugin-npm-import` in order to understand `~`. Necessary changes can be seen in the changes to the examples in this PR.

**NB** Example-setups will not work until the new versions are published and
the nav-frontend-depencencies are bumped.