### PR TITLE
Fikser imports, syntax feil på Lukknapp, Tekstomrade, Snakkeboble, Hjelpetekst

### DIFF
--- a/packages/node_modules/nav-frontend-hjelpetekst/src/hjelpetekst.tsx
+++ b/packages/node_modules/nav-frontend-hjelpetekst/src/hjelpetekst.tsx
@@ -177,7 +177,7 @@ class HjelpetekstBase extends React.Component<HjelpetekstProps, State> {
     }
 
     stateChange(state, value) {
-        return () => this.setState({ [state]: value });
+        return () => this.setState({ [state]: value } as any);
     }
 
     renderContent() {

--- a/packages/node_modules/nav-frontend-lukknapp/src/lukknapp.tsx
+++ b/packages/node_modules/nav-frontend-lukknapp/src/lukknapp.tsx
@@ -1,4 +1,4 @@
-import { PropTypes as PT } from 'prop-types';
+import * as PT from 'prop-types';
 import * as React from 'react';
 import * as classNames from 'classnames';
 

--- a/packages/node_modules/nav-frontend-snakkeboble/src/snakkeboble.tsx
+++ b/packages/node_modules/nav-frontend-snakkeboble/src/snakkeboble.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { PropTypes as PT } from 'prop-types';
+import * as PT from 'prop-types';
 import 'nav-frontend-snakkeboble-style';
 import { Panel } from 'nav-frontend-paneler';
 import { Undertekst } from 'nav-frontend-typografi';

--- a/packages/node_modules/nav-frontend-tekstomrade/src/fragments.tsx
+++ b/packages/node_modules/nav-frontend-tekstomrade/src/fragments.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PT from 'prop-types';
+import * as PT from 'prop-types';
 import Lenke from 'nav-frontend-lenker';
 
 const httpRegex = /^(https?):\/\/.*$/;


### PR DESCRIPTION
Fikser feil som av en eller annen grunn ikke har blitt avdekket tidligere, men som resulterte i byggfeil etter å ha fjernet `node_modules` og `package-lock.json` og kjørt ny `npm install`.