### PR TITLE
CheckboksPanel subtext

### DIFF
--- a/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
@@ -50,6 +50,11 @@
     }
   }
 
+  &__subtext {
+    display: block;
+    margin-top: 0.5rem;
+  }
+
   &--checked {
     background-color: rgba(0, 103, 197, 0.2);
     border: 1px solid transparent;

--- a/packages/node_modules/nav-frontend-skjema/sample/_checkbokspanelgruppe.sample.js
+++ b/packages/node_modules/nav-frontend-skjema/sample/_checkbokspanelgruppe.sample.js
@@ -10,7 +10,7 @@ export default generateSample({
             { label: 'Eplejuice', value: 'juice1', id: 'juice1id' },
             { label: 'Appelsinjuice', value: 'juice2', id: 'juice2id' },
             { label: 'Melk', value: 'melk', disabled: true, id: 'melkid' },
-            { label: 'Ananasjuice', value: 'juice3', id: 'juice4id' }
+            { label: 'Ananasjuice', value: 'juice3', id: 'juice4id', subtext: 'Subtext example' }
         ],
         onChange: () => {}
     }

--- a/packages/node_modules/nav-frontend-skjema/src/checkboks-panel.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/checkboks-panel.tsx
@@ -7,6 +7,7 @@ import 'nav-frontend-skjema-style';
 export interface CheckboksProps {
     checked: boolean;
     label: string;
+    subtext?: string;
     value?: string;
     id?: string;
     disabled?: boolean;
@@ -46,7 +47,7 @@ export class CheckboksPanel extends React.Component<CheckboksPanelProps, Checkbo
     }
 
     render() {
-        const { id, label, onChange, inputProps, disabled } = this.props;
+        const { id, label, subtext, onChange, inputProps, disabled } = this.props;
         const { hasFocus, checked } = this.state;
         const inputId = id || guid();
 
@@ -71,6 +72,7 @@ export class CheckboksPanel extends React.Component<CheckboksPanelProps, Checkbo
                     onChange={this.handleChange}
                 />
                 <span className="inputPanel__label">{label}</span>
+                {subtext && <span className="inputPanel__subtext">{subtext}</span>}
             </label>
         );
     }


### PR DESCRIPTION
Add optional subtext-prop (string) to CheckboksPanel component that renders in a span
on the row below the original label text.