### PR TITLE
Vnext: Veileder -> Guide komponent

### DIFF
--- a/@navikt/ds-css/guide.css
+++ b/@navikt/ds-css/guide.css
@@ -221,6 +221,7 @@
   border-right: 0;
   margin-right: 0.75rem;
 }
+
 /* arrow color */
 .navds-guide__arrow--white {
   border-right-color: white;
@@ -240,6 +241,7 @@
   padding: 1.25rem;
   text-align: left;
 }
+
 /* Bubble position */
 .navds-guide__speech-bubble--floating {
   position: absolute;

--- a/@navikt/ds-css/guide.css
+++ b/@navikt/ds-css/guide.css
@@ -1,0 +1,96 @@
+/* variant?: "default" | "success" | "warning" | "error";
+  theme?: "default" | "info" | "success" | "warning" | "error";
+  size?: "s" | "m" | "l" | "xl";
+  position?: "floating" | "top" | "right" | "bottom" | "left"; */
+
+.navds-guide {
+}
+/* guide variants */
+.navds-guide--default {
+}
+.navds-guide--success {
+}
+.navds-guide--warning {
+}
+.navds-guide--error {
+}
+
+/* positions */
+.navds-guide--floating {
+}
+.navds-guide--top {
+}
+.navds-guide--right {
+}
+.navds-guide--bottom {
+}
+.navds-guide--left {
+}
+
+/* Guide illustration frame */
+.navds-guide__illustration {
+}
+/* Illustration sizes */
+.navds-guide__illustration--s {
+}
+.navds-guide__illustration--m {
+}
+.navds-guide__illustration--l {
+}
+.navds-guide__illustration--xl {
+}
+
+/* Illustration themes */
+.navds-guide__illustration--default {
+}
+.navds-guide__illustration--info {
+}
+.navds-guide__illustration--success {
+}
+.navds-guide__illustration--waring {
+}
+.navds-guide__illustration--error {
+}
+
+.navds-guide__illustration--center {
+}
+.navds-guide__illustration--transparent {
+}
+.navds-guide__illustration--nomask {
+}
+
+.navds-guide__arrow {
+}
+/* Arrow positions */
+.navds-guide__arrow--floating {
+}
+.navds-guide__arrow--top {
+}
+.navds-guide__arrow--right {
+}
+.navds-guide__arrow--bottom {
+}
+.navds-guide__arrow--left {
+}
+/* arrow color */
+.navds-guide__arrow--white {
+}
+
+/* guide speech-bubble */
+.navds-guide__speech-bubble {
+}
+/* Bubble position */
+.navds-guide__speech-bubble--floating {
+}
+.navds-guide__speech-bubble--top {
+}
+.navds-guide__speech-bubble--right {
+}
+.navds-guide__speech-bubble--bottom {
+}
+.navds-guide__speech-bubble--left {
+}
+
+/* bubble color */
+.navds-guide__speech-bubble--white {
+}

--- a/@navikt/ds-css/guide.css
+++ b/@navikt/ds-css/guide.css
@@ -6,20 +6,6 @@
 }
 
 /* guide variants */
-
-/* .navds-guide--default .navds-guide__speech-bubble {
-  background-color: var(--navds-color-orange-20);
-}
-
-.navds-guide--default .navds-guide__arrow {
-  border-right: 1.25rem solid var(--navds-color-orange-20);
-}
-
-.navds-guide--default .navds-guide__arrow--left {
-  border-right: 0;
-  border-left: 1.25rem solid var(--navds-color-orange-20);
-} */
-
 .navds-guide--success .navds-guide__speech-bubble {
   background-color: var(--navds-color-green-20);
 }
@@ -153,9 +139,6 @@
 }
 
 /* Illustration themes */
-
-/* .navds-guide__illustration--default {
-} */
 .navds-guide__illustration--info {
   background: var(--navds-color-lightblue-30);
 }

--- a/@navikt/ds-css/guide.css
+++ b/@navikt/ds-css/guide.css
@@ -4,7 +4,9 @@
   justify-content: center;
   position: relative;
 }
+
 /* guide variants */
+
 /* .navds-guide--default .navds-guide__speech-bubble {
   background-color: var(--navds-color-orange-20);
 }
@@ -58,8 +60,10 @@
 }
 
 /* positions */
+
 /* .navds-guide--floating {
 } */
+
 .navds-guide--top {
   flex-direction: column;
 }
