### PR TITLE
Versionering oppdatering

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -90,10 +90,7 @@ jobs:
       - run: git remote set-url origin https://KenAJoh:$NAV_DS_TOKEN@github.com/$GITHUB_REPOSITORY.git
         env:
           NAV_DS_TOKEN: ${{secrets.GIT_REPO}}
-      - run: yarn lerna version patch --include-merged-tags --no-private --no-push --yes
-      - run: yarn fix:versions
-      - run: git commit -a -m "Lerna versionbump [ci skip]" || true
-      - run: git push && git push --tags
+      - run: yarn lerna version patch --include-merged-tags --no-private --yes
       - run: yarn lerna publish from-package --yes
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTOMATION}}

--- a/packages/nav-frontend-ekspanderbartpanel-style/package.json
+++ b/packages/nav-frontend-ekspanderbartpanel-style/package.json
@@ -17,13 +17,13 @@
   "peerDependencies": {
     "nav-frontend-chevron-style": "^1.0.3",
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-paneler-style": "^0.3.34",
+    "nav-frontend-paneler-style": "^1.0.0",
     "nav-frontend-typografi-style": "^1.0.33"
   },
   "devDependencies": {
     "nav-frontend-chevron-style": "^1.0.3",
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-paneler-style": "^0.3.34",
+    "nav-frontend-paneler-style": "^1.0.0",
     "nav-frontend-typografi-style": "^1.0.33",
     "react": "^16.8.0"
   }

--- a/packages/nav-frontend-fullbreddeknapp-style/package.json
+++ b/packages/nav-frontend-fullbreddeknapp-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-fullbreddeknapp-style",
-  "version": "0.3.10",
+  "version": "1.0.0",
   "main": "src/index.less",
   "license": "MIT",
   "files": [

--- a/packages/nav-frontend-grid-style/package.json
+++ b/packages/nav-frontend-grid-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-grid-style",
-  "version": "0.2.26",
+  "version": "1.0.0",
   "main": "src/index.less",
   "license": "MIT",
   "files": [

--- a/packages/nav-frontend-grid/package.json
+++ b/packages/nav-frontend-grid/package.json
@@ -19,14 +19,14 @@
   "peerDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-grid-style": "^0.2.26",
+    "nav-frontend-grid-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   },
   "devDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-grid-style": "^0.2.26",
+    "nav-frontend-grid-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   }

--- a/packages/nav-frontend-hjelpetekst/package.json
+++ b/packages/nav-frontend-hjelpetekst/package.json
@@ -21,7 +21,7 @@
     "nav-frontend-hjelpetekst-style": "^2.0.40",
     "nav-frontend-ikoner-assets": "^2.0.9",
     "nav-frontend-js-utils": "^1.0.16",
-    "nav-frontend-popover": "^0.0.45",
+    "nav-frontend-popover": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   },
@@ -32,7 +32,7 @@
     "nav-frontend-hjelpetekst-style": "^2.0.40",
     "nav-frontend-ikoner-assets": "^2.0.9",
     "nav-frontend-js-utils": "^1.0.16",
-    "nav-frontend-popover": "^0.0.45",
+    "nav-frontend-popover": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   },

--- a/packages/nav-frontend-lenkepanel-style/package.json
+++ b/packages/nav-frontend-lenkepanel-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-lenkepanel-style",
-  "version": "0.3.49",
+  "version": "1.0.0",
   "main": "src/index.less",
   "license": "MIT",
   "files": [
@@ -17,12 +17,12 @@
   "peerDependencies": {
     "nav-frontend-chevron-style": "^1.0.3",
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-paneler-style": "^0.3.34"
+    "nav-frontend-paneler-style": "^1.0.0"
   },
   "devDependencies": {
     "nav-frontend-chevron-style": "^1.0.3",
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-paneler-style": "^0.3.34",
+    "nav-frontend-paneler-style": "^1.0.0",
     "react": "^16.8.0"
   }
 }

