### PR TITLE
Hotfix sidehøyde

### DIFF
--- a/website/src/pages/styles.less
+++ b/website/src/pages/styles.less
@@ -7,7 +7,6 @@
 
   .mainWrapper {
     height: 100%;
-    display: flex;
     flex-direction: column;
 
     .contentWrapper {


### PR DESCRIPTION
- Firefox defaultet til noe lignende `height: fit-content` noe som gjorde at scroll på sidebar ikke fungerte og sidemenyen ble ødelagt.