### PR TITLE
Legger til quickfix for radiopanel: viser eksplisitt blå bakgrunn og hvit "checked" når en ikke hovrer over panelet

### DIFF
--- a/packages/node_modules/nav-frontend-skjema-style/src/radio-panel.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/radio-panel.less
@@ -5,7 +5,8 @@
     &--checked {
       cursor: default;
 
-      &:hover:not(.inputPanel--disabled) {
+      &:hover:not(.inputPanel--disabled),
+      &:not(:hover):not(.inputPanel--disabled) {
         background-color: rgba(0, 103, 197, 0.2);
         border: 1px solid transparent;
         box-shadow: none;


### PR DESCRIPTION
På et radiopanel forsvinner blå bakgrunn og hvit "checker" når jeg ikke hovrer over panelet. Før #383 var det ikke synlig i det hele tatt.