### PR TITLE
Bytte til lambda-syntaks for 'handleKeyDown' handler

### DIFF
--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base.tsx
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base.tsx
@@ -73,7 +73,7 @@ class EkspanderbartpanelBase extends React.PureComponent<EkspanderbartpanelBaseP
         }
     }
 
-    handleKeyDown(event) {
+    handleKeyDown = (event) => {
         if (event.keyCode === keyCodes.tab && this.isCloseAnimation) {
             event.preventDefault();
         }


### PR DESCRIPTION
gjøre at 'this' får lexical scoping og dermed refererer til klasse instansen

Fixes #766