### PR TITLE
[FIX] Refactor speechbubble til dot-notasjon

### DIFF
--- a/.storybook/stories/migration.stories.mdx
+++ b/.storybook/stories/migration.stories.mdx
@@ -219,3 +219,11 @@ Props må fikses for de som har brukt denne komponenten, i tilleg til å endre n
 ## MicroCard
 
 - Oppdatert med OverridableComponent
+
+## SpeechBubble
+
+Implementert med Dot-notasjon
+
+- `<Bubble/>` -> `<SpeechBubble.Bubble/>`
+
+Bubble er fortsatt eksportert så vil ikke brekke noe for de som har begynt å ta denne i bruk.

--- a/@navikt/ds-react/src/speech-bubble/Bubble.tsx
+++ b/@navikt/ds-react/src/speech-bubble/Bubble.tsx
@@ -16,7 +16,11 @@ export interface BubbleProps extends HTMLAttributes<HTMLDivElement> {
   backgroundColor?: string;
 }
 
-const Bubble = forwardRef<HTMLDivElement, BubbleProps>(
+export type BubbleType = React.ForwardRefExoticComponent<
+  BubbleProps & React.RefAttributes<HTMLDivElement>
+>;
+
+const Bubble: BubbleType = forwardRef(
   ({ children, className, topText, backgroundColor, ...rest }, ref) => {
     return (
       <div

--- a/@navikt/ds-react/src/speech-bubble/SpeechBubble.tsx
+++ b/@navikt/ds-react/src/speech-bubble/SpeechBubble.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef, HTMLAttributes } from "react";
 import cl from "classnames";
+import { Bubble, BubbleType } from ".";
 
 export interface SpeechBubbleProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -27,6 +28,13 @@ export interface SpeechBubbleProps extends HTMLAttributes<HTMLDivElement> {
    * @default "left"
    */
   position?: "left" | "right";
+}
+
+interface SpeechBubbleComponent
+  extends React.ForwardRefExoticComponent<
+    SpeechBubbleProps & React.RefAttributes<HTMLDivElement>
+  > {
+  Bubble: BubbleType;
 }
 
 const SpeechBubble = forwardRef<HTMLDivElement, SpeechBubbleProps>(
@@ -78,6 +86,8 @@ const SpeechBubble = forwardRef<HTMLDivElement, SpeechBubbleProps>(
       </div>
     );
   }
-);
+) as SpeechBubbleComponent;
+
+SpeechBubble.Bubble = Bubble;
 
 export default SpeechBubble;

--- a/@navikt/ds-react/src/speech-bubble/stories/speechbubble.stories.mdx
+++ b/@navikt/ds-react/src/speech-bubble/stories/speechbubble.stories.mdx
@@ -11,27 +11,31 @@ breaking-changes før v1 er klar. Anbefaler da å ikke override styling som er b
 
 ```jsx
 <SpeechBubble illustration="OLA" topText="Ola Normann 01.01.21 14:00">
-  <Bubble>
+  <SpeechBubble.Bubble>
     Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-  </Bubble>
-  <Bubble>Tempor fugiat amet eu sint in in ullamco.</Bubble>
-  <Bubble>
+  </SpeechBubble.Bubble>
+  <SpeechBubble.Bubble>
+    Tempor fugiat amet eu sint in in ullamco.
+  </SpeechBubble.Bubble>
+  <SpeechBubble.Bubble>
     Adipisicing laborum est eu laborum est sit in commodo enim sint laboris
     labore nisi ut.
-  </Bubble>
+  </SpeechBubble.Bubble>
 </SpeechBubble>
 ```
 
 <Canvas>
   <SpeechBubble illustration="OLA" topText="Ola Normann 01.01.21 14:00">
-    <Bubble>
+    <SpeechBubble.Bubble>
       Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-    </Bubble>
-    <Bubble>Tempor fugiat amet eu sint in in ullamco.</Bubble>
-    <Bubble>
+    </SpeechBubble.Bubble>
+    <SpeechBubble.Bubble>
+      Tempor fugiat amet eu sint in in ullamco.
+    </SpeechBubble.Bubble>
+    <SpeechBubble.Bubble>
       Adipisicing laborum est eu laborum est sit in commodo enim sint laboris
       labore nisi ut.
-    </Bubble>
+    </SpeechBubble.Bubble>
   </SpeechBubble>
 </Canvas>
 
@@ -41,27 +45,29 @@ Speechbubble kan bli posisjonert "left" og "right" med `position`-proppen
 
 ```jsx
 <SpeechBubble illustration="OLA" position="left">
-  <Bubble>
+  <SpeechBubble.Bubble>
     Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-  </Bubble>
+  </SpeechBubble.Bubble>
 </SpeechBubble>
 <SpeechBubble illustration="OLA" position="right">
-  <Bubble>
+  <SpeechBubble.Bubble>
     Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-  </Bubble>
+  </SpeechBubble.Bubble>
 </SpeechBubble>
 ```
 
 <Canvas>
   <div>
     <SpeechBubble illustration="OLA" position="left">
-      <Bubble>
+      <SpeechBubble.Bubble>
         Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-      </Bubble>
+      </SpeechBubble.Bubble>
     </SpeechBubble>
     <br />
     <SpeechBubble illustration="PER" position="right">
-      <Bubble>Ipsum laborum culpa ea ea commodo eiusmod in aute.</Bubble>
+      <SpeechBubble.Bubble>
+        Ipsum laborum culpa ea ea commodo eiusmod in aute.
+      </SpeechBubble.Bubble>
     </SpeechBubble>
   </div>
 </Canvas>
@@ -77,9 +83,9 @@ Man kan endre bakgrunnsfargen selv med `illustrationBgColor` og `backgroundColor
   illustrationBgColor="var(--navds-color-lightblue-10)"
   backgroundColor="var(--navds-color-lightblue-20)"
 >
-  <Bubble>
+  <SpeechBubble.Bubble>
     Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-  </Bubble>
+  </SpeechBubble.Bubble>
 </SpeechBubble>
 ```
 
@@ -90,9 +96,9 @@ Man kan endre bakgrunnsfargen selv med `illustrationBgColor` og `backgroundColor
     illustrationBgColor="var(--navds-color-lightblue-10)"
     backgroundColor="var(--navds-color-lightblue-20)"
   >
-    <Bubble>
+    <SpeechBubble.Bubble>
       Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-    </Bubble>
+    </SpeechBubble.Bubble>
   </SpeechBubble>
 </Canvas>
 
@@ -103,17 +109,17 @@ Hvis man bruker en illustrasjon i SVG-fromat vil den fungere likt `nav-frontend-
 
 ```jsx
 <SpeechBubble illustration={<Illustration />} position="left">
-  <Bubble>
+  <SpeechBubble.Bubble>
     Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-  </Bubble>
+  </SpeechBubble.Bubble>
 </SpeechBubble>
 ```
 
 <Canvas>
   <SpeechBubble illustration={<Illustration />} position="left">
-    <Bubble>
+    <SpeechBubble.Bubble>
       Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-    </Bubble>
+    </SpeechBubble.Bubble>
   </SpeechBubble>
 </Canvas>
 
@@ -136,14 +142,16 @@ Hvis man bruker en illustrasjon i SVG-fromat vil den fungere likt `nav-frontend-
     </div>
   }
 >
-  <Bubble>
+  <SpeechBubble.Bubble>
     Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-  </Bubble>
-  <Bubble>Tempor fugiat amet eu sint in in ullamco.</Bubble>
-  <Bubble>
+  </SpeechBubble.Bubble>
+  <SpeechBubble.Bubble>
+    Tempor fugiat amet eu sint in in ullamco.
+  </SpeechBubble.Bubble>
+  <SpeechBubble.Bubble>
     Adipisicing laborum est eu laborum est sit in commodo enim sint laboris
     labore nisi ut.
-  </Bubble>
+  </SpeechBubble.Bubble>
 </SpeechBubble>
 ```
 
@@ -162,13 +170,15 @@ Hvis man bruker en illustrasjon i SVG-fromat vil den fungere likt `nav-frontend-
       </div>
     }
   >
-    <Bubble>
+    <SpeechBubble.Bubble>
       Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-    </Bubble>
-    <Bubble>Tempor fugiat amet eu sint in in ullamco.</Bubble>
-    <Bubble>
+    </SpeechBubble.Bubble>
+    <SpeechBubble.Bubble>
+      Tempor fugiat amet eu sint in in ullamco.
+    </SpeechBubble.Bubble>
+    <SpeechBubble.Bubble>
       Adipisicing laborum est eu laborum est sit in commodo enim sint laboris
       labore nisi ut.
-    </Bubble>
+    </SpeechBubble.Bubble>
   </SpeechBubble>
 </Canvas>

--- a/@navikt/ds-react/src/speech-bubble/stories/speechbubble.stories.tsx
+++ b/@navikt/ds-react/src/speech-bubble/stories/speechbubble.stories.tsx
@@ -17,14 +17,16 @@ export const All = () => {
         topText="Ola Normann 01.01.21 14:00"
         backgroundColor="var(--navds-color-lightblue-20)"
       >
-        <Bubble>
+        <SpeechBubble.Bubble>
           Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-        </Bubble>
-        <Bubble>Tempor fugiat amet eu sint in in ullamco.</Bubble>
-        <Bubble>
+        </SpeechBubble.Bubble>
+        <SpeechBubble.Bubble>
+          Tempor fugiat amet eu sint in in ullamco.
+        </SpeechBubble.Bubble>
+        <SpeechBubble.Bubble>
           Adipisicing laborum est eu laborum est sit in commodo enim sint
           laboris labore nisi ut.
-        </Bubble>
+        </SpeechBubble.Bubble>
       </SpeechBubble>
       <SpeechBubble
         illustration={<div>KAJ</div>}
@@ -43,54 +45,60 @@ export const All = () => {
         position="right"
         backgroundColor="var(--navds-color-gray-10)"
       >
-        <Bubble>
+        <SpeechBubble.Bubble>
           Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-        </Bubble>
-        <Bubble>Tempor fugiat amet eu sint in in ullamco.</Bubble>
-        <Bubble>
+        </SpeechBubble.Bubble>
+        <SpeechBubble.Bubble>
+          Tempor fugiat amet eu sint in in ullamco.
+        </SpeechBubble.Bubble>
+        <SpeechBubble.Bubble>
           Adipisicing laborum est eu laborum est sit in commodo enim sint
           laboris labore nisi ut.
-        </Bubble>
+        </SpeechBubble.Bubble>
       </SpeechBubble>
       <SpeechBubble
         illustration={<div>KAJ</div>}
         topText="Ola Normann 01.01.21 14:00"
         position="left"
       >
-        <Bubble>
+        <SpeechBubble.Bubble>
           Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-        </Bubble>
-        <Bubble>Tempor fugiat amet eu sint in in ullamco.</Bubble>
-        <Bubble>
+        </SpeechBubble.Bubble>
+        <SpeechBubble.Bubble>
+          Tempor fugiat amet eu sint in in ullamco.
+        </SpeechBubble.Bubble>
+        <SpeechBubble.Bubble>
           Adipisicing laborum est eu laborum est sit in commodo enim sint
           laboris labore nisi ut.
-        </Bubble>
+        </SpeechBubble.Bubble>
       </SpeechBubble>
       <SpeechBubble
         illustration={<div>KAJ</div>}
         topText="Ola Normann 01.01.21 14:00"
         position="right"
       >
-        <Bubble>
+        <SpeechBubble.Bubble>
           Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-        </Bubble>
-        <Bubble>Tempor fugiat amet eu sint in in ullamco.</Bubble>
+        </SpeechBubble.Bubble>
+        <SpeechBubble.Bubble>
+          Tempor fugiat amet eu sint in in ullamco.
+        </SpeechBubble.Bubble>
       </SpeechBubble>
       <SpeechBubble
         illustration={<div>KAJ</div>}
         topText="Ola Normann 01.01.21 14:00"
         position="left"
       >
-        <Bubble>
+        <SpeechBubble.Bubble>
           Aute minim nisi sunt mollit duis sunt nulla minim non proident.
-        </Bubble>
+        </SpeechBubble.Bubble>
       </SpeechBubble>
       <SpeechBubble
         illustration={<div>KAJ</div>}
         topText="Ola Normann 01.01.21 14:00"
         position="right"
       >
-        <Bubble>Per skriver....</Bubble>
+        <SpeechBubble.Bubble>Per skriver....</SpeechBubble.Bubble>
       </SpeechBubble>
     </div>
   );


### PR DESCRIPTION
- Eksporterer fortsatt Bubble separart, slik at løsningen ikke brekker for de som allerede bruker den.


Begge fungerer: 
```jsx
<SpeechBubble>
	<Bubble/>
</SpeechBubble>

<SpeechBubble>
	<SpeechBubble.Bubble/>
</SpeechBubble>
```