### PR TITLE
Rettet opp skrivefeil i design.nav.no

### DIFF
--- a/guideline-app/app/ui/containers/resources/icon/Icons.mdx
+++ b/guideline-app/app/ui/containers/resources/icon/Icons.mdx
@@ -14,7 +14,7 @@ import { NAVLogoCircle, SketchLogo, GithubLogo } from '../../../../assets/images
 <br/>
 
 <Alertstripe type="info" solid>
-    På grunn av lisensvilkårene for Streamline-pakken er disse ressursene er kun tilgjengelige for NAV-ansatte. Ta kontakt med <Lenke href="mailto:designsystemet@nav.no">designsystemet@nav.no</Lenke> hvis du ikke kommer inn.
+    På grunn av lisensvilkårene for Streamline-pakken er disse ressursene kun tilgjengelige for NAV-ansatte. Ta kontakt med <Lenke href="mailto:designsystemet@nav.no">designsystemet@nav.no</Lenke> hvis du ikke kommer inn.
 </Alertstripe>
 
 ## Sketch ressurser

--- a/guideline-app/app/ui/containers/resources/icon/tabs/Resources.mdx
+++ b/guideline-app/app/ui/containers/resources/icon/tabs/Resources.mdx
@@ -5,7 +5,7 @@ import Alertstripe from 'NavFrontendModules/nav-frontend-alertstriper';
 import { NAVLogoCircle, SketchLogo, GithubLogo } from '../../../../../assets/images/svg';
 
 <Alertstripe type="info" solid>
-    På grunn av lisensvilkårene for Streamline-pakken er disse ressursene er kun tilgjengelige for NAV-ansatte. Ta kontakt med <Lenke href="mailto:designsystemet@nav.no">designsystemet@nav.no</Lenke> hvis du ikke kommer inn.
+    På grunn av lisensvilkårene for Streamline-pakken er disse ressursene kun tilgjengelige for NAV-ansatte. Ta kontakt med <Lenke href="mailto:designsystemet@nav.no">designsystemet@nav.no</Lenke> hvis du ikke kommer inn.
 </Alertstripe>
 
 ## Sketch ressurser


### PR DESCRIPTION
Rettet opp en liten skrivefeil i sidene til design.nav.no under seksjonen om ikoner (se https://design.nav.no/resources/icons). Teksten står øverst på siden i en blå alertstripe.