### PR TITLE
[FIX] Button padding fix

### DIFF
--- a/.storybook/stories/roadmap.stories.mdx
+++ b/.storybook/stories/roadmap.stories.mdx
@@ -44,12 +44,6 @@ eks darkmode.
 Dette er noe vi ikke har på planene for tiden, men etterhvert som ting faller på plass så vil dette være
 noe vi kunne ta en titt på hvis vi ser at det trengs.
 
-## Feature-flagging
-
-Ideen om å ta i bruk feature-flagging er noe som virker veldig interessant og vil da se på muligheten for å kunne levere
-større endringe i feature-flags for testing, og da publisere under eks major-bump i faste intervaller. Dette vil da kunne
-gjøre det enklere for deg som consumer av pakkene å ha oversikt over endringer og hva som må migreres.
-
 ## Versjonering
 
 To av de nye pakkene under `@navikt`, da `ds-css` og `ds-react` er nå versjonert under to store pakker med alle komponentene. I fremtiden vil vi se på å

--- a/@navikt/ds-css/button.css
+++ b/@navikt/ds-css/button.css
@@ -64,13 +64,11 @@
   margin: 0;
   text-align: center;
   text-decoration: none;
-  border-color: var(--navds-button-color-border);
+  border: none;
   border-radius: 2px;
-  border-style: solid;
-  border-width: 2px;
   min-height: 48px;
   min-width: 48px;
-  padding: var(--navds-spacing-2) var(--navds-spacing-2);
+  padding: var(--navds-spacing-2);
   flex-shrink: 0;
 }
 
@@ -103,28 +101,37 @@
  * .navds-button--secondary *
  **************************/
 
+.navds-button--secondary {
+  box-shadow: inset 0 0 0 2px var(--navds-button-color-border);
+}
+
 .navds-button--secondary:hover {
   color: var(--navds-button-color-secondary-text-hover);
   background-color: var(--navds-button-color-secondary-background-hover);
-  border-color: transparent;
+  box-shadow: none;
+}
+
+.navds-button--secondary:focus {
+  box-shadow: inset 0 0 0 2px var(--navds-button-color-border),
+    var(--navds-shadow-focus);
 }
 
 .navds-button--secondary:active {
   color: var(--navds-button-color-secondary-text-active);
   background-color: var(--navds-button-color-secondary-background-active);
-  border-color: transparent;
+  box-shadow: none;
 }
 
 .navds-button--secondary:focus:hover {
-  border-color: var(--navds-button-color-secondary-border-focus-active-hover);
-  border-width: 1px;
-  padding: calc(0.25rem + 1px) calc(0.5rem + 1px);
+  box-shadow: inset 0 0 0 1px
+      var(--navds-button-color-secondary-border-focus-active-hover),
+    var(--navds-shadow-focus);
 }
 
 .navds-button--secondary:focus:active {
-  border-color: var(--navds-button-color-secondary-border-focus-active-hover);
-  border-width: 1px;
-  padding: calc(0.25rem + 1px) calc(0.5rem + 1px);
+  box-shadow: inset 0 0 0 1px
+      var(--navds-button-color-secondary-border-focus-active-hover),
+    var(--navds-shadow-focus);
 }
 
 /****************************
@@ -132,28 +139,27 @@
  ****************************/
 
 .navds-button--tertiary {
-  border-color: var(--navds-button-color-tertiary-border);
   background-color: var(--navds-button-color-tertiary-background);
 }
 
 .navds-button--tertiary:hover {
-  border-color: var(--navds-button-color-tertiary-border-hover);
+  box-shadow: inset 0 0 0 2px var(--navds-button-color-tertiary-border-hover);
 }
 
 .navds-button--tertiary:focus {
-  border-color: var(--navds-button-color-tertiary-border-focus);
+  box-shadow: inset 0 0 0 2px var(--navds-button-color-tertiary-border-focus),
+    var(--navds-shadow-focus);
 }
 
 .navds-button--tertiary:active {
   color: var(--navds-button-color-tertiary-text-active);
   background-color: var(--navds-button-color-tertiary-background-active);
-  border-color: var(--navds-button-color-tertiary-border-active);
-  border-width: 1px;
-  padding: calc(0.5rem + 1px) calc(0.5rem + 1px);
+  box-shadow: inset 0 0 0 1px var(--navds-button-color-tertiary-border-active);
 }
 
