### PR TITLE
AnchorMenu history-state fiks

### DIFF
--- a/@navikt/ds-react/src/accordion-anchor-menu/ActiveAnchorStore.tsx
+++ b/@navikt/ds-react/src/accordion-anchor-menu/ActiveAnchorStore.tsx
@@ -40,7 +40,7 @@ export const ActiveAnchorProvider = ({ children }) => {
         const urlWithoutHash = href.replace(hash, "");
         const urlWithAnchor = `${urlWithoutHash}#${lastPassedAnchor}`;
         const title = document.title;
-        window.history.pushState(lastPassedAnchor, title, urlWithAnchor);
+        window.history.replaceState(window.history.state, title, urlWithAnchor);
         setActiveAnchor(lastPassedAnchor);
       }
     };


### PR DESCRIPTION
- Beholder state-objektet når history oppdateres ved scrolling med anchor-menu. Dette benyttes ved async navigering mellom sider i bl.a. next.js, og denne vil brekke dersom state'en overskrives.
- Bruker replaceState istedenfor pushState slik at frem/tilbake-knapper i browser oppfører seg mer som forventet (?)