### PR TITLE
update Input to support modern refs

### DIFF
--- a/packages/nav-frontend-skjema/src/input.tsx
+++ b/packages/nav-frontend-skjema/src/input.tsx
@@ -47,7 +47,9 @@ export interface InputProps
   /**
    * Referanse til selve inputfeltet. Brukes for eksempel til å sette fokus
    */
-  inputRef?: (element: HTMLInputElement | null) => any;
+  inputRef?:
+    | ((element: HTMLInputElement | null) => any)
+    | React.RefObject<HTMLInputElement>;
   /**
    * Label for tekstfeltet
    */
@@ -158,7 +160,10 @@ class Input extends React.Component<InputProps> {
   /**
    * Referanse til selve inputfeltet. Brukes for eksempel til å sette fokus
    */
-  inputRef: PT.func,
+  inputRef: PT.oneOfType([
+    PT.func,
+    PT.shape({ current: PT.instanceOf(Element) }),
+  ]),
   /**
    * Classname som blir satt på komponentwrapperen
    */


### PR DESCRIPTION
Hooken `useRef` er av typen `RefObject<T>`. Siden `inputRef` bare sendes direkte videre til en `input` så burde denne typingen være grei for å støtte at man bruker hook-refs.