### PR TITLE
Flyttet chromatic til tidligere i workflow

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # Required to retrieve git history
       - uses: actions/setup-node@v1
         with:
           node-version: 14
@@ -33,17 +31,38 @@ jobs:
         run: yarn boot
       - name: Eslint and Stylelint
         run: yarn lint
-      - name: Chromatic snapshot
-        uses: chromaui/action@v1
-        with:
-          token: ${{ secrets.GIT_REPO }}
-          projectToken: ${{ secrets.CHROMATIC }}
-          exitZeroOnChanges: false
       - name: Test gatsby-build
         run: yarn build:gatsby
 
-  publish-npm:
+  chromatic:
     needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Required to retrieve git history
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Node-modules cache
+        uses: actions/cache@v2
+        id: node-cache
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Install deps
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: Gulp-build
+        run: yarn boot
+      - uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GIT_REPO }}
+          projectToken: ${{ secrets.CHROMATIC }}
+          exitZeroOnChanges: true
+
+  publish-npm:
+    needs: chromatic
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -31,38 +31,17 @@ jobs:
         run: yarn boot
       - name: Eslint and Stylelint
         run: yarn lint
-      - name: Test gatsby-build
-        run: yarn build:gatsby
-
-  chromatic:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # Required to retrieve git history
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Node-modules cache
-        uses: actions/cache@v2
-        id: node-cache
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: Install deps
-        if: steps.node-cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
-      - name: Gulp-build
-        run: yarn boot
-      - uses: chromaui/action@v1
+      - name: Chromatic snapshot
+        uses: chromaui/action@v1
         with:
           token: ${{ secrets.GIT_REPO }}
           projectToken: ${{ secrets.CHROMATIC }}
           exitZeroOnChanges: false
+      - name: Test gatsby-build
+        run: yarn build:gatsby
 
   publish-npm:
-    needs: chromatic
+    needs: build
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Required to retrieve git history
       - uses: actions/setup-node@v1
         with:
           node-version: 14


### PR DESCRIPTION
- Gjort siden chromatic er grunnen til ~95% av feilede build. Ønsker derfor å få feilen tidligere etter ca 3-4 min istedenfor 9+ min. 
- Kan også vurderes å ikke feile buildet når chromatic har endringer, men heller gi warninger.