### PR TITLE
Rendre innhold når EkspanderbartPanel er lukket

### DIFF
--- a/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
@@ -25,10 +25,6 @@
     }
   }
 
-  &__hiddenContent {
-    display: none;
-  }
-
   &__flex-wrapper { // Safari ~9 bug, button/fieldset kan ikke ha flex
     display: flex;
     align-items: center;

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
@@ -24,6 +24,9 @@
       }
     }
   }
+  &__hiddenContent {
+    display: none;
+  }
 
   &__flex-wrapper { // Safari ~9 bug, button/fieldset kan ikke ha flex
     display: flex;

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
@@ -24,6 +24,7 @@
       }
     }
   }
+
   &__hiddenContent {
     display: none;
   }

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as classnames from 'classnames';
 import { UnmountClosed as Collapse, CollapseProps } from 'react-collapse';
 import 'nav-frontend-ekspanderbartpanel-style';
+import { guid } from 'nav-frontend-js-utils';
 
 export interface EkspanderbartpanelBasePureProps {
     heading: React.ReactNode;
@@ -68,6 +69,7 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
         }: EkspanderbartpanelBasePureProps = this.props;
 
         const renderHiddenContent = renderContentWhenClosed && apen === false;
+        const hiddenContentId = guid();
         return (
             <div className={cls(apen, border!, className)} {...renderProps}>
                 <button
@@ -75,6 +77,8 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
                     onKeyDown={(event) => this.tabHandler(event)}
                     onClick={onClick}
                     aria-expanded={apen}
+                    aria-controls={renderHiddenContent ? hiddenContentId : undefined}
+                    role={renderHiddenContent ? 'tab' : undefined}
                     type="button"
                 >
                     <div className="ekspanderbartPanel__flex-wrapper">
@@ -82,12 +86,20 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
                         <span className="ekspanderbartPanel__indikator" />
                     </div>
                 </button>
-                <Collapse isOpened={apen} onRest={this.onRestProxy} {...collapseProps}>
+                <Collapse
+                    isOpened={apen}
+                    onRest={this.onRestProxy}
+                    {...collapseProps}
+                >
                     <article aria-label={ariaTittel} className="ekspanderbartPanel__innhold">
                         {children}
                     </article>
                 </Collapse>
-                {renderHiddenContent && <div className="ekspanderbartPanel__hiddenContent">{children}</div>}
+                {renderHiddenContent &&
+                    <div role="tabpanel" className="ekspanderbartPanel__hiddenContent" id={hiddenContentId}>
+                        {children}
+                    </div>
+                }
             </div>
         );
     }

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
@@ -24,11 +24,16 @@ const cls = (apen: boolean, border: boolean, className?: string) =>
     });
 
 class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBasePureProps, {}> {
+    componentId: string;
     static defaultProps: Partial<EkspanderbartpanelBasePureProps> = {
         border: false
     };
-
     private isCloseAnimation: boolean = false;
+
+    constructor(props: EkspanderbartpanelBasePureProps) {
+        super(props);
+        this.componentId = guid();
+    }
 
     componentWillReceiveProps(nextProps) {
         if (this.props.apen && !nextProps.apen) {
@@ -68,9 +73,8 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
             ...renderProps
         }: EkspanderbartpanelBasePureProps = this.props;
 
-        const renderHiddenContent = renderContentWhenClosed && !apen;
-        const hiddenContentId = (collapseProps && collapseProps.id) || guid();
-        const CollapseComponent = renderHiddenContent ? Collapse : UnmountClosed;
+        const hiddenContentId = (collapseProps && collapseProps.id) || this.componentId;
+        const CollapseComponent = renderContentWhenClosed ? Collapse : UnmountClosed;
         return (
             <div className={cls(apen, border!, className)} {...renderProps}>
                 <button
@@ -78,7 +82,7 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
                     onKeyDown={(event) => this.tabHandler(event)}
                     onClick={onClick}
                     aria-expanded={apen}
-                    aria-controls={renderHiddenContent ? hiddenContentId : undefined}
+                    aria-controls={renderContentWhenClosed ? hiddenContentId : undefined}
                     type="button"
                 >
                     <div className="ekspanderbartPanel__flex-wrapper">
@@ -87,7 +91,7 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
                     </div>
                 </button>
                 <CollapseComponent
-                    id={renderHiddenContent ? undefined : hiddenContentId}
+                    id={renderContentWhenClosed ? hiddenContentId : undefined}
                     isOpened={apen}
                     onRest={this.onRestProxy}
                     {...collapseProps}

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
@@ -24,7 +24,7 @@ const cls = (apen: boolean, border: boolean, className?: string) =>
     });
 
 class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBasePureProps, {}> {
-    componentId: string;
+    contentId: string;
     static defaultProps: Partial<EkspanderbartpanelBasePureProps> = {
         border: false
     };
@@ -32,7 +32,7 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
 
     constructor(props: EkspanderbartpanelBasePureProps) {
         super(props);
-        this.componentId = guid();
+        this.contentId = guid();
     }
 
     componentWillReceiveProps(nextProps) {
@@ -73,16 +73,16 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
             ...renderProps
         }: EkspanderbartpanelBasePureProps = this.props;
 
-        const hiddenContentId = (collapseProps && collapseProps.id) || this.componentId;
+        const contentId = (collapseProps && collapseProps.id) || this.contentId;
         const CollapseComponent = renderContentWhenClosed ? Collapse : UnmountClosed;
         return (
-            <div className={cls(apen, border!, className)} {...renderProps}>
+            <div className={cls(apen, border!, className)} { ...renderProps }>
                 <button
                     className="ekspanderbartPanel__hode"
                     onKeyDown={(event) => this.tabHandler(event)}
                     onClick={onClick}
                     aria-expanded={apen}
-                    aria-controls={renderContentWhenClosed ? hiddenContentId : undefined}
+                    aria-controls={contentId}
                     type="button"
                 >
                     <div className="ekspanderbartPanel__flex-wrapper">
@@ -91,7 +91,7 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
                     </div>
                 </button>
                 <CollapseComponent
-                    id={renderContentWhenClosed ? hiddenContentId : undefined}
+                    id={contentId}
                     isOpened={apen}
                     onRest={this.onRestProxy}
                     {...collapseProps}

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as classnames from 'classnames';
-import { UnmountClosed as Collapse, CollapseProps } from 'react-collapse';
+import { UnmountClosed, Collapse, CollapseProps } from 'react-collapse';
 import 'nav-frontend-ekspanderbartpanel-style';
 import { guid } from 'nav-frontend-js-utils';
 
@@ -69,7 +69,8 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
         }: EkspanderbartpanelBasePureProps = this.props;
 
         const renderHiddenContent = renderContentWhenClosed && !apen;
-        const hiddenContentId = collapseProps && collapseProps.id || guid();
+        const hiddenContentId = (collapseProps && collapseProps.id) || guid();
+        const CollapseComponent = renderHiddenContent ? Collapse : UnmountClosed;
         return (
             <div className={cls(apen, border!, className)} {...renderProps}>
                 <button
@@ -85,7 +86,7 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
                         <span className="ekspanderbartPanel__indikator" />
                     </div>
                 </button>
-                <Collapse
+                <CollapseComponent
                     id={renderHiddenContent ? undefined : hiddenContentId}
                     isOpened={apen}
                     onRest={this.onRestProxy}
@@ -94,12 +95,7 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
                     <article aria-label={ariaTittel} className="ekspanderbartPanel__innhold">
                         {children}
                     </article>
-                </Collapse>
-                {renderHiddenContent &&
-                    <div className="ekspanderbartPanel__hiddenContent" id={hiddenContentId}>
-                        {children}
-                    </div>
-                }
+                </CollapseComponent>
             </div>
         );
     }

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
@@ -78,7 +78,6 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
                     onClick={onClick}
                     aria-expanded={apen}
                     aria-controls={renderHiddenContent ? hiddenContentId : undefined}
-                    role={renderHiddenContent ? 'tab' : undefined}
                     type="button"
                 >
                     <div className="ekspanderbartPanel__flex-wrapper">
@@ -96,7 +95,7 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
                     </article>
                 </Collapse>
                 {renderHiddenContent &&
-                    <div role="tabpanel" className="ekspanderbartPanel__hiddenContent" id={hiddenContentId}>
+                    <div className="ekspanderbartPanel__hiddenContent" id={hiddenContentId}>
                         {children}
                     </div>
                 }

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
@@ -69,7 +69,7 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
         }: EkspanderbartpanelBasePureProps = this.props;
 
         const renderHiddenContent = renderContentWhenClosed && !apen;
