### PR TITLE
Fjernet normalize.css dependecy i core

### DIFF
--- a/packages/nav-frontend-core/less/core.less
+++ b/packages/nav-frontend-core/less/core.less
@@ -10,7 +10,7 @@
 @import "_elevasjon.less";
 
 // Reset and dependencies
-@import (less) "normalize.css";
+@import "./vendor/_normalize.less";
 @import "print.less";
 
 // Core CSS

--- a/packages/nav-frontend-core/package.json
+++ b/packages/nav-frontend-core/package.json
@@ -10,9 +10,6 @@
     "/less",
     "/css"
   ],
-  "dependencies": {
-    "normalize.css": "^8.0.1"
-  },
   "devDependencies": {
     "lessc": "^1.0.2"
   },


### PR DESCRIPTION
- Brukere av eldre `less-loader` versjoner kunne få litt uheldige feil med bruk av modul over lokal fil. Venter med bruk av `normalize.css` pakken til major bump