### PR TITLE
Fjern overflødige peerDependencies fra style-pakker

### DIFF
--- a/packages/node_modules/nav-frontend-hjelpetekst-style/README.md
+++ b/packages/node_modules/nav-frontend-hjelpetekst-style/README.md
@@ -3,7 +3,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-hjelpetekst-style babel-polyfill babel-runtime classnames nav-frontend-core nav-frontend-lenker-style nav-frontend-lukknapp-style nav-frontend-typografi-style react --save
+npm install nav-frontend-hjelpetekst-style nav-frontend-core nav-frontend-lenker-style nav-frontend-lukknapp-style nav-frontend-typografi-style --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 

--- a/packages/node_modules/nav-frontend-hjelpetekst-style/package.json
+++ b/packages/node_modules/nav-frontend-hjelpetekst-style/package.json
@@ -19,13 +19,9 @@
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
-    "babel-polyfill": "^6.26.0",
-    "babel-runtime": "^6.22.0",
-    "classnames": "^2.2.5",
     "nav-frontend-core": "^4.0.2",
     "nav-frontend-lenker-style": "^0.2.16",
     "nav-frontend-lukknapp-style": "^0.2.16",
-    "nav-frontend-typografi-style": "^1.0.10",
-    "react": "^15.4.2 || ^16.0.0"
+    "nav-frontend-typografi-style": "^1.0.10"
   }
 }

--- a/packages/node_modules/nav-frontend-hjelpetekst/README.md
+++ b/packages/node_modules/nav-frontend-hjelpetekst/README.md
@@ -3,7 +3,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-hjelpetekst classnames nav-frontend-hjelpetekst-style babel-polyfill babel-runtime nav-frontend-core nav-frontend-lenker-style nav-frontend-lukknapp-style nav-frontend-typografi-style react nav-frontend-ikoner-assets nav-frontend-lukknapp prop-types nav-frontend-typografi --save
+npm install nav-frontend-hjelpetekst classnames nav-frontend-hjelpetekst-style nav-frontend-core nav-frontend-lenker-style nav-frontend-lukknapp-style nav-frontend-typografi-style nav-frontend-ikoner-assets nav-frontend-lukknapp prop-types react nav-frontend-typografi --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 

--- a/packages/node_modules/nav-frontend-lenkepanel-style/README.md
+++ b/packages/node_modules/nav-frontend-lenkepanel-style/README.md
@@ -3,7 +3,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-lenkepanel-style nav-frontend-chevron-style nav-frontend-core nav-frontend-paneler-style react --save
+npm install nav-frontend-lenkepanel-style nav-frontend-chevron-style nav-frontend-core nav-frontend-paneler-style --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 