@@ -182,7 +186,9 @@
 
 .navds-guide__arrow {
   border-bottom: 1.25rem solid transparent;
-  border-right: 1.25rem solid #efefef; /* change tp gray-10 ? */
+
+  /* change tp gray-10 ? */
+  border-right: 1.25rem solid #efefef;
   display: block;
   height: 1.25rem;
   order: 2;
@@ -205,7 +211,8 @@
   border-top: 1.25rem solid transparent;
 }
 .navds-guide__arrow--left {
-  border-left: 1.25rem solid #efefef; /* change tp gray-10 ? */
+  /* change tp gray-10 ? */
+  border-left: 1.25rem solid #efefef;
   border-top: 1.25rem solid transparent;
   border-right: 0;
   margin-right: 0.75rem;
@@ -221,7 +228,8 @@
 
 /* guide speech-bubble */
 .navds-guide__speech-bubble {
-  background: #efefef; /* Change to gray-10 ? */
+  /* change tp gray-10 ? */
+  background: #efefef;
   border-radius: 0.5rem;
   order: 1;
   padding: 1.25rem;

--- a/@navikt/ds-css/guide.css
+++ b/@navikt/ds-css/guide.css
@@ -94,6 +94,7 @@
   height: 90%;
   width: 100%;
 }
+
 /* Illustration sizes */
 .navds-guide__illustration--s {
   height: 5rem;
@@ -152,6 +153,7 @@
 }
 
 /* Illustration themes */
+
 /* .navds-guide__illustration--default {
 } */
 .navds-guide__illustration--info {
@@ -193,6 +195,7 @@
   height: 1.25rem;
   order: 2;
 }
+
 /* Arrow positions */
 .navds-guide__arrow--floating {
   position: absolute;
@@ -211,9 +214,10 @@
   border-top: 1.25rem solid transparent;
 }
 .navds-guide__arrow--left {
+  border-top: 1.25rem solid transparent;
+
   /* change tp gray-10 ? */
   border-left: 1.25rem solid #efefef;
-  border-top: 1.25rem solid transparent;
   border-right: 0;
   margin-right: 0.75rem;
 }
@@ -228,9 +232,10 @@
 
 /* guide speech-bubble */
 .navds-guide__speech-bubble {
+  border-radius: 0.5rem;
+
   /* change tp gray-10 ? */
   background: #efefef;
-  border-radius: 0.5rem;
   order: 1;
   padding: 1.25rem;
   text-align: left;

--- a/@navikt/ds-css/guide.css
+++ b/@navikt/ds-css/guide.css
@@ -1,96 +1,238 @@
-/* variant?: "default" | "success" | "warning" | "error";
-  theme?: "default" | "info" | "success" | "warning" | "error";
-  size?: "s" | "m" | "l" | "xl";
-  position?: "floating" | "top" | "right" | "bottom" | "left"; */
-
 .navds-guide {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  position: relative;
 }
 /* guide variants */
-.navds-guide--default {
+/* .navds-guide--default .navds-guide__speech-bubble {
+  background-color: var(--navds-color-orange-20);
 }
-.navds-guide--success {
+
+.navds-guide--default .navds-guide__arrow {
+  border-right: 1.25rem solid var(--navds-color-orange-20);
 }
-.navds-guide--warning {
+
+.navds-guide--default .navds-guide__arrow--left {
+  border-right: 0;
+  border-left: 1.25rem solid var(--navds-color-orange-20);
+} */
+
+.navds-guide--success .navds-guide__speech-bubble {
+  background-color: var(--navds-color-green-20);
 }
-.navds-guide--error {
+
+.navds-guide--success .navds-guide__arrow {
+  border-right: 1.25rem solid var(--navds-color-green-20);
+}
+
+.navds-guide--success .navds-guide__arrow--left {
+  border-right: 0;
+  border-left: 1.25rem solid var(--navds-color-green-20);
+}
+
+.navds-guide--warning .navds-guide__speech-bubble {
+  background-color: var(--navds-color-orange-20);
+}
+
+.navds-guide--warning .navds-guide__arrow {
+  border-right: 1.25rem solid var(--navds-color-orange-20);
+}
+
+.navds-guide--warning .navds-guide__arrow--left {
+  border-right: 0;
+  border-left: 1.25rem solid var(--navds-color-orange-20);
+}
+
+.navds-guide--error .navds-guide__speech-bubble {
+  background-color: var(--navds-color-danger-default);
+}
+
+.navds-guide--error .navds-guide__arrow {
+  border-right: 1.25rem solid var(--navds-color-danger-default);
+}
+
+.navds-guide--error .navds-guide__arrow--left {
+  border-right: 0;
+  border-left: 1.25rem solid var(--navds-color-danger-default);
 }
 
 /* positions */
-.navds-guide--floating {
-}
+/* .navds-guide--floating {
+} */
 .navds-guide--top {
+  flex-direction: column;
 }
 .navds-guide--right {
+  flex-direction: row-reverse;
 }
 .navds-guide--bottom {
+  flex-direction: column-reverse;
 }
 .navds-guide--left {
+  flex-direction: row;
 }
 
 /* Guide illustration frame */
 .navds-guide__illustration {
+  align-items: flex-end;
+  background: var(--navds-color-gray-20);
+  border-radius: 50%;
+  display: flex;
+  flex-shrink: 0;
+  justify-content: center;
+  order: 3;
+  overflow: hidden;
+}
+
+.navds-guide__illustration svg,
+.navds-guide__illustration img {
+  height: 90%;
+  width: 100%;
 }
 /* Illustration sizes */
 .navds-guide__illustration--s {
+  height: 5rem;
+  width: 5rem;
 }
+
+.navds-guide__illustration--s ~ .navds-guide__speech-bubble--floating {
+  bottom: 5rem;
+}
+
+.navds-guide__illustration--s ~ .navds-guide__arrow--floating {
+  bottom: 4.1rem;
+  transform: scale(0.5);
+}
+
 .navds-guide__illustration--m {
+  height: 6.25rem;
+  width: 6.25rem;
 }
+
+.navds-guide__illustration--m ~ .navds-guide__speech-bubble--floating {
+  bottom: 6.5rem;
+}
+
+.navds-guide__illustration--m ~ .navds-guide__arrow--floating {
+  bottom: 5.5rem;
+  transform: scale(0.666667);
+}
+
 .navds-guide__illustration--l {
+  height: 10rem;
+  width: 10rem;
 }
+
+.navds-guide__illustration--l ~ .navds-guide__speech-bubble--floating {
+  bottom: 10rem;
+}
+
+.navds-guide__illustration--l ~ .navds-guide__arrow--floating {
+  bottom: 8.8rem;
+  transform: scale(1.06667);
+}
+
 .navds-guide__illustration--xl {
+  height: 15rem;
+  width: 15rem;
+}
+
+.navds-guide__illustration--xl ~ .navds-guide__speech-bubble--floating {
+  bottom: 15rem;
+}
+
+.navds-guide__illustration--xl ~ .navds-guide__arrow--floating {
+  bottom: 14rem;
+  transform: scale(1.6);
 }
 
 /* Illustration themes */
-.navds-guide__illustration--default {
-}
+/* .navds-guide__illustration--default {
+} */
 .navds-guide__illustration--info {
+  background: var(--navds-color-lightblue-30);
 }
+
 .navds-guide__illustration--success {
+  background: var(--navds-color-green-20);
 }
+
 .navds-guide__illustration--waring {
+  background: var(--navds-color-orange-20);
 }
+
 .navds-guide__illustration--error {
+  background: var(--navds-color-red-20);
 }
 
 .navds-guide__illustration--center {
+  align-items: center;
+}
+.navds-guide__illustration--center svg,
+.navds-guide__illustration--center img {
+  height: 100%;
 }
 .navds-guide__illustration--transparent {
+  background: none;
 }
 .navds-guide__illustration--nomask {
+  overflow: visible;
 }
 
 .navds-guide__arrow {
+  border-bottom: 1.25rem solid transparent;
+  border-right: 1.25rem solid #efefef; /* change tp gray-10 ? */
+  display: block;
+  height: 1.25rem;
+  order: 2;
 }
 /* Arrow positions */
 .navds-guide__arrow--floating {
+  position: absolute;
+  right: 50%;
 }
 .navds-guide__arrow--top {
+  margin-right: 40px;
 }
 .navds-guide__arrow--right {
+  margin-left: 0.75rem;
+  border-top: 1.25rem solid transparent;
 }
 .navds-guide__arrow--bottom {
+  border-bottom: 0;
+  margin-right: 40px;
+  border-top: 1.25rem solid transparent;
 }
 .navds-guide__arrow--left {
+  border-left: 1.25rem solid #efefef; /* change tp gray-10 ? */
+  border-top: 1.25rem solid transparent;
+  border-right: 0;
+  margin-right: 0.75rem;
 }
 /* arrow color */
 .navds-guide__arrow--white {
+  border-right-color: white;
+}
+
+.navds-guide__arrow--left.navds-guide__arrow--white {
+  border-left-color: white;
 }
 
 /* guide speech-bubble */
 .navds-guide__speech-bubble {
+  background: #efefef; /* Change to gray-10 ? */
+  border-radius: 0.5rem;
+  order: 1;
+  padding: 1.25rem;
+  text-align: left;
 }
 /* Bubble position */
 .navds-guide__speech-bubble--floating {
-}
-.navds-guide__speech-bubble--top {
-}
-.navds-guide__speech-bubble--right {
-}
-.navds-guide__speech-bubble--bottom {
-}
-.navds-guide__speech-bubble--left {
+  position: absolute;
 }
 
 /* bubble color */
 .navds-guide__speech-bubble--white {
+  background: white;
 }

--- a/@navikt/ds-css/index.css
+++ b/@navikt/ds-css/index.css
@@ -7,6 +7,7 @@
 @import "content-container.css";
 @import "copy-to-clipboard.css";
 @import "grid.css";
+@import "guide.css";
 @import "internal-header.css";
 @import "layouts.css";
 @import "link.css";

--- a/@navikt/ds-react/src/guide/Guide.tsx
+++ b/@navikt/ds-react/src/guide/Guide.tsx
@@ -1,0 +1,104 @@
+import React, { forwardRef, HTMLAttributes } from "react";
+import cl from "classnames";
+
+const wrapperCls = (
+  className: string | undefined,
+  position: string,
+  variant: string
+) =>
+  cl(
+    "navds-guide",
+    className,
+    `navds-guide--${position}`,
+    `navds-guide--${variant}`
+  );
+
+const illustrationCls = (
+  center: boolean,
+  transparent: boolean,
+  noMask: boolean,
+  size: string,
+  theme: string
+) =>
+  cl(
+    "navds-guide__illustration",
+    `navds-guide__illustration--${size}`,
+    `navds-guide__illustration--${theme}`,
+    {
+      "navds-guide__illustration--center": center,
+      "navds-guide__illustration--transparent": transparent,
+      "navds-guide__illustration--nomask": noMask,
+    }
+  );
+
+const arrowCls = (position: string, whiteSpeechBubble: boolean) =>
+  cl("navds-guide__arrow", `navds-guide__arrow--${position}`, {
+    "navds-guide__arrow--white": whiteSpeechBubble,
+  });
+
+const speechBubbleCls = (position: string, whiteSpeechBubble: boolean) =>
+  cl("navds-guide__speech-bubble", `navds-guide__speech-bubble--${position}`, {
+    "navds-guide__speech-bubble--white": whiteSpeechBubble,
+  });
+
+export interface GuideProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Component content
+   */
+  children?: React.ReactNode;
+  /**
+   * @ignore
+   */
+  className?: string;
+  illustration: React.ReactNode;
+  transparent?: boolean;
+  noMask?: boolean;
+  center?: boolean;
+  variant?: "default" | "success" | "warning" | "error";
+  theme?: "default" | "info" | "success" | "warning" | "error";
+  size?: "s" | "m" | "l" | "xl";
+  position?: "floating" | "top" | "right" | "bottom" | "left";
+  whiteSpeechBubble?: boolean;
+}
+
+const Guide = forwardRef<HTMLDivElement, GuideProps>(
+  (
+    {
+      children,
+      className,
+      center = false,
+      noMask = false,
+      transparent = false,
+      illustration,
+      variant = "default",
+      theme = "default",
+      size = "m",
+      position = "floating",
+      whiteSpeechBubble = false,
+      ...rest
+    },
+    ref
+  ) => {
+    return (
+      <div
+        ref={ref}
+        className={wrapperCls(className, position, variant)}
+        {...rest}
+      >
+        <div
+          className={illustrationCls(center, transparent, noMask, size, theme)}
+        >
+          {illustration}
+        </div>
+        {children && <span className={arrowCls(position, whiteSpeechBubble)} />}
+        {children && (
+          <div className={speechBubbleCls(position, whiteSpeechBubble)}>
+            {children}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+export default Guide;

--- a/@navikt/ds-react/src/guide/Guide.tsx
+++ b/@navikt/ds-react/src/guide/Guide.tsx
@@ -50,14 +50,49 @@ export interface GuideProps extends HTMLAttributes<HTMLDivElement> {
    * @ignore
    */
   className?: string;
+  /**
+   * Custom svg/img element (preferably svg)
+   */
   illustration: React.ReactNode;
+  /**
+   * Turns off background on illustration
+   * @default false
+   */
   transparent?: boolean;
+  /**
+   * Turns off cropping of illustration
+   * @default false
+   */
   noMask?: boolean;
+  /**
+   * Center aligns illustation and renders it in full height
+   * @default false
+   */
   center?: boolean;
+  /**
+   * Changes variant of speech-bubble based on wanted message and tone
+   * @default "default"
+   */
   variant?: "default" | "success" | "warning" | "error";
+  /**
+   * Predefined background-themes for the illustration
+   * @default "default"
+   */
   theme?: "default" | "info" | "success" | "warning" | "error";
+  /**
+   * Predefined size properties for illustration
+   * @default "m"
+   */
   size?: "s" | "m" | "l" | "xl";
+  /**
+   * Position of speech-bubble in refenrece to illustration
+   * @default "floating"
+   */
   position?: "floating" | "top" | "right" | "bottom" | "left";
+  /**
+   * Renders the speech-bubble with white backround
+   * @default false
+   */
   whiteSpeechBubble?: boolean;
 }
 

--- a/@navikt/ds-react/src/guide/index.ts
+++ b/@navikt/ds-react/src/guide/index.ts
@@ -1,0 +1,2 @@
+export { default as Guide } from "./Guide";
+export * from "./Guide";

--- a/@navikt/ds-react/src/guide/stories/guide.stories.tsx
+++ b/@navikt/ds-react/src/guide/stories/guide.stories.tsx
@@ -8,7 +8,7 @@ export default {
 
 export const All = () => {
   return (
-    <div style={{ display: "grid", gridAutoRows: "8rem", rowGap: "5rem" }}>
+    <div style={{ display: "grid", gridAutoRows: "8rem", rowGap: "10rem" }}>
       <div style={{ display: "flex", gap: "2rem" }}>
         <Guide theme="default" illustration={<SvgTemplate />} />
         <Guide theme="success" illustration={<SvgTemplate />} />
@@ -16,7 +16,13 @@ export const All = () => {
         <Guide theme="error" illustration={<SvgTemplate />} />
         <Guide theme="info" illustration={<SvgTemplate />} />
       </div>
-      <div style={{ display: "flex", gap: "2rem" }}>
+      <div
+        style={{
+          display: "flex",
+          columnGap: "5rem",
+          height: "5rem",
+        }}
+      >
         <Guide theme="default" illustration={<SvgTemplate />}>
           With text in speech bubble!
         </Guide>

--- a/@navikt/ds-react/src/guide/stories/guide.stories.tsx
+++ b/@navikt/ds-react/src/guide/stories/guide.stories.tsx
@@ -8,9 +8,151 @@ export default {
 
 export const All = () => {
   return (
-    <div>
-      <h1>Guide</h1>
-      <Guide />
+    <div style={{ display: "grid", gridAutoRows: "8rem", rowGap: "5rem" }}>
+      <div style={{ display: "flex", gap: "2rem" }}>
+        <Guide theme="default" illustration={<SvgTemplate />} />
+        <Guide theme="success" illustration={<SvgTemplate />} />
+        <Guide theme="warning" illustration={<SvgTemplate />} />
+        <Guide theme="error" illustration={<SvgTemplate />} />
+        <Guide theme="info" illustration={<SvgTemplate />} />
+      </div>
+      <div style={{ display: "flex", gap: "2rem" }}>
+        <Guide theme="default" illustration={<SvgTemplate />}>
+          With text in speech bubble!
+        </Guide>
+        <Guide transparent theme="default" illustration={<SvgTemplate />}>
+          With text in speech bubble and transparent background!
+        </Guide>
+        <Guide center theme="default" illustration={<SvgTemplate />}>
+          With text in speech bubble and center
+        </Guide>
+      </div>
+      <div style={{ display: "flex", gap: "2rem" }}>
+        <Guide size="s" illustration={<SvgTemplate />}>
+          Size s illustration
+        </Guide>
+        <Guide size="m" illustration={<SvgTemplate />}>
+          Size m illustration
+        </Guide>
+        <Guide size="l" illustration={<SvgTemplate />}>
+          Size l illustration
+        </Guide>
+        <Guide size="xl" illustration={<SvgTemplate />}>
+          Size xl illustration
+        </Guide>
+      </div>
+      <div>
+        <div style={{ height: "fit-content" }}>
+          <Guide position="left" illustration={<SvgTemplate />}>
+            position left speechbubble
+          </Guide>
+          <Guide position="right" illustration={<SvgTemplate />}>
+            position right speechbubble
+          </Guide>
+          <Guide position="top" illustration={<SvgTemplate />}>
+            position top speechbubble
+          </Guide>
+          <Guide position="bottom" illustration={<SvgTemplate />}>
+            position bottom speechbubble
+          </Guide>
+        </div>
+        <div style={{ background: "#f1f1f1", height: "fit-content" }}>
+          <Guide
+            position="left"
+            whiteSpeechBubble
+            illustration={<SvgTemplate />}
+          >
+            whiteSpeechBubble & position left speechbubble
+          </Guide>
+          <Guide
+            position="right"
+            whiteSpeechBubble
+            illustration={<SvgTemplate />}
+          >
+            whiteSpeechBubble & position right speechbubble
+          </Guide>
+          <Guide
+            position="top"
+            whiteSpeechBubble
+            illustration={<SvgTemplate />}
+          >
+            whiteSpeechBubble & position top speechbubble
+          </Guide>
+          <Guide
+            position="bottom"
+            whiteSpeechBubble
+            illustration={<SvgTemplate />}
+          >
+            whiteSpeechBubble & position bottom speechbubble
+          </Guide>
+        </div>
+      </div>
     </div>
   );
 };
+
+const SvgTemplate = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 93">
+    <path
+      fill="#e7e5e2"
+      d="M14 50.7C15 52.3 17.9 81 26.5 81S39 51.8 39 50.3c-13.2-7.6-25 .4-25 .4z"
+    />
+    <path
+      fill="#5c4378"
+      d="M38.7 50.2c6 2.9 15.3 10.9 15.3 18.3V93H0V68.5c0-7.1 8.5-14.8 14.5-18-.3.2-.5.3-.5.3 1 1.7 3.8 9.2 12.4 9.2C35 60 39 51.9 39 50.4c-.1-.1-.2-.2-.3-.2z"
+    />
+    <path
+      fill="#d2242a"
+      d="M46.7 76H31.2c-.7 0-1.3-.6-1.2-1.3v-8.5c0-.7.6-1.3 1.3-1.3h15.5c.7 0 1.3.6 1.3 1.3v8.5c-.1.7-.7 1.3-1.4 1.3"
+    />
+    <path
+      fill="#fff"
+      d="M42.9 71c0 2.1-1.7 3.8-3.8 3.8-2.1 0-3.8-1.7-3.8-3.8s1.7-3.8 3.8-3.8c2.1 0 3.8 1.7 3.8 3.8m-8.7 1.7h-.7l.8-1.9h.7l-.8 1.9zm9.3 0H43l.8-1.9h.5l-.8 1.9zm1.2 0h-.2l.8-1.9h.2l-.8 1.9z"
+    />
+    <path
+      fill="#c52d35"
+      d="M36.2 72.7h.6s.1 0 .1-.1v-1.8s0-.1-.1-.1h-.6s-.1 0-.1.1l-.2.6v.1h.2l.1 1.2c0-.1 0 0 0 0"
+    />
+    <path
+      fill="#c52d35"
+      d="M37.5 72.7h.6s.1 0 .1-.1v-1.8s0-.1-.1-.1h-.9s-.1 0-.1.1l-.2.6-.1.1h.5c.1 0 .2.1.2.2v1c-.1-.1-.1 0 0 0m2.6-1.9h-.6s-.1 0-.1.1v1.8s0 .1.1.1h.6s.1 0 .1-.1l.2-.6V72h-.2l-.1-1.2"
+    />
+    <path
+      fill="#c52d35"
+      d="M37.7 72.7h.4s.1 0 .1-.1l.2-.6v-.1h-.2c0 .1-.5.8-.5.8zm3.9-1.9h.7s.1 0 0 .1l-.7 1.8H41l.6-1.9"
+    />
+    <path
+      fill="#c52d35"
+      d="M40.8 70.8h-1c-.1 0 .3.1.3.1l.7 1.7s0 .1.1.1h.6l-.7-1.9m-1.3.6v.4s-.1-.4-.3-.4c-.3 0-.3.2-.3.3 0 .1.1.3.2.3h.5l-.3.7H39c-.2 0-.9-.3-.9-.9 0-.6.5-1 .9-1 .2-.1.5.2.5.6 0-.1 0-.1 0 0z"
+    />
+    <path
+      fill="#5a1f57"
+      d="M39.9 66.7h-1.6c-.1 0-.2-.1-.2-.2v-.3c0-.1.1-.2.2-.2h1.6c.1 0 .2.1.2.2v.3c0 .2-.1.2-.2.2"
+    />
+    <path fill="#c2b5cf" d="M38.7 66.5h.9V64h-.9v2.5z" />
+    <path
+      fill="#e7e5e2"
+      d="M47.2 35.3C44.7 45.6 36.6 53.1 27 53.1S9.3 45.6 6.8 35.3c-.2.1-.5.1-.8.1-1.1 0-2-.8-2-1.7v-7c0-1 .9-1.7 2-1.7h.2C7.7 13.1 16.4 4 27 4c10.6 0 19.3 9.1 20.8 21h.2c1.1 0 2 .8 2 1.7v7c0 1-.9 1.7-2 1.7-.3 0-.5 0-.8-.1z"
+    />
+    <path
+      fill="#635e59"
+      d="M19 27.6c-1.4.1-1.9-2-1.4-3.4.1-.3.6-1.5 1.4-1.5.8 0 1.2.7 1.3.8.6 1.4.3 4-1.3 4.1m16.2 0c1.4.1 1.9-2 1.4-3.4-.1-.3-.6-1.5-1.4-1.5-.8 0-1.2.7-1.3.8-.6 1.4-.3 4 1.3 4.1"
+    />
+    <path
+      fill="#d1bfa3"
+      d="M26.8 34.6c-.4 0-.7-.1-1-.2-.3-.1-.4-.4-.3-.7.1-.3.4-.4.7-.3.5.2 1.5.1 2.2-.4.7-.4 1.1-1 1.2-1.5.1-.4-.1-.9-.4-1.3-.2-.2-.8-.2-1.6-.1-.3 0-.5-.1-.6-.4 0-.3.1-.5.4-.6 1.2-.2 2.1 0 2.6.6.5.7.8 1.4.6 2.1-.1.8-.7 1.6-1.7 2.2-.6.3-1.4.6-2.1.6z"
+    />
+    <path
+      fill="#593a32"
+      d="M27.1 42.1h-.3c-5.3-.2-7.3-4.1-7.4-4.3-.1-.3 0-.6.2-.7.2-.1.6 0 .7.2.1.1 1.9 3.6 6.6 3.8 4.7.2 6.4-3.7 6.4-3.7.1-.3.4-.4.7-.3.3.1.4.4.3.7-.1 0-2.1 4.3-7.2 4.3z"
+    />
+    <path
+      fill="#f6b873"
+      d="M6.6 30.7c.1-.1.1-.2.1-.3v-2c-.1-5.6 1.8-8.1 3.4-10.1 0 0-1 4.3-.3 3.4 3.8-5 21.4-1.6 25-8.1.5 3.6-4.1 4.6-4.1 4.6 3.7.7 6.9-.8 7.7-2.5.3 1.4-.6 2.4-1.9 3.4 4.5-.9 4.6-4 4.6-4 .6 4.1 5.3 2.5 5.3 9.3v6c0 .3.2.6.5.6h.5c.3 0 .5-.3.5-.6V26c.3-15.6-8.5-26-20.6-26C15.9 0 5 10.4 5 24.1v6.3c0 .4.2.6.5.6h.6c.2 0 .3-.1.5-.3"
+    />
+    <path
+      fill="#f6b873"
+      d="M25.9 43.4c-4.4 0-8-1.4-8-3.2s3.6-3.2 8-3.2 8 1.4 8 3.2c0 1.8-3.6 3.2-8 3.2m.8-9.4c-2.9 0-4.7.7-8.8 2.1-12.7 4.6-11.6-14-11.6-14C3.4 46 18.6 52 26.5 52c8.1 0 24.1-8.1 21-30 0 0 .4 17.1-12.9 13.8-3.7-.9-5-1.8-7.9-1.8z"
+    />
+  </svg>
+);

--- a/@navikt/ds-react/src/guide/stories/guide.stories.tsx
+++ b/@navikt/ds-react/src/guide/stories/guide.stories.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Guide } from "../index";
+import { Meta } from "@storybook/react/types-6-0";
+export default {
+  title: "ds-react/guide",
+  component: Guide,
+} as Meta;
+
+export const All = () => {
+  return (
+    <div>
+      <h1>Guide</h1>
+      <Guide />
+    </div>
+  );
+};

--- a/@navikt/ds-react/src/index.ts
+++ b/@navikt/ds-react/src/index.ts
@@ -35,6 +35,7 @@ export { Modal, ModalProps } from "./modal/index";
 export { Popover, PopoverProps } from "./popover/index";
 export { Tag, TagProps } from "./tag/index";
 export { Panel, PanelProps } from "./panel/index";
+export { Guide, GuideProps } from "./guide/index";
 export {
   Heading,
   HeadingProps,

--- a/@navikt/ds-react/src/index.ts
+++ b/@navikt/ds-react/src/index.ts
@@ -15,8 +15,9 @@ export {
   ContentContainer,
   ContentContainerProps,
 } from "./content-container/index";
-export { Cell, CellProps, Grid, GridProps } from "./grid/index";
 export { CopyToClipboard } from "./copy-to-clipboard/index";
+export { Cell, CellProps, Grid, GridProps } from "./grid/index";
+export { Guide, GuideProps } from "./guide/index";
 export {
   InternalHeader,
   InternalHeaderProps,
@@ -32,10 +33,9 @@ export {
 } from "./layouts/index";
 export { Link, LinkProps } from "./link/index";
 export { Modal, ModalProps } from "./modal/index";
+export { Panel, PanelProps } from "./panel/index";
 export { Popover, PopoverProps } from "./popover/index";
 export { Tag, TagProps } from "./tag/index";
-export { Panel, PanelProps } from "./panel/index";
-export { Guide, GuideProps } from "./guide/index";
 export {
   Heading,
   HeadingProps,

--- a/packages/nav-frontend-veileder/stories/veileder.stories.tsx
+++ b/packages/nav-frontend-veileder/stories/veileder.stories.tsx
@@ -104,16 +104,16 @@ export const All = () => {
         </Veileder>
       </div>
       <div style={{ display: "flex", gap: "2rem" }}>
-        <Veileder center storrelse="S">
+        <Veileder center storrelse="S" tekst="med tekst">
           <SvgTemplate />
         </Veileder>
-        <Veileder storrelse="M">
+        <Veileder storrelse="M" tekst="med tekst">
           <SvgTemplate />
         </Veileder>
-        <Veileder storrelse="L">
+        <Veileder storrelse="L" tekst="med tekst">
           <SvgTemplate />
         </Veileder>
-        <Veileder storrelse="XL">
+        <Veileder storrelse="XL" tekst="med tekst">
           <SvgTemplate />
         </Veileder>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -17361,6 +17361,28 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+nav-frontend-core@^5.0.11, nav-frontend-core@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/nav-frontend-core/-/nav-frontend-core-5.1.1.tgz#564df53fdfa61f084950841bd6e3668fab41bfeb"
+  integrity sha512-oK6VFJggnMIHsEBWXArsv+d9IO9uqUc1dp4kplHrRmTeYT2tN+pb1DA6BUOHXplGe062DIe241zYz4/lrGsmAg==
+
+nav-frontend-knapper-style@^1.0.17:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/nav-frontend-knapper-style/-/nav-frontend-knapper-style-1.1.2.tgz#700c3ee14f8e757d0d4e706a4b1ee5488eae9a40"
+  integrity sha512-A8y4PkjAUBTjs4HzWJuGvk1rwXHE5Slz2SsnedqPt79Oyy+/msp+f/WyIRSsCyzp2qcMQyhcj1JSccqglpBbBA==
+
+nav-frontend-knapper@^2.0.32:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/nav-frontend-knapper/-/nav-frontend-knapper-2.1.4.tgz#8eea6a82a5f014987e22a4aba02f847a1382e220"
+  integrity sha512-qq4d6mZ1wlvo62cNe4rwWbTgupEyJlaQzZNuYLWCCkIbSDNR6vz/pkfAue57lsFgeAXAWK4YC13r/8MbMu6f+w==
+
+nav-frontend-typografi-style@^1.0.35:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/nav-frontend-typografi-style/-/nav-frontend-typografi-style-1.1.1.tgz#cfcfd6c9650ef3a1176e0954645feaf494723808"
+  integrity sha512-AaXOmWMX+7kU/bFlzKgb4fLzUBEqedZfV00ri8TChWOoP+fR9t9cdBaWKkFiMQqlttA6n6IRrTCKYXhuquQWzQ==
+  dependencies:
+    nav-frontend-core "^5.1.1"
+
 needle@^2.5.2:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz#24dbb55f2509e2324b4a99d61f413982013ccdbe"


### PR DESCRIPTION
## TODO
- Tokenisere farger/verdier brukt i css filen
- Se på endring av bakgrunnsfargen `#efefef` til eks `#f1f1f1`

## Endringer fra veileder: 
- `tekst` prop for innhold i snakkebobble -> `children`
- `children`-prop for illustratsjonen -> `illustration`-prop

### Props

Component content, innhold i speech-bubble:
`children?: React.ReactNode;`

Custom svg/img element (preferably svg)
`illustration: React.ReactNode;`
     
Turns off background on illustration
@default false
`transparent?: boolean;`

Turns off cropping of illustration
@default false
`noMask?: boolean;`

Center aligns illustation and renders it in full height
@default false
`center?: boolean;`

Changes variant of speech-bubble based on wanted message and tone
@default "default"
`variant?: "default" | "success" | "warning" | "error";`

Predefined background-themes for the illustration
@default "default"
`theme?: "default" | "info" | "success" | "warning" | "error";`

Predefined size properties for illustration
@default "m"
`size?: "s" | "m" | "l" | "xl";`

Position of speech-bubble in refenrece to illustration
@default "floating"
`position?: "floating" | "top" | "right" | "bottom" | "left";`

Renders the speech-bubble with white backround
@default false
`whiteSpeechBubble?: boolean;`


<img width="648" alt="Screenshot 2021-05-31 at 10 18 24" src="https://user-images.githubusercontent.com/26967723/120163205-8f4ae600-c1f9-11eb-876a-f309bb0cd90a.png">
<img width="754" alt="Screenshot 2021-05-31 at 10 18 13" src="https://user-images.githubusercontent.com/26967723/120163211-907c1300-c1f9-11eb-82f0-b94c2f2fd08e.png">
