### PR TITLE
Bruk samme prop-type fra MicroCard for next/link

### DIFF
--- a/@navikt/ds-react/src/link/Link.tsx
+++ b/@navikt/ds-react/src/link/Link.tsx
@@ -1,16 +1,11 @@
 import React, { forwardRef } from "react";
 import cl from "classnames";
 
-export interface LinkProps
-  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
-  /**
-   * Link text
-   */
-  children: React.ReactNode;
-  /**
-   * Link anchor should direct to
-   */
-  href: string;
+export interface LinkProps {
+  props: {
+    children: string;
+  } & React.HTMLAttributes<HTMLAnchorElement>;
+  defaultComponent: "a";
 }
 
 const Link = forwardRef<HTMLAnchorElement, LinkProps>(


### PR DESCRIPTION
Viser seg at MicroCard spiller veldig mye bedre ball sammen med `next/link´ og `passHref`. Holder det å bare bytte type slik?