### PR TITLE
Fikser Veileder snakkeboble style bug

### DIFF
--- a/packages/node_modules/nav-frontend-veileder-style/src/index.less
+++ b/packages/node_modules/nav-frontend-veileder-style/src/index.less
@@ -214,6 +214,7 @@
     &--venstre {
       border-left: 1.25rem solid #efefef;
       border-top: 1.25rem solid transparent;
+      border-right: 0;
       margin-right: 0.75rem;
     }
   }


### PR DESCRIPTION
Fikser dette:
<img width="285" alt="screenshot 2019-01-11 at 08 17 39" src="https://user-images.githubusercontent.com/74510/51018928-8fd77900-1579-11e9-9bb9-5e66da1f182f.png">
Til dette:
<img width="266" alt="screenshot 2019-01-11 at 08 17 54" src="https://user-images.githubusercontent.com/74510/51018944-949c2d00-1579-11e9-9223-270df8887cf6.png">