--- a/packages/nav-frontend-lenkepanel/package.json
+++ b/packages/nav-frontend-lenkepanel/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-lenkepanel-style": "^0.3.49",
+    "nav-frontend-lenkepanel-style": "^1.0.0",
     "nav-frontend-typografi": "^3.0.2",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
@@ -27,7 +27,7 @@
     "@types/classnames": "^2.2.3",
     "@types/react": "15.0.23 || ^16.0.0",
     "classnames": "^2.2.5",
-    "nav-frontend-lenkepanel-style": "^0.3.49",
+    "nav-frontend-lenkepanel-style": "^1.0.0",
     "nav-frontend-typografi": "^3.0.2",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"

--- a/packages/nav-frontend-lenker-style/package.json
+++ b/packages/nav-frontend-lenker-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-lenker-style",
-  "version": "0.2.42",
+  "version": "1.0.0",
   "main": "src/lenker-style.less",
   "license": "MIT",
   "files": [

--- a/packages/nav-frontend-lenker/package.json
+++ b/packages/nav-frontend-lenker/package.json
@@ -18,13 +18,13 @@
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-lenker-style": "^0.2.42",
+    "nav-frontend-lenker-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   },
   "devDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-lenker-style": "^0.2.42",
+    "nav-frontend-lenker-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   },

--- a/packages/nav-frontend-lesmerpanel-style/package.json
+++ b/packages/nav-frontend-lesmerpanel-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-lesmerpanel-style",
-  "version": "0.0.47",
+  "version": "1.0.0",
   "main": "src/lesmerpanel-style.less",
   "license": "MIT",
   "files": [
@@ -16,11 +16,11 @@
   },
   "devDependencies": {
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-paneler-style": "^0.3.34",
+    "nav-frontend-paneler-style": "^1.0.0",
     "react": "^16.8.0"
   },
   "peerDependencies": {
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-paneler-style": "^0.3.34"
+    "nav-frontend-paneler-style": "^1.0.0"
   }
 }

--- a/packages/nav-frontend-lesmerpanel/package.json
+++ b/packages/nav-frontend-lesmerpanel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-lesmerpanel",
-  "version": "0.0.66",
+  "version": "1.0.0",
   "main": "lib/lesmerpanel.js",
   "types": "lib/lesmerpanel.d.ts",
   "license": "MIT",
@@ -20,7 +20,7 @@
     "classnames": "^2.2.5",
     "nav-frontend-chevron": "^1.0.27",
     "nav-frontend-js-utils": "^1.0.16",
-    "nav-frontend-lesmerpanel-style": "^0.0.47",
+    "nav-frontend-lesmerpanel-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0",
     "react-collapse": "^5.0.0"
@@ -30,7 +30,7 @@
     "classnames": "^2.2.5",
     "nav-frontend-chevron": "^1.0.27",
     "nav-frontend-js-utils": "^1.0.16",
-    "nav-frontend-lesmerpanel-style": "^0.0.47",
+    "nav-frontend-lesmerpanel-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0",
     "react-collapse": "^5.0.0"

--- a/packages/nav-frontend-lukknapp-style/package.json
+++ b/packages/nav-frontend-lukknapp-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-lukknapp-style",
-  "version": "0.2.37",
+  "version": "1.0.0",
   "main": "src/lukknapp-style.less",
   "license": "MIT",
   "files": [

--- a/packages/nav-frontend-lukknapp/package.json
+++ b/packages/nav-frontend-lukknapp/package.json
@@ -18,13 +18,13 @@
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-lukknapp-style": "^0.2.37",
+    "nav-frontend-lukknapp-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   },
   "devDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-lukknapp-style": "^0.2.37",
+    "nav-frontend-lukknapp-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   },

--- a/packages/nav-frontend-modal-style/package.json
+++ b/packages/nav-frontend-modal-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-modal-style",
-  "version": "0.3.51",
+  "version": "1.0.0",
   "main": "src/index.less",
   "license": "MIT",
   "files": [
@@ -16,13 +16,13 @@
   },
   "peerDependencies": {
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-lukknapp-style": "^0.2.37",
-    "nav-frontend-paneler-style": "^0.3.34"
+    "nav-frontend-lukknapp-style": "^1.0.0",
+    "nav-frontend-paneler-style": "^1.0.0"
   },
   "devDependencies": {
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-lukknapp-style": "^0.2.37",
-    "nav-frontend-paneler-style": "^0.3.34",
+    "nav-frontend-lukknapp-style": "^1.0.0",
+    "nav-frontend-paneler-style": "^1.0.0",
     "react": "^16.8.0"
   }
 }

