### PR TITLE
For å kunne bruke inputRef i typescript

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/input.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/input.tsx
@@ -37,7 +37,7 @@ export interface NavFrontendInputProps extends React.InputHTMLAttributes<HTMLInp
     /**
      * Referanse til selve inputfeltet. Brukes for eksempel til å sette fokus
      */
-    inputRef?: (element: HTMLInputElement) => any;
+    inputRef?: (element: HTMLInputElement | null) => any;
     /**
      * Label for tekstfeltet
      */

--- a/packages/node_modules/nav-frontend-skjema/src/input.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/input.tsx
@@ -37,7 +37,7 @@ export interface NavFrontendInputProps extends React.InputHTMLAttributes<HTMLInp
     /**
      * Referanse til selve inputfeltet. Brukes for eksempel til å sette fokus
      */
-    inputRef?: () => any;
+    inputRef?: (element: HTMLInputElement) => any;
     /**
      * Label for tekstfeltet
      */


### PR DESCRIPTION
Er på tynn grunn nå, men ser ut som alle funksjoner som brukes som inputRef blir populert med input-elementet.