### PR TITLE
UU-fix for Alertstripe ikoner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 > **Obs!** Denne endringsloggen blir manuelt og uregelmessig oppdatert, og er hovedsakelig ment som en grov retrospektiv oppsummering for både tekniske og ikke-tekniske lesere. Det kan dermed ta en stund før publiserte endringer blir loggført her. For å se de siste faktiske endringene kan du ta en titt på [commit-historikken](https://github.com/navikt/nav-frontend-moduler/commits/master), [PR-historikken](https://github.com/navikt/nav-frontend-moduler/pulls?q=is%3Apr+is%3Aclosed) og/eller [release-oversikten](https://github.com/navikt/nav-frontend-moduler/releases) for NPM-pakkene våre.
 
+## 04. Januar 2021
+
+### Oppdaterte Alertstripe komponent for bedre UU
+
+[Pull-request](https://github.com/navikt/nav-frontend-moduler/pull/940)
+
+SVG-ikonene Alertstripe brukte har nå `role="img"` og `aria-label` for å fikse
+[WCAG 2.1 SC 1.1.1](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)
+
+### Fikset Math kalkulering for LESS v4
+
+[Pull-request](https://github.com/navikt/nav-frontend-moduler/pull/937)
+
+- Chevron mixin kalkulerte `Floor` uten parentes rundt intern kalkulering, noe LESS v4 ikke taklet.
+
+### Oppdatert eksempel-prosjekt for CRA og Webpack
+
+[Pull-request](https://github.com/navikt/nav-frontend-moduler/pull/931)
+
+- Oppdatert til nyeste CRA
+- Oppdatert til enklere eslint config
+- Satt opp prettier, pretty-quick og stylelint
+- Satt opp husky for commit og push (v4)
+- Begge bruker nå nav-frontend-core for scaffolding by default
+
+## 21. Desember 2020
+
+### Fikset mixins for LESS v4
+
+[Pull-request](https://github.com/navikt/nav-frontend-moduler/pull/930)
+
+- LESS v4 krever at alle mixins må bli brukt med parentes.
+
+`.skjemaelement__input;` ❌
+
+`.skjemaelement__input();` ✅
+
 ## 14. Desember 2020
 
 ### Endringer Chevron

--- a/packages/nav-frontend-alertstriper/src/alertstripe.tsx
+++ b/packages/nav-frontend-alertstriper/src/alertstripe.tsx
@@ -66,7 +66,12 @@ class AlertStripe extends React.Component<Props> {
       <div className={cls(type, form, className)} {...props}>
         <span className="alertstripe__ikon">
           <span className="sr-only">{type}</span>
-          <Ikon kind={ikonKind(type)} size={size} />
+          <Ikon
+            role="img"
+            aria-label={`${type}-ikon`}
+            kind={ikonKind(type)}
+            size={size}
+          />
         </span>
         <Normaltekst className="alertstripe__tekst" tag="div">
           {children}


### PR DESCRIPTION
Endringer for å tilfredsstille https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html
- Satt `role="img"` på  SVG
- Satt `aria-labelby` på SVG

Sideeffect: Oppdaterer også Changelog i samme slengen

Resolves #939 
