### PR TITLE
Ny disabled side under design.nav.no/accessibility

### DIFF
--- a/guideline-app/app/ui/containers/accessibility/disabled/AccessibilityDisabled.mdx
+++ b/guideline-app/app/ui/containers/accessibility/disabled/AccessibilityDisabled.mdx
@@ -66,6 +66,7 @@ Her må man da også være sikker på at brukeren ikke vil "savne" dette element
 </DoDont>
 
 <br/>
+
 ## Mer om disabled-attributtet
 <Lenkepanel className="resource-link" href="https://uxdesign.cc/why-you-shouldnt-include-disabled-interaction-elements-in-your-design-system-76a2d4307faf" border>
     <Undertittel className="lenkepanel__heading">Artikkel om bruk av `disabled`</Undertittel>

--- a/guideline-app/app/ui/containers/accessibility/disabled/AccessibilityDisabled.mdx
+++ b/guideline-app/app/ui/containers/accessibility/disabled/AccessibilityDisabled.mdx
@@ -1,8 +1,9 @@
 import { Ingress, Undertittel } from 'NavFrontendModules/nav-frontend-typografi';
-import { Input, Radio, RadioGruppe } from 'NavFrontendModules/nav-frontend-skjema';
+import { Input, Radio, RadioGruppe, Feiloppsummering } from 'NavFrontendModules/nav-frontend-skjema';
 import Lenkepanel from 'NavFrontendModules/nav-frontend-lenkepanel';
 import { DoDont, Do, Dont } from '../../../components/do-dont/DoDont';
 import Hjelpetekst from 'NavFrontendModules/nav-frontend-hjelpetekst'
+import { Knapp } from 'NavFrontendModules/nav-frontend-knapper';
 
 import './styles.less';
 
@@ -44,9 +45,27 @@ Her må man da også være sikker på at brukeren ikke vil "savne" dette element
 	</Dont>
 </DoDont>
 
+<br />
+
+<br />
+
+<DoDont className="placeholders__dodont">
+	<Do>
+        <Knapp className="doButton" type="hoved">Neste</Knapp>
+        <Feiloppsummering className="botMargin"
+            tittel="For å gå videre må du rette opp følgende:"
+            feil={[
+                { skjemaelementId: '1', feilmelding: 'Du må oppgi et navn' },
+                { skjemaelementId: '2', feilmelding: 'Du må oppgi en adresse' }
+            ]}
+        />
+    </Do>
+    <Dont>
+        <Knapp className="botMargin" type="hoved" disabled>Neste</Knapp>
+	</Dont>
+</DoDont>
 
 <br/>
-
 ## Mer om disabled-attributtet
 <Lenkepanel className="resource-link" href="https://uxdesign.cc/why-you-shouldnt-include-disabled-interaction-elements-in-your-design-system-76a2d4307faf" border>
     <Undertittel className="lenkepanel__heading">Artikkel om bruk av `disabled`</Undertittel>

