### PR TITLE
Oppdatert omit props for form-elementer

### DIFF
--- a/@navikt/ds-react/src/form/Fieldset/Fieldset.tsx
+++ b/@navikt/ds-react/src/form/Fieldset/Fieldset.tsx
@@ -82,7 +82,7 @@ const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
         }}
       >
         <fieldset
-          {...omit(rest, ["errorId"])}
+          {...omit(rest, ["errorId", "error", "size"])}
           {...inputProps}
           ref={ref}
           className={cl(

--- a/@navikt/ds-react/src/form/Select.tsx
+++ b/@navikt/ds-react/src/form/Select.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, SelectHTMLAttributes } from "react";
 import cl from "classnames";
 import { Expand } from "@navikt/ds-icons";
-import { BodyShort, Label } from "..";
+import { BodyShort, Label, omit } from "..";
 import ErrorMessage from "./ErrorMessage";
 import { FormFieldProps, useFormField } from "./useFormField";
 
@@ -78,7 +78,7 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>((props, ref) => {
       )}
       <div className="navds-select__container">
         <select
-          {...rest}
+          {...omit(rest, ["error", "errorId", "size"])}
           {...inputProps}
           ref={ref}
           className={cl(

--- a/@navikt/ds-react/src/form/TextField.tsx
+++ b/@navikt/ds-react/src/form/TextField.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, InputHTMLAttributes } from "react";
 import cl from "classnames";
-import { BodyShort, Label } from "..";
+import { BodyShort, Label, omit } from "..";
 import ErrorMessage from "./ErrorMessage";
 import { FormFieldProps, useFormField } from "./useFormField";
 
@@ -70,7 +70,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
         </BodyShort>
       )}
       <input
-        {...rest}
+        {...omit(rest, ["error", "errorId", "size"])}
         {...inputProps}
         ref={ref}
         type="text"

--- a/@navikt/ds-react/src/form/Textarea.tsx
+++ b/@navikt/ds-react/src/form/Textarea.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from "react";
 import cl from "classnames";
 import TextareaAutosize from "@material-ui/core/TextareaAutosize";
-import { BodyShort, Label } from "..";
+import { BodyShort, Label, omit } from "..";
 import ErrorMessage from "./ErrorMessage";
 import { FormFieldProps, useFormField } from "./useFormField";
 import { useId } from "..";
@@ -92,7 +92,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         )}
         <div className="navds-textarea__wrapper">
           <TextareaAutosize
-            {...rest}
+            {...omit(rest, ["error", "errorId", "size"])}
             {...inputProps}
             ref={ref}
             className={cl(


### PR DESCRIPTION
Unngår at eks "error" proppen blir satt rett på input da.