### PR TITLE
oppdatert sr-only

### DIFF
--- a/packages/node_modules/nav-frontend-core/less/_mixins.less
+++ b/packages/node_modules/nav-frontend-core/less/_mixins.less
@@ -95,4 +95,5 @@ CLEARFIX
   overflow: hidden;
   clip: rect(0,0,0,0);
   border: 0;
+  white-space: nowrap;
 }


### PR DESCRIPTION
voiceover + safari har noen issues med sr-only elementer innenfor en flexbox. 
`white-space: nowrap` gjør at dette fungerer bedre igjen.

Løser #679 