### PR TITLE
Linker til figma på design.nav.no, lang="no" for eksempel oppsett

### DIFF
--- a/examples/cra/public/index.html
+++ b/examples/cra/public/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="no">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/examples/webpack/public/index.html
+++ b/examples/webpack/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"></html>
+<html lang="no"></html>
 <html>
   <head>
     <meta charset="UTF-8">

--- a/guideline-app/app/assets/images/svg.js
+++ b/guideline-app/app/assets/images/svg.js
@@ -338,3 +338,15 @@ export const CopyIcon = () => (
         </g>
     </svg>
 );
+
+export const FigmaIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 38 57">
+        <g>
+            <path fill="#1abcfe" d="M19 28.5a9.5 9.5 0 1 1 19 0 9.5 9.5 0 0 1-19 0z" />
+            <path fill="#0acf83" d="M0 47.5A9.5 9.5 0 0 1 9.5 38H19v9.5a9.5 9.5 0 1 1-19 0z" />
+            <path fill="#ff7262" d="M19 0v19h9.5a9.5 9.5 0 1 0 0-19H19z" />
+            <path fill="#f24e1e" d="M0 9.5A9.5 9.5 0 0 0 9.5 19H19V0H9.5A9.5 9.5 0 0 0 0 9.5z" />
+            <path fill="#a259ff" d="M0 28.5A9.5 9.5 0 0 0 9.5 38H19V19H9.5A9.5 9.5 0 0 0 0 28.5z" />
+        </g>
+    </svg>
+);

--- a/guideline-app/app/ui/containers/resources/icon/Icons.mdx
+++ b/guideline-app/app/ui/containers/resources/icon/Icons.mdx
@@ -3,7 +3,7 @@ import Lenkepanel from 'NavFrontendModules/nav-frontend-lenkepanel';
 import Alertstripe from 'NavFrontendModules/nav-frontend-alertstriper';
 import { Ingress } from 'NavFrontendModules/nav-frontend-typografi';
 
-import { NAVLogoCircle, SketchLogo, GithubLogo } from '../../../../assets/images/svg';
+import { NAVLogoCircle, SketchLogo, FigmaIcon, GithubLogo } from '../../../../assets/images/svg';
 
 # Ikoner
 
@@ -16,6 +16,13 @@ import { NAVLogoCircle, SketchLogo, GithubLogo } from '../../../../assets/images
 <Alertstripe type="info" solid>
     På grunn av lisensvilkårene for Streamline-pakken er disse ressursene kun tilgjengelige for NAV-ansatte. Ta kontakt med oss på slack-kanalen #Desingsystem hvis du ikke kommer inn.
 </Alertstripe>
+
+## Figma ressurser
+
+<Lenkepanel className="resource-link" href="https://www.figma.com/file/3AjAxeQP4uMFgqSazKXxOh/NAV-Ikonbiblioteket-Streamline" border>
+    <FigmaIcon />
+    Ikon&shy;bibliotek
+</Lenkepanel>
 
 ## Sketch ressurser
 

--- a/guideline-app/app/ui/containers/resources/icon/tabs/Resources.mdx
+++ b/guideline-app/app/ui/containers/resources/icon/tabs/Resources.mdx
@@ -2,11 +2,19 @@ import Lenke from 'NavFrontendModules/nav-frontend-lenker';
 import Lenkepanel from 'NavFrontendModules/nav-frontend-lenkepanel';
 import Alertstripe from 'NavFrontendModules/nav-frontend-alertstriper';
 
-import { NAVLogoCircle, SketchLogo, GithubLogo } from '../../../../../assets/images/svg';
+import { NAVLogoCircle, SketchLogo, FigmaIcon, GithubLogo } from '../../../../../assets/images/svg';
 
 <Alertstripe type="info">
 På grunn av lisensvilkårene for Streamline-pakken er disse ressursene kun tilgjengelige for NAV-ansatte. Ta kontakt med oss på slack-kanalen #Desingsystem hvis du ikke kommer inn.
 </Alertstripe>
+
+
+## Figma ressurser
+
+<Lenkepanel className="resource-link" href="https://www.figma.com/file/3AjAxeQP4uMFgqSazKXxOh/NAV-Ikonbiblioteket-Streamline" border>
+    <FigmaIcon />
+    Ikon&shy;bibliotek
+</Lenkepanel>
 
 ## Sketch ressurser
 

--- a/guideline-app/app/ui/containers/resources/illustration/tabs/Resources.mdx
+++ b/guideline-app/app/ui/containers/resources/illustration/tabs/Resources.mdx
@@ -1,7 +1,15 @@
 import Lenkepanel from 'NavFrontendModules/nav-frontend-lenkepanel';
 import Alertstripe from 'NavFrontendModules/nav-frontend-alertstriper';
 
