### PR TITLE
popover-position updates nå onMount

### DIFF
--- a/packages/nav-frontend-popover/src/popover.tsx
+++ b/packages/nav-frontend-popover/src/popover.tsx
@@ -83,6 +83,7 @@ class Popover extends React.Component<PopoverProps, PopoverState> {
     this.scrollParents.forEach((scrollParent) =>
       scrollParent.addEventListener("scroll", this.handleScroll)
     );
+    this.props.ankerEl && this.updatePosition(this.props);
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
- `updatePosition()` kjøres hvis popover mountes med `ankerEl`

Resolves #987 