### PR TITLE
fjernet tellerId fra textarea sitt aria-describedby

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/md/skjemagruppe/Skjemagruppe.overview.mdx
+++ b/packages/node_modules/nav-frontend-skjema/md/skjemagruppe/Skjemagruppe.overview.mdx
@@ -3,7 +3,7 @@ import { InlineCode } from './../../../../../guideline-app/app/ui/components/cod
 import { guid } from 'nav-frontend-js-utils';
 import Alertstripe from 'nav-frontend-alertstriper';
 import { Undertittel, Ingress } from 'nav-frontend-typografi';
-import { SkjemaGruppe, Radio, RadioGruppe, Checkbox, CheckboxGruppe, Input } from './../../';
+import { SkjemaGruppe, Radio, RadioGruppe, Checkbox, CheckboxGruppe, Input, TextareaControlled } from './../../';
 
 ## Normal/Fieldset
 
@@ -125,6 +125,7 @@ Skjemagrupper brukes vanligvis for å gruppere flere radioknapper eller checkbox
     <SkjemaGruppe feil="Her er det noe feil">
         <Input label="Fornavn" />
         <Input label="Etternavn" />
+        <TextareaControlled label="Textarea-label"/>
     </SkjemaGruppe>
 </Example>
 
@@ -132,6 +133,7 @@ Skjemagrupper brukes vanligvis for å gruppere flere radioknapper eller checkbox
 <SkjemaGruppe feil="Her er det noe feil">
     <Input label="Fornavn" />
     <Input label="Etternavn" />
