### PR TITLE
Display font size of each typography component in clear text in doc

### DIFF
--- a/packages/nav-frontend-typografi/md/Typografi.overview.mdx
+++ b/packages/nav-frontend-typografi/md/Typografi.overview.mdx
@@ -42,7 +42,10 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Sidetittel>Sidetittel</Sidetittel>
-  <Undertekst>40px semi bold</Undertekst>
+  <Undertekst>Font size: 40px</Undertekst>
+  <Undertekst>Line height: 44px</Undertekst>
+  <Undertekst>Font weight: 600 semi bold</Undertekst>
+
 </Example>
 
 ```jsx
@@ -52,7 +55,9 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Innholdstittel>Innholdstittel</Innholdstittel>
-  <Undertekst>32px semi bold</Undertekst>
+  <Undertekst>Font size: 32px</Undertekst>
+  <Undertekst>Line height: 36px</Undertekst>
+  <Undertekst>Font weight: 600 semi bold</Undertekst>
 </Example>
 
 ```jsx
@@ -62,7 +67,9 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Systemtittel>Systemtittel</Systemtittel>
-  <Undertekst>24px semi bold</Undertekst>
+  <Undertekst>Font size: 24px</Undertekst>
+  <Undertekst>Line height: 28px</Undertekst>
+  <Undertekst>Font weight: 600 semi bold</Undertekst>
 </Example>
 
 ```jsx
@@ -72,7 +79,9 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Undertittel>Undertittel</Undertittel>
-  <Undertekst>20px semi bold</Undertekst>
+  <Undertekst>Font size: 20px</Undertekst>
+  <Undertekst>Line height: 25px</Undertekst>
+  <Undertekst>Font weight: 600 semi bold</Undertekst>
 </Example>
 
 ```jsx
@@ -82,7 +91,9 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Ingress>Ingress</Ingress>
-  <Undertekst>20px regular</Undertekst>
+  <Undertekst>Font size: 18px</Undertekst>
+  <Undertekst>Line height: 26px</Undertekst>
+  <Undertekst>Font weight: 400 regular</Undertekst>
 </Example>
 
 ```jsx
@@ -92,7 +103,9 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Element>Element</Element>
-  <Undertekst>16px semi bold</Undertekst>
+  <Undertekst>Font size: 16px</Undertekst>
+  <Undertekst>Line height: 22px</Undertekst>
+  <Undertekst>Font weight: 600 semi bold</Undertekst>
 </Example>
 
 ```jsx
@@ -102,7 +115,9 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Feilmelding>Feilmelding</Feilmelding>
-  <Undertekst>16px semi bold</Undertekst>
+  <Undertekst>Font size: 16px</Undertekst>
+  <Undertekst>Line height: 22px</Undertekst>
+  <Undertekst>Font weight: 600 semi bold</Undertekst>
 </Example>
 
 ```jsx
@@ -112,7 +127,9 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Normaltekst>Normaltekst</Normaltekst>
-  <Undertekst>16px regular</Undertekst>
+  <Undertekst>Font size: 16px</Undertekst>
+  <Undertekst>Line height: 22px</Undertekst>
+  <Undertekst>Font weight: 400 regular</Undertekst>
 </Example>
 
 ```jsx
@@ -122,7 +139,9 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Undertekst>Undertekst</Undertekst>
-  <Undertekst>14px regular</Undertekst>
+  <Undertekst>Font size: 14px</Undertekst>
+  <Undertekst>Line height: 20px</Undertekst>
+  <Undertekst>Font weight: 400 regular</Undertekst>
 </Example>
 
 ```jsx
@@ -132,7 +151,9 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <UndertekstBold>UndertekstBold</UndertekstBold>
-  <Undertekst>14px semi bold</Undertekst>
+  <Undertekst>Font size: 14px</Undertekst>
+  <Undertekst>Line height: 20px</Undertekst>
+  <Undertekst>Font weight: 600 semi bold</Undertekst>
 </Example>
 
 ```jsx

