### PR TITLE
Satt max-length for innhold til 80ch

### DIFF
--- a/packages/node_modules/nav-frontend-skjema-style/src/bekreft-checkboks-panel.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/bekreft-checkboks-panel.less
@@ -14,6 +14,7 @@
 
   .bekreftCheckboksPanel__innhold {
     .typo-normal-mixin();
+    max-width: 80ch;
     margin-bottom: 1rem;
   }
 


### PR DESCRIPTION
- En `ch` tilsvarer bredden til en standard `0`
https://uu.difi.no/krav-og-regelverk/wcag-20-standarden/ikke-lovpalagte-krav/148-visuell-presentasjon-niva-aaa

Closes navikt/Designsystemet/issues/164