### PR TITLE
bugfix-prop-types-fieldset

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/checkboks-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/checkboks-panel-gruppe.tsx
@@ -52,7 +52,7 @@ class CheckboksPanelGruppe extends React.Component<CheckboksPanelGruppeProps> {
 
 (CheckboksPanelGruppe as React.ComponentClass).propTypes = {
     checkboxes: PT.array.isRequired,
-    legend: PT.element.isRequired,
+    legend: PT.node.isRequired,
     onChange: PT.func.isRequired,
     feil: skjemaelementFeilmeldingShape
 };

--- a/packages/node_modules/nav-frontend-skjema/src/fieldset.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/fieldset.tsx
@@ -41,7 +41,7 @@ class Fieldset extends React.Component<FieldsetProps> {
     /**
      * legend for fieldset
      */
-    legend: PT.element.isRequired
+    legend: PT.node.isRequired
 };
 
 (Fieldset as React.ComponentClass).defaultProps = {

--- a/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/radio-panel-gruppe.tsx
@@ -105,7 +105,7 @@ class RadioPanelGruppe extends React.Component<RadioPanelGruppeProps> {
 (RadioPanelGruppe as React.ComponentClass).propTypes = {
     radios: PT.array.isRequired,
     name: PT.string.isRequired,
-    legend: PT.element.isRequired,
+    legend: PT.node.isRequired,
     onChange: PT.func.isRequired,
     className: PT.string,
     feil: skjemaelementFeilmeldingShape


### PR DESCRIPTION
* Forrgie PR hadde en bug i prop-types sjekkingen av legend. pt.element != React.ReactNode