### PR TITLE
Fikser slik at det er mulig å override default <span> i children på ikonknapper

### DIFF
--- a/packages/node_modules/nav-frontend-ikonknapper/src/hamburgerknapp.tsx
+++ b/packages/node_modules/nav-frontend-ikonknapper/src/hamburgerknapp.tsx
@@ -7,7 +7,7 @@ class Hamburgerknapp extends React.Component<KnappBaseProps> {
         return (
             <KnappBase type="flat" form="kompakt" {...this.props}>
                 <Ikon kind="hamburger" />
-                <span className="sr-only">{this.props.children || 'Meny'}</span>
+                {this.props.children || <span className="sr-only">Meny</span>}
             </KnappBase>
         );
     }

--- a/packages/node_modules/nav-frontend-ikonknapper/src/lukknapp.tsx
+++ b/packages/node_modules/nav-frontend-ikonknapper/src/lukknapp.tsx
@@ -7,7 +7,7 @@ class Lukknapp extends React.Component<KnappBaseProps> {
         return (
             <KnappBase type="flat" form="kompakt" {...this.props}>
                 <Ikon kind="x" />
-                <span className="sr-only">{this.props.children || 'Lukk'}</span>
+                {this.props.children || <span className="sr-only">Lukk</span>}
             </KnappBase>
         );
     }

--- a/packages/node_modules/nav-frontend-ikonknapper/src/menyknapp.tsx
+++ b/packages/node_modules/nav-frontend-ikonknapper/src/menyknapp.tsx
@@ -6,7 +6,7 @@ class Menyknapp extends React.Component<KnappBaseProps> {
     render() {
         return (
             <KnappBase form="kompakt" {...this.props}>
-                <span>{this.props.children || 'Meny'}</span>
+                {this.props.children || <span>Meny</span>}
                 <Chevron type="ned" />
             </KnappBase>
         );

--- a/packages/node_modules/nav-frontend-ikonknapper/src/nesteknapp.tsx
+++ b/packages/node_modules/nav-frontend-ikonknapper/src/nesteknapp.tsx
@@ -6,7 +6,7 @@ class Nesteknapp extends React.Component<KnappBaseProps> {
     render() {
         return (
             <KnappBase type="flat" form="kompakt" {...this.props}>
-                <span>{this.props.children || 'Neste'}</span>
+                {this.props.children || <span>Neste</span>}
                 <Chevron type="høyre" />
             </KnappBase>
         );

--- a/packages/node_modules/nav-frontend-ikonknapper/src/systemerknapp.tsx
+++ b/packages/node_modules/nav-frontend-ikonknapper/src/systemerknapp.tsx
@@ -7,7 +7,7 @@ class Systemerknapp extends React.Component<KnappBaseProps> {
         return (
             <KnappBase type="flat" form="kompakt" {...this.props}>
                 <Ikon kind="systemer" />
-                <span className="sr-only">{this.props.children || 'Systemer'}</span>
+                {this.props.children || <span className="sr-only">Systemer</span>}
             </KnappBase>
         );
     }

--- a/packages/node_modules/nav-frontend-ikonknapper/src/søkeknapp.tsx
+++ b/packages/node_modules/nav-frontend-ikonknapper/src/søkeknapp.tsx
@@ -7,7 +7,7 @@ class Søkeknapp extends React.Component<KnappBaseProps> {
         return (
             <KnappBase form="kompakt" {...this.props}>
                 <Ikon kind="søk" />
-                <span>{this.props.children || 'Søk'}</span>
+                {this.props.children || <span>Søk</span>}
             </KnappBase>
         );
     }

--- a/packages/node_modules/nav-frontend-ikonknapper/src/tilbakeknapp.tsx
+++ b/packages/node_modules/nav-frontend-ikonknapper/src/tilbakeknapp.tsx
@@ -7,7 +7,7 @@ class Tilbakeknapp extends React.Component<KnappBaseProps> {
         return (
             <KnappBase type="flat" form="kompakt" {...this.props}>
                 <Chevron type="venstre" />
-                <span>{this.props.children || 'Tilbake'}</span>
+                {this.props.children || <span>Tilbake</span>}
             </KnappBase>
         );
     }


### PR DESCRIPTION
Fikser slik at:

```jsx
<Menyknapp>
    <span className="sr-only">Meny</span>
</Menyknapp>
```

Ikke lenger blir:

```html
<button>
    <span>
        <span class="sr-only">Meny</span>
    </span>
    (ikon)
</button>
```

Men:

```html
<button>
    <span class="sr-only">Meny</span>
    (ikon)
</button>
```

For alle ikonknapper.