### PR TITLE
Tabell komponent

### DIFF
--- a/packages/node_modules/nav-frontend-tabell-style/src/index.less
+++ b/packages/node_modules/nav-frontend-tabell-style/src/index.less
@@ -1,4 +1,5 @@
 @import (reference) '~nav-frontend-core/less/_variabler';
+@import './nav-tabell';
 
 // tabell-spesifike ting
 .tabell-enkel {

--- a/packages/node_modules/nav-frontend-tabell-style/src/nav-tabell.less
+++ b/packages/node_modules/nav-frontend-tabell-style/src/nav-tabell.less
@@ -1,0 +1,92 @@
+@import (reference) '~nav-frontend-core/less/core';
+
+table.nav-frontend-tabell {
+  width: 100%;
+}
+
+th.nav_table_head_cell {
+  padding: 0.5rem;
+}
+
+tr.nav_table_head_row {
+  display: flex;
+  flex-direction: row;
+}
+
+th.nav_table_head_cell {
+}
+
+tbody.nav_table_body {
+}
+
+td.nav_table_cell {
+  position: relative;
+}
+
+tr.nav_table_row {
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid @navGra40;
+}
+
+@media screen and (max-width: 640px ) {
+
+  thead.nav_table_head {
+    display: none;
+  }
+
+  tr.nav_table_row {
+    flex-direction: column;
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+
+  td.nav_table_cell {
+    padding: 1px 0.5rem 1px 0.5rem;
+    width: 100% !important;
+    text-align: left !important;
+  }
+
+  thead.nav_table_head-small-screen {
+    display: block;
+    border-bottom: 1px solid @navGra40;
+
+    th.nav_table_cell {
+      padding: 1px 0.5rem 1px 0.5rem;
+    }
+  }
+
+}
+
+@media screen and (min-width: 641px ) {
+
+  thead.nav_table_head-small-screen {
+    display: none;
+  }
+
+  thead.nav_table_head {
+    display: block;
+    border-bottom: 1px solid @navGra40;
+  }
+
+  tr.nav_table_row {
+    flex-direction: row;
+    height: 48px;
+    align-items: center;
+  }
+
+  td.nav_table_cell {
+    padding: 0.5rem;
+  }
+
+  td.nav_table_cell:not(:first-child)::before {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 0.6rem;
+    left: 0;
+    height: 1.3rem;
+    width: 2px;
+    border-left: 1px solid @navGra40;
+  }
+}

--- a/packages/node_modules/nav-frontend-tabell/README.md
+++ b/packages/node_modules/nav-frontend-tabell/README.md
@@ -1,0 +1,9 @@
+# react-module: nav-frontend-tabell
+
+<!-- AUTO-GENERATED-CONTENT:START (INSTALL) -->
+Autogen this
+<!-- AUTO-GENERATED-CONTENT:END *-->
+
+<!-- AUTO-GENERATED-CONTENT:START (DISCLAIMER) -->
+Autogen this
+<!-- AUTO-GENERATED-CONTENT:END *-->

--- a/packages/node_modules/nav-frontend-tabell/md/Tabell.accessibility.md
+++ b/packages/node_modules/nav-frontend-tabell/md/Tabell.accessibility.md
@@ -1,0 +1,1 @@
+Denne filen kan fjernes hvis komponenten ikke trenger noen spesielle retningslinjer for tilgjengelighet.

--- a/packages/node_modules/nav-frontend-tabell/md/Tabell.ingress.md
+++ b/packages/node_modules/nav-frontend-tabell/md/Tabell.ingress.md
@@ -1,0 +1,1 @@
+Tabellkomponent som produserer standard html table element og responsiv css med flex.

--- a/packages/node_modules/nav-frontend-tabell/md/Tabell.overview.mdx
+++ b/packages/node_modules/nav-frontend-tabell/md/Tabell.overview.mdx
@@ -1,0 +1,158 @@
+import Example from './../../../../guideline-app/app/ui/components/example/Example';
+import { NavTable, Head, HeadCell, Body, Row, Cell, SmallScreenHeader } from './..';
+
+## Normal
+
+Kolonnebredder angis i relative enheter. Tre kolonner, hvor de to første er dobbelt så brede som den siste
+settes med: `columnWidths={[2,2,1]}`. Høyre- og venstrejustering av celler: `align="left|right"`.
+
+<Example>
+    <NavTable columnWidths={[2,2,1]}>
+        <Head>
+            <HeadCell>
+                Filnavn
+            </HeadCell>
+            <HeadCell>
+                Beskrivelse
+            </HeadCell>
+            <HeadCell align="right">
+                Dato lagt til
+            </HeadCell>
+        </Head>
+        <Body>
+            <Row key={1}>
+                <Cell>
+                    Leiekontrakt.pdf
+                </Cell>
+                <Cell>
+                    Husleiekontrakt
+                </Cell>
+                <Cell align="right">
+                    01.01.2019
+                </Cell>
+            </Row>
+            <Row key={2}>
+                <Cell>
+                    Havslum.pdf
+                </Cell>
+                <Cell>
+                    Strømregning
+                </Cell>
+                <Cell align="right">
+                    01.02.2019
+                </Cell>
+            </Row>
+        </Body>
+    </NavTable>
+</Example>
+
+```jsx
+<NavTable columnWidths={[2,2,1]}>
+    <Head>
+        <HeadCell>
+            Filnavn
+        </HeadCell>
+        <HeadCell>
+            Beskrivelse
+        </HeadCell>
+        <HeadCell align="right">
+            Dato lagt til
+        </HeadCell>
+    </Head>
+    <Body>
+        <Row key={1}>
+            <Cell>
+                Leiekontrakt.pdf
+            </Cell>
+            <Cell>
+                Husleiekontrakt
+            </Cell>
+            <Cell align="right">
+                01.01.2019
+            </Cell>
+        </Row>
+        <Row key={2}>
+            <Cell>
+                Havslum.pdf
+            </Cell>
+            <Cell>
+                Strømregning
+            </Cell>
+            <Cell align="right">
+                01.02.2019
+            </Cell>
+        </Row>
+    </Body>
+</NavTable>
+```
+
+## Mobilvisning
+
+På små skjermer vises ikke tabellheader. Det kan være en idè å ha en alternativ header som vises på små skjermer, som
+legges inn i `<SmallScreenHeader>`. Brekkpunḱtet for mobilvisning av tabellen er satt til `640px`.
+
+<NavTable columnWidths={[2,1]}>
+    <SmallScreenHeader>
+        Filer
+    </SmallScreenHeader>
+    <Head>
+        <HeadCell>
+            Filnavn
+        </HeadCell>
+        <HeadCell align="right">
+            Dato
+        </HeadCell>
+    </Head>
+    <Body>
+        <Row key={1}>
+            <Cell>
+                Kontrakt.pdf
+            </Cell>
+            <Cell align="right">
+                01.01.2019
+            </Cell>
+        </Row>
+        <Row key={2}>
+            <Cell>
+                Havslum.pdf
+            </Cell>
+            <Cell align="right">
+                01.02.2019
+            </Cell>
+        </Row>
+    </Body>
+</NavTable>
+
+```jsx
+<NavTable columnWidths={[2,1]}>
+    <SmallScreenHeader>
+        Filer
+    </SmallScreenHeader>
+    <Head>
+        <HeadCell>
+            Filnavn
+        </HeadCell>
+        <HeadCell align="right">
+            Dato
+        </HeadCell>
+    </Head>
+    <Body>
+        <Row key={1}>
+            <Cell>
+                Kontrakt.pdf
+            </Cell>
+            <Cell align="right">
+                01.01.2019
+            </Cell>
+        </Row>
+        <Row key={2}>
+            <Cell>
+                Havslum.pdf
+            </Cell>
+            <Cell align="right">
+                01.02.2019
+            </Cell>
+        </Row>
+    </Body>
+</NavTable>
+```

--- a/packages/node_modules/nav-frontend-tabell/package.json
+++ b/packages/node_modules/nav-frontend-tabell/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "nav-frontend-tabell",
+  "version": "0.0.1",
+  "main": "lib/tabell.js",
+  "types": "lib/tabell.d.ts",
+  "license": "MIT",
+  "files": ["/src", "/lib"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
+  },
+  "peerDependencies": {
+    "react": "^15.4.2 || ^16.0.0"
+  },
+  "devDependencies": {
+    "react": "^15.4.2 || ^16.0.0"
+  }
+}

--- a/packages/node_modules/nav-frontend-tabell/src/tabell.tsx
+++ b/packages/node_modules/nav-frontend-tabell/src/tabell.tsx
@@ -1,0 +1,156 @@
+import * as React from 'react';
+import * as PT from 'prop-types';
+import { Element, Normaltekst } from 'nav-frontend-typografi';
+import * as classnames from 'classnames';
+import 'nav-frontend-tabell-style';
+
+interface NavTableContextInterface {
+    columnWidths: number[];
+}
+
+const NavTableContext = React.createContext<NavTableContextInterface>({ columnWidths: [] });
+
+export interface NavTabellProps {
+    /**
+     * Egendefinert klassenavn.
+     */
+    className?: string;
+    children: any;
+    /**
+     * Relative kolonnebredder.
+     */
+    columnWidths: number[];
+}
+
+const NavTable: React.StatelessComponent<NavTabellProps> = ({ className, children, columnWidths }) => {
+    const navTableContext: NavTableContextInterface = {
+        columnWidths
+    };
+    return (
+        <NavTableContext.Provider value={navTableContext}>
+            <table className={classnames('nav-frontend-tabell', className)}>
+                {children}
+            </table>
+        </NavTableContext.Provider>
+    );
+};
+
+const NavTabellContextConsumer = NavTableContext.Consumer;
+
+interface NavTableCellProps {
+    children: any;
+    align?: string;
+    width?: string;
+}
+
+const HeadCell: React.StatelessComponent<NavTableCellProps> = ({ children, align, width }) => {
+    const textAlign = align && align === 'right' ? 'right' : 'left';
+    const cellWidth = (width ? width : '40%');
+    return (
+        <th className="nav_table_head_cell" style={{ textAlign, width: cellWidth }}>
+            <Element>
+                {children}
+            </Element>
+        </th>
+    );
+};
+
+const adjustChildrenWidths = (navTableContext: NavTableContextInterface, children: any): React.ReactNode[] =>{
+    const sum: number = navTableContext.columnWidths.reduce((a: number, b: number) => a + b);
+    const columnWidthsInPercent: number[] = navTableContext.columnWidths.map((item: number) => {
+        return (item / sum) * 100;
+    });
+    let index: number = -1;
+    const widthAdjustedChildren = React.Children.map(children, (tableHeadCell: any) => {
+        index = index + 1;
+        return React.cloneElement(tableHeadCell, {
+            width: columnWidthsInPercent[index] + '%'
+        });
+    });
+    return widthAdjustedChildren;
+};
+
+const Head: React.StatelessComponent<{children: React.ReactNode[]}> = ({ children }) => {
+    return (
+        <NavTabellContextConsumer>
+            { (navTableContext: NavTableContextInterface) => {
+                const widthAdjustedChildren = adjustChildrenWidths(navTableContext, children);
+                return (
+                    <thead className="nav_table_head">
+                        <tr className="nav_table_head_row" >
+                            {widthAdjustedChildren}
+                        </tr>
+                    </thead>
+                );
+            } }
+        </NavTabellContextConsumer>
+    );
+};
+
+const SmallScreenHeader: React.StatelessComponent<{children: React.ReactNode[]}> = ({ children }) => {
+    return (
+        <thead className="nav_table_head-small-screen">
+            <tr>
+                <th className="nav_table_cell">
+                    <Element>
+                        {children}
+                    </Element>
+                </th>
+            </tr>
+        </thead>
+    );
+};
+
+const Body: React.StatelessComponent<{children: any}> = ({ children }) => {
+    return (
+        <tbody className="nav_table_body">
+            {children}
+        </tbody>
+    );
+};
+
+const Row: React.StatelessComponent<{children: any}> = ({ children }) => {
+    return (
+        <NavTabellContextConsumer>
+            { (navTableContext: NavTableContextInterface) => {
+                const widthAdjustedChildren = adjustChildrenWidths(navTableContext, children);
+                return (
+                    <tr className="nav_table_row">
+                        {widthAdjustedChildren}
+                    </tr>
+                );
+            } }
+        </NavTabellContextConsumer>
+    );
+};
+
+const Cell: React.StatelessComponent<NavTableCellProps> = ({ children, align, width }) => {
+    const textAlign = align && align === 'right' ? 'right' : 'left';
+    const cellWidth = (width ? width : '40%');
+    return (
+        <td className="nav_table_cell" style={{ textAlign, width: cellWidth }}>
+            <Normaltekst>
+                {children}
+            </Normaltekst>
+        </td>
+    );
+};
+
+(NavTable as React.StatelessComponent).propTypes = {
+    /**
+     * Egendefinert klassenavn.
+     */
+    className: PT.string,
+    children: PT.node.isRequired,
+    columnWidths: PT.arrayOf(PT.number)
+};
+
+export {
+    NavTable,
+    Head,
+    HeadCell,
+    Body,
+    Row,
+    Cell,
+    SmallScreenHeader
+};


### PR DESCRIPTION
Tabellkomponent som produserer standard html table element og responsiv css med flex.

![image](https://user-images.githubusercontent.com/1520/64433126-2551eb00-d0be-11e9-89f3-fd7ffe7710d1.png)

Issues:
 - Brekkpunktet for mobilvisning er hardkodet til 640px. For små tabeller med få kolonner, så trenger man ikke egen mobilvisning.