+    <TextareaControlled label="Textarea-label" />
 </SkjemaGruppe>
 ```
 

--- a/packages/node_modules/nav-frontend-skjema/src/textarea.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/textarea.tsx
@@ -72,7 +72,9 @@ class Textarea extends React.Component<TextareaProps> {
     private mirror: HTMLDivElement | null = null;
     private tekstomrade: HTMLTextAreaElement | null = null;
     private textareaId: string = this.props.id || guid();
+    private maxTegnId?: string = this.props.maxLength ? guid() : undefined;
     private descriptionId?: string = this.props.description ? guid() : undefined;
+    private describedbyId: string = [this.descriptionId, this.maxTegnId].filter((id) => !!id).join(' ');
 
     static propTypes = {
         /**
@@ -189,6 +191,12 @@ class Textarea extends React.Component<TextareaProps> {
                                 </div>
                             }
                             <div className="textarea--medMeta__wrapper">
+                                {
+                                    this.props.maxLength &&
+                                    <span id={this.maxTegnId} className="sr-only">
+                                        Tekstområde med plass til {this.props.maxLength} tegn.
+                                    </span>
+                                }
                                 <EventThrottler event="resize" callback={this.updateHeight} delay={100}>
                                     <textarea
                                         ref={(textarea) => {
@@ -202,7 +210,7 @@ class Textarea extends React.Component<TextareaProps> {
                                         style={{ height: '30px' }}
                                         aria-invalid={!!feilmelding}
                                         aria-errormessage={(feilmelding) ? feilmeldingId : undefined}
-                                        aria-describedby={this.descriptionId}
+                                        aria-describedby={this.describedbyId}
                                         {...other}
                                     />
                                 </EventThrottler>

--- a/packages/node_modules/nav-frontend-skjema/src/textarea.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/textarea.tsx
@@ -54,7 +54,7 @@ export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextArea
      */
     feil?: React.ReactNode | boolean;
     tellerTekst?: (antallTegn: number, maxLength: number) => React.ReactNode;
-    textareaRef?: () => any;
+    textareaRef?: (textarea: HTMLTextAreaElement | null) => any;
 }
 
 interface TextareaDefaultProps {
@@ -69,8 +69,10 @@ type PropsWithDefault = TextareaProps & TextareaDefaultProps;
  * Selvekspanderende tekstområde med teller
  */
 class Textarea extends React.Component<TextareaProps> {
-    private mirror;
-    private tekstomrade;
+    private mirror: HTMLDivElement | null = null;
+    private tekstomrade: HTMLTextAreaElement | null = null;
+    private textareaId: string = this.props.id || guid();
+    private descriptionId?: string = this.props.description ? guid() : undefined;
 
     static propTypes = {
         /**
@@ -152,29 +154,6 @@ class Textarea extends React.Component<TextareaProps> {
         }
     }
 
-    // tslint:disable-next-line max-line-length
-    renderTextareaElement(textareaRef, textareaClass, textareaId, feilmelding, feilmeldingId, descriptionId, tellerId, name, onChange, other) {
-        const describedBy = [descriptionId, tellerId].filter((id) => !!id).join(' ');
-        return (
-            <textarea
-                ref={(textarea) => {
-                    this.tekstomrade = textarea;
-                    if (textareaRef !== undefined) textareaRef(textarea);
-                }}
-                onChange={onChange}
-                className={inputCls(textareaClass, feilmelding)}
-                type="text"
-                id={textareaId}
-                name={name}
-                style={{ height: '30px' }}
-                aria-invalid={!!feilmelding}
-                aria-errormessage={(feilmelding) ? feilmeldingId : undefined}
-                aria-describedby={describedBy}
-                {...other}
-            />
-        );
-    }
-
     render() {
         const {
             label,
@@ -189,7 +168,6 @@ class Textarea extends React.Component<TextareaProps> {
             onChange,
             ...other
         } = this.props as PropsWithDefault;
-        const textareaId = id || guid();
         const antallTegn = other.value.length;
 
         return (
@@ -197,46 +175,42 @@ class Textarea extends React.Component<TextareaProps> {
                 {(context: SkjemaGruppeFeilContextProps) => {
                     const feilmelding = context.feil || feil;
                     const feilmeldingId = context.feilmeldingId || guid();
-                    const descriptionId = description ? guid() : undefined;
-                    const tellerId = guid();
-                    const textareaEl = this.renderTextareaElement(
-                        textareaRef,
-                        textareaClass,
-                        textareaId,
-                        feilmelding,
-                        feilmeldingId,
-                        descriptionId,
-                        tellerId,
-                        name,
-                        onChange,
-                        other
-                    );
 
                     return (
                         <div className="skjemaelement textarea__container">
-                            {label && <Label htmlFor={textareaId}>{label}</Label>}
+                            {label && <Label htmlFor={this.textareaId}>{label}</Label>}
                             {
                                 description &&
                                 <div
                                     className="skjemaelement__description"
-                                    id={descriptionId}
+                                    id={this.descriptionId}
                                 >
                                     {description}
                                 </div>
                             }
                             <div className="textarea--medMeta__wrapper">
                                 <EventThrottler event="resize" callback={this.updateHeight} delay={100}>
-                                    {textareaEl}
-                                </EventThrottler>
-                                {
-                                    !!maxLength &&
-                                    <Teller
-                                        id={tellerId}
-                                        antallTegn={antallTegn}
-                                        maxLength={maxLength}
-                                        tellerTekst={tellerTekst}
+                                    <textarea
+                                        ref={(textarea) => {
+                                            this.tekstomrade = textarea;
+                                            if (textareaRef !== undefined) textareaRef(textarea);
+                                        }}
+                                        onChange={onChange}
+                                        className={inputCls(textareaClass, feilmelding)}
+                                        id={this.textareaId}
+                                        name={name}
+                                        style={{ height: '30px' }}
+                                        aria-invalid={!!feilmelding}
+                                        aria-errormessage={(feilmelding) ? feilmeldingId : undefined}
+                                        aria-describedby={this.descriptionId}
+                                        {...other}
                                     />
-                                }
+                                </EventThrottler>
+                                <Teller
+                                    antallTegn={antallTegn}
+                                    maxLength={maxLength}
+                                    tellerTekst={tellerTekst}
+                                />
                             </div>
                             {
                                 !!!context.feil && !!feil &&
@@ -258,15 +232,17 @@ class Textarea extends React.Component<TextareaProps> {
 }
 
 interface TellerProps {
-    id: string;
     antallTegn: number;
     maxLength: number;
     tellerTekst: (antallTegn: number, maxLength: number) => React.ReactNode;
 }
 
 const Teller = (props: TellerProps) => {
+    if (props.maxLength <= 0) {
+        return null;
+    }
     return (
-        <p id={props.id} className="textarea--medMeta__teller">
+        <p className="textarea--medMeta__teller">
             {props.tellerTekst(props.antallTegn, props.maxLength)}
         </p>
     );


### PR DESCRIPTION
telleren er by-default en live-region pga `aria-live` attributte. aria-describedby gjorde derfor at teller-tekster ble lest opp dobbelt.

Flyttet id-generering ut av render-metoden slik at disse ikke gjenskapes ved hver render og skaper unødvendig dom-oppdateringer.


**NB** Ser at tellerId biten ble lagt til nå nylig i sammenheng med introduksjonen av `SkjemaGruppeFeilContext.Consumer` biten. Vet noen noe mer om bakgrunnen der?