### PR TITLE
Gjort proptable litt mer rigid og leselig

### DIFF
--- a/website/src/components/proptable/PropTable.jsx
+++ b/website/src/components/proptable/PropTable.jsx
@@ -1,4 +1,4 @@
-import React, {useRef} from "react";
+import React, { useRef } from "react";
 import PT from "prop-types";
 import cn from "classnames";
 
@@ -16,8 +16,8 @@ const PropTable = ({ moduleProps, ...props }) => {
     ...propTypes[key],
   }));
 
-  const table = useRef()
-  const headers = ["Property", "Type", "Required", "Description", "Default"];
+  const table = useRef();
+  const headers = ["Property", "Type", "Default", "Required", "Description"];
 
   return (
     <OverflowDetector>
@@ -97,16 +97,28 @@ const parseDescription = (desc) => {
 const PropTypeTableRow = (props) => {
   const desc = parseDescription(parsePropValue(props.val.description));
   return (
-    <tr className={cn({ deprecated: typeof desc === "object" })}>
+    <tr
+      className={cn("proptable__tr", { deprecated: typeof desc === "object" })}
+    >
       <td>
-        <strong>{parsePropValue(props.val.name)}</strong>
+        <div>
+          <strong>{parsePropValue(props.val.name)}</strong>
+        </div>
       </td>
       <td>
-        <code className="inline">{parsePropValue(props.val.type)}</code>
+        <div>
+          <code className="inline">{parsePropValue(props.val.type)}</code>
+        </div>
       </td>
-      <td>{parsePropValue(props.val.required)}</td>
-      <td>{desc}</td>
-      <td>{parsePropValue(props.val.defaultValue)}</td>
+      <td>
+        <div>{parsePropValue(props.val.defaultValue)}</div>
+      </td>
+      <td>
+        <div>{props.val.required ? "✅" : "❌"}</div>
+      </td>
+      <td>
+        <div>{desc}</div>
+      </td>
     </tr>
   );
 };

--- a/website/src/components/proptable/styles.less
+++ b/website/src/components/proptable/styles.less
@@ -49,8 +49,8 @@
     justify-content: space-between;
 
     nav {
-      padding-right: 2rem;
-      margin-right: 2rem;
+      padding-right: 1rem;
+      margin-right: 1rem;
       border-right: 1px solid @navLysGra;
       flex: 1 1 auto;
 

--- a/website/src/components/proptable/styles.less
+++ b/website/src/components/proptable/styles.less
@@ -126,3 +126,12 @@
     }
   }
 }
+
+.proptable__tr {
+  div {
+    max-width: 14rem;
+    max-height: 8rem;
+    display: block;
+    overflow-y: scroll;
+  }
+}


### PR DESCRIPTION
- <td> har nå max/min width, samt max height slik at utseende på innholdet ikke varierer så ekstremt mellom sider (eks Alertstriper og bekreftcheckboxpanel nå)
- Flyttet om på rekkefølgen for info
- Emojies over true/false for `required`. Er dette noe vi ønsker, samt ønsker vi noen mer nøytrale? Tanken er å gjøre informasjonen klarere å forstå ved et raskt overblikk.

## Ny
<img width="950" alt="Screenshot 2020-11-05 at 14 24 27" src="https://user-images.githubusercontent.com/26967723/98246678-e98d0c80-1f72-11eb-98a3-fa8db33629e7.png">

## Gammel
<img width="964" alt="Screenshot 2020-11-05 at 14 30 08" src="https://user-images.githubusercontent.com/26967723/98247086-73d57080-1f73-11eb-96d0-1f5bdcd18905.png">

