### PR TITLE
Add prop for feilRenderer in Feiloppsummering

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/feiloppsummering.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/feiloppsummering.tsx
@@ -24,7 +24,7 @@ export interface FeiloppsummeringProps extends React.HTMLAttributes<HTMLDivEleme
     /**
      * Alternativ renderer for feil, f.eks. dersom en ikke kan lenke til inputelement vha #id
      */
-    feilRenderer: (feil: FeiloppsummeringFeil) => React.ReactNode;
+    customFeilRenderer: (feil: FeiloppsummeringFeil) => React.ReactNode;
 }
 
 export interface FeiloppsummeringFeil {
@@ -40,7 +40,7 @@ export interface FeiloppsummeringFeil {
 
 class Feiloppsummering extends React.Component<FeiloppsummeringProps> {
     render() {
-        const { children, className, innerRef, tittel, feil, feilRenderer, ...rest } = this.props;
+        const { children, className, innerRef, tittel, feil, customFeilRenderer, ...rest } = this.props;
         return (
             <div
                 ref={innerRef}
@@ -54,8 +54,8 @@ class Feiloppsummering extends React.Component<FeiloppsummeringProps> {
                     {
                         feil.map((item) => (
                             <li key={item.skjemaelementId}>
-                                { feilRenderer ?
-                                    feilRenderer(item) :
+                                { customFeilRenderer ?
+                                    customFeilRenderer(item) :
                                     <Lenke href={`#${item.skjemaelementId}`}>{item.feilmelding}</Lenke>
                                 }
                             </li>

--- a/packages/node_modules/nav-frontend-skjema/src/feiloppsummering.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/feiloppsummering.tsx
@@ -21,6 +21,10 @@ export interface FeiloppsummeringProps extends React.HTMLAttributes<HTMLDivEleme
      * Liste over feil
      */
     feil: FeiloppsummeringFeil[];
+    /**
+     * Alternativ renderer for feil, f.eks. dersom en ikke kan lenke til inputelement vha #id
+     */
+    feilRenderer: (feil: FeiloppsummeringFeil) => React.ReactNode;
 }
 
 export interface FeiloppsummeringFeil {
@@ -36,7 +40,7 @@ export interface FeiloppsummeringFeil {
 
 class Feiloppsummering extends React.Component<FeiloppsummeringProps> {
     render() {
-        const { children, className, innerRef, tittel, feil, ...rest } = this.props;
+        const { children, className, innerRef, tittel, feil, feilRenderer, ...rest } = this.props;
         return (
             <div
                 ref={innerRef}
@@ -50,7 +54,10 @@ class Feiloppsummering extends React.Component<FeiloppsummeringProps> {
                     {
                         feil.map((item) => (
                             <li key={item.skjemaelementId}>
-                                <Lenke href={`#${item.skjemaelementId}`}>{item.feilmelding}</Lenke>
+                                { feilRenderer ?
+                                    feilRenderer(item) :
+                                    <Lenke href={`#${item.skjemaelementId}`}>{item.feilmelding}</Lenke>
+                                }
                             </li>
                         ))
                     }

--- a/packages/node_modules/nav-frontend-skjema/src/feiloppsummering.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/feiloppsummering.tsx
@@ -24,7 +24,7 @@ export interface FeiloppsummeringProps extends React.HTMLAttributes<HTMLDivEleme
     /**
      * Alternativ renderer for feil, f.eks. dersom en ikke kan lenke til inputelement vha #id
      */
-    customFeilRenderer: (feil: FeiloppsummeringFeil) => React.ReactNode;
+    customFeilRender: (feil: FeiloppsummeringFeil) => React.ReactNode;
 }
 
 export interface FeiloppsummeringFeil {
@@ -40,7 +40,7 @@ export interface FeiloppsummeringFeil {
 
 class Feiloppsummering extends React.Component<FeiloppsummeringProps> {
     render() {
-        const { children, className, innerRef, tittel, feil, customFeilRenderer, ...rest } = this.props;
+        const { children, className, innerRef, tittel, feil, customFeilRender: customFeilRender, ...rest } = this.props;
         return (
             <div
                 ref={innerRef}
@@ -54,8 +54,8 @@ class Feiloppsummering extends React.Component<FeiloppsummeringProps> {
                     {
                         feil.map((item) => (
                             <li key={item.skjemaelementId}>
-                                { customFeilRenderer ?
-                                    customFeilRenderer(item) :
+                                { customFeilRender ?
+                                    customFeilRender(item) :
                                     <Lenke href={`#${item.skjemaelementId}`}>{item.feilmelding}</Lenke>
                                 }
                             </li>


### PR DESCRIPTION
Dersom en er nødt til å bruke HashRouter i en app, blir det krøll når lenken i en feilmelding bruker # for å lenke til elementet med feil. Enkleste vei for fiks er å åpne for at en kan sende inn egen renderer for enkeltfeil, så kan de som har behov løse lenkingen fra feilmeldig til inputfelt selv.