### PR TITLE
setappelement extender nå Modal komponent

### DIFF
--- a/@navikt/ds-react/modal/Modal.tsx
+++ b/@navikt/ds-react/modal/Modal.tsx
@@ -27,12 +27,11 @@ export interface ModalProps {
    */
   shouldCloseOnOverlayClick?: boolean;
   /**
-   * @ignore
+   * User defined classname for wrapper element
    */
   className?: string;
   /**
    * User defined classname for modal content
-   * @default ""
    */
   contentClassName?: string;
 }

--- a/@navikt/ds-react/modal/Modal.tsx
+++ b/@navikt/ds-react/modal/Modal.tsx
@@ -27,16 +27,24 @@ export interface ModalProps {
    */
   shouldCloseOnOverlayClick?: boolean;
   /**
-   * User defined classname for wrapper element
+   * @ignore
    */
   className?: string;
   /**
    * User defined classname for modal content
+   * @default ""
    */
   contentClassName?: string;
 }
 
-const Modal = forwardRef<ReactModal, ModalProps>(
+type ModalLifecycle = {
+  setAppElement?: (element: any) => void;
+};
+
+const Modal: ModalLifecycle &
+  React.ForwardRefExoticComponent<
+    ModalProps & React.RefAttributes<ReactModal>
+  > = forwardRef<ReactModal, ModalProps>(
   (
     {
       children,
@@ -89,8 +97,6 @@ const Modal = forwardRef<ReactModal, ModalProps>(
   }
 );
 
-export const setAppElement = (element) => {
-  ReactModal.setAppElement(element);
-};
+Modal.setAppElement = (element) => ReactModal.setAppElement(element);
 
 export default Modal;


### PR DESCRIPTION
Bruker kan nå kjøre `Modal.setAppElement("#root")` uten å måtte importere react-modal lokalt