### PR TITLE
RadioRef prop på radiopanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 > **Obs!** Denne endringsloggen blir manuelt og uregelmessig oppdatert, og er hovedsakelig ment som en grov retrospektiv oppsummering for både tekniske og ikke-tekniske lesere. Det kan dermed ta en stund før publiserte endringer blir loggført her. For å se de siste faktiske endringene kan du ta en titt på [commit-historikken](https://github.com/navikt/nav-frontend-moduler/commits/master), [PR-historikken](https://github.com/navikt/nav-frontend-moduler/pulls?q=is%3Apr+is%3Aclosed) og/eller [release-oversikten](https://github.com/navikt/nav-frontend-moduler/releases) for NPM-pakkene våre.
 
+## 08. Januar 2021
+
+### Oppdatert RadioPanel med prop radioRef
+
+[Pull-request](https://github.com/navikt/nav-frontend-moduler/pull/943)
+
+Kan nå sette ref på RadioPanel
+[Dokumentasjon](http://localhost:8000/components/radiopanelgruppe/#bruk-av-radioref)
+
 ## 04. Januar 2021
 
 ### Oppdaterte Alertstripe komponent for bedre UU

--- a/packages/nav-frontend-skjema/md/radiopanelgruppe/Radiopanelgruppe.overview.mdx
+++ b/packages/nav-frontend-skjema/md/radiopanelgruppe/Radiopanelgruppe.overview.mdx
@@ -1,6 +1,5 @@
 import RadioPanelGruppeExample from "./../../sample/_radiopanelgruppe.example.js";
 import { RadioPanelGruppe } from "./../../";
-import Knapp from "nav-frontend-knapper";
 
 ## Normal
 

--- a/packages/nav-frontend-skjema/md/radiopanelgruppe/Radiopanelgruppe.overview.mdx
+++ b/packages/nav-frontend-skjema/md/radiopanelgruppe/Radiopanelgruppe.overview.mdx
@@ -51,7 +51,7 @@ import { RadioPanelGruppe } from "./../../";
 </Example>
 
 ```jsx
-const panelRef = useRef(null);
+const juice1Ref = useRef(null);
 
 <RadioPanelGruppe
   name="samplename"
@@ -61,7 +61,7 @@ const panelRef = useRef(null);
       label: "Eplejuice",
       value: "juice1",
       id: "juice1id",
-      radioRef: (ref) => (panelRef.current = ref),
+      radioRef: (ref) => (juice1Ref.current = ref),
     },
     { label: "Appelsinjuice", value: "juice2", id: "juice2id" },
     { label: "Melk", value: "melk", disabled: true, id: "melkid" },

--- a/packages/nav-frontend-skjema/md/radiopanelgruppe/Radiopanelgruppe.overview.mdx
+++ b/packages/nav-frontend-skjema/md/radiopanelgruppe/Radiopanelgruppe.overview.mdx
@@ -1,5 +1,6 @@
 import RadioPanelGruppeExample from "./../../sample/_radiopanelgruppe.example.js";
 import { RadioPanelGruppe } from "./../../";
+import Knapp from "nav-frontend-knapper";
 
 ## Normal
 
@@ -42,4 +43,33 @@ import { RadioPanelGruppe } from "./../../";
   onChange={this.onChange}
   feil={{ feilmelding: "Her er det en feil." }}
 />
+```
+
+## Bruk av radioRef
+
+<Example>
+  <RadioPanelGruppeExample button name="example-3" />
+</Example>
+
+```jsx
+const panelRef = useRef(null);
+
+<RadioPanelGruppe
+  name="samplename"
+  legend="Hvilken drikke er best?"
+  radios={[
+    {
+      label: "Eplejuice",
+      value: "juice1",
+      id: "juice1id",
+      radioRef: (ref) => (panelRef.current = ref),
+    },
+    { label: "Appelsinjuice", value: "juice2", id: "juice2id" },
+    { label: "Melk", value: "melk", disabled: true, id: "melkid" },
+    { label: "Ananasjuice", value: "juice3", id: "juice4id" },
+  ]}
+  checked={this.state.checked}
+  onChange={this.onChange}
+  feil={{ feilmelding: "Her er det en feil." }}
+/>;
 ```

--- a/packages/nav-frontend-skjema/sample/_radiopanelgruppe.example.js
+++ b/packages/nav-frontend-skjema/sample/_radiopanelgruppe.example.js
@@ -1,17 +1,18 @@
-import React from "react";
-
+import React, { createRef } from "react";
+import Knapp from "nav-frontend-knapper";
 import { RadioPanelGruppe } from "..";
 
 class RadioPanelGruppeExample extends React.Component {
   constructor(props) {
     super(props);
     this.state = { checked: "juice1" };
-
+    this.ref = createRef();
     this.radios = [
       {
         label: "Eplejuice",
         value: "juice1",
         id: `juice1id-${this.props.name}`,
+        radioRef: (ref) => (this.ref.current = ref),
       },
       {
         label: "Appelsinjuice",
@@ -38,14 +39,24 @@ class RadioPanelGruppeExample extends React.Component {
 
   render() {
     return (
-      <RadioPanelGruppe
-        name={this.props.name}
-        legend="Hvilken drikke er best?"
-        radios={this.radios}
-        checked={this.state.checked}
-        onChange={this.onChange}
-        feil={this.props.feil ? "Her er det en feil." : undefined}
-      />
+      <div>
+        <RadioPanelGruppe
+          name={this.props.name}
+          legend="Hvilken drikke er best?"
+          radios={this.radios}
+          checked={this.state.checked}
+          onChange={this.onChange}
+          feil={this.props.feil ? "Her er det en feil." : undefined}
+        />
+        {this.props.button && (
+          <Knapp
+            style={{ marginTop: "1rem" }}
+            onClick={() => this.ref.current.focus()}
+          >
+            Fokus radiopanel
+          </Knapp>
+        )}
+      </div>
     );
   }
 }

--- a/packages/nav-frontend-skjema/src/radio-panel.tsx
+++ b/packages/nav-frontend-skjema/src/radio-panel.tsx
@@ -7,6 +7,10 @@ import "nav-frontend-skjema-style";
 export interface RadioPanelProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label: React.ReactNode;
+  /**
+   * Referanse til selve radioknappen. Brukes for eksempel til å sette fokus
+   */
+  radioRef?: (element: HTMLInputElement | null) => any;
 }
 
 export interface RadioPanelState {
@@ -27,7 +31,7 @@ export class RadioPanel extends React.Component<
   }
 
   render() {
-    const { id, label, checked, disabled, ...other } = this.props;
+    const { id, label, checked, disabled, radioRef, ...other } = this.props;
     const { hasFocus } = this.state;
     const inputId = id || guid();
 
@@ -51,6 +55,7 @@ export class RadioPanel extends React.Component<
               disabled={disabled}
               aria-invalid={!!context.feil}
               aria-errormessage={context.feilmeldingId}
+              ref={radioRef}
               {...other}
               onFocus={() => this.toggleOutline()}
               onBlur={() => this.toggleOutline()}

--- a/packages/nav-frontend-skjema/stories/radiopanel.stories.tsx
+++ b/packages/nav-frontend-skjema/stories/radiopanel.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { createRef, useRef } from "react";
 import { RadioPanel, RadioPanelGruppe } from "../src/index";
 import { Meta } from "@storybook/react/types-6-0";
 
@@ -27,7 +27,11 @@ export const radioPanel = () => {
             id: "juice1id",
             checked: true,
           },
-          { label: "Appelsinjuice", value: "juice2", id: "juice2id" },
+          {
+            label: "Appelsinjuice",
+            value: "juice2",
+            id: "juice2id",
+          },
           { label: "Melk", value: "melk", disabled: true, id: "melkid" },
           { label: "Ananasjuice", value: "juice3", id: "juice4id" },
         ]}

--- a/packages/nav-frontend-skjema/stories/radiopanel.stories.tsx
+++ b/packages/nav-frontend-skjema/stories/radiopanel.stories.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, useRef } from "react";
+import React from "react";
 import { RadioPanel, RadioPanelGruppe } from "../src/index";
 import { Meta } from "@storybook/react/types-6-0";
 


### PR DESCRIPTION
> https://nav-it.slack.com/archives/C6HJFRRMY/p1610012428140800

- Kan nå bruke radioRef for å legge til ref på hvert radiopanel, enten direkte på komponenten eller gjennom `RadioPanelGruppe`

```
{
        label: "Eplejuice",
        value: "juice1",
        id: `123`,
        radioRef: (ref) => (this.ref.current = ref),
},
```

- Eksempel er oppdatert for å vise denne endringen
