### PR TITLE
coerceing av maxLength til boolean slik at den ikke havner i dom-en

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/textarea.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/textarea.tsx
@@ -192,7 +192,7 @@ class Textarea extends React.Component<TextareaProps> {
                             }
                             <div className="textarea--medMeta__wrapper">
                                 {
-                                    this.props.maxLength &&
+                                    !!this.props.maxLength &&
                                     <span id={this.maxTegnId} className="sr-only">
                                         Tekstområde med plass til {this.props.maxLength} tegn.
                                     </span>


### PR DESCRIPTION
`0` er falsy, men blir likevel spyttet ut DOMen. Ved å tvinge typen til boolean hindrer vi dette, men beholder ønsket funksjonalitet om at teller-teksten blir borte om man setter `maxLength=0`

Fikser opp i buggen nevnt her; https://github.com/navikt/nav-frontend-moduler/pull/736#issuecomment-639408543_