--- a/packages/nav-frontend-typografi/md/Typografi.overview.mdx
+++ b/packages/nav-frontend-typografi/md/Typografi.overview.mdx
@@ -42,6 +42,7 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Sidetittel>Sidetittel</Sidetittel>
+  <Undertekst>40px semi bold</Undertekst>
 </Example>
 
 ```jsx
@@ -51,6 +52,7 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Innholdstittel>Innholdstittel</Innholdstittel>
+  <Undertekst>32px semi bold</Undertekst>
 </Example>
 
 ```jsx
@@ -60,6 +62,7 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Systemtittel>Systemtittel</Systemtittel>
+  <Undertekst>24px semi bold</Undertekst>
 </Example>
 
 ```jsx
@@ -69,6 +72,7 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Undertittel>Undertittel</Undertittel>
+  <Undertekst>20px semi bold</Undertekst>
 </Example>
 
 ```jsx
@@ -78,6 +82,7 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Ingress>Ingress</Ingress>
+  <Undertekst>20px regular</Undertekst>
 </Example>
 
 ```jsx
@@ -87,6 +92,7 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Element>Element</Element>
+  <Undertekst>16px semi bold</Undertekst>
 </Example>
 
 ```jsx
@@ -96,6 +102,7 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Feilmelding>Feilmelding</Feilmelding>
+  <Undertekst>16px semi bold</Undertekst>
 </Example>
 
 ```jsx
@@ -105,6 +112,7 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Normaltekst>Normaltekst</Normaltekst>
+  <Undertekst>16px regular</Undertekst>
 </Example>
 
 ```jsx
@@ -114,6 +122,7 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <Undertekst>Undertekst</Undertekst>
+  <Undertekst>14px regular</Undertekst>
 </Example>
 
 ```jsx
@@ -123,6 +132,7 @@ i ønsket less fil og da legge til klassen `app` på elementet som pakker in pro
 
 <Example>
   <UndertekstBold>UndertekstBold</UndertekstBold>
+  <Undertekst>14px semi bold</Undertekst>
 </Example>
 
 ```jsx

--- a/yarn.lock
+++ b/yarn.lock
@@ -2637,6 +2637,21 @@
     "@navikt/ds-tokens" "0.1.0-beta.6"
     normalize.css "^8.0.1"
 
+"@navikt/ds-react@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@navikt/ds-react/-/ds-react-0.1.0.tgz#8fe2b54906e78e669a0ebdbd5ca6e8918b52bc36"
+  integrity sha512-RfbZeXsbebAsCLO3MClWm76vbPgDiKszXleKvtl5n5HD2uiUacVduMjuYitxpXD7nnE6d1p+bRkrx7m88jcAEQ==
+  dependencies:
+    "@navikt/ds-css" "0.1.0"
+    "@navikt/ds-icons" "^0.1.0"
+    "@popperjs/core" "^2.5.4"
+    classnames "^2.2.6"
+    react-collapse "^5.1.0"
+    react-merge-refs "^1.1.0"
+    react-modal "3.12.1"
+    react-popper "^2.2.4"
+    uuid "^8.3.2"
+
 "@navikt/ds-tokens@0.1.0-beta.6":
   version "0.1.0-beta.6"
   resolved "https://registry.yarnpkg.com/@navikt/ds-tokens/-/ds-tokens-0.1.0-beta.6.tgz#e5248c45a47c8625e650b14bbf08d6d1132249e2"
@@ -18951,7 +18966,7 @@ react-docgen@^5.0.0, react-docgen@^5.1.0, react-docgen@^5.3.0, react-docgen@^5.3
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-"react-docgen@github:devongovett/react-docgen#importing":
+react-docgen@devongovett/react-docgen#importing:
   version "5.0.0-beta.1"
   resolved "https://codeload.github.com/devongovett/react-docgen/tar.gz/3b3bbf63063b0d2f98d6c7cd87eee19e253b2d91"
   dependencies:


### PR DESCRIPTION
Dette er for å gjøre typografien lettere å implementere i miljøer uten kontroll over kode (f.eks. tableau) for ikke-tekniske folk (f.eks. Lars).