### PR TITLE
Ny header

### DIFF
--- a/website/src/components/layout/header/header.jsx
+++ b/website/src/components/layout/header/header.jsx
@@ -57,6 +57,7 @@ const Header = ({ ...props }) => {
             onClick={() => toggleMobileNav()}
             {...ariaHidden}
           />
+          <div style={{ flexGrow: 1 }} />
           <MainNav />
         </div>
       </header>

--- a/website/src/components/layout/header/header.less
+++ b/website/src/components/layout/header/header.less
@@ -6,7 +6,6 @@
   line-height: auto;
   border-bottom: 4px solid @navLysGra;
   z-index: 200;
-
   height: 100%;
 
   &__content {

--- a/website/src/components/layout/header/header.less
+++ b/website/src/components/layout/header/header.less
@@ -7,8 +7,17 @@
   border-bottom: 4px solid @navLysGra;
   z-index: 200;
 
+  height: 100%;
+
   &__content {
-    padding: 1.5rem 2rem 0;
+    top: 4px;
+    padding: 1.3rem 2rem 0;
+    padding-bottom: 1.3rem;
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+    height: 100%;
+    min-height: 6.875rem;
 
     .header__logo {
       display: inline-flex;
@@ -24,7 +33,7 @@
         padding-left: 1rem;
         padding-right: 1rem;
         margin: 0;
-        margin-top: 1.2rem;
+        margin-top: 1.4rem;
       }
 
       &:hover {
@@ -44,13 +53,13 @@
 
   @media (max-width: 1094px) {
     .header__content {
-      padding-bottom: 1.5rem;
+      padding-bottom: 1.3rem;
     }
   }
 
   @media (max-width: 550px) {
     .header__content {
-      padding: 1rem 1.5rem;
+      padding: 1rem 1.5rem 1rem;
 
       svg {
         width: 4.7rem;
@@ -60,7 +69,7 @@
         font-size: 1.375rem;
         padding-left: 0.75rem;
         padding-right: 0.75rem;
-        margin-top: 0.77rem;
+        margin-top: 1.65rem;
       }
     }
   }
@@ -68,7 +77,7 @@
   // Em since typografi component has auto adjustment at max-width 30em
   @media (max-width: 30em) {
     .header__content {
-      padding: 1rem 1.5rem;
+      padding: 1rem 1.5rem 1rem;
 
       svg {
         width: 3.75rem;
@@ -78,7 +87,7 @@
         font-size: 1.25rem;
         padding-left: 0.5rem;
         padding-right: 0.5rem;
-        margin-top: 0.5rem;
+        margin-top: 1.55rem;
       }
     }
   }

--- a/website/src/components/layout/header/main-nav/MainNav.jsx
+++ b/website/src/components/layout/header/main-nav/MainNav.jsx
@@ -23,14 +23,13 @@ const MainNav = () => {
               </Link>
             </li>
           ))}
-          <div style={{ flexGrow: 1 }} />
+          <div />
           <li>
             <a
               href="https://github.com/navikt/nav-frontend-moduler"
               className="github"
             >
               <GithubLogo />
-              Github
             </a>
           </li>
         </ul>

--- a/website/src/components/layout/header/main-nav/MainNav.jsx
+++ b/website/src/components/layout/header/main-nav/MainNav.jsx
@@ -23,7 +23,6 @@ const MainNav = () => {
               </Link>
             </li>
           ))}
-          <div />
           <li>
             <a
               href="https://github.com/navikt/nav-frontend-moduler"

--- a/website/src/components/layout/header/main-nav/styles.less
+++ b/website/src/components/layout/header/main-nav/styles.less
@@ -1,13 +1,14 @@
 @import (reference) "nav-frontend-core/less/_variabler";
 
 .mainNav {
-  //flex: 1 1 100%;
   background: white;
   margin-bottom: -1.3rem;
+
   &__wrapper {
     display: flex;
     justify-content: space-between;
     height: 100%;
+
     ul {
       list-style: none;
       display: flex;

--- a/website/src/components/layout/header/main-nav/styles.less
+++ b/website/src/components/layout/header/main-nav/styles.less
@@ -43,12 +43,14 @@
             border-bottom: 4px solid @navBla;
             z-index: 1;
           }
+
           &:active {
             outline: none;
             color: @fokusFarge;
             border-bottom: 4px solid @fokusFarge;
             z-index: 1;
           }
+
           &.active:focus {
             outline: none;
             border-bottom: 4px solid @navBla;

--- a/website/src/components/layout/header/main-nav/styles.less
+++ b/website/src/components/layout/header/main-nav/styles.less
@@ -1,48 +1,66 @@
 @import (reference) "nav-frontend-core/less/_variabler";
 
 .mainNav {
-  margin-top: 1rem;
+  //flex: 1 1 100%;
   background: white;
-
+  margin-bottom: -1.3rem;
   &__wrapper {
     display: flex;
     justify-content: space-between;
-
+    height: 100%;
     ul {
       list-style: none;
       display: flex;
       margin: 0;
-      padding: 0;
       width: 100%;
+      flex-wrap: wrap;
 
       li {
         a {
+          height: 100%;
           white-space: nowrap;
           display: block;
-          font-size: 1.1rem;
-          color: @navBla;
+          font-size: 1.2rem;
+          color: @navMorkGra;
           padding: 0.75rem 1.25rem;
+          padding-bottom: 1.3rem;
           text-decoration: none;
           border-bottom: 4px solid transparent;
           position: relative;
           top: 4px;
+          padding-top: 1.4rem;
 
           &:hover {
-            background: #f8f8f8;
+            color: @navBla;
             border-bottom: 4px solid @navBla;
+            z-index: 1;
           }
 
           &:focus {
             outline: none;
-            box-shadow: 0 0 0 3px @fokusFarge;
+            color: @navBla;
+            border-bottom: 4px solid @navBla;
+            z-index: 1;
+          }
+          &:active {
+            outline: none;
+            color: @fokusFarge;
+            border-bottom: 4px solid @fokusFarge;
+            z-index: 1;
+          }
+          &.active:focus {
+            outline: none;
+            border-bottom: 4px solid @navBla;
+            color: @navBla;
             z-index: 1;
           }
 
           &.active {
             background: white;
             font-weight: bold;
-            border-bottom: 4px solid @navBla;
+            border-bottom: 4px solid @fokusFarge;
             color: @navMorkGra;
+            z-index: 1;
           }
 
           &.github {

--- a/website/src/components/layout/layout.less
+++ b/website/src/components/layout/layout.less
@@ -13,7 +13,7 @@
       display: flex;
       flex: 1;
       background: white;
-      height: calc(100vh - 151px);
+      height: calc(100vh - 6.875rem);
       min-height: 0;
       position: relative;
 


### PR DESCRIPTION
- Testet med 300% zoom og 200%/32px font-size, er mer nå mer UU kompatibel.

![Nov-06-2020 15-47-34](https://user-images.githubusercontent.com/26967723/98379300-6d182d80-2047-11eb-8455-f0818b974fa0.gif)

## NY
<img width="1679" alt="Screenshot 2020-11-06 at 15 16 23" src="https://user-images.githubusercontent.com/26967723/98376358-a8186200-2043-11eb-95e4-7e9db0128223.png">

## Gammel
<img width="1680" alt="Screenshot 2020-11-06 at 15 16 45" src="https://user-images.githubusercontent.com/26967723/98376391-b1093380-2043-11eb-914a-a5307f936f0e.png">
