### PR TITLE
Fix warnings in toggle-gruppe

### DIFF
--- a/packages/node_modules/nav-frontend-toggle/src/toggle-gruppe-pure.tsx
+++ b/packages/node_modules/nav-frontend-toggle/src/toggle-gruppe-pure.tsx
@@ -22,7 +22,7 @@ export interface ToggleGruppePureProps {
 
 class ToggleGruppePure extends React.PureComponent<ToggleGruppePureProps> {
     render() {
-        const renderProps = omit(this.props, 'className', 'children', 'kompakt', 'toggles');
+        const renderProps = omit(this.props, 'className', 'children', 'kompakt', 'toggles', 'defaultToggles');
         return (
             <div className={classnames('toggleGruppe', this.props.className)} {...renderProps}>
                 {

--- a/packages/node_modules/nav-frontend-toggle/src/toggle-knapp-pure.tsx
+++ b/packages/node_modules/nav-frontend-toggle/src/toggle-knapp-pure.tsx
@@ -32,7 +32,7 @@ class ToggleKnappPure extends React.PureComponent<ToggleKnappPureProps> {
     };
 
     render() {
-        const renderProps = omit(this.props, 'children', 'pressed', 'kompakt');
+        const renderProps = omit(this.props, 'children', 'pressed', 'kompakt', 'isRequired');
         const knappId = guid();
         return (
             <button
@@ -61,7 +61,7 @@ export const ToggleKnappPurePropsShape = PT.shape({
      * Custom onChange handler
      */
     onChange: PT.func
-});
+}).isRequired;
 
 (ToggleKnappPure as React.ComponentClass).propTypes = ToggleKnappPurePropsShape;
 


### PR DESCRIPTION
Fjerner 'defaultToggles' og 'isRequired' fra renderProps slik at de ikke blir satt på DOM-elementer.
La til 'isRequired' på 'ToggleKnappPurePropsShape' slik at React slutter å klage på at '`isRequired` is marked as required'.