### PR TITLE
Fjerner undøvendig mixin for border på ekspandertpanel

### DIFF
--- a/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel-style/src/index.less
@@ -58,7 +58,6 @@
   }
 
   &--border {
-    .panel-border-mixin();
     .panel-interaktiv-mixin();
 
     &.ekspanderbartPanel--apen {


### PR DESCRIPTION
Fjerner panel-border-mixin for &--border da denne blir overskrevet av panel-interaktiv-mixin.