### PR TITLE
Fix popover position in IE11

### DIFF
--- a/packages/node_modules/nav-frontend-popover/src/popover.tsx
+++ b/packages/node_modules/nav-frontend-popover/src/popover.tsx
@@ -115,36 +115,36 @@ class Popover extends React.Component<PopoverProps, PopoverState> {
 
         switch (props.orientering) {
             case PopoverOrientering.OverHoyre:
-                left = ankerOffset.x + ankerOffset.width - popoverOffset.width;
-                top = ankerOffset.y - avstandTilAnker - popoverOffset.height;
+                left = ankerOffset.left + ankerOffset.width - popoverOffset.width;
+                top = ankerOffset.top - avstandTilAnker - popoverOffset.height;
                 break;
             case PopoverOrientering.OverVenstre:
-                left = ankerOffset.x;
-                top = ankerOffset.y - avstandTilAnker - popoverOffset.height;
+                left = ankerOffset.left;
+                top = ankerOffset.top - avstandTilAnker - popoverOffset.height;
                 break;
             case PopoverOrientering.Venstre:
-                left = ankerOffset.x - popoverOffset.width - avstandTilAnker;
-                top = ankerOffset.y + (ankerOffset.height / 2) - (popoverOffset.height / 2);
+                left = ankerOffset.left - popoverOffset.width - avstandTilAnker;
+                top = ankerOffset.top + (ankerOffset.height / 2) - (popoverOffset.height / 2);
                 break;
             case PopoverOrientering.Hoyre:
-                left = ankerOffset.x + ankerOffset.width + avstandTilAnker;
-                top = ankerOffset.y + (ankerOffset.height / 2) - (popoverOffset.height / 2);
+                left = ankerOffset.left + ankerOffset.width + avstandTilAnker;
+                top = ankerOffset.top + (ankerOffset.height / 2) - (popoverOffset.height / 2);
                 break;
             case PopoverOrientering.UnderHoyre:
-                left = ankerOffset.x + ankerOffset.width - popoverOffset.width;
-                top = ankerOffset.y + ankerOffset.height + avstandTilAnker;
+                left = ankerOffset.left + ankerOffset.width - popoverOffset.width;
+                top = ankerOffset.top + ankerOffset.height + avstandTilAnker;
                 break;
             case PopoverOrientering.UnderVenstre:
-                left = ankerOffset.x;
-                top = ankerOffset.y + ankerOffset.height + avstandTilAnker;
+                left = ankerOffset.left;
+                top = ankerOffset.top + ankerOffset.height + avstandTilAnker;
                 break;
             case PopoverOrientering.Under:
-                left = ankerOffset.x + (ankerOffset.width / 2) - (popoverOffset.width / 2);
-                top = ankerOffset.y + ankerOffset.height + avstandTilAnker;
+                left = ankerOffset.left + (ankerOffset.width / 2) - (popoverOffset.width / 2);
+                top = ankerOffset.top + ankerOffset.height + avstandTilAnker;
                 break;
             default: // PopoverOrientering.Over
-                left = ankerOffset.x + (ankerOffset.width / 2) - (popoverOffset.width / 2);
-                top = ankerOffset.y - avstandTilAnker - popoverOffset.height;
+                left = ankerOffset.left + (ankerOffset.width / 2) - (popoverOffset.width / 2);
+                top = ankerOffset.top - avstandTilAnker - popoverOffset.height;
                 break;
         }
 
@@ -153,7 +153,7 @@ class Popover extends React.Component<PopoverProps, PopoverState> {
         left = Math.max(0, left);
         left = Math.min(Math.abs(left), Math.abs(viewPortDimensions.w - popoverOffset.width));
 
-        const pilLeft = ankerOffset.x + (ankerOffset.width / 2) - left - 1;
+        const pilLeft = ankerOffset.left + (ankerOffset.width / 2) - left - 1;
 
         return { left, top, pilLeft };
     }


### PR DESCRIPTION
#609 
x og y fra getBoundingClientRect finnes ikke i IE, bruker left og top som har samme verdier.