### PR TITLE
Fikset lokal-visning av docGen-data for windows

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,17 +32,23 @@ let srcEx;
 let assetsEx;
 let libFragment;
 let srcFragment;
+let tsDocLib;
+let tsDocSrc;
 
 if (path.win32 === path) {
     srcEx = /(packages\\node_modules\\[^/]+)\\src\\/;
     assetsEx = /(packages\\node_modules\\[^/]+)\\assets\\/;
     libFragment = '$1\\lib\\';
     srcFragment = '$1\\src\\';
+    tsDocLib = /\\lib\\/g;
+    tsDocSrc = '\\src\\';
 } else {
     srcEx = new RegExp('(packages/node_modules/[^/]+)/src/');
     assetsEx = new RegExp('(packages/node_modules/[^/]+)/assets/');
     libFragment = '$1/lib/';
     srcFragment = '$1/src/';
+    tsDocLib = /\/lib\//g;
+    tsDocSrc = '/src/';
 }
 
 function mapToDest(filepath) {
@@ -103,15 +109,21 @@ function buildJs() {
 }
 
 function parseTsAndAppendDocInfo(contents, file) {
-    const tsPath = file.path.replace(/\/lib\//g, '/src/').replace(/.js$/g, '.tsx');
+    const tsPath = file.path.replace(tsDocLib, tsDocSrc).replace(/.js$/g, '.tsx');
 
     let docInfo;
     let docInfoString;
 
     if (fs.existsSync(tsPath)) {
-        docInfo = tsDocgen.parse(tsPath)[0];
+        const docs = tsDocgen.parse(tsPath);
+        docInfo = docs[0];
 
-        const exceptions = ['StatelessComponent', 'EventThrottler', 'Container', 'createDynamicHighlightingRule'];
+        // Yeah, superhack. Men react-docgen-typescript velger alltid feil export fra tekstomrade filen
+        if (docInfo.displayName === 'createDynamicHighlightingRule') {
+            docInfo = docs[1];
+        }
+
+        const exceptions = ['StatelessComponent', 'EventThrottler', 'Container'];
 
         if (exceptions.indexOf(docInfo.displayName) !== -1) {
             return contents;


### PR DESCRIPTION
Fikset workaround for Tekstomrade slik at teknisk-fane kan fungere som forventet.
De andre endringene gjør at docgen-generering lokalt også fungerer for windows-brukere. 

Verifisert endringer på window og osx.
