### PR TITLE
[FIX] short-uuid -> uuid (short-uuid brekker sanity)

### DIFF
--- a/@navikt/ds-react/package.json
+++ b/@navikt/ds-react/package.json
@@ -42,7 +42,7 @@
     "react-merge-refs": "^1.1.0",
     "react-modal": "3.12.1",
     "react-popper": "^2.2.4",
-    "short-uuid": "^4.2.0"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/react-router-dom": "^5.1.8",

--- a/@navikt/ds-react/src/util/useId.ts
+++ b/@navikt/ds-react/src/util/useId.ts
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useState } from "react";
-import ShortUuid from "short-uuid";
+import { v4 as uuidv4 } from "uuid";
 
 const canUseDOM = (): boolean => {
   return (
@@ -15,7 +15,7 @@ export const useId: (id?: string) => string = (id) => {
   const [newId, setNewId] = useState<string | undefined>(undefined);
 
   useClientLayoutEffect(() => {
-    setNewId(ShortUuid.generate());
+    setNewId(uuidv4());
   }, []);
 
   return id ?? newId ?? "";

--- a/yarn.lock
+++ b/yarn.lock
@@ -11698,11 +11698,6 @@ follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.3.tgz#6ada78118d8d24caee595595accdc0ac6abd022e"
   integrity sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==
 
-follow-redirects@^1.14.0:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.3.tgz#6ada78118d8d24caee595595accdc0ac6abd022e"
-  integrity sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==
-
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -22837,14 +22832,6 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
-
-short-uuid@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/short-uuid/-/short-uuid-4.2.0.tgz#3706d9e7287ac589dc5ffe324d3e34817a07540b"
-  integrity sha512-r3cxuPPZSuF0QkKsK9bBR7u+7cwuCRzWzgjPh07F5N2iIUNgblnMHepBY16xgj5t1lG9iOP9k/TEafY1qhRzaw==
-  dependencies:
-    any-base "^1.1.0"
-    uuid "^8.3.2"
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Short-uuid kan ikke kjøres av Sanity-studio og komponentene kan da ikke brukes i sanity-client.
- Endret tilbake til vanlig `uuid`. 