--- a/packages/nav-frontend-modal/package.json
+++ b/packages/nav-frontend-modal/package.json
@@ -20,7 +20,7 @@
     "@types/react-modal": "^3.1.2",
     "classnames": "^2.2.5",
     "nav-frontend-lukknapp": "^1.0.48",
-    "nav-frontend-modal-style": "^0.3.51",
+    "nav-frontend-modal-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0",
     "react-modal": "^2.2.4 || ^3.3.1"
@@ -29,7 +29,7 @@
     "@types/react-modal": "^3.1.2",
     "classnames": "^2.2.5",
     "nav-frontend-lukknapp": "^1.0.48",
-    "nav-frontend-modal-style": "^0.3.51",
+    "nav-frontend-modal-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0",
     "react-modal": "^2.2.4 || ^3.3.1"

--- a/packages/nav-frontend-paneler-style/package.json
+++ b/packages/nav-frontend-paneler-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-paneler-style",
-  "version": "0.3.34",
+  "version": "1.0.0",
   "main": "src/index.less",
   "license": "MIT",
   "files": [

--- a/packages/nav-frontend-paneler/package.json
+++ b/packages/nav-frontend-paneler/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-paneler-style": "^0.3.34",
+    "nav-frontend-paneler-style": "^1.0.0",
     "nav-frontend-typografi": "^3.0.2",
     "nav-frontend-typografi-style": "^1.0.33",
     "prop-types": "^15.5.10",
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "classnames": "^2.2.5",
-    "nav-frontend-paneler-style": "^0.3.34",
+    "nav-frontend-paneler-style": "^1.0.0",
     "nav-frontend-typografi": "^3.0.2",
     "nav-frontend-typografi-style": "^1.0.33",
     "prop-types": "^15.5.10",

--- a/packages/nav-frontend-popover-style/package.json
+++ b/packages/nav-frontend-popover-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-popover-style",
-  "version": "0.0.14",
+  "version": "1.0.0",
   "main": "src/popover-style.less",
   "license": "MIT",
   "files": [

--- a/packages/nav-frontend-popover/package.json
+++ b/packages/nav-frontend-popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-popover",
-  "version": "0.0.45",
+  "version": "1.0.0",
   "main": "lib/popover.js",
   "types": "lib/popover.d.ts",
   "license": "MIT",
@@ -19,7 +19,7 @@
   "peerDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-js-utils": "^1.0.16",
-    "nav-frontend-popover-style": "^0.0.14",
+    "nav-frontend-popover-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0",
     "react-dom": "^15.4.2 || ^16.0.0"
@@ -29,7 +29,7 @@
     "@types/react": "15.0.23 || ^16.0.0",
     "classnames": "^2.2.5",
     "nav-frontend-js-utils": "^1.0.16",
-    "nav-frontend-popover-style": "^0.0.14",
+    "nav-frontend-popover-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0",
     "react-dom": "^15.4.2 || ^16.0.0"

--- a/packages/nav-frontend-skjema-style/package.json
+++ b/packages/nav-frontend-skjema-style/package.json
@@ -16,13 +16,13 @@
   },
   "devDependencies": {
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-paneler-style": "^0.3.34",
+    "nav-frontend-paneler-style": "^1.0.0",
     "nav-frontend-typografi-style": "^1.0.33",
     "react": "^16.8.0"
   },
   "peerDependencies": {
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-paneler-style": "^0.3.34",
+    "nav-frontend-paneler-style": "^1.0.0",
     "nav-frontend-typografi-style": "^1.0.33"
   }
 }