-import { NAVLogoCircle, SketchLogo, ZeplinLogo, GithubLogo } from '../../../../../assets/images/svg';
+import { NAVLogoCircle, SketchLogo, FigmaIcon, ZeplinLogo, GithubLogo } from '../../../../../assets/images/svg';
+
+
+## Figma ressurser
+
+<Lenkepanel className="resource-link" href="https://www.figma.com/file/Fqn33tUPirzG8jLsI7kpc4/NAV-illustrasjonsbiblioteket-2.1-Figma" border>
+    <FigmaIcon />
+    Illustrasjons&shy;bibliotek
+</Lenkepanel>
 
 ## Sketch ressurser
 

--- a/guideline-app/app/ui/containers/resources/new-project/NewProject.mdx
+++ b/guideline-app/app/ui/containers/resources/new-project/NewProject.mdx
@@ -4,7 +4,7 @@ import Lenkepanel, { LenkepanelBase } from 'NavFrontendModules/nav-frontend-lenk
 import Alertstripe from 'NavFrontendModules/nav-frontend-alertstriper';
 import Lenke from 'NavFrontendModules/nav-frontend-lenker';
 import Panel from 'NavFrontendModules/nav-frontend-paneler';
-import { NAVLogoCircle, SketchLogo, ZeplinLogo, GithubLogo } from '../../../../assets/images/svg';
+import { NAVLogoCircle, SketchLogo, FigmaIcon, ZeplinLogo, GithubLogo } from '../../../../assets/images/svg';
 import './styles.less';
 
 # Start nytt prosjekt
@@ -14,6 +14,17 @@ import './styles.less';
 </Ingress>
 
 ## For designere
+
+### Figma-ressurser
+
+<Lenkepanel className="resource-link" href="https://www.figma.com/file/kze2fE59WLaATAS9XAM7Es/NAV-UI-biblioteket-2.1-Figma" border>
+    <FigmaIcon />
+    UI-bibliotek
+</Lenkepanel>
+<Lenkepanel className="resource-link" href="https://www.figma.com/file/Fqn33tUPirzG8jLsI7kpc4/NAV-illustrasjonsbiblioteket-2.1-Figma" border>
+    <FigmaIcon />
+    Illustrasjons&shy;bibliotek
+</Lenkepanel>
 
 ### Sketch-ressurser
 

--- a/guideline-app/app/ui/containers/resources/new-project/NewProject.mdx
+++ b/guideline-app/app/ui/containers/resources/new-project/NewProject.mdx
@@ -25,6 +25,10 @@ import './styles.less';
     <FigmaIcon />
     Illustrasjons&shy;bibliotek
 </Lenkepanel>
+<Lenkepanel className="resource-link" href="https://www.figma.com/file/3AjAxeQP4uMFgqSazKXxOh/NAV-Ikonbiblioteket-Streamline" border>
+    <FigmaIcon />
+    Ikon&shy;bibliotek
+</Lenkepanel>
 
 ### Sketch-ressurser
 

--- a/guideline-app/app/ui/containers/resources/typography/Typography.mdx
+++ b/guideline-app/app/ui/containers/resources/typography/Typography.mdx
@@ -12,7 +12,7 @@ import Lenke from 'NavFrontendModules/nav-frontend-lenker';
 
 # Typografi
 
-<Ingress>NAV sin font er Source Sans Pro.</Ingress>
+<Ingress>NAV sin font er Source Sans Pro og kan tas i bruk med vår egen <Lenke border href="/components/typografi">Typografi-komponent</Lenke></Ingress>
 
 ## Source Sans Pro
 

--- a/guideline-app/app/ui/containers/resources/typography/Typography.mdx
+++ b/guideline-app/app/ui/containers/resources/typography/Typography.mdx
@@ -16,16 +16,14 @@ import Lenke from 'NavFrontendModules/nav-frontend-lenker';
 
 ## Source Sans Pro
 
-<div>
-    <strong style={{fontSize: '100px', lineHeight: '75px', float: 'left', marginRight: 16, marginBottom: 16}}>Aa</strong>
+<div className="sanspro--padding">
+    <strong className="strongAa">Aa</strong>
     <p>
         Source® Sans Pro, Adobe sin første open source font-familie, ble designet av Paul D. Hunt. Det er en sans serif font som er ment å fungere spesielt bra på digitale brukergrensesnitt.
     </p>
-    <p>
-        <Lenke href="https://fonts.google.com/specimen/Source+Sans+Pro">Last ned fra Google Fonts</Lenke>
-    </p>
-    <div className="clearfix" />
 </div>
+
+<Lenkepanel border href="https://fonts.google.com/specimen/Source+Sans+Pro">Last ned fra Google Fonts</Lenkepanel>
 
 ## Typografisk hierarki
 

--- a/guideline-app/app/ui/containers/resources/typography/styles.less
+++ b/guideline-app/app/ui/containers/resources/typography/styles.less
@@ -1,0 +1,13 @@
+
+.strongAa {
+    font-size: 100px;
+    line-height: 75px; 
+    float: left;
+    margin-right: 16px;
+}
+
+.sanspro {
+    &--padding {
+        margin-bottom: 40px;
+    }
+}


### PR DESCRIPTION
- lang="no" satt grunnet https://nav-it.slack.com/archives/C60FFACN5/p1594993450320600
- Utbedret info under `/resources/typography`