### PR TITLE
always underline bekreftCheckboksPanel label on hover

### DIFF
--- a/packages/nav-frontend-skjema-style/src/bekreft-checkboks-panel.less
+++ b/packages/nav-frontend-skjema-style/src/bekreft-checkboks-panel.less
@@ -22,6 +22,10 @@
     margin-bottom: 0;
   }
 
+  .checkboks:hover + .skjemaelement__label {
+    text-decoration: underline;
+  }
+
   &--checked {
     background-color: @navGronnLighten80;
     border-color: @navGronnLighten80;
@@ -45,7 +49,6 @@
 
         &:hover {
           color: @navMorkGra;
-          text-decoration: underline;
 
           &::before {
             background-color: @navGronnDarken40;


### PR DESCRIPTION
Fikser en uu-feil hvor forskjellen på default og hover stil ikke var stor nok.