### PR TITLE
parse nextjs router url

### DIFF
--- a/docs/components/layout/sidebar/Menu.tsx
+++ b/docs/components/layout/sidebar/Menu.tsx
@@ -6,13 +6,14 @@ import {
   AccordionMenuItem,
 } from "@navikt/ds-react";
 import React from "react";
+import parseUrl from "url-parse";
 
 const MenuLink = (node) => {
   const { asPath } = useRouter();
 
   return (
     <Link href={node.pathName} passHref>
-      <AccordionMenuItem active={asPath === node.pathName}>
+      <AccordionMenuItem active={parseUrl(asPath).pathname === node.pathName}>
         {node.title}
       </AccordionMenuItem>
     </Link>
@@ -25,7 +26,7 @@ const isActive = (children, path) => {
       ? isActive(child.children, path)
       : child.pathName === path;
   });
-  return active;
+  return !!active;
 };
 
 const mapToComponents = (node, path) => {
@@ -48,7 +49,7 @@ const Menu = ({ menu }) => {
   const { asPath } = useRouter();
   return (
     <AccordionMenu>
-      {menu.map((item) => mapToComponents(item, asPath.split("#")[0]))}
+      {menu.map((item) => mapToComponents(item, parseUrl(asPath).pathname))}
     </AccordionMenu>
   );
 };

--- a/docs/package.json
+++ b/docs/package.json
@@ -44,7 +44,8 @@
     "css-loader": "^5.2.0",
     "webpack": "^4.44.2",
     "jszip": "^3.6.0",
-    "canvg": "^3.0.7"
+    "canvg": "^3.0.7",
+    "url-parse": "^1.5.1"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^10.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24470,7 +24470,7 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.1.8, url-parse@^1.4.3, url-parse@^1.4.7:
+url-parse@^1.1.8, url-parse@^1.4.3, url-parse@^1.4.7, url-parse@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
   integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==


### PR DESCRIPTION
`asPath.split("#")[0]` funka dårlig for meg når urlen hadde query params, så for å være litt mer future proof la jeg til en url-parsing-pakke.