### PR TITLE
Transformerer exporterte variabelnavn til camelcase

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,7 @@ const cssfont64 = require('gulp-cssfont64-formatter');
 const merge = require('merge2');
 const configureSvgIcon = require('react-svg-icon-generator-fork').default;
 const addVariablesExportPlugin = require('./_scripts/gulp-export-less-variables');
+const camelcase = require('lodash.camelcase');
 
 const jsScripts = './packages/node_modules/*/src/**/*.js';
 const tsScripts = './packages/node_modules/*/src/**/*.ts*';
@@ -190,7 +191,7 @@ function buildCssfonts() {
 function exportLessVariables() {
     const file = './packages/node_modules/nav-frontend-core/less';
     return gulp.src(`${file}/_variabler.less`)
-        .pipe(addVariablesExportPlugin())
+        .pipe(addVariablesExportPlugin({ exportNames: camelcase }))
         .pipe(gulp.dest(file));
 }
 

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "lesshint": "^3.1.0",
     "lesshint-reporter-stylish": "^2.0.1",
     "lessvars": "0.0.5",
+    "lodash.camelcase": "^4.3.0",
     "lodash.throttle": "^4.1.1",
     "markdown-magic": "^0.1.19",
     "merge2": "^1.2.0",

--- a/packages/node_modules/nav-frontend-alertstriper-style/package.json
+++ b/packages/node_modules/nav-frontend-alertstriper-style/package.json
@@ -11,14 +11,14 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-ikoner-assets": "^2.0.1",
     "nav-frontend-paneler-style": "^0.3.20",
     "nav-frontend-typografi-style": "^1.0.21",
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-ikoner-assets": "^2.0.1",
     "nav-frontend-paneler-style": "^0.3.20",
     "nav-frontend-typografi-style": "^1.0.21"

--- a/packages/node_modules/nav-frontend-core/package.json
+++ b/packages/node_modules/nav-frontend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-core",
-  "version": "4.0.13",
+  "version": "5.0.0",
   "description": "",
   "main": "less/core.less",
   "author": "NAV",

--- a/packages/node_modules/nav-frontend-ekspanderbartpanel-style/package.json
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel-style/package.json
@@ -12,13 +12,13 @@
   },
   "peerDependencies": {
     "nav-frontend-chevron-style": "^0.3.5",
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-paneler-style": "^0.3.20",
     "nav-frontend-typografi-style": "^1.0.21"
   },
   "devDependencies": {
     "nav-frontend-chevron-style": "^0.3.5",
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-paneler-style": "^0.3.20",
     "nav-frontend-typografi-style": "^1.0.21",
     "react": "^15.4.2 || ^16.0.0"

--- a/packages/node_modules/nav-frontend-etiketter-style/package.json
+++ b/packages/node_modules/nav-frontend-etiketter-style/package.json
@@ -11,10 +11,10 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13"
+    "nav-frontend-core": "^5.0.0"
   }
 }

--- a/packages/node_modules/nav-frontend-etiketter/package.json
+++ b/packages/node_modules/nav-frontend-etiketter/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-etiketter-style": "^1.0.2",
     "nav-frontend-typografi": "^2.0.20",
     "prop-types": "^15.5.10",
@@ -22,7 +22,7 @@
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-etiketter-style": "^1.0.2",
     "nav-frontend-typografi": "^2.0.20",
     "prop-types": "^15.5.10",

--- a/packages/node_modules/nav-frontend-grid/package.json
+++ b/packages/node_modules/nav-frontend-grid/package.json
@@ -14,14 +14,14 @@
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-grid-style": "^0.2.20",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   },
   "devDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-grid-style": "^0.2.20",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"

--- a/packages/node_modules/nav-frontend-hjelpetekst-style/package.json
+++ b/packages/node_modules/nav-frontend-hjelpetekst-style/package.json
@@ -11,11 +11,11 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-typografi-style": "^1.0.21"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-typografi-style": "^1.0.21"
   }
 }

--- a/packages/node_modules/nav-frontend-knapper-style/package.json
+++ b/packages/node_modules/nav-frontend-knapper-style/package.json
@@ -11,12 +11,12 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-typografi-style": "^1.0.21",
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-typografi-style": "^1.0.21"
   }
 }

--- a/packages/node_modules/nav-frontend-lenkepanel-style/package.json
+++ b/packages/node_modules/nav-frontend-lenkepanel-style/package.json
@@ -12,12 +12,12 @@
   },
   "peerDependencies": {
     "nav-frontend-chevron-style": "^0.3.5",
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-paneler-style": "^0.3.20"
   },
   "devDependencies": {
     "nav-frontend-chevron-style": "^0.3.5",
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-paneler-style": "^0.3.20",
     "react": "^15.4.2 || ^16.0.0"
   }

--- a/packages/node_modules/nav-frontend-lenker-style/package.json
+++ b/packages/node_modules/nav-frontend-lenker-style/package.json
@@ -11,10 +11,10 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13"
+    "nav-frontend-core": "^5.0.0"
   }
 }

--- a/packages/node_modules/nav-frontend-lesmerpanel-style/package.json
+++ b/packages/node_modules/nav-frontend-lesmerpanel-style/package.json
@@ -11,12 +11,12 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-paneler-style": "^0.3.20",
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-paneler-style": "^0.3.20"
   }
 }

