### PR TITLE
Scroll er nå bare "smooth" onFocus

### DIFF
--- a/@navikt/ds-css/baseline/baseline.css
+++ b/@navikt/ds-css/baseline/baseline.css
@@ -6,7 +6,7 @@
 @import "print.css";
 @import "utility.css";
 
-html {
+html:focus-within {
   scroll-behavior: smooth;
 }
 

--- a/docs/styles/globals.css
+++ b/docs/styles/globals.css
@@ -3,7 +3,6 @@ body {
   padding: 0;
   margin: 0;
   background-color: var(--bg-primary);
-  scroll-behavior: smooth;
 }
 
 * {


### PR DESCRIPTION
Smooth-scroll bare satt i `html:focus-within`
Slipper da at det er smooth-scroll når man gjør eks ctrl + f søk på siden.

Takk for tips @winsvold !