### PR TITLE
Alert + confirmation-panel link color

### DIFF
--- a/@navikt/ds-css/form/confirmation-panel.css
+++ b/@navikt/ds-css/form/confirmation-panel.css
@@ -27,12 +27,6 @@
   border: 1px solid transparent;
 }
 
-.navds-confirmation-panel--checked
-  > .navds-confirmation-panel__content
-  .navds-link:not(:focus) {
-  color: var(--navds-color-darkgray);
-}
-
 .navds-confirmation-panel
   .navds-checkbox__input:hover
   + .navds-checkbox__label {

--- a/@navikt/ds-css/form/confirmation-panel.css
+++ b/@navikt/ds-css/form/confirmation-panel.css
@@ -23,7 +23,7 @@
 }
 
 .navds-confirmation-panel--error {
-  background-color: #f3e3e3;
+  background-color: var(--navds-color-error-background);
   border: 1px solid transparent;
 }
 

--- a/@navikt/ds-css/link.css
+++ b/@navikt/ds-css/link.css
@@ -7,6 +7,14 @@
   gap: 0.25rem;
 }
 
+.navds-alert--error .navds-link {
+  color: var(--navds-color-text-primary);
+}
+
+.navds-alert--info .navds-link {
+  color: var(--navds-color-text-primary);
+}
+
 .navds-link:hover {
   text-decoration: none;
 }

--- a/@navikt/ds-css/link.css
+++ b/@navikt/ds-css/link.css
@@ -7,11 +7,9 @@
   gap: 0.25rem;
 }
 
-.navds-alert--error .navds-link {
-  color: var(--navds-color-text-primary);
-}
-
-.navds-alert--info .navds-link {
+.navds-alert--error .navds-link,
+.navds-alert--info .navds-link,
+.navds-confirmation-panel--error .navds-link {
   color: var(--navds-color-text-primary);
 }
 

--- a/@navikt/ds-react/src/link/stories/link.stories.tsx
+++ b/@navikt/ds-react/src/link/stories/link.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Alert } from "../..";
 import { Link } from "..";
 import { Add } from "@navikt/ds-icons";
+import { ConfirmationPanel } from "../../form";
 export default {
   title: "ds-react/link",
   component: Link,
@@ -12,16 +13,17 @@ export const All = () => {
     <>
       <h1>Link</h1>
       <Link href="#">Dette er en tekstlenke</Link>
-      <h1>Icon after</h1>
+      <h2>Icon after</h2>
       <Link href="#">
         <span>Dette er en tekstlenke</span>
         <Add />
       </Link>
-      <h1>Icon before</h1>
+      <h2>Icon before</h2>
       <Link href="#">
         <Add />
         <span>Dette er en tekstlenke </span>
       </Link>
+      <h2>På farget bakgrunn</h2>
       <Alert variant="error">
         Her er en <Link href="#about">lenke</Link> på farget bakgrunn
       </Alert>
@@ -34,6 +36,18 @@ export const All = () => {
       <Alert variant="warning">
         Her er en <Link href="#about">lenke</Link> på farget bakgrunn
       </Alert>
+      <ConfirmationPanel label="Samtykke?" checked={false} error="feilmelding">
+        Her er en <Link href="#about">lenke</Link> på farget bakgrunn
+      </ConfirmationPanel>
+      <ConfirmationPanel label="Samtykke?" checked error="feilmelding">
+        Her er en <Link href="#about">lenke</Link> på farget bakgrunn
+      </ConfirmationPanel>
+      <ConfirmationPanel label="Samtykke?" checked={false}>
+        Her er en <Link href="#about">lenke</Link> på farget bakgrunn
+      </ConfirmationPanel>
+      <ConfirmationPanel label="Samtykke?" checked>
+        Her er en <Link href="#about">lenke</Link> på farget bakgrunn
+      </ConfirmationPanel>
     </>
   );
 };

--- a/@navikt/ds-react/src/link/stories/link.stories.tsx
+++ b/@navikt/ds-react/src/link/stories/link.stories.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Link } from "../index";
+import { Alert } from "../..";
+import { Link } from "..";
 import { Add } from "@navikt/ds-icons";
 export default {
   title: "ds-react/link",
@@ -21,6 +22,18 @@ export const All = () => {
         <Add />
         <span>Dette er en tekstlenke </span>
       </Link>
+      <Alert variant="error">
+        Her er en <Link href="#about">lenke</Link> på farget bakgrunn
+      </Alert>
+      <Alert variant="info">
+        Her er en <Link href="#about">lenke</Link> på farget bakgrunn
+      </Alert>
+      <Alert variant="success">
+        Her er en <Link href="#about">lenke</Link> på farget bakgrunn
+      </Alert>
+      <Alert variant="warning">
+        Her er en <Link href="#about">lenke</Link> på farget bakgrunn
+      </Alert>
     </>
   );
 };


### PR DESCRIPTION
Jeg sjekket kontrasten til lenkefargen mot bakgrunnene i alert og confirmation-panel, og satt lenkefargen til `var(--navds-text-color-primary)` der hvor kontrasten var dårligere enn 4.5