### PR TITLE
Fikset versionering etter feil med publisering til NPM

### DIFF
--- a/packages/node_modules/nav-frontend-ekspanderbartpanel/package.json
+++ b/packages/node_modules/nav-frontend-ekspanderbartpanel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-ekspanderbartpanel",
-  "version": "3.0.23",
+  "version": "3.0.24",
   "main": "lib/index.js",
   "license": "MIT",
   "types": "lib/index.d.ts",

--- a/packages/node_modules/nav-frontend-lesmerpanel/package.json
+++ b/packages/node_modules/nav-frontend-lesmerpanel/package.json
@@ -13,7 +13,6 @@
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
   "peerDependencies": {
-    "@types/react-collapse": "^4.0.1",
     "classnames": "^2.2.5",
     "nav-frontend-chevron": "^1.0.13",
     "nav-frontend-js-utils": "^1.0.9",

--- a/packages/node_modules/nav-frontend-modal/package.json
+++ b/packages/node_modules/nav-frontend-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-modal",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",

--- a/packages/node_modules/nav-frontend-skjema-style/package.json
+++ b/packages/node_modules/nav-frontend-skjema-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-skjema-style",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "main": "src/index.less",
   "license": "MIT",
   "files": [

--- a/packages/node_modules/nav-frontend-skjema/package.json
+++ b/packages/node_modules/nav-frontend-skjema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-skjema",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",
@@ -17,7 +17,7 @@
     "classnames": "^2.2.5",
     "nav-frontend-js-utils": "^1.0.9",
     "nav-frontend-lenker": "^1.0.41",
-    "nav-frontend-skjema-style": "^2.0.10",
+    "nav-frontend-skjema-style": "^2.0.11",
     "nav-frontend-typografi": "^2.0.26",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
@@ -27,7 +27,7 @@
     "classnames": "^2.2.5",
     "nav-frontend-js-utils": "^1.0.9",
     "nav-frontend-lenker": "^1.0.41",
-    "nav-frontend-skjema-style": "^2.0.10",
+    "nav-frontend-skjema-style": "^2.0.11",
     "nav-frontend-typografi": "^2.0.26",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"

--- a/packages/node_modules/nav-frontend-toggle/package.json
+++ b/packages/node_modules/nav-frontend-toggle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-toggle",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
Hva skjedde:
- Det ble merged en PR merged som gjorde endringer i tre komponenter: https://github.com/navikt/nav-frontend-moduler/pull/783
- En av disse komponentene var `nav-frontend-lesmerpanel` som `Navikt` organisasjonen på NPM ikke eier. 
- Travis CI lastet da opp 2/3 komponenter til NPM, men feilet på denne som vi ikke har tilgang til. 
- Oppdateringen av versjon i package.json som lerna automatisk gjør ble da ikke pushet til master på Github ved denne PR eller nye PR siden CI feiler på npm publish av denne komponenten.
- Dette førte til følgefeil der pakker ble publisert riktig ved første endring etter denne  feilen, men endringer etter det feiler. Dette er siden lerna henter versjonsnummer fra master som ikke er oppdatert og prøver da å publisere npm pakker til versjonsnummer som allerede finnes.

Fix: 
- Alle pakker som ikke fikk versjonsnummeret sitt riktig oppdatert skal nå ha riktig versjonsnummer.
- Endringen til `nav-frontend-lesmerpanel` er fjernet inntil problemet er fikset.