-.navds-button--small.navds-button--tertiary:active {
-  padding: calc(0.25rem + 1px) calc(0.5rem + 1px);
+.navds-button--tertiary:active:focus {
+  box-shadow: inset 0 0 0 1px var(--navds-button-color-tertiary-border-active),
+    var(--navds-shadow-focus);
 }
 
 /*************************
@@ -163,29 +169,20 @@
 
 .navds-button--primary {
   background-color: var(--navds-button-color-primary-background);
-  border-color: var(--navds-button-color-primary-border);
   color: var(--navds-button-color-primary-text);
 }
 
 .navds-button--danger {
   background-color: var(--navds-button-color-danger-background);
-  border-color: var(--navds-button-color-danger-border);
   color: var(--navds-button-color-danger-text);
-}
-
-.navds-button--primary,
-.navds-button--danger {
-  border-width: 1px;
 }
 
 .navds-button--primary:hover {
   background-color: var(--navds-button-color-primary-background-hover);
-  border-color: var(--navds-button-color-primary-border-hover);
 }
 
 .navds-button--danger:hover {
   background-color: var(--navds-button-color-danger-background-hover);
-  border-color: var(--navds-button-color-danger-border-hover);
 }
 
 .navds-button--primary:active {
@@ -197,11 +194,13 @@
 }
 
 .navds-button--primary:focus {
-  border-color: var(--navds-button-color-primary-border-focus);
+  box-shadow: inset 0 0 0 1px var(--navds-button-color-primary-border-focus),
+    var(--navds-shadow-focus);
 }
 
 .navds-button--danger:focus {
-  border-color: var(--navds-button-color-danger-border-focus);
+  box-shadow: inset 0 0 0 1px var(--navds-button-color-danger-border-focus),
+    var(--navds-shadow-focus);
 }
 
 /**************************
@@ -212,11 +211,6 @@
   color: var(--navds-button-color-text-disabled);
   background-color: var(--navds-button-color-background-disabled);
   cursor: not-allowed;
-  border-width: 0;
   box-shadow: none;
   transform: none;
-}
-
-.navds-button:disabled.navds-button--tertiary:active {
-  padding: var(--navds-spacing-2) var(--navds-spacing-2);
 }

--- a/@navikt/ds-css/button.css
+++ b/@navikt/ds-css/button.css
@@ -66,9 +66,8 @@
   text-decoration: none;
   border: none;
   border-radius: 2px;
-  min-height: 48px;
   min-width: 48px;
-  padding: var(--navds-spacing-2);
+  padding: var(--navds-spacing-3);
   flex-shrink: 0;
 }
 
@@ -88,8 +87,8 @@
 }
 
 .navds-button--small {
-  padding: var(--navds-spacing-1) var(--navds-spacing-2);
-  min-height: 32px;
+  padding: 0.375rem var(--navds-spacing-2);
+  min-width: 32px;
 }
 
 .navds-button:focus {

--- a/@navikt/ds-css/button.css
+++ b/@navikt/ds-css/button.css
@@ -1,41 +1,37 @@
 :root {
-  --navds-button-color-text: var(--navds-color-action-default);
-  --navds-button-color-background: var(--navds-color-background);
-  --navds-button-color-border: var(--navds-color-action-default);
-
   /* Primary */
   --navds-button-color-primary-text: var(--navds-color-white);
+  --navds-button-color-primary-border-focus: var(--navds-color-white);
   --navds-button-color-primary-background: var(--navds-color-action-default);
-  --navds-button-color-primary-border: var(--navds-color-action-default);
   --navds-button-color-primary-background-hover: var(
     --navds-color-action-hover
   );
-  --navds-button-color-primary-border-hover: var(--navds-color-action-hover);
   --navds-button-color-primary-background-active: var(
     --navds-color-action-active
   );
-  --navds-button-color-primary-border-focus: var(--navds-color-white);
 
-  /* secondary */
+  /* Secondary */
+  --navds-button-color-secondary-text: var(--navds-color-action-default);
   --navds-button-color-secondary-text-hover: var(--navds-color-text-inverse);
-  --navds-button-color-secondary-background-hover: var(
-    --navds-color-action-hover
-  );
   --navds-button-color-secondary-text-active: var(--navds-color-text-inverse);
-  --navds-button-color-secondary-background-active: var(
-    --navds-color-action-active
-  );
+  --navds-button-color-secondary-border: var(--navds-color-action-default);
   --navds-button-color-secondary-border-focus-active-hover: var(
     --navds-color-white
   );
+  --navds-button-color-secondary-background: var(--navds-color-background);
+  --navds-button-color-secondary-background-hover: var(
+    --navds-color-action-hover
+  );
+  --navds-button-color-secondary-background-active: var(
+    --navds-color-action-active
+  );
 
-  /* tertiary */
-  --navds-button-color-tertiary-border: transparent;
-  --navds-button-color-tertiary-background: transparent;
+  /* Tertiary */
+  --navds-button-color-tertiary-text: var(--navds-color-action-default);
+  --navds-button-color-tertiary-text-active: var(--navds-color-text-inverse);
   --navds-button-color-tertiary-border-hover: var(--navds-color-action-default);
   --navds-button-color-tertiary-border-focus: var(--navds-color-action-default);
   --navds-button-color-tertiary-border-active: var(--navds-color-white);
-  --navds-button-color-tertiary-text-active: var(--navds-color-text-inverse);
   --navds-button-color-tertiary-background-active: var(
     --navds-color-action-active
   );
@@ -43,9 +39,7 @@
   /* Danger */
   --navds-button-color-danger-text: var(--navds-color-white);
   --navds-button-color-danger-background: var(--navds-color-danger-default);
-  --navds-button-color-danger-border: var(--navds-color-danger-default);
   --navds-button-color-danger-background-hover: var(--navds-color-danger-hover);
-  --navds-button-color-danger-border-hover: var(--navds-color-danger-hover);
   --navds-button-color-danger-background-active: var(
     --navds-color-danger-active
   );
@@ -59,22 +53,32 @@
 .navds-button {
   display: inline-flex;
   cursor: pointer;
-  background-color: var(--navds-button-color-background);
-  color: var(--navds-button-color-text);
   margin: 0;
   text-align: center;
   text-decoration: none;
   border: none;
+  background: none;
   border-radius: 2px;
   min-width: 48px;
   padding: var(--navds-spacing-3);
   flex-shrink: 0;
 }
 
+.navds-button--small {
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+  min-width: 32px;
+}
+
+.navds-button:focus {
+  outline: none;
+  box-shadow: var(--navds-shadow-focus);
+}
+
 .navds-button__inner {
+  margin: auto;
   display: flex;
   align-items: center;
-  margin: auto;
   gap: var(--navds-spacing-2);
 }
 
@@ -86,14 +90,26 @@
   font-size: 1.25rem;
 }
 
