### PR TITLE
Forbedrer støtte for knapper som lenker

### DIFF
--- a/packages/node_modules/nav-frontend-knapper-style/src/mixins.less
+++ b/packages/node_modules/nav-frontend-knapper-style/src/mixins.less
@@ -51,7 +51,7 @@
 
     &:hover,
     &:focus {
-      box-shadow:none;
+      box-shadow: none;
       background-color: @grayIcon;
       border-color: @grayIcon;
       color: @white;

--- a/packages/node_modules/nav-frontend-knapper-style/src/mixins.less
+++ b/packages/node_modules/nav-frontend-knapper-style/src/mixins.less
@@ -48,6 +48,14 @@
     &:after {
       display: none;
     }
+
+    &:hover,
+    &:focus {
+      box-shadow:none;
+      background-color: @grayIcon;
+      border-color: @grayIcon;
+      color: @white;
+    }
   }
 }
 
@@ -75,10 +83,6 @@
     color: @textColor;
     border-color: @highlighColor;
     background-color: @highlighColor;
-  }
-
-  &:visited {
-    color: @textColor;
   }
 
   &:disabled {
@@ -164,10 +168,6 @@
 .knappramme-mixin(@mainColor, @activeColor, @textHoverColor) {
   border: 2px solid @mainColor;
   color: @mainColor;
-
-  &:visited {
-    color: @mainColor;
-  }
 
   &:hover {
     background-color: @mainColor;

--- a/packages/node_modules/nav-frontend-knapper/md/Knapp.overview.mdx
+++ b/packages/node_modules/nav-frontend-knapper/md/Knapp.overview.mdx
@@ -123,6 +123,28 @@ Alle knappene har støtte for disabled stil.
 <Flatknapp disabled>Flat</Flatknapp>
 ```
 
+## Som lenke
+
+Du kan også velge å implementere knappene våre som lenker. I så fall trenger du bare å installere [nav-frontend-knapper-style](https://www.npmjs.com/package/nav-frontend-knapper-style)-pakken, og deretter legge til CSS-klassene på lenkene selv.
+
+<Alertstripe type="advarsel">Vær obs på at det ikke finnes noe <code className="inline">disabled</code>-attributt for lenker. For å "disable" en lenke må du i stedet fjerne <code className="inline">href</code>-attributtet.</Alertstripe>
+
+<Example>
+    <a href="#som-lenke" className="knapp">Normal</a><br/><br/>
+    <a href="#som-lenke" className="knapp knapp--hoved">Hoved</a><br/><br/>
+    <a href="#som-lenke" className="knapp knapp--fare">Fare</a><br/><br/>
+    <a href="#som-lenke" className="knapp knapp--flat">Flat</a><br/><br/>
+    <a className="knapp knapp--disabled">Disabled</a>
+</Example>
+
+```jsx
+<a href="#som-lenke" className="knapp">Normal</a>
+<a href="#som-lenke" className="knapp knapp--hoved">Hoved</a>
+<a href="#som-lenke" className="knapp knapp--fare">Fare</a>
+<a href="#som-lenke" className="knapp knapp--flat">Flat</a>
+<a className="knapp knapp--disabled">Disabled</a>
+```
+
 ## Med ikon
 
 <Alertstripe type="info">


### PR DESCRIPTION
<img width="1130" alt="Screenshot 2019-08-28 at 20 21 48" src="https://user-images.githubusercontent.com/74510/63882056-7df3fa80-c9d1-11e9-975f-c748c5e52cb3.png">

Og fikser bug hvor knapper som lenker fikk hvit skrift på `:focus`.