### PR TITLE
@types i peerDep for react-collapse og react-modal

### DIFF
--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/package.json
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/package.json
@@ -13,6 +13,7 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "peerDependencies": {
+    "@types/react-collapse": "^4.0.1",
     "classnames": "^2.2.5",
     "nav-frontend-ekspanderbartpanel-style": "^1.0.19",
     "nav-frontend-js-utils": "^1.0.9",

--- a/packages/node_modules/nav-frontend-lesmerpanel/package.json
+++ b/packages/node_modules/nav-frontend-lesmerpanel/package.json
@@ -13,6 +13,7 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "peerDependencies": {
+    "@types/react-collapse": "^4.0.1",
     "classnames": "^2.2.5",
     "nav-frontend-chevron": "^1.0.13",
     "nav-frontend-js-utils": "^1.0.9",

--- a/packages/node_modules/nav-frontend-modal/package.json
+++ b/packages/node_modules/nav-frontend-modal/package.json
@@ -13,6 +13,7 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "peerDependencies": {
+    "@types/react-modal": "^3.1.2",
     "classnames": "^2.2.5",
     "nav-frontend-lukknapp": "^1.0.31",
     "nav-frontend-modal-style": "^0.3.35",


### PR DESCRIPTION
- Vil gjøre at `@types/react-collapse` og/eller `@types/react-modal` vil være lagt til i `install` teksten som er under fks https://design.nav.no/components/ekspanderbartpanel/technical. 
- Dette vil gjøre det lettere for brukerene å ta i bruk extended props for disse komponentene.

Resolves #779 
Tenker den meste effektive løsningen for nå er å ha med types som `default`, selv om bruker potensielt ikke trenger det for sitt prosjekt. 