--- a/packages/node_modules/nav-frontend-lukknapp-style/package.json
+++ b/packages/node_modules/nav-frontend-lukknapp-style/package.json
@@ -11,10 +11,10 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13"
+    "nav-frontend-core": "^5.0.0"
   }
 }

--- a/packages/node_modules/nav-frontend-modal-style/package.json
+++ b/packages/node_modules/nav-frontend-modal-style/package.json
@@ -11,12 +11,12 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-lukknapp-style": "^0.2.23",
     "nav-frontend-paneler-style": "^0.3.20"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-lukknapp-style": "^0.2.23",
     "nav-frontend-paneler-style": "^0.3.20",
     "react": "^15.4.2 || ^16.0.0"

--- a/packages/node_modules/nav-frontend-paneler-style/package.json
+++ b/packages/node_modules/nav-frontend-paneler-style/package.json
@@ -11,10 +11,10 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13"
+    "nav-frontend-core": "^5.0.0"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "react": "^15.4.2 || ^16.0.0"
   }
 }

--- a/packages/node_modules/nav-frontend-popover-style/package.json
+++ b/packages/node_modules/nav-frontend-popover-style/package.json
@@ -11,6 +11,6 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13"
+    "nav-frontend-core": "^5.0.0"
   }
 }

--- a/packages/node_modules/nav-frontend-skjema-style/package.json
+++ b/packages/node_modules/nav-frontend-skjema-style/package.json
@@ -11,13 +11,13 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-paneler-style": "^0.3.20",
     "nav-frontend-typografi-style": "^1.0.21",
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-paneler-style": "^0.3.20",
     "nav-frontend-typografi-style": "^1.0.21"
   }

--- a/packages/node_modules/nav-frontend-snakkeboble-style/package.json
+++ b/packages/node_modules/nav-frontend-snakkeboble-style/package.json
@@ -11,12 +11,12 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-typografi-style": "^1.0.21",
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-typografi-style": "^1.0.21"
   }
 }

--- a/packages/node_modules/nav-frontend-stegindikator-style/package.json
+++ b/packages/node_modules/nav-frontend-stegindikator-style/package.json
@@ -7,11 +7,11 @@
     "/src"
   ],
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-typografi-style": "^1.0.21"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-typografi-style": "^1.0.21",
     "react": "^15.4.2 || ^16.0.0"
   }

--- a/packages/node_modules/nav-frontend-tabell-style/package.json
+++ b/packages/node_modules/nav-frontend-tabell-style/package.json
@@ -11,10 +11,10 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13"
+    "nav-frontend-core": "^5.0.0"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "react": "^15.4.2 || ^16.0.0"
   }
 }

--- a/packages/node_modules/nav-frontend-tabs-style/package.json
+++ b/packages/node_modules/nav-frontend-tabs-style/package.json
@@ -7,11 +7,11 @@
     "/src"
   ],
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-typografi-style": "^1.0.21"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-typografi-style": "^1.0.21",
     "react": "^15.4.2 || ^16.0.0"
   }

--- a/packages/node_modules/nav-frontend-toggle-style/package.json
+++ b/packages/node_modules/nav-frontend-toggle-style/package.json
@@ -7,13 +7,13 @@
     "/src"
   ],
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-knapper-style": "^0.3.37",
     "nav-frontend-typografi-style": "^1.0.21",
     "react": "^15.4.2 || ^16.0.0"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-knapper-style": "^0.3.37",
     "nav-frontend-typografi-style": "^1.0.21",
     "react": "^15.4.2 || ^16.0.0"

--- a/packages/node_modules/nav-frontend-typografi-style/package.json
+++ b/packages/node_modules/nav-frontend-typografi-style/package.json
@@ -11,10 +11,10 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "dependencies": {
-    "nav-frontend-core": "^4.0.13"
+    "nav-frontend-core": "^5.0.0"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "react": "^15.4.2 || ^16.0.0"
   }
 }

--- a/packages/node_modules/nav-frontend-typografi/package.json
+++ b/packages/node_modules/nav-frontend-typografi/package.json
@@ -14,13 +14,13 @@
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-typografi-style": "^1.0.21",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   },
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-typografi-style": "^1.0.21",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"

--- a/packages/node_modules/nav-frontend-veileder-style/package.json
+++ b/packages/node_modules/nav-frontend-veileder-style/package.json
@@ -7,10 +7,10 @@
     "/src"
   ],
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13"
+    "nav-frontend-core": "^5.0.0"
   }
 }

--- a/packages/node_modules/nav-frontend-veilederpanel-style/package.json
+++ b/packages/node_modules/nav-frontend-veilederpanel-style/package.json
@@ -7,13 +7,13 @@
     "/src"
   ],
   "devDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-paneler-style": "^0.3.20",
     "nav-frontend-typografi-style": "^1.0.21",
     "react": "^15.4.2 || ^16.0.0"
   },
   "peerDependencies": {
-    "nav-frontend-core": "^4.0.13",
+    "nav-frontend-core": "^5.0.0",
     "nav-frontend-paneler-style": "^0.3.20",
     "nav-frontend-typografi-style": "^1.0.21"
   }


### PR DESCRIPTION
Er i teorien en breaking-change, så burde kanskje bumpe major-versjon for nav-frontend-core? Eller hva tenker folk?