### PR TITLE
compile to es6 and set sideEffects: false to enable tree shaking

### DIFF
--- a/@navikt/ds-icons/package.json
+++ b/@navikt/ds-icons/package.json
@@ -36,5 +36,6 @@
     "lodash.startcase": "4.4.0",
     "react": "^16.8.0 || ^17.0.0",
     "rimraf": "3.0.2"
-  }
+  },
+  "sideEffects": false
 }

--- a/@navikt/ds-icons/tsconfig.json
+++ b/@navikt/ds-icons/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../utilities/build/tsconfig-pakker.json",
   "compilerOptions": {
+    "module": "ES6",
     "outDir": "./lib",
     "rootDir": "./src",
     "esModuleInterop": true,


### PR DESCRIPTION
Hva er nedsiden ved å distribuere pakken som es6 framfor CommonJS? 

Jeg fikk ikke til å tree shake icons med create-react-app når den var CommonJS, men i es6 funka det...