### PR TITLE
Extracted classes into single files in nav-frontend-skjema

### DIFF
--- a/packages/nav-frontend-skjema/src/checkboks-panel-gruppe.tsx
+++ b/packages/nav-frontend-skjema/src/checkboks-panel-gruppe.tsx
@@ -1,87 +1,9 @@
-/* eslint-disable max-classes-per-file */
 import * as React from "react";
 import * as PT from "prop-types";
-import * as classNames from "classnames";
-import { guid } from "nav-frontend-js-utils";
+import { CheckboksPanel, CheckboksPanelProps, SkjemaGruppe } from ".";
 import "nav-frontend-skjema-style";
-import {
-  SkjemaGruppe,
-  SkjemaGruppeFeilContext,
-  SkjemaGruppeFeilContextProps,
-} from ".";
-
-export interface CheckboksPanelProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
-  label: React.ReactNode;
-  subtext?: string;
-}
-
-export interface CheckboksPanelState {
-  checked: boolean;
-  hasFocus: boolean;
-}
-
-export class CheckboksPanel extends React.Component<
-  CheckboksPanelProps,
-  CheckboksPanelState
-> {
-  constructor(props: CheckboksPanelProps) {
-    super(props);
-    this.state = { hasFocus: false, checked: !!this.props.checked };
-  }
-
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(newProps) {
-    this.setState({ checked: !!newProps.checked });
-  }
-
-  handleChange = (e) => {
-    this.setState({ checked: e.target.checked });
-    if (typeof this.props.onChange === "function") this.props.onChange(e);
-  };
-
-  toggleOutline() {
-    this.setState({ hasFocus: !this.state.hasFocus });
-  }
-
-  render() {
-    const { id, label, subtext, disabled, ...other } = this.props;
-    const { hasFocus, checked } = this.state;
-    const inputId = id || guid();
-
-    const cls = classNames("inputPanel checkboksPanel", {
-      "inputPanel--checked": checked && !disabled,
-      "inputPanel--focused": hasFocus && !disabled,
-      "inputPanel--disabled": disabled === true,
-    });
-
-    return (
-      <SkjemaGruppeFeilContext.Consumer>
-        {(context: SkjemaGruppeFeilContextProps) => (
-          <label className={cls} htmlFor={inputId}>
-            <input
-              id={inputId}
-              className="inputPanel__field"
-              type="checkbox"
-              checked={checked}
-              aria-checked={checked}
-              disabled={disabled}
-              aria-invalid={!!context.feil}
-              aria-errormessage={context.feilmeldingId}
-              {...other}
-              onFocus={() => this.toggleOutline()}
-              onBlur={() => this.toggleOutline()}
-              onChange={this.handleChange}
-            />
-            <span className="inputPanel__label">{label}</span>
-            {subtext && <span className="inputPanel__subtext">{subtext}</span>}
-          </label>
-        )}
-      </SkjemaGruppeFeilContext.Consumer>
-    );
-  }
-}
-
+import { guid } from "nav-frontend-js-utils";
+import classNames from "classnames";
 export interface CheckboksPanelGruppeProps {
   /**
    * Array av checkbokser

--- a/packages/nav-frontend-skjema/src/checkboks-panel.tsx
+++ b/packages/nav-frontend-skjema/src/checkboks-panel.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+import * as classNames from "classnames";
+import { guid } from "nav-frontend-js-utils";
+import "nav-frontend-skjema-style";
+import { SkjemaGruppeFeilContext, SkjemaGruppeFeilContextProps } from ".";
+
+export interface CheckboksPanelProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: React.ReactNode;
+  subtext?: string;
+}
+
+export interface CheckboksPanelState {
+  checked: boolean;
+  hasFocus: boolean;
+}
+
+class CheckboksPanel extends React.Component<
+  CheckboksPanelProps,
+  CheckboksPanelState
+> {
+  constructor(props: CheckboksPanelProps) {
+    super(props);
+    this.state = { hasFocus: false, checked: !!this.props.checked };
+  }
+
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(newProps) {
+    this.setState({ checked: !!newProps.checked });
+  }
+
+  handleChange = (e) => {
+    this.setState({ checked: e.target.checked });
+    if (typeof this.props.onChange === "function") this.props.onChange(e);
+  };
+
+  toggleOutline() {
+    this.setState({ hasFocus: !this.state.hasFocus });
+  }
+
+  render() {
+    const { id, label, subtext, disabled, ...other } = this.props;
+    const { hasFocus, checked } = this.state;
+    const inputId = id || guid();
+
+    const cls = classNames("inputPanel checkboksPanel", {
+      "inputPanel--checked": checked && !disabled,
+      "inputPanel--focused": hasFocus && !disabled,
+      "inputPanel--disabled": disabled === true,
+    });
+
+    return (
+      <SkjemaGruppeFeilContext.Consumer>
+        {(context: SkjemaGruppeFeilContextProps) => (
+          <label className={cls} htmlFor={inputId}>
+            <input
+              id={inputId}
+              className="inputPanel__field"
+              type="checkbox"
+              checked={checked}
+              aria-checked={checked}
+              disabled={disabled}
+              aria-invalid={!!context.feil}
+              aria-errormessage={context.feilmeldingId}
+              {...other}
+              onFocus={() => this.toggleOutline()}
+              onBlur={() => this.toggleOutline()}
+              onChange={this.handleChange}
+            />
+            <span className="inputPanel__label">{label}</span>
+            {subtext && <span className="inputPanel__subtext">{subtext}</span>}
+          </label>
+        )}
+      </SkjemaGruppeFeilContext.Consumer>
+    );
+  }
+}
+
+export default CheckboksPanel;

--- a/packages/nav-frontend-skjema/src/checkbox-gruppe.tsx
+++ b/packages/nav-frontend-skjema/src/checkbox-gruppe.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import * as classNames from "classnames";
+import { SkjemaGruppe, SkjemaGruppeProps } from ".";
+import "nav-frontend-skjema-style";
+
+class CheckboxGruppe extends React.Component<SkjemaGruppeProps> {
+  render() {
+    const { children, className, ...other } = this.props;
+    return (
+      <SkjemaGruppe
+        className={classNames("checkboxgruppe", className)}
+        {...other}
+      >
+        {children}
+      </SkjemaGruppe>
+    );
+  }
+}
+
+export default CheckboxGruppe;

--- a/packages/nav-frontend-skjema/src/checkbox.tsx
+++ b/packages/nav-frontend-skjema/src/checkbox.tsx
@@ -1,30 +1,10 @@
-/* eslint-disable max-classes-per-file */
 import * as PT from "prop-types";
 import * as React from "react";
 import * as classNames from "classnames";
 import { guid } from "nav-frontend-js-utils";
 import SkjemaelementFeilmelding from "./skjemaelement-feilmelding";
-import {
-  SkjemaGruppe,
-  SkjemaGruppeProps,
-  SkjemaGruppeFeilContext,
-  SkjemaGruppeFeilContextProps,
-} from ".";
+import { SkjemaGruppeFeilContext, SkjemaGruppeFeilContextProps } from ".";
 import "nav-frontend-skjema-style";
-
-export class CheckboxGruppe extends React.Component<SkjemaGruppeProps> {
-  render() {
-    const { children, className, ...other } = this.props;
-    return (
-      <SkjemaGruppe
-        className={classNames("checkboxgruppe", className)}
-        {...other}
-      >
-        {children}
-      </SkjemaGruppe>
-    );
-  }
-}
 
 const cls = (className) => classNames("skjemaelement", className);
 const inputCls = (harFeil) =>

--- a/packages/nav-frontend-skjema/src/index.ts
+++ b/packages/nav-frontend-skjema/src/index.ts
@@ -5,7 +5,8 @@ export {
   default as TextareaControlled,
   TextareaControlledProps,
 } from "./textarea-controlled";
-export { default as Checkbox, CheckboxProps, CheckboxGruppe } from "./checkbox";
+export { default as Checkbox, CheckboxProps } from "./checkbox";
+export { default as CheckboxGruppe } from "./checkbox-gruppe";
 export { default as Radio, RadioProps } from "./radio";
 export { default as RadioGruppe } from "./radio-gruppe";
 export { default as Select, SelectProps } from "./select";
@@ -20,9 +21,8 @@ export { default as ToggleKnapp, ToggleKnappProps } from "./toggle-knapp";
 export {
   default as RadioPanelGruppe,
   RadioPanelGruppeProps,
-  RadioPanel,
-  RadioPanelProps,
 } from "./radio-panel-gruppe";
+export { default as RadioPanel, RadioPanelProps } from "./radio-panel";
 export {
   default as CheckboksPanelGruppe,
   CheckboksPanelGruppeProps,

--- a/packages/nav-frontend-skjema/src/index.ts
+++ b/packages/nav-frontend-skjema/src/index.ts
@@ -6,7 +6,8 @@ export {
   TextareaControlledProps,
 } from "./textarea-controlled";
 export { default as Checkbox, CheckboxProps, CheckboxGruppe } from "./checkbox";
-export { default as Radio, RadioProps, RadioGruppe } from "./radio";
+export { default as Radio, RadioProps } from "./radio";
+export { default as RadioGruppe } from "./radio-gruppe";
 export { default as Select, SelectProps } from "./select";
 export {
   default as SkjemaGruppe,

--- a/packages/nav-frontend-skjema/src/index.ts
+++ b/packages/nav-frontend-skjema/src/index.ts
@@ -26,9 +26,11 @@ export {
 export {
   default as CheckboksPanelGruppe,
   CheckboksPanelGruppeProps,
-  CheckboksPanel,
-  CheckboksPanelProps,
 } from "./checkboks-panel-gruppe";
+export {
+  default as CheckboksPanel,
+  CheckboksPanelProps,
+} from "./checkboks-panel";
 export {
   default as BekreftCheckboksPanel,
   BekreftCheckboksPanelProps,

--- a/packages/nav-frontend-skjema/src/radio-gruppe.tsx
+++ b/packages/nav-frontend-skjema/src/radio-gruppe.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import * as classNames from "classnames";
+import { SkjemaGruppe, SkjemaGruppeProps } from ".";
+
+class RadioGruppe extends React.Component<SkjemaGruppeProps> {
+  render() {
+    const { children, className, ...other } = this.props;
+    return (
+      <SkjemaGruppe className={classNames("radiogruppe", className)} {...other}>
+        {children}
+      </SkjemaGruppe>
+    );
+  }
+}
+
+export default RadioGruppe;

--- a/packages/nav-frontend-skjema/src/radio-gruppe.tsx
+++ b/packages/nav-frontend-skjema/src/radio-gruppe.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as classNames from "classnames";
 import { SkjemaGruppe, SkjemaGruppeProps } from ".";
-
+import "nav-frontend-skjema-style";
 class RadioGruppe extends React.Component<SkjemaGruppeProps> {
   render() {
     const { children, className, ...other } = this.props;

--- a/packages/nav-frontend-skjema/src/radio-panel-gruppe.tsx
+++ b/packages/nav-frontend-skjema/src/radio-panel-gruppe.tsx
@@ -1,72 +1,10 @@
-/* eslint-disable max-classes-per-file */
 import * as React from "react";
 import * as PT from "prop-types";
 import * as classNames from "classnames";
 import { guid } from "nav-frontend-js-utils";
-import {
-  SkjemaGruppe,
-  SkjemaGruppeFeilContext,
-  SkjemaGruppeFeilContextProps,
-} from ".";
+import { RadioPanel, RadioPanelProps, SkjemaGruppe } from ".";
+
 import "nav-frontend-skjema-style";
-
-export interface RadioPanelProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
-  label: React.ReactNode;
-}
-
-export interface RadioPanelState {
-  hasFocus: boolean;
-}
-
-export class RadioPanel extends React.Component<
-  RadioPanelProps,
-  RadioPanelState
-> {
-  constructor(props: RadioPanelProps) {
-    super(props);
-    this.state = { hasFocus: false };
-  }
-
-  toggleOutline() {
-    this.setState({ hasFocus: !this.state.hasFocus });
-  }
-
-  render() {
-    const { id, label, checked, disabled, ...other } = this.props;
-    const { hasFocus } = this.state;
-    const inputId = id || guid();
-
-    const cls = classNames("inputPanel radioPanel", {
-      "inputPanel--checked": checked && !disabled,
-      "inputPanel--focused": hasFocus && !disabled,
-      "inputPanel--disabled": disabled === true,
-    });
-
-    return (
-      <SkjemaGruppeFeilContext.Consumer>
-        {(context: SkjemaGruppeFeilContextProps) => (
-          <label className={cls} htmlFor={inputId}>
-            <input
-              id={inputId}
-              className="inputPanel__field"
-              type="radio"
-              checked={checked}
-              aria-checked={checked}
-              disabled={disabled}
-              aria-invalid={!!context.feil}
-              aria-errormessage={context.feilmeldingId}
-              {...other}
-              onFocus={() => this.toggleOutline()}
-              onBlur={() => this.toggleOutline()}
-            />
-            <span className="inputPanel__label">{label}</span>
-          </label>
-        )}
-      </SkjemaGruppeFeilContext.Consumer>
-    );
-  }
-}
 
 export interface RadioPanelGruppeProps {
   /**

--- a/packages/nav-frontend-skjema/src/radio-panel.tsx
+++ b/packages/nav-frontend-skjema/src/radio-panel.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+import * as classNames from "classnames";
+import { guid } from "nav-frontend-js-utils";
+import { SkjemaGruppeFeilContext, SkjemaGruppeFeilContextProps } from ".";
+import "nav-frontend-skjema-style";
+
+export interface RadioPanelProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: React.ReactNode;
+}
+
+export interface RadioPanelState {
+  hasFocus: boolean;
+}
+
+export class RadioPanel extends React.Component<
+  RadioPanelProps,
+  RadioPanelState
+> {
+  constructor(props: RadioPanelProps) {
+    super(props);
+    this.state = { hasFocus: false };
+  }
+
+  toggleOutline() {
+    this.setState({ hasFocus: !this.state.hasFocus });
+  }
+
+  render() {
+    const { id, label, checked, disabled, ...other } = this.props;
+    const { hasFocus } = this.state;
+    const inputId = id || guid();
+
+    const cls = classNames("inputPanel radioPanel", {
+      "inputPanel--checked": checked && !disabled,
+      "inputPanel--focused": hasFocus && !disabled,
+      "inputPanel--disabled": disabled === true,
+    });
+
+    return (
+      <SkjemaGruppeFeilContext.Consumer>
+        {(context: SkjemaGruppeFeilContextProps) => (
+          <label className={cls} htmlFor={inputId}>
+            <input
+              id={inputId}
+              className="inputPanel__field"
+              type="radio"
+              checked={checked}
+              aria-checked={checked}
+              disabled={disabled}
+              aria-invalid={!!context.feil}
+              aria-errormessage={context.feilmeldingId}
+              {...other}
+              onFocus={() => this.toggleOutline()}
+              onBlur={() => this.toggleOutline()}
+            />
+            <span className="inputPanel__label">{label}</span>
+          </label>
+        )}
+      </SkjemaGruppeFeilContext.Consumer>
+    );
+  }
+}
+
+export default RadioPanel;

--- a/packages/nav-frontend-skjema/src/radio.tsx
+++ b/packages/nav-frontend-skjema/src/radio.tsx
@@ -1,27 +1,9 @@
-/* eslint-disable indent */
-/* eslint-disable max-classes-per-file */
 import * as PT from "prop-types";
 import * as React from "react";
 import * as classNames from "classnames";
 import { guid } from "nav-frontend-js-utils";
 import "nav-frontend-skjema-style";
-import {
-  SkjemaGruppe,
-  SkjemaGruppeProps,
-  SkjemaGruppeFeilContext,
-  SkjemaGruppeFeilContextProps,
-} from ".";
-
-export class RadioGruppe extends React.Component<SkjemaGruppeProps> {
-  render() {
-    const { children, className, ...other } = this.props;
-    return (
-      <SkjemaGruppe className={classNames("radiogruppe", className)} {...other}>
-        {children}
-      </SkjemaGruppe>
-    );
-  }
-}
+import { SkjemaGruppeFeilContext, SkjemaGruppeFeilContextProps } from ".";
 
 const cls = (className) => classNames("skjemaelement", className);
 

--- a/packages/nav-frontend-skjema/src/skjemaelement-feilmelding.tsx
+++ b/packages/nav-frontend-skjema/src/skjemaelement-feilmelding.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Feilmelding } from "nav-frontend-typografi";
+import "nav-frontend-skjema-style";
 
 class SkjemaelementFeilmelding extends React.Component<
   React.HTMLAttributes<HTMLDivElement>

--- a/packages/nav-frontend-skjema/src/textarea-controlled.tsx
+++ b/packages/nav-frontend-skjema/src/textarea-controlled.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as PT from "prop-types";
 import { omit } from "nav-frontend-js-utils";
 import Textarea from "./textarea";
+import "nav-frontend-skjema-style";
 
 export interface TextareaControlledProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {


### PR DESCRIPTION
- Makes react-docgen propely read props.
- React-docgen now gets props from all components in `nav-frontend-skjema`
Should not ™️  change any functionality in component.