### PR TITLE
Fikser error styling på Checkbox, label hover style tweak

### DIFF
--- a/packages/node_modules/nav-frontend-skjema-style/src/checkbox.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/checkbox.less
@@ -33,10 +33,14 @@
     top: 0;
   }
 
-  &:hover + .skjemaelement__label:before {
-    border-color: @navBla;
-    .mixin-transition(200ms, border-color);
-    background-color: @navBlaLighten80;
+  &:hover + .skjemaelement__label {
+    color: @navBla;
+
+    &:before {
+      border-color: @navBla;
+      .mixin-transition(200ms, border-color);
+      background-color: @navBlaLighten80;
+    }
   }
 
   &:disabled + .skjemaelement__label:before {

--- a/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
@@ -96,5 +96,9 @@
       border: 1px solid transparent;
       background-image: @checkWhite;
     }
+
+    .inputPanel__label {
+      color: @navBla;
+    }
   }
 }

--- a/packages/node_modules/nav-frontend-skjema-style/src/validering.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/validering.less
@@ -23,7 +23,8 @@
   border-color: @redError;
   background-color: @pinkErrorBg;
 
-  &.checkboks, &.radio {
+  &.checkboks,
+  &.radio {
     &:not(:checked) + .skjemaelement__label {
       &:before {
         border-color: @redError;

--- a/packages/node_modules/nav-frontend-skjema-style/src/validering.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/validering.less
@@ -22,4 +22,13 @@
 .skjemaelement__input--harFeil {
   border-color: @redError;
   background-color: @pinkErrorBg;
+
+  &.checkboks, &.radio {
+    &:not(:checked) + .skjemaelement__label {
+      &:before {
+        border-color: @redError;
+        background-color: @pinkErrorBg;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fikser dette:
<img width="497" alt="screenshot 2019-01-17 at 16 11 28" src="https://user-images.githubusercontent.com/74510/51327948-a0548b80-1a72-11e9-80c6-8735ad367dce.png">

Og legger til at labels på Checkbox, Radio, CheckboxPanelGruppe, RadioPanelGruppe blir `@navBla` på hover.