### PR TITLE
Make input-panel detectable by react-modal

### DIFF
--- a/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
+++ b/packages/node_modules/nav-frontend-skjema-style/src/input-panel.less
@@ -26,7 +26,7 @@
     .typo-normal-mixin();
     position: absolute;
     width: 0;
-    height: 0;
+    height: 1px;
     opacity: 0;
 
     &:checked + .inputPanel__label:before {


### PR DESCRIPTION
react-modal sin focusmanager sjekker på om elementer har høyde og bredde, for å vite om en ett element kan ta fokus eller ikke. På grunn av at både height og width settes til 0 på inputPanel__field, blir det en bug når checkboxpanel/radiopanel er første fokuserbare element i en modal. `height: 1px` fixen er en basic fix.

Egentlig burde en kanskje funnet en annen måte å style check/radio på, enn ved å skjule input-elementet. Det er jo risiko for at andre moduler + verktøy plutselig også skipper elementer som er skjult.

Bugen kan sees her: https://navikt.github.io/sif-common-forms/#/næring - velg "Legg til", og tab frem og tilbake i dialogen, da ser en at focusmanageren feiler.