### PR TITLE
Utbedret FnrInput eksempel og accessibility

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/md/fnrinput/FnrInput.accessibility.md
+++ b/packages/node_modules/nav-frontend-skjema/md/fnrinput/FnrInput.accessibility.md
@@ -1,0 +1,8 @@
+## Valg av lengde
+
+Lengden på inputfelt skal tilpasses det antallet tegn bruker skal fylle inn. For et fødselsnummer som omhandler 11 tegn, vil dette være
+`bredde="S"` og vi oppfordrer da bruk av den bredden som vist på eksempelet under [Oversikt](https://design.nav.no/components/fnrinput/).
+
+## Mer informasjon
+
+- [Valg av lengde (design.nav.no)](https://design.nav.no/components/input#lengde)

--- a/packages/node_modules/nav-frontend-skjema/md/fnrinput/FnrInput.accessibility.md
+++ b/packages/node_modules/nav-frontend-skjema/md/fnrinput/FnrInput.accessibility.md
@@ -1,8 +1,3 @@
-## Valg av lengde
+## Lenge på inputfelt
 
-Lengden på inputfelt skal tilpasses det antallet tegn bruker skal fylle inn. For et fødselsnummer som omhandler 11 tegn, vil dette være
-`bredde="S"` og vi oppfordrer da bruk av den bredden som vist på eksempelet under [Oversikt](https://design.nav.no/components/fnrinput/).
-
-## Mer informasjon
-
-- [Valg av lengde (design.nav.no)](https://design.nav.no/components/input#lengde)
+Som nevnt på [komponent-siden for Input](/components/input#lengde) så bør inputfeltenes lengde tilpasses det antallet tegn som brukeren skal fylle inn. For fødselsnummer på 11 siffer anbefaler vi å bruke `bredde="S"`.

--- a/packages/node_modules/nav-frontend-skjema/md/fnrinput/FnrInput.overview.mdx
+++ b/packages/node_modules/nav-frontend-skjema/md/fnrinput/FnrInput.overview.mdx
@@ -13,6 +13,7 @@ Komponenten bruker [@navikt/fnrvalidator](https://github.com/navikt/fnrvalidator
 ```jsx
 <FnrInput
     label="Fødselsnummer (11 siffer)"
+    bredde="S"
     value={this.state.value}
     onChange={(e) => this.setState({value: e.target.value})}
     onValidate={(valid) => this.setState({ valid })}

--- a/packages/node_modules/nav-frontend-skjema/sample/_fnr-input.example.js
+++ b/packages/node_modules/nav-frontend-skjema/sample/_fnr-input.example.js
@@ -16,6 +16,7 @@ export default class FnrInputExample extends Component {
             <div>
                 <FnrInput
                     label="Fødselsnummer (11 siffer)"
+                    bredde="S"
                     value={this.state.value}
                     onChange={(e) => this.setState({ value: e.target.value })}
                     onValidate={(valid) => this.setState({ valid })}


### PR DESCRIPTION
Oppfordrer til bruk av bredde="S"