### PR TITLE
Css-Color for hver typo-komponent

### DIFF
--- a/packages/node_modules/nav-frontend-typografi-style/src/index.less
+++ b/packages/node_modules/nav-frontend-typografi-style/src/index.less
@@ -11,31 +11,37 @@
 
 .typo-sidetittel {
   margin: 0;
+  color: @navMorkGra;
   .typo-sidetittel-mixin();
 }
 
 .typo-innholdstittel {
   margin: 0;
+  color: @navMorkGra;
   .typo-innholdstittel-mixin();
 }
 
 .typo-systemtittel {
   margin: 0;
+  color: @navMorkGra;
   .typo-systemtittel-mixin();
 }
 
 .typo-undertittel {
   margin: 0;
+  color: @navMorkGra;
   .typo-undertittel-mixin();
 }
 
 .typo-ingress {
   margin: 0;
+  color: @navMorkGra;
   .typo-ingress-mixin();
 }
 
 .typo-element {
   margin: 0;
+  color: @navMorkGra;
   .typo-element-mixin();
 }
 
@@ -47,20 +53,24 @@
 
 .typo-normal {
   margin: 0;
+  color: @navMorkGra;
   .typo-normal-mixin();
 }
 
 .typo-etikett-liten {
   margin: 0;
+  color: @navMorkGra;
   .typo-etikett-liten-mixin();
 }
 
 .typo-undertekst-bold {
   margin: 0;
+  color: @navMorkGra;
   .typo-undertekst-bold-mixin();
 }
 
 .typo-undertekst {
   margin: 0;
+  color: @navMorkGra;
   .typo-undertekst-mixin();
 }


### PR DESCRIPTION
- Slipper da at bruker må ta i bruk `.app` for å få riktig font-farge når typo-komponenter blir brukt