### PR TITLE
Ny `mini` 24px versjon, Farge og border sammkjørt med Alerstripes 

### DIFF
--- a/development/app/components/App.js
+++ b/development/app/components/App.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 import Alertstripe from 'NavFrontendModules/nav-frontend-alertstriper';
 import Lenke from 'NavFrontendModules/nav-frontend-lenker';
 import { Undertittel } from 'NavFrontendModules/nav-frontend-typografi';
-import Etikett from 'NavFrontendModules/nav-frontend-etiketter';
-
 
 import './styles.less';
 
@@ -25,19 +23,12 @@ export default class App extends Component {
     render() {
         return (
             <div>
-                <div>
-                    <Etikett type="info">Dette er en etikett</Etikett>
-                    <Etikett type="suksess">Dette er en etikett</Etikett>
-                    <Etikett type="advarsel">Dette er en etikett</Etikett>
-                    <Etikett type="fokus">Dette er en etikett</Etikett>
-                </div>
+                <Alertstripe type="suksess">
+                    <Undertittel>Utviklingsmiljø kjører!</Undertittel>
+                </Alertstripe>
                 <br/>
-                <div>
-                    <Etikett type="info" mini>Dette er en etikett</Etikett>
-                    <Etikett type="suksess" mini>Dette er en etikett</Etikett>
-                    <Etikett type="advarsel" mini>Dette er en etikett</Etikett>
-                    <Etikett type="fokus" mini>Dette er en etikett</Etikett>
-                </div>
+                <p>Gå til <code>/development/app/components/App.js</code> for å begynne utviklingen.</p>
+                <p>Du finner <Lenke href="https://github.com/navikt/nav-frontend-moduler/blob/master/CONTRIBUTING.md">dokumentasjon og veiledning</Lenke> her.</p>
             </div>
         );
     }

--- a/development/app/components/App.js
+++ b/development/app/components/App.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import Alertstripe from 'NavFrontendModules/nav-frontend-alertstriper';
 import Lenke from 'NavFrontendModules/nav-frontend-lenker';
 import { Undertittel } from 'NavFrontendModules/nav-frontend-typografi';
+import Etikett from 'NavFrontendModules/nav-frontend-etiketter';
+
 
 import './styles.less';
 
@@ -23,12 +25,19 @@ export default class App extends Component {
     render() {
         return (
             <div>
-                <Alertstripe type="suksess">
-                    <Undertittel>Utviklingsmiljø kjører!</Undertittel>
-                </Alertstripe>
+                <div>
+                    <Etikett type="info">Dette er en etikett</Etikett>
+                    <Etikett type="suksess">Dette er en etikett</Etikett>
+                    <Etikett type="advarsel">Dette er en etikett</Etikett>
+                    <Etikett type="fokus">Dette er en etikett</Etikett>
+                </div>
                 <br/>
-                <p>Gå til <code>/development/app/components/App.js</code> for å begynne utviklingen.</p>
-                <p>Du finner <Lenke href="https://github.com/navikt/nav-frontend-moduler/blob/master/CONTRIBUTING.md">dokumentasjon og veiledning</Lenke> her.</p>
+                <div>
+                    <Etikett type="info" mini>Dette er en etikett</Etikett>
+                    <Etikett type="suksess" mini>Dette er en etikett</Etikett>
+                    <Etikett type="advarsel" mini>Dette er en etikett</Etikett>
+                    <Etikett type="fokus" mini>Dette er en etikett</Etikett>
+                </div>
             </div>
         );
     }

--- a/packages/node_modules/nav-frontend-etiketter-style/package.json
+++ b/packages/node_modules/nav-frontend-etiketter-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-etiketter-style",
-  "version": "0.3.20",
+  "version": "1.0.0",
   "main": "src/index.less",
   "license": "MIT",
   "files": [

--- a/packages/node_modules/nav-frontend-etiketter-style/src/_mixins.less
+++ b/packages/node_modules/nav-frontend-etiketter-style/src/_mixins.less
@@ -1,5 +1,5 @@
 .etikett() {
   display: inline-block;
-  padding: 5px 10px;
-  border-radius: @border-radius-small;
+  padding: 4px 9px;
+  border-radius: @border-radius-base;
 }

--- a/packages/node_modules/nav-frontend-etiketter-style/src/index.less
+++ b/packages/node_modules/nav-frontend-etiketter-style/src/index.less
@@ -2,24 +2,29 @@
 @import './_mixins';
 
 .etikett {
+
   .etikett();
 
   &--advarsel {
     background-color: @redErrorLighten60;
     border: 1px solid @redError;
   }
+
   &--suksess {
     background-color: @navGronnLighten60;
     border: 1px solid @navGronn;
   }
+
   &--fokus {
     background-color: @navOransjeLighten60;
     border: 1px solid @navOransjeDarken20;
   }
+
   &--info {
     background-color: @navLysBlaLighten60;
     border: 1px solid @navLysBlaDarken40;
   }
+
   &--mini {
     padding: 1px 8px;
   }

--- a/packages/node_modules/nav-frontend-etiketter-style/src/index.less
+++ b/packages/node_modules/nav-frontend-etiketter-style/src/index.less
@@ -1,27 +1,26 @@
 @import (reference) '~nav-frontend-core/less/_variabler';
 @import './_mixins';
 
-
-.etikett--advarsel {
+.etikett {
   .etikett();
-  background-color: @redErrorLighten60;
-}
 
-.etikett--suksess {
-  .etikett();
-  background-color: @navGronnLighten60;
-}
-
-.etikett--fokus {
-  .etikett();
-  background-color: @navOransjeLighten60;
-}
-
-.etikett--info {
-  .etikett();
-  background-color: @navLysBlaLighten60;
-}
-
-.etikett--mini {
-  padding: 2px 4px;
+  &--advarsel {
+    background-color: @redErrorLighten60;
+    border: 1px solid @redError;
+  }
+  &--suksess {
+    background-color: @navGronnLighten60;
+    border: 1px solid @navGronn;
+  }
+  &--fokus {
+    background-color: @navOransjeLighten60;
+    border: 1px solid @navOransjeDarken20;
+  }
+  &--info {
+    background-color: @navLysBlaLighten60;
+    border: 1px solid @navLysBlaDarken40;
+  }
+  &--mini {
+    padding: 1px 8px;
+  }
 }

--- a/packages/node_modules/nav-frontend-etiketter-style/src/index.less
+++ b/packages/node_modules/nav-frontend-etiketter-style/src/index.less
@@ -19,5 +19,9 @@
 
 .etikett--info {
   .etikett();
-  background-color: @grayIcon;
+  background-color: @navLysBlaLighten60;
+}
+
+.etikett--mini {
+  padding: 2px 4px;
 }

--- a/packages/node_modules/nav-frontend-etiketter/md/Etikett.overview.mdx
+++ b/packages/node_modules/nav-frontend-etiketter/md/Etikett.overview.mdx
@@ -1,5 +1,7 @@
 import Example from './../../../../guideline-app/app/ui/components/example/Example';
 import Etikett from './../';
+import Alertstripe from './../../nav-frontend-alertstriper';
+
 
 ## Alle etiketter side om side
 
@@ -19,4 +21,28 @@ sparsomt. Mange etiketter med forskjellige farger og grupperinger kan skape mer 
 <Etikett type="info">Info</Etikett>
 <Etikett type="advarsel">Advarsel</Etikett>
 <Etikett type="fokus">Fokus</Etikett>
+```
+
+## Mini
+
+Alle etiketter kan rendres i en mindre `24px` versjon med `14px` font.
+
+<Alertstripe type="advarsel">
+    Som hovedregel burde man alltid bruke de normale etikettene våre. For tilfeller med svært 
+    begrenset plass kan de mindre
+    etikettene brukes <strong>unntaksvis ved klart behov</strong>.
+</Alertstripe>
+
+<Example>
+    <Etikett mini type="suksess">Suksess</Etikett>&nbsp;
+    <Etikett mini type="info">Info</Etikett>&nbsp;
+    <Etikett mini type="advarsel">Advarsel</Etikett>&nbsp;
+    <Etikett mini type="fokus">Fokus</Etikett>
+</Example>
+
+```jsx
+<Etikett mini type="suksess">Suksess</Etikett>
+<Etikett mini type="info">Info</Etikett>
+<Etikett mini type="advarsel">Advarsel</Etikett>
+<Etikett mini type="fokus">Fokus</Etikett>
 ```

--- a/packages/node_modules/nav-frontend-etiketter/package.json
+++ b/packages/node_modules/nav-frontend-etiketter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-etiketter",
-  "version": "1.0.31",
+  "version": "2.0.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",
@@ -15,7 +15,7 @@
   "devDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-core": "^4.0.12",
-    "nav-frontend-etiketter-style": "^0.3.20",
+    "nav-frontend-etiketter-style": "^1.0.0",
     "nav-frontend-typografi": "^2.0.18",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
@@ -23,7 +23,7 @@
   "peerDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-core": "^4.0.12",
-    "nav-frontend-etiketter-style": "^0.3.20",
+    "nav-frontend-etiketter-style": "^1.0.0",
     "nav-frontend-typografi": "^2.0.18",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"

--- a/packages/node_modules/nav-frontend-etiketter/src/index.tsx
+++ b/packages/node_modules/nav-frontend-etiketter/src/index.tsx
@@ -18,7 +18,7 @@ export interface EtikettProps extends React.HTMLAttributes<HTMLDivElement> {
      */
     typo?: string;
     /**
-     * Instillinger for å endre etikettens form
+     * Tettere 24px høy, 14px font-size versjon
      */
     mini?: boolean;
 }
@@ -57,7 +57,9 @@ class EtikettBase extends React.Component<EtikettBaseProps> {
      */
     type: PT.oneOf(['suksess', 'info', 'fokus', 'advarsel']).isRequired,
     className: PT.string,
-
+    /**
+     * Tettere 24px høy, 14px font-size versjon
+     */
     mini: PT.bool
 };
 

--- a/packages/node_modules/nav-frontend-etiketter/src/index.tsx
+++ b/packages/node_modules/nav-frontend-etiketter/src/index.tsx
@@ -4,11 +4,12 @@ import * as classNames from 'classnames';
 import TypografiBase from 'nav-frontend-typografi';
 import 'nav-frontend-etiketter-style';
 
-const cls = (type, className) => classNames('etikett', className, {
+const cls = (type, mini, className) => classNames('etikett', className, {
     'etikett--advarsel': type === 'advarsel',
     'etikett--fokus': type === 'fokus',
     'etikett--suksess': type === 'suksess',
-    'etikett--info': type === 'info'
+    'etikett--info': type === 'info',
+    'etikett--mini': mini
 });
 
 export interface EtikettProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -16,6 +17,10 @@ export interface EtikettProps extends React.HTMLAttributes<HTMLDivElement> {
      * Må være en gyldig 'type' prop på Typografi-komponenten, se 'nav-frontend-typografi'
      */
     typo?: string;
+    /**
+     * Instillinger for å endre etikettens form
+     */
+    mini?: boolean;
 }
 /**
  * Etiketter finnes i fire predefinerte farger,
@@ -30,11 +35,12 @@ export interface EtikettBaseProps extends  EtikettProps {
 
 class EtikettBase extends React.Component<EtikettBaseProps> {
     render() {
-        const { type, className, typo = 'normaltekst', children, ...props } = this.props;
-
+        const { type, className, typo, children, mini, ...props } = this.props;
+        let typografi = mini ? 'etikettLiten' : 'normaltekst';
+        typografi = typo ? typo : typografi;
         return (
-            <div className={cls(type, className)} {...props}>
-                <TypografiBase tag="span" type={typo}>{children}</TypografiBase>
+            <div className={cls(type, mini, className)} {...props}>
+                <TypografiBase tag="span" type={typografi}>{children}</TypografiBase>
             </div>
         );
     }
@@ -50,12 +56,14 @@ class EtikettBase extends React.Component<EtikettBaseProps> {
      * Predefinerte farger
      */
     type: PT.oneOf(['suksess', 'info', 'fokus', 'advarsel']).isRequired,
-    className: PT.string
+    className: PT.string,
+
+    mini: PT.bool
 };
 
 (EtikettBase as React.ComponentClass).defaultProps = {
-    typo: 'normaltekst',
-    className: undefined
+    className: undefined,
+    mini: false
 };
 
 export default EtikettBase;

--- a/packages/node_modules/nav-frontend-typografi-style/src/mixins.less
+++ b/packages/node_modules/nav-frontend-typografi-style/src/mixins.less
@@ -72,7 +72,7 @@
   font-size: 14rem / @remUnit;
   line-height: 20rem / @remUnit;
   font-weight: @fontWeightNormal;
-  text-transform: uppercase;
+  //text-transform: uppercase;
 }
 
 .typo-undertekst-bold-mixin() {

--- a/packages/node_modules/nav-frontend-typografi-style/src/mixins.less
+++ b/packages/node_modules/nav-frontend-typografi-style/src/mixins.less
@@ -72,7 +72,6 @@
   font-size: 14rem / @remUnit;
   line-height: 20rem / @remUnit;
   font-weight: @fontWeightNormal;
-  //text-transform: uppercase;
 }
 
 .typo-undertekst-bold-mixin() {


### PR DESCRIPTION
- Info farge fra navGra20 -> navLysBlaLighten60
- Border 1px, samme farge som på Alertstripes og Figma/sketch
- mini versjon som kan toggles likt `<Knapp mini>`. 24px høy og 14px font
Resolves navikt/Designsystemet#123