### PR TITLE
Fix ikke load SkjemaelementFeil fra src

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/textarea-controlled.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/textarea-controlled.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PT from 'prop-types';
 import { omit } from 'nav-frontend-js-utils';
 import Textarea from './textarea';
-import { SkjemaelementFeil } from 'nav-frontend-skjema/src/skjemaelement-feilmelding';
+import { SkjemaelementFeil } from './skjemaelement-feilmelding';
 
 export interface TextareaControlledProps extends React.HTMLAttributes<HTMLTextAreaElement> {
     label: React.ReactNode;


### PR DESCRIPTION
For å fikse feilen:
ERROR in [at-loader] TS6059: File '.../node_modules/nav-frontend-skjema/src/skjemaelement-feilmelding.tsx' is not under 'rootDir' '.../src'. 'rootDir' is expected to contain all source files.