### PR TITLE
className blir nå provided videre til ToggleGruppePure

### DIFF
--- a/packages/node_modules/nav-frontend-toggle/src/toggle-gruppe.tsx
+++ b/packages/node_modules/nav-frontend-toggle/src/toggle-gruppe.tsx
@@ -72,8 +72,7 @@ class ToggleGruppe extends React.Component<ToggleGruppeProps, ToggleGruppeState>
     }
 
     render() {
-        const { className, ...other } = this.props;
-        const renderProps = omit(other, 'children', 'multiSelect', 'toggles', 'minstEn');
+        const renderProps = omit(this.props, 'children', 'multiSelect', 'toggles', 'minstEn');
         const toggles = this.state.toggles.map((toggle, i) => ({
             ...toggle,
             kompakt: this.props.kompakt,


### PR DESCRIPTION
- Gjør at prop `className` blir applied til komponenten når den blir brukt. 

Resolves #781 