### PR TITLE
Viser nå riktige defaultValues for proptable

### DIFF
--- a/utilities/build/props-resolver/gatsby-node.js
+++ b/utilities/build/props-resolver/gatsby-node.js
@@ -32,7 +32,10 @@ const flattenProps = (props) =>
     ? Object.entries(props).map(([key, value]) => ({
         ...value,
         name: key,
-        defaultValue: value.defaultValue?.value,
+        defaultValue:
+          value.defaultValue && value.defaultValue.value
+            ? { value: JSON.stringify(value.defaultValue.value) }
+            : null,
       }))
     : [];
 
@@ -45,9 +48,6 @@ const onCreateNode = (
   try {
     let parsed = null;
     parsed = reactDocgen.parse(node.absolutePath)[0];
-    /* if (!node.absolutePath.includes("nav-frontend")) {
-      console.log(JSON.stringify(flattenProps(parsed.props), null, 4));
-    } */
 
     if (parsed && parsed.displayName) {
       const metadataNode = {
@@ -87,14 +87,30 @@ exports.createSchemaCustomization = ({ actions }) => {
       name: String
       raw: String
     }
-    type PropsType @noInfer {
+    union DefaultValues = intType | floatType | stringType | boolType
+    type intType {
+      value: Int
+    }
+    type floatType {
+      value: Float
+    }
+    type stringType {
+      value: String
+    }
+    type boolType {
+      value: Boolean
+    }
+    type DefaultValue @noInfer {
+      value: String
+    }
+    type PropsType @dontInfer {
       beta: Boolean
       name: String!
       description: String
       required: Boolean
       type: TypeType
       tsType: TsType
-      defaultValue: String
+      defaultValue: DefaultValue
     }
     type ComponentMetadata implements Node @noInfer {
       name: String!

--- a/utilities/build/props-resolver/gatsby-node.js
+++ b/utilities/build/props-resolver/gatsby-node.js
@@ -87,19 +87,6 @@ exports.createSchemaCustomization = ({ actions }) => {
       name: String
       raw: String
     }
-    union DefaultValues = intType | floatType | stringType | boolType
-    type intType {
-      value: Int
-    }
-    type floatType {
-      value: Float
-    }
-    type stringType {
-      value: String
-    }
-    type boolType {
-      value: Boolean
-    }
     type DefaultValue @noInfer {
       value: String
     }

--- a/utilities/build/props-resolver/gatsby-node.js
+++ b/utilities/build/props-resolver/gatsby-node.js
@@ -32,7 +32,7 @@ const flattenProps = (props) =>
     ? Object.entries(props).map(([key, value]) => ({
         ...value,
         name: key,
-        defaultValue: JSON.stringify(value.defaultValue),
+        defaultValue: value.defaultValue?.value,
       }))
     : [];
 
@@ -45,6 +45,9 @@ const onCreateNode = (
   try {
     let parsed = null;
     parsed = reactDocgen.parse(node.absolutePath)[0];
+    /* if (!node.absolutePath.includes("nav-frontend")) {
+      console.log(JSON.stringify(flattenProps(parsed.props), null, 4));
+    } */
 
     if (parsed && parsed.displayName) {
       const metadataNode = {
@@ -84,9 +87,6 @@ exports.createSchemaCustomization = ({ actions }) => {
       name: String
       raw: String
     }
-    type defaultValue @noInfer {
-      value: String
-    }
     type PropsType @noInfer {
       beta: Boolean
       name: String!
@@ -94,7 +94,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       required: Boolean
       type: TypeType
       tsType: TsType
-      defaultValue: defaultValue
+      defaultValue: String
     }
     type ComponentMetadata implements Node @noInfer {
       name: String!

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -79,6 +79,23 @@ module.exports = {
       },
     },
     {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `docgen-vnext`,
+        path: `${__dirname}/../@navikt/ds-react`,
+        ignore: [
+          `**/*.js`,
+          `**/stories/**`,
+          `**/*eksempel.js`,
+          `**/sample/*.js`,
+          `**/*.example.js`,
+          `**/*.mdx`,
+          `**/*.d.*`,
+          `**/lib/**`,
+        ],
+      },
+    },
+    {
       resolve: `gatsby-plugin-layout`,
       options: {
         component: require.resolve(`./src/components/layout/layout.tsx`),

--- a/website/src/useProps.tsx
+++ b/website/src/useProps.tsx
@@ -8,7 +8,9 @@ const useAllProps = () =>
           name
           relativePath
           props {
-            defaultValue
+            defaultValue {
+              value
+            }
             description
             name
             required
@@ -26,9 +28,11 @@ export const useProps = (path) => {
   const props = useAllProps();
 
   return props.filter((prop) => {
-    const propPath = prop.relativePath.match(/nav-frontend-(.*)\/src\//)
-      ? prop.relativePath.match(/nav-frontend-(.*)\/src\//)[1]
-      : "";
+    const match = prop.relativePath.match(/nav-frontend-(.*)\/src\//);
+    const propPath = match && match.length >= 2 ? match[1] : "";
+    if (propPath === pathComp) {
+      console.log(JSON.stringify(props, null, 4));
+    }
     return propPath === pathComp;
   });
 };

--- a/website/src/useProps.tsx
+++ b/website/src/useProps.tsx
@@ -8,9 +8,7 @@ const useAllProps = () =>
           name
           relativePath
           props {
-            defaultValue {
-              value
-            }
+            defaultValue
             description
             name
             required
@@ -28,7 +26,9 @@ export const useProps = (path) => {
   const props = useAllProps();
 
   return props.filter((prop) => {
-    const propPath = prop.relativePath.match(/nav-frontend-(.*)\/src\//)[1];
+    const propPath = prop.relativePath.match(/nav-frontend-(.*)\/src\//)
+      ? prop.relativePath.match(/nav-frontend-(.*)\/src\//)[1]
+      : "";
     return propPath === pathComp;
   });
 };

--- a/website/src/useProps.tsx
+++ b/website/src/useProps.tsx
@@ -30,9 +30,6 @@ export const useProps = (path) => {
   return props.filter((prop) => {
     const match = prop.relativePath.match(/nav-frontend-(.*)\/src\//);
     const propPath = match && match.length >= 2 ? match[1] : "";
-    if (propPath === pathComp) {
-      console.log(JSON.stringify(props, null, 4));
-    }
     return propPath === pathComp;
   });
 };


### PR DESCRIPTION
- react-docgen genererer defaultValue riktig nå
- Håndterer både eks `(Checkbox as React.ComponentClass).defaultProps {}` og inline eks: `{size = "small", ...props}
- Laster nå props for `@navikt/ds-react` for å tilgjengeliggjøre dem for `useProps`

Akkurat nå omgjøres alle defaultValues til `string` siden jeg ikke får union types til å fungere for graphql types
```graphql
type DefaultValue @noInfer {
      value: String
}
```