### PR TITLE
Fikser border-radius på Ekspanderbartpanel innhold

### DIFF
--- a/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
@@ -59,7 +59,7 @@
       border-bottom-right-radius: 0;
     }
 
-    >.ekspanderbartPanel__innhold {
+    .ekspanderbartPanel__innhold {
       border-top-left-radius: 0;
       border-top-right-radius: 0;
     }


### PR DESCRIPTION
Fikser dette:

<img width="686" alt="screen shot 2018-10-18 at 13 24 54" src="https://user-images.githubusercontent.com/74510/47151495-39400300-d2da-11e8-877b-d5d2f50dce29.png">

Til dette:

<img width="688" alt="screen shot 2018-10-18 at 13 33 01" src="https://user-images.githubusercontent.com/74510/47151573-642a5700-d2da-11e8-819f-2bb29c05be2c.png">
