### PR TITLE
Code-preview, bash og npm 

### DIFF
--- a/docs/components/code-preview/Preview.tsx
+++ b/docs/components/code-preview/Preview.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import Tabs from "../tabs/Tabs";
+import style from "./preview.module.css";
+import { renderToString } from "react-dom/server";
+import Bash from "../code/Bash";
+import Prettier from "prettier/standalone";
+import ParserBabel from "prettier/parser-babel";
+
+const prettierOptions = {
+  semi: true,
+  parser: "babel",
+  plugins: [ParserBabel],
+  jsxBracketSameLine: false,
+  printWidth: 30,
+};
+
+interface PreviewProps {
+  react: string;
+  children?: React.ReactElement;
+  hideHtml?: boolean;
+}
+
+const Preview = ({
+  children,
+  react,
+  hideHtml = false,
+  ...props
+}: PreviewProps) => {
+  const [tab, setTab] = useState(0);
+  const handleChange = (x: number) => {
+    setTab(x);
+  };
+
+  const reactFormat = Prettier.format(react, prettierOptions).slice(0, -2);
+  const htmlFormat =
+    !!children &&
+    Prettier.format(
+      renderToString(
+        React.Children.count(children) > 1 ? <div>{children}</div> : children
+      ),
+      prettierOptions
+    )
+      .slice(0, -2)
+      .replace(` data-reactroot=""`, "");
+
+  const tabs = !hideHtml || !!children ? ["REACT", "HTML/CSS"] : ["REACT"];
+
+  return (
+    <div className={style.wrapper}>
+      {!!children && <div className={style.preview}>{children}</div>}
+      <Tabs tabs={tabs} onChange={(x) => handleChange(x)} />
+      {tab === 0 && <Bash code={reactFormat} language="jsx" copy />}
+
+      {(!hideHtml || !!children) && tab === 1 && (
+        <Bash code={htmlFormat} language="jsx" copy />
+      )}
+    </div>
+  );
+};
+
+export default Preview;

--- a/docs/components/code-preview/preview.module.css
+++ b/docs/components/code-preview/preview.module.css
@@ -1,0 +1,13 @@
+.wrapper {
+  padding: 1rem;
+  margin: 1rem 0;
+  background-color: var(--bg-secondary);
+  margin-bottom: 3rem;
+  outline: var(--outline);
+}
+
+.preview {
+  border-bottom: 2px solid var(--code-divider);
+  padding-bottom: 3rem;
+  margin-bottom: 1rem;
+}

--- a/docs/components/code/Bash.tsx
+++ b/docs/components/code/Bash.tsx
@@ -1,0 +1,109 @@
+import copy from "copy-to-clipboard";
+import Prism from "prismjs";
+import style from "./bash.module.css";
+import cl from "classnames";
+import { Files } from "@navikt/ds-icons";
+import { Popover } from "@navikt/ds-react";
+import { useEffect, useRef, useState } from "react";
+import "prismjs/components/prism-jsx.min";
+
+type PrismLanguages =
+  | "extend"
+  | "insertBefore"
+  | "DFS"
+  | "markup"
+  | "html"
+  | "mathml"
+  | "svg"
+  | "xml"
+  | "ssml"
+  | "atom"
+  | "rss"
+  | "css"
+  | "clike"
+  | "javascript"
+  | "js"
+  | "jsx";
+
+export const copyCode = (content) => {
+  if (typeof content === "string") {
+    copy(content, {
+      format: "text/plain",
+    });
+  }
+};
+
+const Bash = ({
+  code,
+  terminal = false,
+  copy = false,
+  language = "html",
+  ...props
+}: {
+  code: string;
+  terminal?: boolean;
+  copy?: boolean;
+  language?: PrismLanguages;
+}) => {
+  const highlighted = terminal
+    ? code
+    : Prism.highlight(code, Prism.languages[language], language);
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const timeoutRef = useRef<NodeJS.Timeout>();
+  const [openPopover, setOpenPopover] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (openPopover) {
+      timeoutRef.current = setTimeout(() => setOpenPopover(false), 1500);
+      return () => timeoutRef.current && clearTimeout(timeoutRef.current);
+    }
+  }, [openPopover]);
+
+  const handleCopy = () => {
+    copyCode(code);
+    setOpenPopover(true);
+  };
+
+  return (
+    <div className={style.preWrapper}>
+      <pre className={style.pre}>
+        <code
+          className={cl(style.code, {
+            [style.codeCopy]: copy,
+            [style.terminal]: terminal,
+          })}
+          {...props}
+          dangerouslySetInnerHTML={{ __html: highlighted }}
+        />
+        {copy && (
+          <>
+            <div className={style.buttonBackground}>
+              <button
+                ref={buttonRef}
+                className={style.copyButton}
+                onClick={() => handleCopy()}
+              >
+                <Files />
+              </button>
+              <Popover
+                role="alert"
+                anchorEl={buttonRef.current}
+                open={openPopover}
+                onClose={() => setOpenPopover(false)}
+                size="small"
+                placement="auto-start"
+                /* arrow={false} */
+              >
+                Kode er kopiert
+              </Popover>
+              )
+            </div>
+          </>
+        )}
+      </pre>
+    </div>
+  );
+};
+
+export default Bash;