-        const hiddenContentId = guid();
+        const hiddenContentId = collapseProps && collapseProps.id || guid();
         return (
             <div className={cls(apen, border!, className)} {...renderProps}>
                 <button

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
@@ -86,6 +86,7 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
                     </div>
                 </button>
                 <Collapse
+                    id={renderHiddenContent ? undefined : hiddenContentId}
                     isOpened={apen}
                     onRest={this.onRestProxy}
                     {...collapseProps}

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
@@ -68,7 +68,7 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
             ...renderProps
         }: EkspanderbartpanelBasePureProps = this.props;
 
-        const renderHiddenContent = renderContentWhenClosed && apen === false;
+        const renderHiddenContent = renderContentWhenClosed && !apen;
         const hiddenContentId = guid();
         return (
             <div className={cls(apen, border!, className)} {...renderProps}>

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base-pure.tsx
@@ -12,10 +12,11 @@ export interface EkspanderbartpanelBasePureProps {
     children?: React.ReactNode;
     collapseProps?: Partial<CollapseProps>;
     border?: boolean;
+    renderContentWhenClosed?: boolean;
 }
 
-const cls = (apen: boolean, border: boolean, className?: string) => classnames(
-    'ekspanderbartPanel', className, {
+const cls = (apen: boolean, border: boolean, className?: string) =>
+    classnames('ekspanderbartPanel', className, {
         'ekspanderbartPanel--lukket': !apen,
         'ekspanderbartPanel--apen': apen,
         'ekspanderbartPanel--border': border
@@ -62,11 +63,13 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
             onClick,
             collapseProps,
             border,
+            renderContentWhenClosed,
             ...renderProps
         }: EkspanderbartpanelBasePureProps = this.props;
 
+        const renderHiddenContent = renderContentWhenClosed && apen === false;
         return (
-            <div className={cls(apen, border!, className)} { ...renderProps }>
+            <div className={cls(apen, border!, className)} {...renderProps}>
                 <button
                     className="ekspanderbartPanel__hode"
                     onKeyDown={(event) => this.tabHandler(event)}
@@ -79,9 +82,12 @@ class EkspanderbartpanelBasePure extends React.Component<EkspanderbartpanelBaseP
                         <span className="ekspanderbartPanel__indikator" />
                     </div>
                 </button>
-                <Collapse isOpened={apen} onRest={this.onRestProxy} {...collapseProps} >
-                    <article aria-label={ariaTittel} className="ekspanderbartPanel__innhold">{children}</article>
+                <Collapse isOpened={apen} onRest={this.onRestProxy} {...collapseProps}>
+                    <article aria-label={ariaTittel} className="ekspanderbartPanel__innhold">
+                        {children}
+                    </article>
                 </Collapse>
+                {renderHiddenContent && <div className="ekspanderbartPanel__hiddenContent">{children}</div>}
             </div>
         );
     }


### PR DESCRIPTION
På åpne sider er det behov for at innholdet er indekserbart for google, selv om panelet er lukket. Brute force variant her hvor en rendrer en egen div som har display: none, dersom en setter prop renderContentWhenClosed til true