### PR TITLE
Oppdatert kontraster kode-eksempel

### DIFF
--- a/website/src/components/code/Code.tsx
+++ b/website/src/components/code/Code.tsx
@@ -6,6 +6,7 @@ import Popover, { PopoverOrientering } from "nav-frontend-popover";
 import { Normaltekst } from "nav-frontend-typografi";
 import { CopyIcon } from "../assets/images/svg";
 import "./styles.less";
+import "./theme.css";
 
 export const copyImport = (e, content: string) => {
   copy(content, {

--- a/website/src/components/code/theme.css
+++ b/website/src/components/code/theme.css
@@ -1,0 +1,105 @@
+/* Generated with http://k88hudson.github.io/syntax-highlighting-theme-generator/www */
+/* http://k88hudson.github.io/react-markdocs */
+/**
+ * @author k88hudson
+ *
+ * Based on prism.js default theme for JavaScript, CSS and HTML
+ * Based on dabblet (http://dabblet.com)
+ * @author Lea Verou
+ */
+
+:not(pre) > code[class*="language-"] {
+  padding: 0.1em 0.3em;
+  border-radius: 0.3em;
+  color: #c30000;
+  background: #f4f4f4;
+}
+/*********************************************************
+* Tokens
+*/
+.namespace {
+  opacity: 0.7;
+}
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #627070;
+}
+.token.punctuation {
+  color: #6e6e6e;
+}
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #990055;
+}
+.token.selector,
+.token.attr-name,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #517900;
+}
+.token.string {
+  color: #0077aa;
+}
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+  color: #806245;
+  background: #ffffff;
+}
+.token.atrule,
+.token.attr-value,
+.token.keyword,
+.token.class-name {
+  color: #0077aa;
+}
+.token.function {
+  color: #c42545;
+}
+.token.regex,
+.token.important,
+.token.variable {
+  color: #9c6400;
+}
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+.token.italic {
+  font-style: italic;
+}
+.token.entity {
+  cursor: help;
+}
+/*********************************************************
+* Line highlighting
+*/
+pre[data-line] {
+  position: relative;
+}
+pre[class*="language-"] > code[class*="language-"] {
+  position: relative;
+  z-index: 1;
+}
+.line-highlight {
+  position: absolute;
+  left: 0;
+  right: 0;
+  padding: inherit 0;
+  margin-top: 1em;
+  background: #f7ebc6;
+  box-shadow: inset 5px 0 0 #f7d87c;
+  z-index: 0;
+  pointer-events: none;
+  line-height: inherit;
+  white-space: pre;
+}


### PR DESCRIPTION
- Mindre endringer for å treffe 4.5:1

<img width="299" alt="Screenshot 2020-12-14 at 12 28 12" src="https://user-images.githubusercontent.com/26967723/102076344-de49be00-3e07-11eb-9e5b-84e6925d0840.png">
<img width="678" alt="Screenshot 2020-12-14 at 12 28 18" src="https://user-images.githubusercontent.com/26967723/102076349-df7aeb00-3e07-11eb-9b14-272792c3241f.png">


Resolves #917 