--- a/packages/node_modules/nav-frontend-lenkepanel-style/package.json
+++ b/packages/node_modules/nav-frontend-lenkepanel-style/package.json
@@ -13,8 +13,7 @@
   "peerDependencies": {
     "nav-frontend-chevron-style": "^0.3.4",
     "nav-frontend-core": "^4.0.2",
-    "nav-frontend-paneler-style": "^0.3.10",
-    "react": "^15.4.2 || ^16.0.0"
+    "nav-frontend-paneler-style": "^0.3.10"
   },
   "devDependencies": {
     "nav-frontend-chevron-style": "^0.3.4",

--- a/packages/node_modules/nav-frontend-lenkepanel/README.md
+++ b/packages/node_modules/nav-frontend-lenkepanel/README.md
@@ -3,7 +3,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-lenkepanel babel-polyfill classnames nav-frontend-lenkepanel-style nav-frontend-chevron-style nav-frontend-core nav-frontend-paneler-style react nav-frontend-typografi nav-frontend-typografi-style prop-types --save
+npm install nav-frontend-lenkepanel babel-polyfill classnames nav-frontend-lenkepanel-style nav-frontend-chevron-style nav-frontend-core nav-frontend-paneler-style nav-frontend-typografi nav-frontend-typografi-style prop-types react --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 
@@ -15,7 +15,7 @@ Default implementasjonen gir bare en bare `a`-tag, men her har man ta mulighet t
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-lenkepanel babel-polyfill classnames nav-frontend-lenkepanel-style nav-frontend-chevron-style nav-frontend-core nav-frontend-paneler-style react nav-frontend-typografi nav-frontend-typografi-style prop-types --save
+npm install nav-frontend-lenkepanel babel-polyfill classnames nav-frontend-lenkepanel-style nav-frontend-chevron-style nav-frontend-core nav-frontend-paneler-style nav-frontend-typografi nav-frontend-typografi-style prop-types react --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 

--- a/packages/node_modules/nav-frontend-modal-style/README.md
+++ b/packages/node_modules/nav-frontend-modal-style/README.md
@@ -3,7 +3,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-modal-style nav-frontend-core nav-frontend-lukknapp-style nav-frontend-paneler-style react --save
+npm install nav-frontend-modal-style nav-frontend-core nav-frontend-lukknapp-style nav-frontend-paneler-style --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 

--- a/packages/node_modules/nav-frontend-modal-style/package.json
+++ b/packages/node_modules/nav-frontend-modal-style/package.json
@@ -13,8 +13,7 @@
   "peerDependencies": {
     "nav-frontend-core": "^4.0.2",
     "nav-frontend-lukknapp-style": "^0.2.16",
-    "nav-frontend-paneler-style": "^0.3.10",
-    "react": "^15.4.2 || ^16.0.0"
+    "nav-frontend-paneler-style": "^0.3.10"
   },
   "devDependencies": {
     "nav-frontend-core": "^4.0.2",

--- a/packages/node_modules/nav-frontend-stegindikator-style/README.md
+++ b/packages/node_modules/nav-frontend-stegindikator-style/README.md
@@ -3,7 +3,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-stegindikator-style nav-frontend-core nav-frontend-typografi-style react --save
+npm install nav-frontend-stegindikator-style nav-frontend-core nav-frontend-typografi-style --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 

--- a/packages/node_modules/nav-frontend-stegindikator-style/package.json
+++ b/packages/node_modules/nav-frontend-stegindikator-style/package.json
@@ -8,8 +8,7 @@
   ],
   "peerDependencies": {
     "nav-frontend-core": "^4.0.2",
-    "nav-frontend-typografi-style": "^1.0.10",
-    "react": "^15.4.2 || ^16.0.0"
+    "nav-frontend-typografi-style": "^1.0.10"
   },
   "devDependencies": {
     "nav-frontend-core": "^4.0.2",

--- a/packages/node_modules/nav-frontend-tabell-style/README.md
+++ b/packages/node_modules/nav-frontend-tabell-style/README.md
@@ -3,7 +3,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-tabell-style nav-frontend-core react --save
+npm install nav-frontend-tabell-style nav-frontend-core --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 

--- a/packages/node_modules/nav-frontend-tabell-style/package.json
+++ b/packages/node_modules/nav-frontend-tabell-style/package.json
@@ -11,8 +11,7 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.2",
-    "react": "^15.4.2 || ^16.0.0"
+    "nav-frontend-core": "^4.0.2"
   },
   "devDependencies": {
     "nav-frontend-core": "^4.0.2",

--- a/packages/node_modules/nav-frontend-veileder-style/README.md
+++ b/packages/node_modules/nav-frontend-veileder-style/README.md
@@ -3,7 +3,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-veileder-style nav-frontend-core react --save
+npm install nav-frontend-veileder-style nav-frontend-core --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 

--- a/packages/node_modules/nav-frontend-veileder-style/package.json
+++ b/packages/node_modules/nav-frontend-veileder-style/package.json
@@ -11,7 +11,6 @@
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.2",
-    "react": "^15.4.2 || ^16.0.0"
+    "nav-frontend-core": "^4.0.2"
   }
 }

--- a/packages/node_modules/nav-frontend-veileder/README.md
+++ b/packages/node_modules/nav-frontend-veileder/README.md
@@ -3,7 +3,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-veileder classnames nav-frontend-veileder-style nav-frontend-core react prop-types --save
+npm install nav-frontend-veileder classnames nav-frontend-veileder-style nav-frontend-core prop-types react --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 

--- a/packages/node_modules/nav-frontend-veilederpanel-style/README.md
+++ b/packages/node_modules/nav-frontend-veilederpanel-style/README.md
@@ -3,7 +3,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-veilederpanel-style nav-frontend-core nav-frontend-paneler-style nav-frontend-typografi-style react --save
+npm install nav-frontend-veilederpanel-style nav-frontend-core nav-frontend-paneler-style nav-frontend-typografi-style --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 

--- a/packages/node_modules/nav-frontend-veilederpanel-style/package.json
+++ b/packages/node_modules/nav-frontend-veilederpanel-style/package.json
@@ -15,7 +15,6 @@
   "peerDependencies": {
     "nav-frontend-core": "^4.0.2",
     "nav-frontend-paneler-style": "^0.3.10",
-    "nav-frontend-typografi-style": "^1.0.10",
-    "react": "^15.4.2 || ^16.0.0"
+    "nav-frontend-typografi-style": "^1.0.10"
   }
 }

--- a/packages/node_modules/nav-frontend-veilederpanel/README.md
+++ b/packages/node_modules/nav-frontend-veilederpanel/README.md
@@ -3,7 +3,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
 ### Installering:
 ```
-npm install nav-frontend-veilederpanel nav-frontend-veileder classnames nav-frontend-veileder-style nav-frontend-core react prop-types nav-frontend-veilederpanel-style nav-frontend-paneler-style nav-frontend-typografi-style --save
+npm install nav-frontend-veilederpanel nav-frontend-veileder classnames nav-frontend-veileder-style nav-frontend-core prop-types react nav-frontend-veilederpanel-style nav-frontend-paneler-style nav-frontend-typografi-style --save
 ```
 <!-- AUTO-GENERATED-CONTENT:END *-->
 


### PR DESCRIPTION
Enkelte *-style-moduler krever React og andre peerDependencies uten å bruke disse. Dette fører til feilmeldinger hvis modulene brukes i et prosjekt uten React.