--- a/guideline-app/app/ui/containers/accessibility/disabled/AccessibilityDisabled.mdx
+++ b/guideline-app/app/ui/containers/accessibility/disabled/AccessibilityDisabled.mdx
@@ -1,0 +1,53 @@
+import { Ingress, Undertittel } from 'NavFrontendModules/nav-frontend-typografi';
+import { Input, Radio, RadioGruppe } from 'NavFrontendModules/nav-frontend-skjema';
+import Lenkepanel from 'NavFrontendModules/nav-frontend-lenkepanel';
+import { DoDont, Do, Dont } from '../../../components/do-dont/DoDont';
+import Hjelpetekst from 'NavFrontendModules/nav-frontend-hjelpetekst'
+
+import './styles.less';
+
+# Bruk av Disabled-attributtet
+
+<Ingress>Disabled attributten gir oss muligheten til å hindre brukeren i å påvirke diverse HTML-Elementer som fks: input og button, men på bekostning av UX og UU. </Ingress>
+
+## Hvorfor unngå disable attributten?
+
+Bruk av `disabled` kan virke som en veldig grei måte å hindre brukeren tilgang til forskjellige elementer, men glemmer ofte hva vi da krever av brukeren.
+
+- Ikke alle brukerene vet at elementet <i><u>kan</u></i> være deaktivert, som da fører til forvirring.
+- Deaktiverte elementer har ofte dårlig kontrast.
+- Man forventer at brukeren skal vite hvorfor de ikke kan bruke elementet, men dette er ikke alltid tilfellet.
+- Deaktiverte elementer uten mulighet til fokus vil gjøre det vanskelig for skjermlesere å få all informasjonen den trenger.
+
+## Alternativ
+
+Så hva kan man bruke som erstattning for skjema-elementer og knapper da?
+
+Et alternativ er å fjerne elementet helt fra siden hvis brukeren ikke skal kunne ta det i bruk. 
+Her må man da også være sikker på at brukeren ikke vil "savne" dette elementet og da blir forvirret når det ikke er å finne på siden, eventuelt kan man også fortelle brukeren hvorfor muligheten ikke er der.
+
+<br />
+
+<DoDont className="placeholders__dodont">
+	<Do>
+        <RadioGruppe legend="Når ønsker du å reservere bord?" description="Lunsjservering er desverre ikke tilgjengelig grunnet ombygging av resturant.">
+            <Radio label={'Frokost'} name="tid" />
+            <Radio label={'Middag'} name="tid" />
+        </RadioGruppe>
+    </Do>
+    <Dont>
+        <RadioGruppe legend="Når ønsker du å reservere bord?" >
+            <Radio label={'Frokost'} name="tid" />
+            <Radio label={'Lunsj'} name="tid" disabled />
+            <Radio label={'Middag'} name="tid" />
+        </RadioGruppe>
+	</Dont>
+</DoDont>
+
+
+<br/>
+
+## Mer om disabled-attributtet
+<Lenkepanel className="resource-link" href="https://uxdesign.cc/why-you-shouldnt-include-disabled-interaction-elements-in-your-design-system-76a2d4307faf" border>
+    <Undertittel className="lenkepanel__heading">Artikkel om bruk av `disabled`</Undertittel>
+</Lenkepanel>

--- a/guideline-app/app/ui/containers/accessibility/disabled/AccessibilityDisabledPage.js
+++ b/guideline-app/app/ui/containers/accessibility/disabled/AccessibilityDisabledPage.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import AccessibilityDisabled from './AccessibilityDisabled.mdx';
+import MdxContent from './../../../components/mdx-content/MdxContent';
+
+const AccessibilityDisabledPage = () => (
+    <React.Fragment>
+        <MdxContent>{AccessibilityDisabled}</MdxContent>
+    </React.Fragment>
+);
+
+export default AccessibilityDisabledPage;

--- a/guideline-app/app/ui/containers/accessibility/disabled/styles.less
+++ b/guideline-app/app/ui/containers/accessibility/disabled/styles.less
@@ -2,26 +2,8 @@
 
 
 .placeholders {
-	
-	&__figure {
-		margin:auto;
-		//width: 40%;
-		display: flex;
-		justify-content: center;
-		flex-direction: column;
-		align-items: center;
-		padding-top: 5px;
-		padding-bottom: 10px;	
-	}
-	&__figcaption {
-		text-align: center;
-		padding: 0.5em;
-		font-style: italic;
-		color: @navMorkGra;
-	}
 
 	&__dodont {
-		
 		padding-bottom: 30px;
 	}
 }

--- a/guideline-app/app/ui/containers/accessibility/disabled/styles.less
+++ b/guideline-app/app/ui/containers/accessibility/disabled/styles.less
@@ -21,7 +21,14 @@
 	}
 
 	&__dodont {
-		align-items: flex-end;
+		
 		padding-bottom: 30px;
 	}
+}
+
+.doButton {
+	margin-bottom: 20px;
+}
+.botMargin {
+	margin-bottom: 15px;
 }

--- a/guideline-app/app/ui/containers/accessibility/disabled/styles.less
+++ b/guideline-app/app/ui/containers/accessibility/disabled/styles.less
@@ -1,0 +1,27 @@
+@import (reference) '~NavFrontendCore/less/_variabler';
+
+
+.placeholders {
+	
+	&__figure {
+		margin:auto;
+		//width: 40%;
+		display: flex;
+		justify-content: center;
+		flex-direction: column;
+		align-items: center;
+		padding-top: 5px;
+		padding-bottom: 10px;	
+	}
+	&__figcaption {
+		text-align: center;
+		padding: 0.5em;
+		font-style: italic;
+		color: @navMorkGra;
+	}
+
+	&__dodont {
+		align-items: flex-end;
+		padding-bottom: 30px;
+	}
+}

