### PR TITLE
checkboks-label-som-reactNode

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/checkboks-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/checkboks-panel-gruppe.tsx
@@ -14,7 +14,7 @@ export interface CheckboksPanelGruppeProps {
     /**
      * Overskrift
      */
-    legend: string;
+    legend: React.ReactNode;
     /**
      * Callback-funksjon som blir kalt straks noen av checkboksene endrer state
      */
@@ -52,7 +52,7 @@ class CheckboksPanelGruppe extends React.Component<CheckboksPanelGruppeProps> {
 
 (CheckboksPanelGruppe as React.ComponentClass).propTypes = {
     checkboxes: PT.array.isRequired,
-    legend: PT.string.isRequired,
+    legend: PT.element.isRequired,
     onChange: PT.func.isRequired,
     feil: skjemaelementFeilmeldingShape
 };

--- a/packages/node_modules/nav-frontend-skjema/src/checkboks-panel.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/checkboks-panel.tsx
@@ -6,7 +6,7 @@ import 'nav-frontend-skjema-style';
 
 export interface CheckboksProps {
     checked: boolean;
-    label: string;
+    label: React.ReactNode;
     subtext?: string;
     value?: string;
     id?: string;

--- a/packages/node_modules/nav-frontend-skjema/src/fieldset.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/fieldset.tsx
@@ -8,7 +8,7 @@ const cls = (className) => classNames('skjema__fieldset', className);
 export interface FieldsetProps extends React.HTMLAttributes<HTMLFieldSetElement> {
     children: React.ReactNode | React.ReactNode[];
     className?: string;
-    legend: string;
+    legend: React.ReactNode;
 }
 
 /**
@@ -41,7 +41,7 @@ class Fieldset extends React.Component<FieldsetProps> {
     /**
      * legend for fieldset
      */
-    legend: PT.string.isRequired
+    legend: PT.element.isRequired
 };
 
 (Fieldset as React.ComponentClass).defaultProps = {

--- a/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
@@ -7,7 +7,7 @@ import { SkjemaGruppe, Fieldset } from './';
 import { SkjemaelementFeil, skjemaelementFeilmeldingShape } from './skjemaelement-feilmelding';
 
 export interface RadioProps {
-    label: string;
+    label: React.ReactNode;
     value: string;
     disabled?: boolean;
     inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
@@ -16,7 +16,7 @@ export interface RadioProps {
 export interface RadioPanelGruppeProps {
     radios: RadioProps[];
     name: string;
-    legend: string;
+    legend: React.ReactNode;
     onChange: (event: React.SyntheticEvent<EventTarget>, value: string) => void;
     className?: string;
     checked?: string;
@@ -105,7 +105,7 @@ class RadioPanelGruppe extends React.Component<RadioPanelGruppeProps> {
 (RadioPanelGruppe as React.ComponentClass).propTypes = {
     radios: PT.array.isRequired,
     name: PT.string.isRequired,
-    legend: PT.string.isRequired,
+    legend: PT.element.isRequired,
     onChange: PT.func.isRequired,
     className: PT.string,
     feil: skjemaelementFeilmeldingShape


### PR DESCRIPTION
* Endrer typingen av Checkboks-label, Fieldset-legend, og
RadioPanelGruppe-label til å være ReactNode istendefor string. Gjør det
mulig å sende inn React-komponenter som labels slik at konsumenter har
mer kontroll over hva som rendres i Checkboksen.