### PR TITLE
Improvement/typo mixin skjema elementer

### DIFF
--- a/packages/node_modules/nav-frontend-skjema-style/src/bekreft-checkboks-panel.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/bekreft-checkboks-panel.less
@@ -1,4 +1,5 @@
 @import (reference) '~nav-frontend-paneler-style';
+@import (reference) '~nav-frontend-typografi-style/src/index';
 
 @import './assets/symbols';
 
@@ -12,6 +13,7 @@
   transition: background-color linear 100ms;
 
   .bekreftCheckboksPanel__innhold {
+    .typo-normal-mixin();
     margin-bottom: 1rem;
   }
 

--- a/packages/node_modules/nav-frontend-skjema-style/src/checkbox.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/checkbox.less
@@ -1,4 +1,5 @@
 @import 'assets/symbols';
+@import (reference) '~nav-frontend-typografi-style/src/index';
 
 .mixin-transition(@varighet: 150ms, @type: all) {
   transition: @type @varighet cubic-bezier(0.465, 0.183, 0.153, 0.946);
@@ -68,6 +69,7 @@
 }
 
 .checkboks {
+  .typo-normal-mixin();
   position: absolute;
   opacity: 0;
 

--- a/packages/node_modules/nav-frontend-skjema-style/src/feiloppsummering.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/feiloppsummering.less
@@ -1,9 +1,11 @@
 @import (reference) '~nav-frontend-core/less/_variabler';
 @import (reference) '~nav-frontend-paneler-style';
+@import (reference) '~nav-frontend-typografi-style/src/index';
 
 .feiloppsummering {
   .panel-mixin();
   .panel-focus-mixin();
+  .typo-normal-mixin();
   border-radius: 0px;
   border: 4px solid @redError;
 

--- a/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
@@ -21,7 +21,7 @@
   padding: 1rem 1rem 1rem 3rem;
   position: relative;
   .typo-normal-mixin();
-  
+
   &__field {
     .typo-normal-mixin();
     position: absolute;

--- a/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
@@ -1,4 +1,5 @@
 @import './assets/symbols';
+@import (reference) '~nav-frontend-typografi-style/src/index';
 
 .inputPanelGruppe {
   &__inner + div > .skjemaelement__feilmelding {
@@ -19,8 +20,10 @@
   display: block;
   padding: 1rem 1rem 1rem 3rem;
   position: relative;
-
+  .typo-normal-mixin();
+  
   &__field {
+    .typo-normal-mixin();
     position: absolute;
     width: 0;
     height: 0;

--- a/packages/node_modules/nav-frontend-skjema-style/src/input.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/input.less
@@ -1,6 +1,6 @@
+// lesshint qualifyingElement: false
 @import (reference) '~nav-frontend-typografi-style/src/index';
 
-// lesshint qualifyingElement: false
 .input--xxs {
   width: 35px;
 }

--- a/packages/node_modules/nav-frontend-skjema-style/src/input.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/input.less
@@ -1,3 +1,5 @@
+@import (reference) '~nav-frontend-typografi-style/src/index';
+
 // lesshint qualifyingElement: false
 .input--xxs {
   width: 35px;
@@ -36,6 +38,7 @@
 }
 
 .skjemaelement__input() {
+  .typo-normal-mixin();
   appearance: none;
   padding: 0.5rem;
   background-color: @white;

--- a/packages/node_modules/nav-frontend-skjema-style/src/radioknapp.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/radioknapp.less
@@ -1,4 +1,7 @@
+@import (reference) '~nav-frontend-typografi-style/src/index';
+
 .radioknapp {
+  .typo-normal-mixin();
   + .skjemaelement__label:before {
     border-radius: 50%;
   }

--- a/packages/node_modules/nav-frontend-skjema-style/src/radioknapp.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/radioknapp.less
@@ -2,6 +2,7 @@
 
 .radioknapp {
   .typo-normal-mixin();
+
   + .skjemaelement__label:before {
     border-radius: 50%;
   }

--- a/packages/node_modules/nav-frontend-skjema-style/src/select.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/select.less
@@ -15,11 +15,6 @@
     display: none; // Skjuler pil i IE10
   }
 
-  // Fikser bug der options er grå/ikke i henhold til UU kontrast på firefox
-  option {
-    color: @navMorkGra;
-  }
-
   // Modellert etter chevrons, men vi alt må kjøres i pseudo-elemnter ligger koden her.
   .chevronline() {
     pointer-events: none; // gjør at en kan klikke igjennom denne (pilen), slik at select åpner seg

--- a/packages/node_modules/nav-frontend-skjema-style/src/select.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/select.less
@@ -15,6 +15,10 @@
     display: none; // Skjuler pil i IE10
   }
 
+  // Fikser bug der options er grå/ikke i henhold til UU kontrast på firefox
+  option {
+    color: @navMorkGra;
+  }
 
   // Modellert etter chevrons, men vi alt må kjøres i pseudo-elemnter ligger koden her.
   .chevronline() {

--- a/packages/node_modules/nav-frontend-skjema-style/src/skjema-gruppe.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/skjema-gruppe.less
@@ -22,6 +22,7 @@
 }
 
 .skjemagruppe__description {
+  .typo-normal-mixin();
   margin-bottom: 1rem;
 }
 

--- a/packages/node_modules/nav-frontend-skjema-style/src/textarea.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/textarea.less
@@ -1,4 +1,5 @@
 @import (reference) '~nav-frontend-core/less/_variabler';
+@import (reference) '~nav-frontend-typografi-style/src/index';
 
 .textarea--medMeta {
   resize: none;
@@ -36,6 +37,7 @@
 
 // NB: viktig at denne styles slik at tekstbrytning blir identisk med textareaet
 .textareamirror {
+  .typo-normal-mixin();
   .skjemaelement__input;
   white-space: pre-wrap;
   display: inline-block;

--- a/packages/node_modules/nav-frontend-skjema/md/skjemagruppe/Skjemagruppe.overview.mdx
+++ b/packages/node_modules/nav-frontend-skjema/md/skjemagruppe/Skjemagruppe.overview.mdx
@@ -135,7 +135,7 @@ Skjemagrupper brukes vanligvis for å gruppere flere radioknapper eller checkbox
 </SkjemaGruppe>
 ```
 
-### Uten propagering av feil til barnekomponenter
+### Uten propagering av feil-prop til children
 
 Bruk `utenFeilPropagering`-propen for å bestemme om `feil`-propen til `SkjemaGruppe` skal propageres til children.
 


### PR DESCRIPTION
Lagt inn typo-normal-mixin() på enkelte skjema-elementer der dette ikke ble/kunne ende opp med å bli satt. Eneste visuelle/merkbare endring er på tekst for 'bekreftcheckboxpanel' og lenker for 'feiloppsummering' da grunnet 'line-height' endringer. Denne endringen gjør teksten mer i sync med resten av designsystemet da alt blir mer unisont.