### PR TITLE
eksporterer litt flere typer fra tekstomrade-pakken

### DIFF
--- a/packages/node_modules/nav-frontend-tekstomrade/src/tekstomrade.tsx
+++ b/packages/node_modules/nav-frontend-tekstomrade/src/tekstomrade.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { parse, build, Rule, LinebreakRule } from '@navikt/textparser';
 import { LinkRule, ParagraphRule } from './rules';
 
-export { LinebreakRule, HighlightRule, createDynamicHighlightingRule, BoldRule } from '@navikt/textparser';
+export { LinebreakRule, HighlightRule, createDynamicHighlightingRule, BoldRule, Rule } from '@navikt/textparser';
 export * from './rules';
 
 export interface TekstomradeProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -25,11 +25,13 @@ export interface TekstomradeProps extends React.HTMLAttributes<HTMLDivElement> {
     rules: Rule[];
 }
 
+export const defaultRules: Rule[] = [LinkRule, LinebreakRule, ParagraphRule];
+
 class Tekstomrade extends React.Component<TekstomradeProps> {
     static defaultProps = {
         as: 'div',
         ingenFormattering: false,
-        rules: [LinkRule, LinebreakRule, ParagraphRule]
+        rules: defaultRules
     };
 
     render() {


### PR DESCRIPTION
Eksporterer `defaultRules` som egen named-export siden man til tider bare ønsker å legge til extra regler. Siden `defaultRules` er av typen `Rule[]` så reeksporterer vi også `Rule` slik at konsumenter av pakken ikke trenger å forholde seg til `@navikt/textparser`.