### PR TITLE
Endre Chevron til <span> fra <i>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 > **Obs!** Denne endringsloggen blir manuelt og uregelmessig oppdatert, og er hovedsakelig ment som en grov retrospektiv oppsummering for både tekniske og ikke-tekniske lesere. Det kan dermed ta en stund før publiserte endringer blir loggført her. For å se de siste faktiske endringene kan du ta en titt på [commit-historikken](https://github.com/navikt/nav-frontend-moduler/commits/master), [PR-historikken](https://github.com/navikt/nav-frontend-moduler/pulls?q=is%3Apr+is%3Aclosed) og/eller [release-oversikten](https://github.com/navikt/nav-frontend-moduler/releases) for NPM-pakkene våre.
 
+## 14. Desember 2020
+
+### Endringer Chevron
+
+[Pull-request](https://github.com/navikt/nav-frontend-moduler/pull/916)
+
+- Endret implementasjon til å bruke `<span>` over `<i>` da dette var sett på som dårlig praksis.
+- Bumpet Chevron komponent til v1 da ingen større endringer vil treffe denne komponenten fremmover.
+
 ## 18. januar 2020
 
 ### [Den Store Skjema-oppdateringen™](https://gist.github.com/Lillebo/7394a6e491d479795a6418d93bff638c)

--- a/packages/nav-frontend-chevron-style/package.json
+++ b/packages/nav-frontend-chevron-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-chevron-style",
-  "version": "0.3.10",
+  "version": "1.0.0",
   "main": "src/index.less",
   "license": "MIT",
   "files": [

--- a/packages/nav-frontend-chevron/src/chevron.tsx
+++ b/packages/nav-frontend-chevron/src/chevron.tsx
@@ -43,7 +43,7 @@ export interface NavFrontendChevronProps {
 class NavFrontendChevron extends React.Component<NavFrontendChevronProps> {
   render() {
     const { type, stor, className, ...props } = this.props;
-    return <i className={cls(type, stor, className)} {...props} />;
+    return <span className={cls(type, stor, className)} {...props} />;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3931,13 +3931,6 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react-collapse@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/react-collapse/-/react-collapse-4.0.2.tgz#891ebb8598a10d2168d5b3bfe5dedb4fb05e6537"
-  integrity sha512-hW9T8bPLAf7EZrMapES8YeoByQ2sy8T+QebcoJjOcsdVeqFfjmOlOyApLiIq7kaOeiJ7iiPFoG02VttHMVX5YA==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-collapse@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@types/react-collapse/-/react-collapse-5.0.0.tgz#ffe6173db457b4b147319e1bd522b5b9d3d68fac"


### PR DESCRIPTION
- Bruk av `<i>` regnes som dårlig praksis for ikoner.

- Bumper versjon til v1.0 for å unngå problemer framover etter oppdatering til designsystemet v.2/vnext