--- a/packages/nav-frontend-snakkeboble-style/package.json
+++ b/packages/nav-frontend-snakkeboble-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-snakkeboble-style",
-  "version": "0.2.42",
+  "version": "1.0.0",
   "main": "src/snakkeboble-style.less",
   "license": "MIT",
   "files": [

--- a/packages/nav-frontend-snakkeboble/package.json
+++ b/packages/nav-frontend-snakkeboble/package.json
@@ -20,7 +20,7 @@
     "classnames": "^2.2.5",
     "nav-frontend-paneler": "^2.0.29",
     "nav-frontend-paneler-style": "^0.3.34",
-    "nav-frontend-snakkeboble-style": "^0.2.42",
+    "nav-frontend-snakkeboble-style": "^1.0.0",
     "nav-frontend-typografi": "^3.0.2",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
@@ -28,7 +28,7 @@
   "devDependencies": {
     "nav-frontend-paneler": "^2.0.29",
     "nav-frontend-paneler-style": "^0.3.34",
-    "nav-frontend-snakkeboble-style": "^0.2.42",
+    "nav-frontend-snakkeboble-style": "^1.0.0",
     "nav-frontend-typografi": "^3.0.2",
     "react": "^16.8.0"
   },

--- a/packages/nav-frontend-spinner-style/package.json
+++ b/packages/nav-frontend-spinner-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-spinner-style",
-  "version": "0.2.10",
+  "version": "1.0.0",
   "main": "src/spinner-style.less",
   "license": "MIT",
   "files": [

--- a/packages/nav-frontend-spinner/package.json
+++ b/packages/nav-frontend-spinner/package.json
@@ -19,7 +19,7 @@
   "peerDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-ikoner-assets": "^2.0.9",
-    "nav-frontend-spinner-style": "^0.2.10",
+    "nav-frontend-spinner-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   },
@@ -27,7 +27,7 @@
     "@types/classnames": "^2.2.3",
     "@types/react": "15.0.23 || ^16.0.0",
     "nav-frontend-ikoner-assets": "^2.0.9",
-    "nav-frontend-spinner-style": "^0.2.10",
+    "nav-frontend-spinner-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   },

--- a/packages/nav-frontend-stegindikator/package.json
+++ b/packages/nav-frontend-stegindikator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-stegindikator",
-  "version": "0.0.70",
+  "version": "1.0.0",
   "main": "lib/stegindikator.js",
   "types": "lib/stegindikator.d.js",
   "license": "MIT",

--- a/packages/nav-frontend-tabs-style/package.json
+++ b/packages/nav-frontend-tabs-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-tabs-style",
-  "version": "0.0.41",
+  "version": "1.0.0",
   "main": "src/tabs-style.less",
   "license": "MIT",
   "files": [

--- a/packages/nav-frontend-tabs/package.json
+++ b/packages/nav-frontend-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-tabs",
-  "version": "0.0.62",
+  "version": "1.0.0",
   "main": "lib/tabs.js",
   "types": "lib/tabs.d.ts",
   "license": "MIT",
@@ -15,13 +15,13 @@
   "peerDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-js-utils": "^1.0.16",
-    "nav-frontend-tabs-style": "^0.0.41",
+    "nav-frontend-tabs-style": "^1.0.0",
     "react": "^16.8.0"
   },
   "devDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-js-utils": "^1.0.16",
-    "nav-frontend-tabs-style": "^0.0.41",
+    "nav-frontend-tabs-style": "^1.0.0",
     "react": "^16.8.0"
   },
   "defaultExport": "Tabs"

--- a/packages/nav-frontend-toggle-style/package.json
+++ b/packages/nav-frontend-toggle-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-toggle-style",
-  "version": "0.0.51",
+  "version": "1.0.0",
   "main": "src/toggle-style.less",
   "license": "MIT",
   "files": [

--- a/packages/nav-frontend-toggle/package.json
+++ b/packages/nav-frontend-toggle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-toggle",
-  "version": "0.0.63",
+  "version": "1.0.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",
@@ -15,14 +15,14 @@
   "peerDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-js-utils": "^1.0.16",
-    "nav-frontend-toggle-style": "^0.0.51",
+    "nav-frontend-toggle-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   },
   "devDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-js-utils": "^1.0.16",
-    "nav-frontend-toggle-style": "^0.0.51",
+    "nav-frontend-toggle-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   }

--- a/packages/nav-frontend-veilederpanel-style/package.json
+++ b/packages/nav-frontend-veilederpanel-style/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-veilederpanel-style",
-  "version": "0.0.45",
+  "version": "1.0.0",
   "main": "src/index.less",
   "license": "MIT",
   "files": [
@@ -12,13 +12,13 @@
   },
   "devDependencies": {
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-paneler-style": "^0.3.34",
+    "nav-frontend-paneler-style": "^1.0.0",
     "nav-frontend-typografi-style": "^1.0.33",
     "react": "^16.8.0"
   },
   "peerDependencies": {
     "nav-frontend-core": "^5.0.11",
-    "nav-frontend-paneler-style": "^0.3.34",
+    "nav-frontend-paneler-style": "^1.0.0",
     "nav-frontend-typografi-style": "^1.0.33"
   }
 }

--- a/packages/nav-frontend-veilederpanel/package.json
+++ b/packages/nav-frontend-veilederpanel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nav-frontend-veilederpanel",
-  "version": "0.1.49",
+  "version": "1.0.0",
   "main": "lib/veilederpanel.js",
   "types": "lib/veilederpanel.d.ts",
   "license": "MIT",
@@ -15,14 +15,14 @@
   "peerDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-veileder": "^2.0.39",
-    "nav-frontend-veilederpanel-style": "^0.0.45",
+    "nav-frontend-veilederpanel-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   },
   "devDependencies": {
     "classnames": "^2.2.5",
     "nav-frontend-veileder": "^2.0.39",
-    "nav-frontend-veilederpanel-style": "^0.0.45",
+    "nav-frontend-veilederpanel-style": "^1.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -16248,6 +16248,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+nav-frontend-paneler-style@^0.3.34:
+  version "0.3.34"
+  resolved "https://registry.yarnpkg.com/nav-frontend-paneler-style/-/nav-frontend-paneler-style-0.3.34.tgz#48bc6a4331262658490644976c65258d6b3cbcec"
+  integrity sha512-ufqCAPGofVHrof7yh7TGdby9hMHI6HPr4x4KegeTSXg83jPsW5ElynznkBtfMpsGWTD8MoxBxIJkSOlqEvzbvg==
+
 needle@^2.5.2:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz#24dbb55f2509e2324b4a99d61f413982013ccdbe"
@@ -19198,7 +19203,7 @@ react-use-keypress@^1.0.1:
   dependencies:
     use-latest "^1.2.0"
 
-"react@^15.4.2 || ^16.0.0", react@^16.13.1, react@^16.8.0:
+react@^16.13.1, react@^16.8.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==


### PR DESCRIPTION
Alle pakker som ikke var v1 eller høyere er nå v1.0.0
- Dette er gjort i forberedelse når mange av disse skal deprecates etterhvert som de nye pakkene blir mer fullstending
- Unngår med dette å ha større versionerings problemer for NPM v7, da vi manuelt måtte oppdatere peer-deps for endringer under v1
- Ved å fjerne manuel oppdatering av peerdeps med `yarn fix:version` vil released tags stemme med nyeste commit, noe som gjør at lerna ikke ender opp med å oppdatere unødvendige pakker