### PR TITLE
Flyttet OverridableComponent (Util) ut i egen PR

### DIFF
--- a/@navikt/ds-react/index.ts
+++ b/@navikt/ds-react/index.ts
@@ -1,13 +1,11 @@
-export { default as Accordion, AccordionProps } from "./accordion/src/index";
-export { default as Alert, AlertProps } from "./alert/src/index";
-export { default as Button, ButtonProps } from "./button/src/index";
-export { default as Link, LinkProps } from "./link/src/index";
-export { default as Modal, ModalProps } from "./modal/src/index";
-export { default as Popover, PopoverProps } from "./popover/src/index";
-export { default as Tag, TagProps } from "./tag/src/index";
-export { Grid, Cell, GridProps, CellProps } from "./grid/src/index";
-export { Layout, LayoutProps, SectionProps } from "./layout/src/index";
-
+export { AccordionProps, default as Accordion } from "./accordion/src/index";
+export { AlertProps, default as Alert } from "./alert/src/index";
+export { ButtonProps, default as Button } from "./button/src/index";
+export {
+  ContentContainer,
+  ContentContainerProps,
+} from "./content-container/src/index";
+export { Cell, CellProps, Grid, GridProps } from "./grid/src/index";
 export {
   InternalHeader,
   InternalHeaderProps,
@@ -16,17 +14,17 @@ export {
   InternalHeaderUser,
   InternalHeaderUserProps,
 } from "./internal-header/src/index";
-
+export { Layout, LayoutProps, SectionProps } from "./layout/src/index";
+export { default as Link, LinkProps } from "./link/src/index";
+export { default as Modal, ModalProps } from "./modal/src/index";
+export { default as Popover, PopoverProps } from "./popover/src/index";
+export { default as Tag, TagProps } from "./tag/src/index";
 export {
   Heading,
-  Text,
-  Paragraph,
-  Lead,
   HeadingProps,
+  Lead,
+  Paragraph,
+  Text,
   TextProps,
 } from "./typography/src/index";
-
-export {
-  ContentContainer,
-  ContentContainerProps,
-} from "./content-container/src/index";
+export { OverridableComponent } from "./util/src/index";

--- a/@navikt/ds-react/util/package.json
+++ b/@navikt/ds-react/util/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@navikt/ds-react-util",
+  "author": "NAV Designsystem team",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
+  },
+  "dependencies": {
+    "@navikt/ds-css": "0.1.0",
+    "classnames": "^2.2.6"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0"
+  }
+}

--- a/@navikt/ds-react/util/package.json
+++ b/@navikt/ds-react/util/package.json
@@ -6,10 +6,6 @@
     "type": "git",
     "url": "git+https://github.com/navikt/nav-frontend-moduler.git"
   },
-  "dependencies": {
-    "@navikt/ds-css": "0.1.0",
-    "classnames": "^2.2.6"
-  },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0"
   }

--- a/@navikt/ds-react/util/src/OverridableComponent.ts
+++ b/@navikt/ds-react/util/src/OverridableComponent.ts
@@ -1,0 +1,47 @@
+import React from "react";
+
+/**
+ * A component whose root component can be controlled via a `component` prop.
+ */
+export interface OverridableComponent<M extends OverridableTypeMap> {
+  (props: DefaultComponentProps<M>): React.ReactElement | null;
+
+  <C extends React.ElementType>(
+    props: {
+      component: C;
+    } & OverrideProps<M, C>
+  ): React.ReactElement | null;
+}
+
+/**
+ * Props of the component if `component={Component}` is used.
+ */
+// prettier-ignore
+export type OverrideProps<
+  M extends OverridableTypeMap,
+  C extends React.ElementType
+> = (
+  & BaseProps<M>
+  & Omit<React.ComponentPropsWithRef<C>, keyof BaseProps<M>>
+);
+
+/**
+ * Props if `component={Component}` is NOT used.
+ */
+// prettier-ignore
+export type DefaultComponentProps<
+  M extends OverridableTypeMap
+> = (
+  & BaseProps<M>
+  & Omit<React.ComponentPropsWithRef<M['defaultComponent']>, keyof BaseProps<M>>
+)
+
+/**
+ * Props defined on the component.
+ */
+export type BaseProps<M extends OverridableTypeMap> = M["props"];
+
+export interface OverridableTypeMap {
+  props: {};
+  defaultComponent: React.ElementType;
+}

--- a/@navikt/ds-react/util/src/index.ts
+++ b/@navikt/ds-react/util/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./OverridableComponent";


### PR DESCRIPTION
- Gjør det enklere å ta denne i bruk i utvikling av nye komponenter