### PR TITLE
Fikser Uncaught TypeError i Modal

### DIFF
--- a/packages/node_modules/nav-frontend-modal/src/index.tsx
+++ b/packages/node_modules/nav-frontend-modal/src/index.tsx
@@ -84,7 +84,7 @@ class ModalWrapper extends React.Component<ModalProps, {}> {
         } else if (this.closeButtonRef) {
             this.closeButtonRef.focus();
         } else {
-            if (this.modalRef && (this.modalRef as any).portal) {
+            if (this.modalRef && (this.modalRef as any).portal && (this.modalRef as any).portal.refs.content) {
                 (this.modalRef as any).portal.refs.content.focus();
             }
         }


### PR DESCRIPTION
Legger til en sjekk på om content finnes i portal.refs som gjør at man unngår denne feilen
Uncaught TypeError: Cannot read property 'focus' of undefined