### PR TITLE
Bump major på ikoner-assets

### DIFF
--- a/packages/node_modules/nav-frontend-alertstriper-style/package.json
+++ b/packages/node_modules/nav-frontend-alertstriper-style/package.json
@@ -12,14 +12,14 @@
   },
   "devDependencies": {
     "nav-frontend-core": "^4.0.12",
-    "nav-frontend-ikoner-assets": "^1.0.5",
+    "nav-frontend-ikoner-assets": "^2.0.0",
     "nav-frontend-paneler-style": "^0.3.18",
     "nav-frontend-typografi-style": "^1.0.19",
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
     "nav-frontend-core": "^4.0.12",
-    "nav-frontend-ikoner-assets": "^1.0.5",
+    "nav-frontend-ikoner-assets": "^2.0.0",
     "nav-frontend-paneler-style": "^0.3.18",
     "nav-frontend-typografi-style": "^1.0.19"
   }

--- a/packages/node_modules/nav-frontend-alertstriper/package.json
+++ b/packages/node_modules/nav-frontend-alertstriper/package.json
@@ -15,7 +15,7 @@
   "peerDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-alertstriper-style": "^2.0.10",
-    "nav-frontend-ikoner-assets": "^1.0.5",
+    "nav-frontend-ikoner-assets": "^2.0.0",
     "nav-frontend-typografi": "^2.0.18",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
@@ -24,7 +24,7 @@
     "@types/classnames": "^2.2.3",
     "@types/react": "15.0.23 || ^16.0.0",
     "nav-frontend-alertstriper-style": "^2.0.10",
-    "nav-frontend-ikoner-assets": "^1.0.5",
+    "nav-frontend-ikoner-assets": "^2.0.0",
     "nav-frontend-typografi": "^2.0.18",
     "react": "^15.4.2 || ^16.0.0"
   }

--- a/packages/node_modules/nav-frontend-hjelpetekst/package.json
+++ b/packages/node_modules/nav-frontend-hjelpetekst/package.json
@@ -15,7 +15,7 @@
   "peerDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-hjelpetekst-style": "^2.0.22",
-    "nav-frontend-ikoner-assets": "^1.0.5",
+    "nav-frontend-ikoner-assets": "^2.0.0",
     "nav-frontend-popover": "^0.0.23",
     "react": "^15.4.2 || ^16.0.0"
   },
@@ -24,7 +24,7 @@
     "@types/react": "15.0.23 || ^16.0.0",
     "classnames": "^2.2.5",
     "nav-frontend-hjelpetekst-style": "^2.0.22",
-    "nav-frontend-ikoner-assets": "^1.0.5",
+    "nav-frontend-ikoner-assets": "^2.0.0",
     "nav-frontend-popover": "^0.0.23",
     "react": "^15.4.2 || ^16.0.0"
   }

--- a/packages/node_modules/nav-frontend-ikoner-assets/package.json
+++ b/packages/node_modules/nav-frontend-ikoner-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-ikoner-assets",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "license": "SEE LICENSE IN LICENSE",
   "files": [
     "/src",

--- a/packages/node_modules/nav-frontend-ikonknapper/package.json
+++ b/packages/node_modules/nav-frontend-ikonknapper/package.json
@@ -14,13 +14,13 @@
   },
   "peerDependencies": {
     "nav-frontend-chevron": "^1.0.10",
-    "nav-frontend-ikoner-assets": "^1.0.5",
+    "nav-frontend-ikoner-assets": "^2.0.0",
     "nav-frontend-knapper": "^1.0.40",
     "react": "^15.4.2 || ^16.0.0"
   },
   "devDependencies": {
     "nav-frontend-chevron": "^1.0.10",
-    "nav-frontend-ikoner-assets": "^1.0.5",
+    "nav-frontend-ikoner-assets": "^2.0.0",
     "nav-frontend-knapper": "^1.0.40",
     "react": "^15.4.2 || ^16.0.0"
   }

--- a/packages/node_modules/nav-frontend-spinner/package.json
+++ b/packages/node_modules/nav-frontend-spinner/package.json
@@ -14,7 +14,7 @@
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-ikoner-assets": "^1.0.5",
+    "nav-frontend-ikoner-assets": "^2.0.0",
     "nav-frontend-spinner-style": "^0.2.5",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/classnames": "^2.2.3",
     "@types/react": "15.0.23 || ^16.0.0",
-    "nav-frontend-ikoner-assets": "^1.0.5",
+    "nav-frontend-ikoner-assets": "^2.0.0",
     "nav-frontend-spinner-style": "^0.2.5",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"


### PR DESCRIPTION
`nav-frontend-ikoner-assets` fikk også en breaking change med #676 og burde fått major bump på samme måte som `nav-frontend-spinner`.