-.navds-button--small {
-  padding: 0.375rem var(--navds-spacing-2);
-  min-width: 32px;
+/*************************
+ * .navds-button--primary *
+ *************************/
+
+.navds-button--primary {
+  background-color: var(--navds-button-color-primary-background);
+  color: var(--navds-button-color-primary-text);
 }
 
-.navds-button:focus {
-  outline: none;
-  box-shadow: var(--navds-shadow-focus);
+.navds-button--primary:hover {
+  background-color: var(--navds-button-color-primary-background-hover);
+}
+
+.navds-button--primary:active {
+  background-color: var(--navds-button-color-primary-background-active);
+}
+
+.navds-button--primary:focus {
+  box-shadow: inset 0 0 0 1px var(--navds-button-color-primary-border-focus),
+    var(--navds-shadow-focus);
 }
 
 /**************************
@@ -101,7 +117,9 @@
  **************************/
 
 .navds-button--secondary {
-  box-shadow: inset 0 0 0 2px var(--navds-button-color-border);
+  color: var(--navds-button-color-secondary-text);
+  background-color: var(--navds-button-color-secondary-background);
+  box-shadow: inset 0 0 0 2px var(--navds-button-color-secondary-border);
 }
 
 .navds-button--secondary:hover {
@@ -111,7 +129,7 @@
 }
 
 .navds-button--secondary:focus {
-  box-shadow: inset 0 0 0 2px var(--navds-button-color-border),
+  box-shadow: inset 0 0 0 2px var(--navds-button-color-secondary-border),
     var(--navds-shadow-focus);
 }
 
@@ -121,12 +139,7 @@
   box-shadow: none;
 }
 
-.navds-button--secondary:focus:hover {
-  box-shadow: inset 0 0 0 1px
-      var(--navds-button-color-secondary-border-focus-active-hover),
-    var(--navds-shadow-focus);
-}
-
+.navds-button--secondary:focus:hover,
 .navds-button--secondary:focus:active {
   box-shadow: inset 0 0 0 1px
       var(--navds-button-color-secondary-border-focus-active-hover),
@@ -138,7 +151,7 @@
  ****************************/
 
 .navds-button--tertiary {
-  background-color: var(--navds-button-color-tertiary-background);
+  color: var(--navds-button-color-tertiary-text);
 }
 
 .navds-button--tertiary:hover {
@@ -162,39 +175,20 @@
 }
 
 /*************************
- * .navds-button--primary *
  * .navds-button--danger *
  *************************/
-
-.navds-button--primary {
-  background-color: var(--navds-button-color-primary-background);
-  color: var(--navds-button-color-primary-text);
-}
 
 .navds-button--danger {
   background-color: var(--navds-button-color-danger-background);
   color: var(--navds-button-color-danger-text);
 }
 
-.navds-button--primary:hover {
-  background-color: var(--navds-button-color-primary-background-hover);
-}
-
 .navds-button--danger:hover {
   background-color: var(--navds-button-color-danger-background-hover);
 }
 
-.navds-button--primary:active {
-  background-color: var(--navds-button-color-primary-background-active);
-}
-
 .navds-button--danger:active {
   background-color: var(--navds-button-color-danger-background-active);
-}
-
-.navds-button--primary:focus {
-  box-shadow: inset 0 0 0 1px var(--navds-button-color-primary-border-focus),
-    var(--navds-shadow-focus);
 }
 
 .navds-button--danger:focus {

--- a/@navikt/ds-css/loader.css
+++ b/@navikt/ds-css/loader.css
@@ -88,7 +88,7 @@
   stroke: var(--navds-loader-color-on-button-background);
 }
 
-.navds-button--action .navds-loader .navds-loader__background,
+.navds-button--primary .navds-loader .navds-loader__background,
 .navds-button--danger .navds-loader .navds-loader__background {
   stroke: var(--navds-loader-color-on-button-background);
 }

--- a/@navikt/ds-react/src/button/stories/button.stories.mdx
+++ b/@navikt/ds-react/src/button/stories/button.stories.mdx
@@ -48,16 +48,14 @@ Button har to størrelser: Default 48px min-height og small 32px min-height
 ## Med ikon eller `<Loader />`
 
 Hvis man setter ikoner (svg) eller `<Loader />` rett på button vil størrelsen
-bli justert automatisk.
+bli justert automatisk og sentrert.
 
 <Canvas>
   <Button>
-    <Loader /> Buttontekst
-  </Button>
-  <Button>
-    Buttontekst <Loader />
+    <Loader /> Buttontekst <Loader />
   </Button>
   <Button size="small">
+    <Loader />
     Buttontekst
     <Loader />
   </Button>

--- a/@navikt/ds-react/src/button/stories/button.stories.mdx
+++ b/@navikt/ds-react/src/button/stories/button.stories.mdx
@@ -1,17 +1,17 @@
 import { Meta, Canvas } from "@storybook/addon-docs";
 import { Button, Loader } from "../../index";
-import { Success } from "@navikt/ds-react";
+import { Success } from "@navikt/ds-icons";
 
 <Meta title="ds-react/button/intro" />
 
 # Hvordan ta i bruk Button
 
 ```jsx
-<Button>Buttontekst</Button>
+<Button>Button</Button>
 ```
 
 <Canvas>
-  <Button>Buttontekst</Button>
+  <Button>Button</Button>
 </Canvas>
 
 ## Varianter
@@ -20,10 +20,10 @@ import { Success } from "@navikt/ds-react";
 `primary`, `secondary`, `tertiary` og `danger`
 
 <Canvas>
-  <Button variant="primary">Buttontekst</Button>
-  <Button variant="secondary">Buttontekst</Button>
-  <Button variant="tertiary">Buttontekst</Button>
-  <Button variant="danger">Buttontekst</Button>
+  <Button variant="primary">Primary</Button>
+  <Button variant="secondary">Secondary</Button>
+  <Button variant="tertiary">Tertiary</Button>
+  <Button variant="danger">Danger</Button>
 </Canvas>
 
 ## Sizing
@@ -32,16 +32,16 @@ Button har to størrelser: Default 48px min-height og small 32px min-height
 
 <Canvas>
   <Button size="small" variant="primary">
-    Buttontekst
+    Primary
   </Button>
   <Button size="small" variant="secondary">
-    Buttontekst
+    Secondary
   </Button>
   <Button size="small" variant="tertiary">
-    Buttontekst
+    Tertiary
   </Button>
   <Button size="small" variant="danger">
-    Buttontekst
+    Danger
   </Button>
 </Canvas>
 
@@ -52,11 +52,19 @@ bli justert automatisk og sentrert.
 
 <Canvas>
   <Button>
-    <Loader /> Buttontekst <Loader />
+    <Loader /> Laster... <Loader />
   </Button>
   <Button size="small">
     <Loader />
-    Buttontekst
+    Laster...
     <Loader />
+  </Button>
+  <Button>
+    <Success /> Laster... <Success />
+  </Button>
+  <Button size="small">
+    <Success />
+    Laster...
+    <Success />
   </Button>
 </Canvas>

--- a/@navikt/ds-react/src/button/stories/button.stories.tsx
+++ b/@navikt/ds-react/src/button/stories/button.stories.tsx
@@ -10,12 +10,12 @@ export default {
 const Section = ({ children }) => (
   <div
     style={{
-      display: "grid",
+      display: "flex",
       gap: 16,
       gridAutoFlow: "column",
       justifyContent: "start",
       padding: 24,
-      background: "lightgray",
+      paddingLeft: 0,
     }}
   >
     {children}
@@ -38,7 +38,7 @@ const varSwitch = {
 
 export const All = () => {
   return (
-    <>
+    <div style={{ paddingLeft: "1rem" }}>
       <h1>Button</h1>
       <Section>
         {variants.map((variant) => (
@@ -103,6 +103,6 @@ export const All = () => {
           </Button>
         ))}
       </Section>
-    </>
+    </div>
   );
 };


### PR DESCRIPTION
Ved å bruke `box-shadow` istedenfor `border` slipper vi å sjonglere med `padding`-verdier for å ivareta lik størrelse med ulike `border-width` og `size`-prop. Ikke en veldig "clean" løsning, kanskje, men veldig effektiv.