--- a/guideline-app/app/ui/containers/resources/language/tabs/Principles.mdx
+++ b/guideline-app/app/ui/containers/resources/language/tabs/Principles.mdx
@@ -16,5 +16,5 @@ import Lenke from 'NavFrontendModules/nav-frontend-lenker';
 <br/><br/>
 
 <Alertstripe type="info">
-    Har du forslag til endringer som kan gjøre språksidene i Designsystemet bedre? Send oss gjerne en e-post: <Lenke href="mailto:sprak.nav.no@nav.no">sprak.nav.no@nav.no</Lenke>.
+    Usikker på om bregrepene du bruker er riktige? Alle NAV sine godkjente begrep finner du på <Lenke href="https://data.nav.no/?size=n_30_n&filters%5B0%5D%5Bfield%5D=tittel&filters%5B0%5D%5Bvalues%5D%5B0%5D=&filters%5B0%5D%5Btype%5D=any&filters%5B1%5D%5Bfield%5D=format&filters%5B1%5D%5Bvalues%5D%5B0%5D=godkjent_begrep&filters%5B1%5D%5Btype%5D=all">data.nav.no</Lenke>.
 </Alertstripe>

--- a/guideline-app/app/utils/routing/routes.config.js
+++ b/guideline-app/app/utils/routing/routes.config.js
@@ -126,7 +126,7 @@ const routeConfig = [
             {
                 path: '/accessibility/placeholders',
                 component: AccessibilityPlaceholdersPage,
-                title: 'Placeholders'
+                title: 'Html: Placeholders'
             },
             {
                 path: '/accessibility/disabled',

--- a/guideline-app/app/utils/routing/routes.config.js
+++ b/guideline-app/app/utils/routing/routes.config.js
@@ -19,6 +19,7 @@ import AccessibilityAltTextPage from '../../ui/containers/accessibility/alt-text
 import AccessibilityToolsPage from '../../ui/containers/accessibility/tools/AccessibilityToolsPage';
 // eslint-disable-next-line max-len
 import AccessibilityPlaceholdersPage from '../../ui/containers/accessibility/placeholders/AccessibilityPlaceholdersPage';
+import AccessibilityDisabledPage from '../../ui/containers/accessibility/disabled/AccessibilityDisabledPage';
 import NotFoundPage from '../../ui/containers/404/NotFoundPage';
 import FormValidationPage from '../../ui/containers/patterns/form-validation/FormValidationPage';
 
@@ -126,6 +127,11 @@ const routeConfig = [
                 path: '/accessibility/placeholders',
                 component: AccessibilityPlaceholdersPage,
                 title: 'Placeholders'
+            },
+            {
+                path: '/accessibility/disabled',
+                component: AccessibilityDisabledPage,
+                title: 'Html: Disabled'
             },
             {
                 path: '/accessibility/tools',

--- a/packages/node_modules/nav-frontend-knapper/md/Knapp.overview.mdx
+++ b/packages/node_modules/nav-frontend-knapper/md/Knapp.overview.mdx
@@ -107,7 +107,7 @@ Alle knappene har støtte for disabled stil.
 <Alertstripe type="advarsel">
     Merk at disabled knapper bør unngås, og at man heller bør bruke vanlige knapper
     kombinert med tydelige feilmeldinger hvis handlingen av en eller annen grunn ikke er
-    tillatt. Ler mer om dette i <Lenke href="https://axesslab.com/disabled-buttons-suck/">denne artikkelen</Lenke>.
+    tillatt. Ler mer om dette på <Lenke href="/accessibility/disabled">siden vår om `disabled`</Lenke>.
 </Alertstripe>
 
 <Example>

--- a/packages/node_modules/nav-frontend-skjema/md/checkbox/Checkbox.overview.mdx
+++ b/packages/node_modules/nav-frontend-skjema/md/checkbox/Checkbox.overview.mdx
@@ -1,5 +1,7 @@
 import Example from './../../../../../guideline-app/app/ui/components/example/Example';
 import { Checkbox, CheckboxGruppe } from './../../';
+import Alertstripe from './../../../nav-frontend-alertstriper';
+import Lenke from './../../../nav-frontend-lenker';
 
 ## Normal
 
@@ -12,6 +14,12 @@ import { Checkbox, CheckboxGruppe } from './../../';
 ```
 
 ## Disabled
+
+<Alertstripe type="advarsel">
+    Merk at disabled bør unngås, og at bruken heller bør løses på andre måter, da fks
+    kombinert med tydelige feilmeldinger hvis handlingen av en eller annen grunn ikke er
+    tillatt. Ler mer om dette på <Lenke href="/accessibility/disabled">siden vår om `disabled`</Lenke>.
+</Alertstripe>
 
 <Example>
     <Checkbox label={'Checkbox'} disabled />

--- a/packages/node_modules/nav-frontend-skjema/md/input/Input.overview.mdx
+++ b/packages/node_modules/nav-frontend-skjema/md/input/Input.overview.mdx
@@ -152,6 +152,12 @@ Hvis man ønsker at brukeren skal sette inn tall og da gi dem talltastaturet på
 
 ## Disabled
 
+<Alertstripe type="advarsel">
+    Merk at disabled bør unngås, og at bruken heller bør løses på andre måter, da fks
+    kombinert med tydelige feilmeldinger hvis handlingen av en eller annen grunn ikke er
+    tillatt. Ler mer om dette på <Lenke href="/accessibility/disabled">siden vår om `disabled`</Lenke>.
+</Alertstripe>
+
 <Example>
     <Input label="Inputfelt-label" disabled />
 </Example>

--- a/packages/node_modules/nav-frontend-skjema/md/radio/Radio.overview.mdx
+++ b/packages/node_modules/nav-frontend-skjema/md/radio/Radio.overview.mdx
@@ -15,6 +15,12 @@ import { SkjemaGruppe, Radio, RadioGruppe } from './../../';
 
 ## Disabled
 
+<Alertstripe type="advarsel">
+    Merk at disabled bør unngås, og at bruken heller bør løses på andre måter, da fks
+    kombinert med tydelige feilmeldinger hvis handlingen av en eller annen grunn ikke er
+    tillatt. Ler mer om dette på <Lenke href="/accessibility/disabled">siden vår om `disabled`</Lenke>.
+</Alertstripe>
+
 <Example>
     <Radio label={'Radio-label'} name="minRadioKnapp" disabled />
 </Example>

--- a/packages/node_modules/nav-frontend-skjema/md/select/Select.overview.mdx
+++ b/packages/node_modules/nav-frontend-skjema/md/select/Select.overview.mdx
@@ -31,6 +31,12 @@ import { Select } from './../../';
 
 ## Disabled
 
+<Alertstripe type="advarsel">
+    Merk at disabled bør unngås, og at bruken heller bør løses på andre måter, da fks
+    kombinert med tydelige feilmeldinger hvis handlingen av en eller annen grunn ikke er
+    tillatt. Ler mer om dette på <Lenke href="/accessibility/disabled">siden vår om `disabled`</Lenke>.
+</Alertstripe>
+
 <Example>
     <Select label="Hvilken land er best om sommeren?" disabled>
         <option value="">Velg land</option>

--- a/packages/node_modules/nav-frontend-skjema/md/textarea/Textarea.overview.mdx
+++ b/packages/node_modules/nav-frontend-skjema/md/textarea/Textarea.overview.mdx
@@ -2,6 +2,7 @@ import Example from './../../../../../guideline-app/app/ui/components/example/Ex
 import { Textarea, TextareaControlled } from './../../';
 import TextareaExample from './../../sample/_textarea.example.js';
 import Alertstripe from 'nav-frontend-alertstriper';
+import Lenke from 'nav-frontend-lenker';
 
 ## Normal
 
@@ -24,6 +25,12 @@ import Alertstripe from 'nav-frontend-alertstriper';
 ```
 
 ## Disabled
+
+<Alertstripe type="advarsel">
+    Merk at disabled bør unngås, og at bruken heller bør løses på andre måter, da fks
+    kombinert med tydelige feilmeldinger hvis handlingen av en eller annen grunn ikke er
+    tillatt. Ler mer om dette på <Lenke href="/accessibility/disabled">siden vår om `disabled`</Lenke>.
+</Alertstripe>
 
 <Example>
     <TextareaControlled label="Textarea-label" disabled />


### PR DESCRIPTION
- Alle  skjema-elementer som viser bruk av disabled samt knapper har nå en alert som linker til denne siden.
- Inneholder do/dont eksempler for både input og knapper