### PR TITLE
Fikset Less math "mixins" for Less v4

### DIFF
--- a/packages/nav-frontend-chevron-style/src/mixins.less
+++ b/packages/nav-frontend-chevron-style/src/mixins.less
@@ -1,5 +1,5 @@
 .chevron-mixin(@size: 20) {
-  @height: floor(@size / 10);
+  @height: floor((@size / 10));
 
   display: inline-block;
   flex-shrink: 0;
@@ -39,7 +39,7 @@
 }
 
 .chevron-orientasjon-mixin(@orientasjon, @size: 20) when (@orientasjon = opp) {
-  @offset: floor(@size / 16) + 1;
+  @offset: floor((@size / 16)) + 1;
 
   &::before {
     transform: translateX(~"@{offset}px") rotate(-45deg);
@@ -51,7 +51,7 @@
 }
 
 .chevron-orientasjon-mixin(@orientasjon, @size: 20) when (@orientasjon = ned) {
-  @offset: floor(@size / 16) + 1;
+  @offset: floor((@size / 16)) + 1;
 
   &::before {
     transform: translateX(~"@{offset}px") rotate(45deg);
@@ -63,16 +63,16 @@
 }
 
 .chevron-orientasjon-mixin(@orientasjon, @size: 20)
-when
-(@orientasjon = hoyre) {
+  when
+  (@orientasjon = hoyre) {
   .chevron-orientasjon-mixin(ned, @size);
 
   transform: rotate(-90deg);
 }
 
 .chevron-orientasjon-mixin(@orientasjon, @size: 20)
-when
-(@orientasjon = venstre) {
+  when
+  (@orientasjon = venstre) {
   .chevron-orientasjon-mixin(opp, @size);
 
   transform: rotate(-90deg);

--- a/packages/nav-frontend-chevron-style/src/mixins.less
+++ b/packages/nav-frontend-chevron-style/src/mixins.less
@@ -61,18 +61,14 @@
     transform: translateX(~"-@{offset}px") rotate(-45deg);
   }
 }
-
-.chevron-orientasjon-mixin(@orientasjon, @size: 20)
-  when
-  (@orientasjon = hoyre) {
+// prettier-ignore
+.chevron-orientasjon-mixin(@orientasjon, @size: 20) when (@orientasjon = hoyre) {
   .chevron-orientasjon-mixin(ned, @size);
 
   transform: rotate(-90deg);
 }
-
-.chevron-orientasjon-mixin(@orientasjon, @size: 20)
-  when
-  (@orientasjon = venstre) {
+// prettier-ignore
+.chevron-orientasjon-mixin(@orientasjon, @size: 20) when (@orientasjon = venstre) {
   .chevron-orientasjon-mixin(opp, @size);
 
   transform: rotate(-90deg);


### PR DESCRIPTION
### Fix
`floor(@size / 16)` -> `floor((@size / 16))`

- Antar feilen oppstår da "mixins" **må** ha parentes i less v4 og det da ble noe krøll med kalkuleringen av verdier.

Har søkt etter problemer for lik bruk av math i stilpakkene, men fant ikke noe.
Resolves #934 