### PR TITLE
Link to new figma icons doc

### DIFF
--- a/website/src/pages/resources/icons/resources.mdx
+++ b/website/src/pages/resources/icons/resources.mdx
@@ -15,8 +15,8 @@ import {
 } from "../../../components/assets/images/svg";
 
 <Alertstripe type="info">
-  På grunn av lisensvilkårene for Streamline-pakken er disse ressursene kun
-  tilgjengelige for NAV-ansatte. Ta kontakt med oss på slack-kanalen
+  På grunn av lisensvilkårene for Streamline-pakken er noen av disse ressursene
+  kun tilgjengelige for NAV-ansatte. Ta kontakt med oss på slack-kanalen
   #Desingsystem hvis du ikke kommer inn.
 </Alertstripe>
 
@@ -28,7 +28,7 @@ import {
   border
 >
   <FigmaIcon />
-  Ikon&shy;bibliotek
+  Nytt ikon&shy;bibliotek
 </Lenkepanel>
 <Lenkepanel
   className="resource-link"
@@ -36,7 +36,7 @@ import {
   border
 >
   <FigmaIcon />
-  Gammelt ikon&shy;bibliotek (Streamline, kun tilgjengelig for interne)
+  Gammelt ikon&shy;bibliotek (Streamline)
 </Lenkepanel>
 
 ## Sketch ressurser
@@ -47,7 +47,7 @@ import {
   border
 >
   <SketchLogo />
-  Ikon&shy;bibliotek
+  Ikon&shy;bibliotek (Streamline)
 </Lenkepanel>
 
 ## Github repo
@@ -60,5 +60,5 @@ Alle våre ikoner ligger i et lukket Github-repo her:
   border
 >
   <GithubLogo />
-  Streamline-ikoner
+  Streamline-ikoner (Streamline)
 </Lenkepanel>

--- a/website/src/pages/resources/icons/resources.mdx
+++ b/website/src/pages/resources/icons/resources.mdx
@@ -30,6 +30,14 @@ import {
   <FigmaIcon />
   Ikon&shy;bibliotek
 </Lenkepanel>
+<Lenkepanel
+  className="resource-link"
+  href="https://www.figma.com/file/3AjAxeQP4uMFgqSazKXxOh/NAV-Ikonbiblioteket-Streamline"
+  border
+>
+  <FigmaIcon />
+  Gammelt ikon&shy;bibliotek (Streamline, kun tilgjengelig for interne)
+</Lenkepanel>
 
 ## Sketch ressurser
 

--- a/website/src/pages/resources/icons/resources.mdx
+++ b/website/src/pages/resources/icons/resources.mdx
@@ -24,7 +24,7 @@ import {
 
 <Lenkepanel
   className="resource-link"
-  href="https://www.figma.com/file/3AjAxeQP4uMFgqSazKXxOh/NAV-Ikonbiblioteket-Streamline"
+  href="https://www.figma.com/file/UmEVH3pZ71uJPsSz9ilP3Y/NAV-ikoner-2.1-Figma-i-test"
   border
 >
   <FigmaIcon />

--- a/website/src/pages/resources/new-project.mdx
+++ b/website/src/pages/resources/new-project.mdx
@@ -52,6 +52,14 @@ import {
   <FigmaIcon />
   Ikon&shy;bibliotek
 </Lenkepanel>
+<Lenkepanel
+  className="resource-link"
+  href="https://www.figma.com/file/3AjAxeQP4uMFgqSazKXxOh/NAV-Ikonbiblioteket-Streamline"
+  border
+>
+  <FigmaIcon />
+  Gammelt ikon&shy;bibliotek (Streamline, kun tilgjengelig for interne)
+</Lenkepanel>
 
 ## For utviklere
 

--- a/website/src/pages/resources/new-project.mdx
+++ b/website/src/pages/resources/new-project.mdx
@@ -46,7 +46,7 @@ import {
 </Lenkepanel>
 <Lenkepanel
   className="resource-link"
-  href="https://www.figma.com/file/3AjAxeQP4uMFgqSazKXxOh/NAV-Ikonbiblioteket-Streamline"
+  href="https://www.figma.com/file/UmEVH3pZ71uJPsSz9ilP3Y/NAV-ikoner-2.1-Figma-i-test"
   border
 >
   <FigmaIcon />


### PR DESCRIPTION
Jeg skulle gjøre Figma-dokumentene våre tilgjengelige for verden og tenkte det var et godt tidspunkt å bytte lenke til det nye ikon-dokumentet. Rop ut om det føles feil.