### PR TITLE
Legg til mulighet for å overstyre tag som brukes for tittel i Ekspanderbartpanel

### DIFF
--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-pure.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-pure.tsx
@@ -8,6 +8,7 @@ export interface EkspanderbartpanelPureProps {
     tittelProps?: string;
     apen: boolean;
     border?: boolean;
+    tag?: string;
 }
 
 class EkspanderbartpanelPure extends React.PureComponent<EkspanderbartpanelPureProps> {
@@ -17,9 +18,9 @@ class EkspanderbartpanelPure extends React.PureComponent<EkspanderbartpanelPureP
     };
 
     render() {
-        const { tittel, tittelProps, ...renderProps } = this.props;
+        const { tag, tittel, tittelProps, ...renderProps } = this.props;
         const heading = (
-            <Typografi type={tittelProps!} tag="span" className="ekspanderbartPanel__heading">
+            <Typografi type={tittelProps!} tag={tag || 'span'} className="ekspanderbartPanel__heading">
                 {tittel}
             </Typografi>
         );

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/index.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/index.tsx
@@ -28,6 +28,10 @@ export interface EkspanderbartpanelProps {
      * Hvis komponenten skal brukes på hvit bakgrunn kan denne brukes for å gi den en border
      */
     border?: boolean;
+    /**
+     * Typen tag som brukes for tittelen på Typografi-komponenten
+     */
+    tag?: string;
 }
 
 export interface EkspanderbartpanelState {
@@ -59,7 +63,7 @@ class Ekspanderbartpanel extends React.Component<EkspanderbartpanelProps, Ekspan
     }
 
     render() {
-        const { tittel, tittelProps, ...renderProps } = this.props;
+        const { tag, tittel, tittelProps, ...renderProps } = this.props;
         return (
             <EkspanderbartpanelPure
                 {...renderProps}
@@ -67,6 +71,7 @@ class Ekspanderbartpanel extends React.Component<EkspanderbartpanelProps, Ekspan
                 onClick={this.handleClick}
                 tittel={tittel}
                 tittelProps={tittelProps}
+                tag={tag}
             />
         );
     }


### PR DESCRIPTION
Savner muligheten til å bestemme tag for tittel. Motivasjonen for dette er at vi i teamet har en applikasjon som bruker Ekspanderbartpanel-komponenter som seksjoner på en side, hvor hver tittel fungerer som seksjonsoverskrifter. Det vil da være riktig med tanke på UU å ordne titlene i et overskriftshierarki, h1-h6.

Har lagt til en property "tag" til Ekspanderbartpanel. Den er optional for å bevare bakoverkompatibilitet.