### PR TITLE
fiks bygg på unix-maskiner

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -111,7 +111,7 @@ function parseTsAndAppendDocInfo(contents, file) {
     if (fs.existsSync(tsPath)) {
         docInfo = tsDocgen.parse(tsPath)[0];
 
-        const exceptions = ['StatelessComponent', 'EventThrottler', 'Container'];
+        const exceptions = ['StatelessComponent', 'EventThrottler', 'Container', 'createDynamicHighlightingRule'];
 
         if (exceptions.indexOf(docInfo.displayName) !== -1) {
             return contents;


### PR DESCRIPTION
Rar snålitet som gjør at babel-docgen tolker `createDynamicHighlightingRule` som en react-komponent (?) om man bygger i unix-ligende miljø.
Kan reproduseres på windows ved hjelp linux subsystem for windows.

Anbefaler følgende for å teste PRen;
```
npm run install
npm run build
npm run start-guideline-app
```
Evt `npm run build-guideline-app` og sjekke at output derifra gir mening.