### PR TITLE
Lysere stil på disabled checkbox/radio, mer gjennomført disabled stiler på tvers

### DIFF
--- a/packages/node_modules/nav-frontend-knapper-style/src/index.less
+++ b/packages/node_modules/nav-frontend-knapper-style/src/index.less
@@ -20,7 +20,8 @@
 }
 
 .knapp--flat {
-  .knappflat-mixin(@navBla, @white, @navDypBla)
+  .knappflat-mixin(@navBla, @white, @navDypBla);
+  .knappspinner-mixin(@navBla, @navBlaLighten60, @navBla, @navBlaLighten60);
 }
 
 .knapp--mini {

--- a/packages/node_modules/nav-frontend-knapper-style/src/mixins.less
+++ b/packages/node_modules/nav-frontend-knapper-style/src/mixins.less
@@ -35,6 +35,7 @@
     color: @white;
     box-shadow: none;
     transform: none;
+    cursor: not-allowed;
 
     &:after {
       display: none;

--- a/packages/node_modules/nav-frontend-skjema-style/src/checkbox.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/checkbox.less
@@ -43,12 +43,21 @@
     }
   }
 
-  &:disabled + .skjemaelement__label:before {
-    background-color: @navGra40;
-    border-color: @navGra40;
-    box-shadow: none;
-  }
+  &:disabled {
+    + .skjemaelement__label {
+      color: @navGra60;
 
+      &:hover {
+        cursor: not-allowed;
+      }
+
+      &:before {
+        background-color: @navLysGra;
+        border-color: @navGra60;
+        box-shadow: none;
+      }
+    }
+  }
 }
 
 .checkboks--mork,

--- a/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
@@ -9,13 +9,13 @@
   border: 1px solid @navGra60;
   border-radius: 0.25rem;
   display: block;
-  cursor: pointer;
   padding: 1rem 1rem 1rem 3rem;
   position: relative;
 
   &__field {
-    cursor: pointer;
     position: absolute;
+    width:0;
+    height:0;
     opacity: 0;
 
     &:checked + .inputPanel__label:before {
@@ -31,7 +31,6 @@
 
   &__label {
     .typo-normal-mixin();
-    cursor: pointer;
     line-height: 24px;
 
     &:before {
@@ -63,12 +62,12 @@
 
   &--disabled {
     background-color: @navLysGra;
-    border: 1px solid @navGra20;
     box-shadow: none;
-    cursor: default;
 
-    .inputPanel__label {
-      cursor: default;
+    &:hover,
+    .inputPanel__field:hover,
+    + .inputPanel__label:hover {
+      cursor: not-allowed;
     }
   }
 
@@ -84,6 +83,7 @@
   &:hover:not(.inputPanel--disabled):not(.bekreftCheckboksPanel) {
     border: 1px solid @navBla;
     box-shadow: @grayIcon 0 2px 1px 0;
+    cursor: pointer;
 
     &:not(.inputPanel--checked) {
       .inputPanel__field + .inputPanel__label:before {

--- a/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
@@ -14,8 +14,8 @@
 
   &__field {
     position: absolute;
-    width:0;
-    height:0;
+    width: 0;
+    height: 0;
     opacity: 0;
 
     &:checked + .inputPanel__label:before {

--- a/packages/node_modules/nav-frontend-skjema-style/src/input.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/input.less
@@ -57,8 +57,12 @@
   &:disabled,
   &[readonly] {
     background-color: @navLysGra;
-    border-color: @navGra40;
+    border-color: @navGra60;
     box-shadow: none;
     color: @navMorkGra;
+
+    &:hover {
+      cursor: not-allowed;
+    }
   }
 }

--- a/packages/node_modules/nav-frontend-skjema-style/src/radio-panel.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/radio-panel.less
@@ -3,8 +3,6 @@
 .radioPanel {
   &.inputPanel {
     &--checked {
-      cursor: default;
-
       &:hover:not(.inputPanel--disabled) {
         background-color: rgba(0, 103, 197, 0.2);
         border: 1px solid transparent;
@@ -18,8 +16,6 @@
     }
 
     .inputPanel__label {
-      cursor: default;
-
       &:before {
         border-radius: 50%;
       }

--- a/packages/node_modules/nav-frontend-stegindikator-style/src/index.less
+++ b/packages/node_modules/nav-frontend-stegindikator-style/src/index.less
@@ -78,7 +78,7 @@
     }
 
     &--disabled {
-      pointer-events: none;
+      cursor: not-allowed;
 
       .stegindikator__steg-num {
         color: @navGra60;

--- a/packages/node_modules/nav-frontend-tabs-style/src/tabs-style.less
+++ b/packages/node_modules/nav-frontend-tabs-style/src/tabs-style.less
@@ -72,11 +72,11 @@
     }
 
     &--disabled {
-      opacity: 0.5;
-      color: @navMorkGra;
+      color: @navGra60;
+      cursor: not-allowed;
 
-      &:hover {
-        cursor: not-allowed;
+      .nav-frontend-tabs__tab-label {
+        text-decoration: none;
       }
     }
 


### PR DESCRIPTION
- Endrer labels på disabled checkbox/radio fra @navMorkGra til @navGra60
- Gjør border på disabled elementer litt mørkere for å oppfylle kontrast-kravene på disse (unntatt knapper)
- Legger til `cursor: not-allowed` på samtlige disabled elementer
- Fikser liten :hover-bug på flatknapp med spinner hvor spinner forsvinner