### PR TITLE
Fikset @navikt/ds-react popover + TSerror for nav-frontend-popover

### DIFF
--- a/@navikt/ds-react/popover/Popover.tsx
+++ b/@navikt/ds-react/popover/Popover.tsx
@@ -66,9 +66,16 @@ const Popover = forwardRef<HTMLDivElement, PopoverProps>(
     useEventLister(
       "click",
       useCallback(
-        (e: MouseEvent) =>
-          !popoverRef.current?.contains(e.target as Node) && close(),
-        [close]
+        (e: MouseEvent) => {
+          if (
+            ![anchorEl, popoverRef.current].some((element) =>
+              element?.contains(e.target as Node)
+            )
+          ) {
+            close();
+          }
+        },
+        [anchorEl, close]
       )
     );
 
@@ -124,7 +131,7 @@ const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       <div
         ref={mergedRef}
         className={cl("navds-popover", `navds-popover--${size}`, className, {
-          "popover--hidden": !open || !anchorEl,
+          "navds-popover--hidden": !open || !anchorEl,
         })}
         aria-live="polite"
         aria-hidden={!open || !anchorEl}

--- a/packages/nav-frontend-popover/src/popover.tsx
+++ b/packages/nav-frontend-popover/src/popover.tsx
@@ -123,7 +123,7 @@ class Popover extends React.Component<PopoverProps, PopoverState> {
   handleClick = (e) => {
     if (
       this.state.apen &&
-      !ReactDOM.findDOMNode(this.props.ankerEl).contains(e.target)
+      !ReactDOM.findDOMNode(this.props.ankerEl)?.contains(e.target)
     ) {
       this.props.onRequestClose();
     }


### PR DESCRIPTION
- Anter feil i nav-frontend-popover kommer av en eller annen dep oppdatering
- Feil i `@navikt/ds-react` popover oppstod i nextjs da den feiltolket fokuset til klikket og lukket popover med en gang