--- a/docs/components/code/Import.tsx
+++ b/docs/components/code/Import.tsx
@@ -1,0 +1,22 @@
+import Bash from "./Bash";
+
+interface ImportProps {
+  from: string;
+  imports: string | string[];
+  namedExport?: boolean;
+}
+
+const Import = ({ namedExport = true, from, imports }: ImportProps) => {
+  const genCode = () => {
+    if (Array.isArray(imports)) {
+      return `import { ${imports.join(", ")} } from "${from}";`;
+    } else if (!namedExport) {
+      return `import ${imports} from "${from}";`;
+    } else {
+      return `import { ${imports} } from "${from}";`;
+    }
+  };
+  return <Bash code={genCode()} copy language="jsx"></Bash>;
+};
+
+export default Import;

--- a/docs/components/code/bash.module.css
+++ b/docs/components/code/bash.module.css
@@ -1,0 +1,64 @@
+.pre {
+  padding: 1rem;
+  margin: 1rem 0 0 0;
+  overflow: auto;
+  width: calc(100vw - 2rem);
+  background-color: var(--bg-code);
+  align-items: center;
+  display: flex;
+
+  /* Fixer pixelbug på høyre side av bash-panel */
+  box-shadow: inset -4px 0 0 var(--bg-code);
+}
+
+.preWrapper {
+  position: relative;
+  align-items: center;
+  display: flex;
+}
+
+.terminal {
+  color: var(--color-code);
+}
+
+.code {
+  padding-right: 4rem;
+  color: var(--color-code);
+}
+
+.terminal::before {
+  content: "$ ";
+}
+
+.buttonBackground {
+  width: 3rem;
+  background-color: var(--bg-code);
+  position: absolute;
+  right: 0;
+  margin: 1rem 0;
+  display: flex;
+  justify-content: center;
+  height: calc(100% - 3rem - 0.5rem);
+  align-items: center;
+}
+
+.copyButton {
+  background-color: var(--bg-code);
+  color: white;
+  font-size: 1.5rem;
+  padding: 0.5rem;
+  border: none;
+  align-items: center;
+  display: inline-flex;
+  height: 2.5rem;
+  width: 2.5rem;
+}
+
+.copyButton:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.copyButton:focus {
+  outline: var(--outline-code);
+  outline-offset: var(--outline-offset);
+}

