### PR TITLE
Fikset generering av unik feilmeldingId

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/skjema-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/skjema-gruppe.tsx
@@ -1,7 +1,7 @@
 import * as PT from 'prop-types';
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { guid } from 'nav-frontend-js-utils';
+import { guid, omit } from 'nav-frontend-js-utils';
 import SkjemaelementFeilmelding from './skjemaelement-feilmelding';
 import { Input } from './';
 import 'nav-frontend-skjema-style';
@@ -55,6 +55,7 @@ export interface SkjemaGruppeProps {
  */
 class SkjemaGruppe extends React.Component<SkjemaGruppeProps> {
     render() {
+        let feilmeldingId = this.props.feilmeldingId;
         const {
             children,
             className,
@@ -62,11 +63,23 @@ class SkjemaGruppe extends React.Component<SkjemaGruppeProps> {
             legend,
             description,
             tag = 'fieldset',
-            feilmeldingId,
             utenFeilPropagering,
-            ...other
         } = this.props;
+
+        const domprops = omit(
+            this.props,
+            'children',
+            'className',
+            'feil',
+            'legend',
+            'description',
+            'tag',
+            'utenFeilPropagering',
+            'feilmeldingId'
+        );
+
         const descriptionId = (description) ? guid() : undefined;
+        feilmeldingId = feilmeldingId ? feilmeldingId : guid();
 
         const childrenWithContext =
             <SkjemaGruppeFeilContext.Provider value={{ feil, feilmeldingId }}>
@@ -99,7 +112,7 @@ class SkjemaGruppe extends React.Component<SkjemaGruppeProps> {
                 'aria-invalid': !!feil,
                 'aria-errormessage': (!!feil) ? feilmeldingId : undefined,
                 'aria-describedby': descriptionId,
-                ...other
+                ...domprops
             },
             content
         );
@@ -147,7 +160,6 @@ class SkjemaGruppe extends React.Component<SkjemaGruppeProps> {
 (SkjemaGruppe as React.ComponentClass).defaultProps = {
     className: undefined,
     feil: undefined,
-    feilmeldingId: guid(),
     tag: 'fieldset',
     utenFeilPropagering: undefined
 };

--- a/packages/node_modules/nav-frontend-skjema/src/skjema-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/skjema-gruppe.tsx
@@ -1,7 +1,7 @@
 import * as PT from 'prop-types';
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { guid, omit } from 'nav-frontend-js-utils';
+import { guid } from 'nav-frontend-js-utils';
 import SkjemaelementFeilmelding from './skjemaelement-feilmelding';
 import { Input } from './';
 import 'nav-frontend-skjema-style';
@@ -55,7 +55,7 @@ export interface SkjemaGruppeProps {
  */
 class SkjemaGruppe extends React.Component<SkjemaGruppeProps> {
     render() {
-        let feilmeldingId = this.props.feilmeldingId;
+
         const {
             children,
             className,
@@ -63,23 +63,12 @@ class SkjemaGruppe extends React.Component<SkjemaGruppeProps> {
             legend,
             description,
             tag = 'fieldset',
+            feilmeldingId = guid(),
             utenFeilPropagering,
+            ...other
         } = this.props;
 
-        const domprops = omit(
-            this.props,
-            'children',
-            'className',
-            'feil',
-            'legend',
-            'description',
-            'tag',
-            'utenFeilPropagering',
-            'feilmeldingId'
-        );
-
         const descriptionId = (description) ? guid() : undefined;
-        feilmeldingId = feilmeldingId ? feilmeldingId : guid();
 
         const childrenWithContext =
             <SkjemaGruppeFeilContext.Provider value={{ feil, feilmeldingId }}>
@@ -112,7 +101,7 @@ class SkjemaGruppe extends React.Component<SkjemaGruppeProps> {
                 'aria-invalid': !!feil,
                 'aria-errormessage': (!!feil) ? feilmeldingId : undefined,
                 'aria-describedby': descriptionId,
-                ...domprops
+                ...other
             },
             content
         );


### PR DESCRIPTION
Bug: Alle skjemagrupper fikk samme feilmeldingId
- Fikset ved å fjerne generering av guid i defaultprops da dette er en statisk metode og bare ble kjørt første gang Skjemagruppe klassen ble brukt. 

Closes #733 