### PR TITLE
Oppdatert versjoner for typografi dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Endringslogg
 
-## 04. desember 2020
+## 25. Januar 2021
+
+### Fjernet komponenten EtikettLiten
+
+[#956](https://github.com/navikt/nav-frontend-moduler/pull/956)
+
+- `Undertekst` kan brukes som erstatning da begge har samme styling.
+- Dette fører til en major bump fra v2 -> v3 for `nav-frontend-typografi`
 
 ### Element for sortering av tabell endres
 

--- a/examples/cra/package.json
+++ b/examples/cra/package.json
@@ -15,7 +15,7 @@
     "craco": "^0.0.3",
     "craco-less": "^1.17.1",
     "nav-frontend-core": "^5.0.10",
-    "nav-frontend-typografi": "^2.0.37",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "nav-frontend-typografi-style": "^1.0.31",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "nav-frontend-core": "^5.0.1",
-    "nav-frontend-typografi": "^2.0.23",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "nav-frontend-typografi-style": "^1.0.22",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/packages/nav-frontend-alertstriper/package.json
+++ b/packages/nav-frontend-alertstriper/package.json
@@ -20,7 +20,7 @@
     "classnames": "^2.2.5",
     "nav-frontend-alertstriper-style": "^2.0.33",
     "nav-frontend-ikoner-assets": "^2.0.8",
-    "nav-frontend-typografi": "^2.0.39",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   },
@@ -29,7 +29,7 @@
     "@types/react": "15.0.23 || ^16.0.0",
     "nav-frontend-alertstriper-style": "^2.0.33",
     "nav-frontend-ikoner-assets": "^2.0.8",
-    "nav-frontend-typografi": "^2.0.39",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "react": "^15.4.2 || ^16.0.0"
   },
   "defaultExport": "AlertStripe"

--- a/packages/nav-frontend-lenkepanel/package.json
+++ b/packages/nav-frontend-lenkepanel/package.json
@@ -19,7 +19,7 @@
   "peerDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-lenkepanel-style": "^0.3.47",
-    "nav-frontend-typografi": "^2.0.39",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   },
@@ -28,7 +28,7 @@
     "@types/react": "15.0.23 || ^16.0.0",
     "classnames": "^2.2.5",
     "nav-frontend-lenkepanel-style": "^0.3.47",
-    "nav-frontend-typografi": "^2.0.39",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   },

--- a/packages/nav-frontend-paneler/package.json
+++ b/packages/nav-frontend-paneler/package.json
@@ -19,7 +19,7 @@
   "peerDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-paneler-style": "^0.3.33",
-    "nav-frontend-typografi": "^2.0.39",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "nav-frontend-typografi-style": "^1.0.32",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
@@ -27,7 +27,7 @@
   "devDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-paneler-style": "^0.3.33",
-    "nav-frontend-typografi": "^2.0.39",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "nav-frontend-typografi-style": "^1.0.32",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"

--- a/packages/nav-frontend-skjema/package.json
+++ b/packages/nav-frontend-skjema/package.json
@@ -22,7 +22,7 @@
     "nav-frontend-js-utils": "^1.0.15",
     "nav-frontend-lenker": "^1.0.56",
     "nav-frontend-skjema-style": "^2.0.27",
-    "nav-frontend-typografi": "^2.0.39",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   },
@@ -32,7 +32,7 @@
     "nav-frontend-js-utils": "^1.0.15",
     "nav-frontend-lenker": "^1.0.56",
     "nav-frontend-skjema-style": "^2.0.27",
-    "nav-frontend-typografi": "^2.0.39",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   }

--- a/packages/nav-frontend-snakkeboble/package.json
+++ b/packages/nav-frontend-snakkeboble/package.json
@@ -21,7 +21,7 @@
     "nav-frontend-paneler": "^2.0.25",
     "nav-frontend-paneler-style": "^0.3.33",
     "nav-frontend-snakkeboble-style": "^0.2.40",
-    "nav-frontend-typografi": "^2.0.39",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   },
@@ -29,7 +29,7 @@
     "nav-frontend-paneler": "^2.0.25",
     "nav-frontend-paneler-style": "^0.3.33",
     "nav-frontend-snakkeboble-style": "^0.2.40",
-    "nav-frontend-typografi": "^2.0.39",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "react": "^15.4.2 || ^16.0.0"
   },
   "defaultExport": "Snakkeboble"

--- a/packages/nav-frontend-tekstomrade/package.json
+++ b/packages/nav-frontend-tekstomrade/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "nav-frontend-lenker": "^1.0.56",
-    "nav-frontend-typografi": "^2.0.39",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   },
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "nav-frontend-lenker": "^1.0.56",
-    "nav-frontend-typografi": "^2.0.39",
+    "nav-frontend-typografi": "^3.0.0-beta.1",
     "prop-types": "^15.5.10",
     "react": "^15.4.2 || ^16.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18893,7 +18893,7 @@ react-docgen@^5.0.0, react-docgen@^5.1.0, react-docgen@^5.3.0, react-docgen@^5.3
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-"react-docgen@github:devongovett/react-docgen#importing":
+react-docgen@devongovett/react-docgen#importing:
   version "5.0.0-beta.1"
   resolved "https://codeload.github.com/devongovett/react-docgen/tar.gz/3b3bbf63063b0d2f98d6c7cd87eee19e253b2d91"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -16205,11 +16205,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-nav-frontend-typografi@^2.0.39:
-  version "2.0.39"
-  resolved "https://registry.yarnpkg.com/nav-frontend-typografi/-/nav-frontend-typografi-2.0.39.tgz#036e602e1c6253685132b62f05e42aeafc50fb9c"
-  integrity sha512-YJ2e+nB2C1GdpxkONM87W8to+6ij058WWa6s2k1ABdODtfiHKQd0hJEfgmW9WrJT5e2WM6kkal5IeH3qF3lVuw==
-
 needle@^2.5.2:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz#24dbb55f2509e2324b4a99d61f413982013ccdbe"


### PR DESCRIPTION
- Forrige oppdatering fungerte ikke på grunn av yarn workspaces, men er fikset her.
- Oppdatert Changelog i samme slengen