--- a/docs/components/layout/Layout.tsx
+++ b/docs/components/layout/Layout.tsx
@@ -26,7 +26,7 @@ const Layout = ({ children }: LayoutProps) => {
   useEffect(() => {
     setSidebar(!small);
   }, [small]);
-  /* console.log(sidebar); */
+
   return (
     <div className={style.pageWrapper + " lightTheme"}>
       <Header sidebar={sidebar} onSidebarChange={(x) => setSidebar(x)} />
@@ -35,9 +35,9 @@ const Layout = ({ children }: LayoutProps) => {
         small={small}
         onSidebarChange={(x) => setSidebar(x)}
       />
-      <main>
+      <main className={style.contentWrapper}>
         <ContentContainer>
-          <Grid className={style.contentWrapper}>
+          <Grid>
             <Cell className={style.content} xs={12} sm={12} md={10} lg={7}>
               <Mdx>{children}</Mdx>
             </Cell>

--- a/docs/components/layout/MdxProvider.tsx
+++ b/docs/components/layout/MdxProvider.tsx
@@ -1,6 +1,7 @@
 import { MDXProvider } from "@mdx-js/react";
 import { Heading, Paragraph } from "@navikt/ds-react";
 import Bash from "../code/Bash";
+import Import from "../code/Import";
 import Preview from "../code-preview/Preview";
 /* import Npm from "../npm/Npm"; */
 /* import { Button } from "@navikt/ds-react"; */
@@ -14,6 +15,7 @@ const MdxWrapper = (props) => (
       p: (props) => <Paragraph size="medium" {...props} />,
       Bash,
       Preview,
+      Import,
       /* Npm, */
     }}
     {...props}

--- a/docs/components/layout/MdxProvider.tsx
+++ b/docs/components/layout/MdxProvider.tsx
@@ -3,7 +3,7 @@ import { Heading, Paragraph } from "@navikt/ds-react";
 import Bash from "../code/Bash";
 import Import from "../code/Import";
 import Preview from "../code-preview/Preview";
-/* import Npm from "../npm/Npm"; */
+import Npm from "../npm/Npm";
 /* import { Button } from "@navikt/ds-react"; */
 
 const MdxWrapper = (props) => (
@@ -16,7 +16,7 @@ const MdxWrapper = (props) => (
       Bash,
       Preview,
       Import,
-      /* Npm, */
+      Npm,
     }}
     {...props}
   />

--- a/docs/components/layout/MdxProvider.tsx
+++ b/docs/components/layout/MdxProvider.tsx
@@ -1,8 +1,8 @@
 import { MDXProvider } from "@mdx-js/react";
 import { Heading, Paragraph } from "@navikt/ds-react";
-/* import Bash from "../code/Bash";
+import Bash from "../code/Bash";
 import Preview from "../code-preview/Preview";
-import Npm from "../npm/Npm"; */
+/* import Npm from "../npm/Npm"; */
 /* import { Button } from "@navikt/ds-react"; */
 
 const MdxWrapper = (props) => (
@@ -12,9 +12,9 @@ const MdxWrapper = (props) => (
       h2: (props) => <Heading size="large" level={2} {...props} />,
       h3: (props) => <Heading size="small" level={3} {...props} />,
       p: (props) => <Paragraph size="medium" {...props} />,
-      /* Bash,
+      Bash,
       Preview,
-      Npm, */
+      /* Npm, */
     }}
     {...props}
   />

--- a/docs/components/layout/layout.module.css
+++ b/docs/components/layout/layout.module.css
@@ -90,6 +90,7 @@
   overflow-y: auto;
   overflow: visible;
   margin: 0 auto 0 0;
+  width: 100%;
 }
 
 .content {

--- a/docs/components/npm/Npm.tsx
+++ b/docs/components/npm/Npm.tsx
@@ -1,0 +1,61 @@
+import getConfig from "next/config";
+import Import from "../code/Import";
+import style from "./npm.module.css";
+
+const Npm = ({
+  packName,
+  imports,
+  namedExport,
+}: {
+  packName: string;
+  imports: string | string[];
+  namedExport?: boolean;
+}) => {
+  const { publicRuntimeConfig } = getConfig();
+
+  const packs = publicRuntimeConfig.packages.filter(
+    (pack) => pack.name === packName
+  );
+
+  return (
+    <div>
+      {packs.map(({ name, data }) => (
+        <div key={name}>
+          <span className={style.badges}>
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href={`https://www.npmjs.com/package/${name}`}
+            >
+              <img src={`https://badgen.net/npm/v/${name}`} alt="123" />
+            </a>
+
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href={`https://bundlephobia.com/result?p=${name}`}
+            >
+              <img
+                src={`https://badgen.net/bundlephobia/tree-shaking/${name}`}
+                alt="123"
+              />
+            </a>
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href={`https://bundlephobia.com/result?p=${name}`}
+            >
+              <img
+                src={`https://badgen.net/bundlephobia/min/${name}`}
+                alt="123"
+              />
+            </a>
+          </span>
+          <Import from={name} imports={imports} namedExport={namedExport} />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Npm;

--- a/docs/components/npm/npm.module.css
+++ b/docs/components/npm/npm.module.css
@@ -1,0 +1,5 @@
+.badges {
+  display: flex;
+  column-gap: 0.5rem;
+  flex-wrap: wrap;
+}

--- a/docs/components/tabs/Tabs.tsx
+++ b/docs/components/tabs/Tabs.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import style from "./tabs.module.css";
+import cl from "classnames";
+
+interface TabsProps {
+  onChange: (tab: number) => void;
+  tabs: string[];
+}
+
+const Tabs = ({ onChange, tabs, ...props }: TabsProps) => {
+  const [tab, setTab] = useState(0);
+
+  const handleClick = (x: number) => {
+    onChange(x);
+    setTab(x);
+  };
+
+  return (
+    <ul className={style.ul}>
+      {tabs.map((t, x) => (
+        <li key={t + x} className={style.li}>
+          <button
+            className={cl(style.button, { [style.buttonActive]: x === tab })}
+            onClick={() => handleClick(x)}
+          >
+            {t}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default Tabs;

--- a/docs/components/tabs/tabs.module.css
+++ b/docs/components/tabs/tabs.module.css
@@ -1,0 +1,32 @@
+.ul {
+  padding: 0;
+  margin: 0;
+  display: flex;
+}
+
+.li {
+  list-style: none;
+}
+
+.button {
+  color: var(--tab-color);
+  border: none;
+  background: none;
+  padding: 0.5rem 1.5rem;
+  font-weight: var(--navds-font-weight-bold);
+}
+
+.button:hover {
+  border-bottom: 4px solid var(--navds-color-darkgray);
+  color: var(--navds-color-darkgray);
+}
+
+.button:focus {
+  outline: var(--outline-focus);
+  outline-offset: var(--outline-offset);
+}
+
+.buttonActive {
+  border-bottom: var(--tab-border);
+  color: var(--tab-color-active);
+}

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,6 +1,21 @@
+/* const withBundleAnalyzer = require("@next/bundle-analyzer")({
+  enabled: process.env.ANALYZE === "true",
+}); */
+const glob = require("glob");
 const withMDX = require("@next/mdx")({
   extension: /\.mdx?$/,
 });
+
+const loadPackage = () => {
+  const navFrontend = glob.sync("../packages/**/package.json");
+  const vnext = glob.sync("../@navikt/*/package.json");
+  return [...navFrontend, ...vnext]
+    .filter((file) => !file.includes("node_modules"))
+    .map((file) => {
+      const pack = require(file);
+      return { name: pack.name, data: pack };
+    });
+};
 
 module.exports = withMDX({
   pageExtensions: ["js", "jsx", "mdx"],
@@ -10,5 +25,8 @@ module.exports = withMDX({
       use: ["@svgr/webpack"],
     });
     return config;
+  },
+  publicRuntimeConfig: {
+    packages: loadPackage(),
   },
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,9 @@
     "classnames": "^2.2.6",
     "@next/mdx": "^10.0.8",
     "@mdx-js/loader": "^1.6.22",
+    "@mdx-js/react": "^1.6.22",
+    "copy-to-clipboard": "^3.3.1",
+    "prismjs": "^1.23.0",
     "@svgr/webpack": "^5.5.0",
     "@navikt/ds-css": "^0.2.0",
     "@navikt/ds-react": "^0.2.0"

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
     "react-responsive": "^8.2.0",
     "react-use-keypress": "^1.2.0",
     "classnames": "^2.2.6",
+    "glob": "^7.1.6",
     "@next/mdx": "^10.0.8",
     "@mdx-js/loader": "^1.6.22",
     "@mdx-js/react": "^1.6.22",

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import Layout from "../components/layout/Layout";
 import "../styles/theme.css";
 import "../styles/globals.css";
+import "../styles/prismjs.css";
 import "@navikt/ds-css";
 
 const Website = ({ Component, pageProps }) => {

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -1,3 +1,5 @@
 # Home
 
 Hjemmeside
+
+<Npm packName="@navikt/ds-react" imports="Button" />

--- a/docs/styles/globals.css
+++ b/docs/styles/globals.css
@@ -2,6 +2,7 @@ html,
 body {
   padding: 0;
   margin: 0;
+  background-color: var(--bg-primary);
 }
 
 a {

--- a/docs/styles/prismjs.css
+++ b/docs/styles/prismjs.css
@@ -1,0 +1,122 @@
+/**
+ * Dracula Theme originally by Zeno Rocha [@zenorocha]
+ * https://draculatheme.com/
+ *
+ * Ported for PrismJS by Albert Vallverdu [@byverdu]
+ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+  color: #f8f8f2;
+  background: none;
+  text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+  border-radius: 0.3em;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+  background: #282a36;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+  padding: 0.1em;
+  border-radius: 0.3em;
+  white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #6272a4;
+}
+
+.token.punctuation {
+  color: #f8f8f2;
+}
+
+.namespace {
+  opacity: 0.7;
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #ff79c6;
+}
+
+.token.boolean,
+.token.number {
+  color: #bd93f9;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #50fa7b;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+  color: #f8f8f2;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.function,
+.token.class-name {
+  color: #f1fa8c;
+}
+
+.token.keyword {
+  color: #8be9fd;
+}
+
+.token.regex,
+.token.important {
+  color: #ffb86c;
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+
+.token.italic {
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2551,7 +2551,7 @@
     unist-builder "2.0.3"
     unist-util-visit "2.0.3"
 
-"@mdx-js/react@1.6.22", "@mdx-js/react@^1.6.18", "@mdx-js/react@^1.6.19":
+"@mdx-js/react@1.6.22", "@mdx-js/react@^1.6.18", "@mdx-js/react@^1.6.19", "@mdx-js/react@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-1.6.22.tgz#ae09b4744fddc74714ee9f9d6f17a66e77c43573"
   integrity sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==
@@ -18685,7 +18685,7 @@ prism-react-renderer@^1.1.1:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.2.0.tgz#5ad4f90c3e447069426c8a53a0eafde60909cdf4"
   integrity sha512-GHqzxLYImx1iKN1jJURcuRoA/0ygCcNhfGw1IT8nPIMzarmKQ3Nc+JcG0gi8JXQzuh0C5ShE4npMIoqNin40hg==
 
-prismjs@1.23.0, prismjs@^1.21.0, prismjs@^1.22.0, prismjs@~1.23.0:
+prismjs@1.23.0, prismjs@^1.21.0, prismjs@^1.22.0, prismjs@^1.23.0, prismjs@~1.23.0:
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
   integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==


### PR DESCRIPTION
Code-preview
Html-kode blir autogenerert av Preview-children, mens react-kode blir inlinet react-prop
```jsx
<Preview react={`<Button variant="action">Action</Button>`}>
  <Button variant="action">Action</Button>
</Preview>
```
<img width="766" alt="Screenshot 2021-03-15 at 10 23 31" src="https://user-images.githubusercontent.com/26967723/111131436-880c2880-8578-11eb-90ea-b464bb83968a.png">
<img width="720" alt="Screenshot 2021-03-15 at 10 24 14" src="https://user-images.githubusercontent.com/26967723/111131516-9e19e900-8578-11eb-8a57-d6dd096390b0.png">


Import 
```jsx
<Import from={"@navikt/ds-react"} imports={["Button, "komponenter"]} namedExport={true} />
```
<img width="770" alt="Screenshot 2021-03-15 at 10 23 21" src="https://user-images.githubusercontent.com/26967723/111131424-85a9ce80-8578-11eb-849f-38284977f9a6.png">

Npm
```jsx
<Npm packName="@navikt/ds-react" imports="Button" />
```
<img width="785" alt="Screenshot 2021-03-15 at 10 58 09" src="https://user-images.githubusercontent.com/26967723/111136164-b93b2780-857d-11eb-894b-15258150b7bc.png">

