### PR TITLE
Ekspanderbartpanel: Fokusmarkering forsvinner ikke nå onHover

### DIFF
--- a/packages/nav-frontend-ekspanderbartpanel-style/src/index.less
+++ b/packages/nav-frontend-ekspanderbartpanel-style/src/index.less
@@ -88,14 +88,4 @@
       .chevron-orientasjon-mixin(opp);
     }
   }
-
-  &:hover {
-    &.ekspanderbartPanel--apen {
-      box-shadow: none;
-
-      .ekspanderbartPanel__hode {
-        box-shadow: none;
-      }
-    }
-  }
 }


### PR DESCRIPTION
https://nav-it.slack.com/archives/C7NE7A8UF/p1617960381001800

Tenker selv at det ikke gir mening at focus forsvinner onHover, så stemmer for denne endringen.