### PR TITLE
Set value on RadioPanel from required prop

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
@@ -58,8 +58,8 @@ export class RadioPanel extends React.Component<RadioPanelProps, RadioPanelState
         return (
             <label className={cls} htmlFor={inputId}>
                 <input
-                    {...inputProps}
                     value={value}
+                    {...inputProps}
                     id={inputId}
                     className="inputPanel__field"
                     type="radio"

--- a/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
@@ -45,7 +45,7 @@ export class RadioPanel extends React.Component<RadioPanelProps, RadioPanelState
     }
 
     render() {
-        const { id, checked, disabled, label, name, onChange, inputProps } = this.props;
+        const { id, checked, disabled, label, name, onChange, inputProps, value } = this.props;
         const { hasFocus } = this.state;
         const inputId = id || guid();
 
@@ -59,6 +59,7 @@ export class RadioPanel extends React.Component<RadioPanelProps, RadioPanelState
             <label className={cls} htmlFor={inputId}>
                 <input
                     {...inputProps}
+                    value={value}
                     id={inputId}
                     className="inputPanel__field"
                     type="radio"


### PR DESCRIPTION
Komponenten har påkrevd value prop, men denne settes aldri på <input /> elementet. PR kan få konsekvenser i og med en tidligere har måttet sette denne verdien gjennom radioProps - denne vil nå bli overskrevet av value prop. Men mest sannsynlig har disse vært samme verdi. 

Muligens vurdere om det er breaking change, og dermed bumpe versjonsnummeret tilsvarende? 