### PR TITLE
Ensure content is full width in IE11

### DIFF
--- a/packages/node_modules/nav-frontend-veilederpanel-style/src/index.less
+++ b/packages/node_modules/nav-frontend-veilederpanel-style/src/index.less
@@ -17,6 +17,10 @@
   align-items: center;
   text-align: left;
 
+  &__content {
+    width: 100%;
+  }
+
   .nav-veileder {
     position: absolute;
     top: 1rem;

--- a/packages/node_modules/nav-frontend-veilederpanel/src/veilederpanel.tsx
+++ b/packages/node_modules/nav-frontend-veilederpanel/src/veilederpanel.tsx
@@ -49,7 +49,7 @@ class Veilederpanel extends React.Component<VeilederpanelProps> {
                 <Veileder {...this.props.veilederProps} fargetema={this.props.fargetema} storrelse={storrelse}>
                     {svg}
                 </Veileder>
-                <div>{children}</div>
+                <div className="nav-veilederpanel__content">{children}</div>
             </div>
         );
     }


### PR DESCRIPTION
Fikser en bug i IE 11 hvor innhold-div ikke får full bredde pga flex.