### PR TITLE
Bedre typing av EkspanderbartpanelBase

### DIFF
--- a/packages/nav-frontend-ekspanderbartpanel/_ekspanderbartpanel-base.example.js
+++ b/packages/nav-frontend-ekspanderbartpanel/_ekspanderbartpanel-base.example.js
@@ -1,0 +1,42 @@
+import React, { Component } from "react";
+import { Knapp } from "nav-frontend-knapper";
+import { EkspanderbartpanelBase } from "./";
+
+const btnStyle = { marginRight: "0.5rem", marginBottom: "1rem" };
+export default class EkspanderbartpanelEksempel extends Component {
+  state = {
+    apen: false,
+  };
+
+  open() {
+    this.setState({ apen: true });
+  }
+
+  close() {
+    this.setState({ apen: false });
+  }
+
+  toggle() {
+    this.setState((state) => ({ apen: !state.apen }));
+  }
+
+  render() {
+    return (
+      <div>
+        <Knapp onClick={() => this.open()} style={btnStyle}>
+          Åpne
+        </Knapp>
+        <Knapp onClick={() => this.close()} style={btnStyle}>
+          Lukke
+        </Knapp>
+        <EkspanderbartpanelBase
+          tittel="Kan også klikke her"
+          apen={this.state.apen}
+          onClick={() => this.toggle()}
+        >
+          Alt innholdet ditt
+        </EkspanderbartpanelBase>
+      </div>
+    );
+  }
+}

--- a/packages/nav-frontend-ekspanderbartpanel/md/Ekspanderbartpanel.overview.mdx
+++ b/packages/nav-frontend-ekspanderbartpanel/md/Ekspanderbartpanel.overview.mdx
@@ -3,6 +3,7 @@ ingress: Ekspanderbartpanel er et panel som kan ekspandere eller kollapse innhol
 ---
 
 import Ekspanderbartpanel, { EkspanderbartpanelBase } from "./../";
+import EkspanderbartpanelEksempel from "../_ekspanderbartpanel-base.example.js";
 import Etikett from "nav-frontend-etiketter";
 import { Normaltekst, Undertittel } from "nav-frontend-typografi";
 
@@ -75,4 +76,24 @@ Komponentens `tittel`-prop støtter rikt HTML-innhold.
 >
   Panelet vil da ekspandere og vise innholdet.
 </Ekspanderbartpanel>
+```
+
+## Kontroller komponenten selv
+
+Styr komponent fra ekstern state (controlled components).
+
+<Example>
+  <EkspanderbartpanelEksempel />
+</Example>
+
+```jsx
+<Knapp onClick={() => this.open()}>Åpne</Knapp>
+<Knapp onClick={() => this.close()}>Lukke</Knapp>
+<EkspanderbartpanelBase
+    tittel="Kan også klikke her"
+    apen={this.state.apen}
+    onClick={() => this.toggle()}
+>
+    Alt innholdet ditt
+</EkspanderbartpanelBase>
 ```

--- a/packages/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base.tsx
+++ b/packages/nav-frontend-ekspanderbartpanel/src/ekspanderbartpanel-base.tsx
@@ -41,7 +41,7 @@ export interface EkspanderbartpanelBaseProps
   /**
    * Props til intern instans av react-collapse
    */
-  collapseProps?: Partial<CollapseProps>;
+  collapseProps?: Omit<CollapseProps, "children" | "isOpened">;
   /**
    * Dersom innholdet skal rendres men ikke vises, når panelet er lukket
    */


### PR DESCRIPTION
Forhindrer at konsumentene kan sende inn `isOpen` eller `children` via `CollapseProps`.

Dette påvirker også bruken av `Ekspanderbartpanel` ved å fjerne muligheten til å overstyre collapse via `collapseProps`.