### PR TITLE
Header implementert med dot-notasjon

### DIFF
--- a/@navikt/ds-css/internal-header/index.css
+++ b/@navikt/ds-css/internal-header/index.css
@@ -5,9 +5,9 @@
   display: flex;
   align-items: center;
   background: var(--navds-color-darkgray);
-  color: white;
+  color: var(--navds-color-text-inverse);
   max-width: 100vw;
-  min-height: 50px;
+  min-height: 3rem;
 }
 
 .navds-header__column {

--- a/@navikt/ds-css/internal-header/title.css
+++ b/@navikt/ds-css/internal-header/title.css
@@ -1,11 +1,11 @@
 .navds-header__title {
-  padding: 0 1.5rem 0 1.5rem;
   border-right: 1px solid var(--navds-color-gray-40);
   display: flex;
   align-self: stretch;
   align-items: center;
   text-decoration: none;
   margin: 0;
+  padding: 0 1.5rem;
   color: var(--navds-color-text-inverse);
   font-size: var(--navds-font-size-medium);
   font-weight: var(--navds-font-weight-bold);

--- a/@navikt/ds-react/index.ts
+++ b/@navikt/ds-react/index.ts
@@ -8,10 +8,6 @@ export { default as Tag, TagProps } from "./tag/src/index";
 export {
   InternalHeader,
   InternalHeaderProps,
-  InternalHeaderTitle,
-  InternalHeaderTitleProps,
-  InternalHeaderUser,
-  InternalHeaderUserProps,
 } from "./internal-header/src/index";
 export {
   Heading,

--- a/@navikt/ds-react/internal-header/src/InternalHeader.tsx
+++ b/@navikt/ds-react/internal-header/src/InternalHeader.tsx
@@ -2,6 +2,24 @@ import React, { forwardRef, HTMLAttributes } from "react";
 import cl from "classnames";
 import "@navikt/ds-css/internal-header/index.css";
 import "@navikt/ds-css/typography/index.css";
+import InternalHeaderTitle, {
+  InternalHeaderTitleProps,
+} from "./InternalHeaderTitle";
+import InternalHeaderUser, {
+  InternalHeaderUserProps,
+} from "./InternalHeaderUser";
+
+interface InternalHeaderComponent
+  extends React.ForwardRefExoticComponent<
+    InternalHeaderProps & HTMLAttributes<HTMLElement>
+  > {
+  Title: React.ForwardRefExoticComponent<
+    InternalHeaderTitleProps & HTMLAttributes<HTMLElement>
+  >;
+  User: React.ForwardRefExoticComponent<
+    InternalHeaderUserProps & HTMLAttributes<HTMLDivElement>
+  >;
+}
 
 export interface InternalHeaderProps extends HTMLAttributes<HTMLElement> {
   children?: React.ReactNode;
@@ -13,6 +31,9 @@ const InternalHeader = forwardRef<HTMLElement, InternalHeaderProps>(
       {children}
     </header>
   )
-);
+) as InternalHeaderComponent;
+
+InternalHeader.Title = InternalHeaderTitle;
+InternalHeader.User = InternalHeaderUser;
 
 export default InternalHeader;

--- a/@navikt/ds-react/internal-header/src/index.ts
+++ b/@navikt/ds-react/internal-header/src/index.ts
@@ -2,11 +2,3 @@ export {
   default as InternalHeader,
   InternalHeaderProps,
 } from "./InternalHeader";
-export {
-  default as InternalHeaderTitle,
-  InternalHeaderTitleProps,
-} from "./InternalHeaderTitle";
-export {
-  default as InternalHeaderUser,
-  InternalHeaderUserProps,
-} from "./InternalHeaderUser";

--- a/@navikt/ds-react/internal-header/stories/internal-header.stories.tsx
+++ b/@navikt/ds-react/internal-header/stories/internal-header.stories.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { HashRouter as Router, Link } from "react-router-dom";
-import {
-  InternalHeader,
-  InternalHeaderTitle,
-  InternalHeaderUser,
-} from "../src/index";
+import { InternalHeader } from "../src/index";
 
 export default {
   title: "@navikt/internal-header",
@@ -14,8 +10,8 @@ export default {
 export const All = () => (
   <div>
     <InternalHeader>
-      <InternalHeaderTitle>NAV Sykepenger</InternalHeaderTitle>
-      <InternalHeaderUser name="Kong Harald" ident="D123456" />
+      <InternalHeader.Title>NAV Sykepenger</InternalHeader.Title>
+      <InternalHeader.User name="Kong Harald" ident="D123456" />
     </InternalHeader>
 
     <h1>Uten innhold</h1>
@@ -23,34 +19,34 @@ export const All = () => (
 
     <h1>Title</h1>
     <InternalHeader>
-      <InternalHeaderTitle>Tittel</InternalHeaderTitle>
+      <InternalHeader.Title>Tittel</InternalHeader.Title>
     </InternalHeader>
 
     <h1>Title but not heading</h1>
     <InternalHeader>
-      <InternalHeaderTitle element="span">Tittel</InternalHeaderTitle>
+      <InternalHeader.Title element="span">Tittel</InternalHeader.Title>
     </InternalHeader>
 
     <h1>Title with link</h1>
     <InternalHeader>
-      <InternalHeaderTitle>
+      <InternalHeader.Title>
         <a href="/#">Tittel med lenke</a>
-      </InternalHeaderTitle>
+      </InternalHeader.Title>
     </InternalHeader>
 
     <h1>Title with react-router link</h1>
     <Router>
       <InternalHeader>
-        <InternalHeaderTitle>
+        <InternalHeader.Title>
           <Link to="/">Tittel med lenke</Link>
-        </InternalHeaderTitle>
+        </InternalHeader.Title>
       </InternalHeader>
     </Router>
 
     <h1>Title + User</h1>
     <InternalHeader>
-      <InternalHeaderTitle>NAV Sykepenger</InternalHeaderTitle>
-      <InternalHeaderUser name="Kong Harald" ident="D123456" />
+      <InternalHeader.Title>NAV Sykepenger</InternalHeader.Title>
+      <InternalHeader.User name="Kong Harald" ident="D123456" />
     </InternalHeader>
   </div>
 );


### PR DESCRIPTION
- Kan nå bruke title og user som `InternalHeader.User og InternalHeader.Title`
- Kan da importere bare `InternalHeader` å få alt man trenger