### PR TITLE
Fikser rar position bug på Checkbox/Radio i flex-kontainere med scroll

### DIFF
--- a/packages/node_modules/nav-frontend-skjema-style/src/index.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/index.less
@@ -38,6 +38,7 @@
 
   &--horisontal {
     margin-bottom: 1rem;
+    position: relative;
   }
 }
 


### PR DESCRIPTION
I en litt rar edge case der man har satt opp en `flex`-basert layout som har kolonner i 100% høyde med `overflow-y: scroll` så kan `input`-elementet internt i `Checkbox`- og `Radio`-komponentene få noen rare posisjoner mens man scroller i innholdet:

<img width="613" alt="screen shot 2018-10-17 at 15 32 35" src="https://user-images.githubusercontent.com/74510/47092399-346e4700-d227-11e8-8756-8fbd4d12fc2f.png">

Husker at @winsvold meldte ifra om en annen rar feil for en stund tilbake der sidens layout plutselig "hoppet" når man klikket på checkboksene også (ref. [Slack-melding](https://nav-it.slack.com/archives/C6HJFRRMY/p1534317060000100)). Virker som det var relatert til dette:

![checkbox](https://user-images.githubusercontent.com/74510/47092887-47354b80-d228-11e8-80c4-67af6cfa6af0.gif)

Denne endringen ser ut til å fikse begge disse feilene.