### PR TITLE
Øker default fontsize i nav-frontend til 18/20

### DIFF
--- a/guideline-app/app/assets/styles/base.less
+++ b/guideline-app/app/assets/styles/base.less
@@ -2,7 +2,8 @@
 @import (reference) '~NavFrontendModules/nav-frontend-typografi-style/src/index';
 
 html {
-  font-size: 16px;
+  font-size: 115%; // fallback
+  font-size: calc(107% + 0.25vmin);
   height: 100%;
 }
 

--- a/guideline-app/app/assets/styles/base.less
+++ b/guideline-app/app/assets/styles/base.less
@@ -2,8 +2,10 @@
 @import (reference) '~NavFrontendModules/nav-frontend-typografi-style/src/index';
 
 html {
-  font-size: 115%; // fallback
-  font-size: calc(107% + 0.25vmin);
+  font-size: 115%;
+  @media (min-width: 768px) {
+    font-size: 125%;
+  }
   height: 100%;
 }
 

--- a/guideline-app/app/assets/styles/base.less
+++ b/guideline-app/app/assets/styles/base.less
@@ -3,7 +3,7 @@
 
 html {
   font-size: 115%;
-  @media (min-width: 768px) {
+  @media (min-width: 1200px) {
     font-size: 125%;
   }
   height: 100%;

--- a/packages/node_modules/nav-frontend-core/less/scaffolding.less
+++ b/packages/node_modules/nav-frontend-core/less/scaffolding.less
@@ -20,8 +20,10 @@
 // Body reset
 
 html {
-  font-size: 115%; // fallback
-  font-size: calc(107% + 0.25vmin);
+  font-size: 115%;
+  @media (min-width: 768px) {
+    font-size: 125%;
+  }
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 

--- a/packages/node_modules/nav-frontend-core/less/scaffolding.less
+++ b/packages/node_modules/nav-frontend-core/less/scaffolding.less
@@ -20,7 +20,8 @@
 // Body reset
 
 html {
-  font-size: 16px;
+  font-size: 115%; // fallback
+  font-size: calc(107% + 0.25vmin);
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 

--- a/packages/node_modules/nav-frontend-core/less/scaffolding.less
+++ b/packages/node_modules/nav-frontend-core/less/scaffolding.less
@@ -21,7 +21,7 @@
 
 html {
   font-size: 115%;
-  @media (min-width: 768px) {
+  @media (min-width: 1200px) {
     font-size: 125%;
   }
   -webkit-tap-highlight-color: rgba(0,0,0,0);


### PR DESCRIPTION
Går bort fra px og tar ibruk responsive enhet (%) som også respekterer accessibility-instillinger hos brukere.

Diskusjonen om større font-størrelse blusser opp med jevne mellomrom på Slack og i andre kanaler. For å få fart på denne prosessen har jeg laget en PR med forslag om å øke default font-størrelse på nav.no fra 16px til 18/20px.

For meg handler dette først og fremst om tilgjengelighet: å gjøre innholdet på nav.no lettere å lese og forstå for brukerne våre. Vi har i dag default font-størrelse på 16px, kombinert med en ganske “liten” font. På en side som nav.no mener jeg lesbarheten er enda viktigere enn vanlig da vi har kompliserte tekster med juss og fremmedord, kombinert med at våre brukere ofte er i en krevende livssituasjon. Da trenger de all den hjelpen de kan få.

Vi har eksperimentert med større fontstørrelse på våre sider i et halvt års tid og har bare fått gode erfaringer og tilbakemeldinger. Ser også at flere andre sider på nav.no har tatt grep og skrudd opp fontstørreslen lokalt.

Kunne ramset opp mange flere argumenter, men denne artikkelen belyser og argumenterer mye bedre enn hva jeg får til, anbefalt lesning om du er engasjert i dette :-) https://marvelapp.com/blog/body-text-small/

Mitt forslag:
html {
 font-size: 115%;
 @media (min-width: 1200px) {
   font-size: 125%;
 }
}

Dette vil gi en responsiv fontstørrelse basert på hvor stor skjerm bruker sitter på. Den vil også ta hensyn til eventuelle tilgjengelighetsinnstillinger bruker har gjort i operativsystem eller nettleser.

Med default innstillinger vil størrelsen bli:
18px på mobil
20px på laptop

Jeg tror denne endringen kan innføres uten at det krever særlig innsats fra teamene rundt på nav, men dersom man har stylet mye vha px, altså uten å bruke responsive enheter (rem, em, %, etc.), kan det hende vi vil se noen små styling-glitches her og der. Bruk av px vil uansett være kjapt å rette opp, og jeg kan ikke se for meg at dette faktisk vil knekke funksjonalitet i noen apper før man får ryddet i eventuelle styling-bugs.

Noen apper vil fortsatt ha behov for mindre fontstørrelse, feks interne fagsystemer der brukere ønsker mest mulig info og minst mulig luft. Da kan man overstyre med lokal css ala:
html {
   font-size: 100% !important;
}

Hvordan gjør andre det?
Tilfeldig research:
16/16 nav.no 
18/18 aftenposten.no
18/20 vg.no
18/21 medium.com
17.008/17.008 politiet.no
18/20 skatteetaten.no
18/20 difi.no
Skriftstørrelse i pixler, mobil/desktop

*edit: gikk bort fra  font-size: calc(107% + 0.25vmin) fordi calc og vmin kan ha dårlig støtte i noen eldre nettlesere;