### PR TITLE
Fikset bug der input gikk fra uncontrolled til controlled

### DIFF
--- a/packages/node_modules/nav-frontend-skjema/src/checkboks-panel-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-skjema/src/checkboks-panel-gruppe.tsx
@@ -25,7 +25,7 @@ export class CheckboksPanel extends React.Component<CheckboksPanelProps, Checkbo
 
     // eslint-disable-next-line camelcase
     UNSAFE_componentWillReceiveProps(newProps) {
-        this.setState({ checked: newProps.checked });
+        this.setState({ checked: !!newProps.checked });
     }
 
     handleChange = (e) => {


### PR DESCRIPTION
- `newProps.checked -> !!newProps.checked`. newProps.checked endte opp med å være `undefined` ved flere tilfeller