### PR TITLE
Radiopanelgruppe: Legg til css-klasser

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
@@ -18,6 +18,7 @@ export interface RadioPanelGruppeProps {
     name: string;
     legend: string;
     onChange: (event: React.SyntheticEvent<EventTarget>, value: string) => void;
+    className?: string;
     checked?: string;
     feil?: SkjemaelementFeil;
 }
@@ -79,19 +80,22 @@ export class RadioPanel extends React.Component<RadioPanelProps, RadioPanelState
 
 class RadioPanelGruppe extends React.Component<RadioPanelGruppeProps> {
     render() {
-        const { radios, name, legend, feil, checked, onChange } = this.props;
+        const { radios, name, legend, feil, checked, onChange, className } = this.props;
+        const cls = classNames('inputPanelGruppe', className);
         return (
-            <SkjemaGruppe className="inputPanelGruppe" feil={feil}>
+            <SkjemaGruppe className={cls} feil={feil}>
                 <Fieldset legend={legend}>
-                    {radios.map((radio: RadioProps) => (
-                        <RadioPanel
-                            name={name}
-                            key={`${name}-${radio.value}`}
-                            checked={checked === radio.value}
-                            onChange={(event: React.SyntheticEvent<EventTarget>) => onChange(event, radio.value)}
-                            {...radio}
-                        />
-                    ))}
+                    <div className="inputPanelGruppe__inner">
+                        {radios.map((radio: RadioProps) => (
+                            <RadioPanel
+                                name={name}
+                                key={`${name}-${radio.value}`}
+                                checked={checked === radio.value}
+                                onChange={(event: React.SyntheticEvent<EventTarget>) => onChange(event, radio.value)}
+                                {...radio}
+                            />
+                        ))}
+                    </div>
                 </Fieldset>
             </SkjemaGruppe>
         );
@@ -103,6 +107,7 @@ class RadioPanelGruppe extends React.Component<RadioPanelGruppeProps> {
     name: PT.string.isRequired,
     legend: PT.string.isRequired,
     onChange: PT.func.isRequired,
+    className: PT.string,
     feil: skjemaelementFeilmeldingShape
 };
 


### PR DESCRIPTION
Lagt på en indre div på radiopanelgruppe innenfor fieldset slik at man kan styre css-en til radioknappene. Mulighet for å sende med css-klasser til radiopanelgruppe-komponenten