### PR TITLE
justify-content: center på knapper. knappbase ble endret fra inline-b…

### DIFF
--- a/packages/node_modules/nav-frontend-knapper-style/src/mixins.less
+++ b/packages/node_modules/nav-frontend-knapper-style/src/mixins.less
@@ -1,6 +1,7 @@
 .knappbase-mixin(@font-family) {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   font-weight: 600;
   font-family: @font-family;
   font-size: 1em;


### PR DESCRIPTION
…lock til inline-flex nylig. Dette førte til at innhold i knapper med stor bredde ble venstrejustert