### PR TITLE
Add mixin for skjemaelement__input

### DIFF
--- a/packages/node_modules/nav-frontend-skjema-style/src/input.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/input.less
@@ -35,7 +35,7 @@
   width: 100%;
 }
 
-.skjemaelement__input {
+.skjemaelement__input() {
   appearance: none;
   padding: 0.5rem;
   background-color: @white;
@@ -65,4 +65,8 @@
       cursor: not-allowed;
     }
   }
+}
+
+.skjemaelement__input {
+  .skjemaelement__input();
 }


### PR DESCRIPTION
Konkret behov er å kunne sette styling på en input-komponent inne i en tredjepartskomponent. Jeg ønsker ikke å copy-paste stylingen inn i egen kode, så da er det bedre at stylingen er tilgjengelig som en mixin. Ideelt sett burde nok mixins bli lagt til en egen fil som kun hadde mixins, men det er en større omlegging/endring.

Kanskje noe å vurdere på noen av de andre komponentene også.