### PR TITLE
Legger til 'tabPanel' prop på Panel-komponent

### DIFF
--- a/packages/node_modules/nav-frontend-paneler-style/src/index.less
+++ b/packages/node_modules/nav-frontend-paneler-style/src/index.less
@@ -13,3 +13,7 @@
 .panel--border {
   .panel-border-mixin();
 }
+
+.panel--tabPanel {
+  .panel-tabPanel-mixin();
+}

--- a/packages/node_modules/nav-frontend-paneler-style/src/mixins.less
+++ b/packages/node_modules/nav-frontend-paneler-style/src/mixins.less
@@ -33,3 +33,10 @@
 .panel-border-mixin() {
   border: 1px solid @navGra20;
 }
+
+.panel-tabPanel-mixin() {
+  border: 1px solid @navGra20;
+  border-top: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/packages/node_modules/nav-frontend-paneler/src/index.tsx
+++ b/packages/node_modules/nav-frontend-paneler/src/index.tsx
@@ -3,8 +3,9 @@ import * as React from 'react';
 import * as classNames from 'classnames';
 import 'nav-frontend-paneler-style';
 
-const cls = (className, border) => classNames('panel', className, {
-    'panel--border': border
+const cls = (className, border, tabPanel) => classNames('panel', className, {
+    'panel--border': border,
+    'panel--tabPanel': tabPanel
 });
 
 export interface PanelBaseProps {
@@ -20,16 +21,21 @@ export interface PanelBaseProps {
      * Hvis komponenten skal brukes på hvit bakgrunn kan denne brukes for å gi den en border
      */
     border?: boolean;
+    /**
+     * Hvis komponenten skal brukes i kombinasjon med Tabs kan denne brukes for å gi den en passende border
+     */
+    tabPanel?: boolean;
 }
 
 class PanelBase extends React.Component<PanelBaseProps> {
     static defaultProps: Partial<PanelBaseProps> = {
-        border: false
+        border: false,
+        tabPanel: false
     };
     render() {
-        const { children, className, border, ...props } = this.props;
+        const { children, className, border, tabPanel, ...props } = this.props;
         return (
-            <div className={cls(className, border)} {...props}>{children}</div>
+            <div className={cls(className, border, tabPanel)} {...props}>{children}</div>
         );
     }
 }
@@ -37,11 +43,14 @@ class PanelBase extends React.Component<PanelBaseProps> {
 (PanelBase as React.ComponentClass).propTypes = {
     className: PT.string,
     children: PT.node.isRequired,
-    border: PT.bool
+    border: PT.bool,
+    tabPanel: PT.bool
 };
+
 (PanelBase as React.ComponentClass).defaultProps = {
     className: undefined,
-    border: false
+    border: false,
+    tabPanel: false
 };
 
 export default PanelBase;


### PR DESCRIPTION
Hvis komponenten skal brukes i kombinasjon med Tabs-komponenten kan denne propen brukes for å gi panelet en passende styling. Tidligere var man nødt til å manuelt sette `border-top: 0; border-top-left-radius: 0; border-top-right-radius: 0;`.

<img width="742" alt="screenshot 2019-01-11 at 09 18 56" src="https://user-images.githubusercontent.com/74510/51021533-1db76200-1582-11e9-8d11-8799f4990d4d.png">
