### PR TITLE
[FIX] Setter aria-live til polite bare når 20 tegn gjenstår...

### DIFF
--- a/@navikt/ds-react/src/form/Textarea.tsx
+++ b/@navikt/ds-react/src/form/Textarea.tsx
@@ -140,7 +140,7 @@ export const Counter = ({ maxLength, currentLength, size }) => {
       className={cl("navds-textarea__counter", {
         "navds-textarea__counter--error": difference < 0,
       })}
-      aria-live="polite"
+      aria-live={difference < 20 ? "polite" : "off"}
       size={size}
     >
       {difference < 0

--- a/packages/nav-frontend-skjema/src/textarea.tsx
+++ b/packages/nav-frontend-skjema/src/textarea.tsx
@@ -283,7 +283,10 @@ const Teller = (props: TellerProps) => {
 function defaultTellerTekst(antallTegn, maxLength) {
   const difference = maxLength - antallTegn;
   return (
-    <span className={tellerTekstCls(difference)} aria-live="polite">
+    <span
+      className={tellerTekstCls(difference)}
+      aria-live={difference > 20 ? "off" : "polite"}
+    >
       {difference >= 0 && `Du har ${difference} tegn igjen`}
       {difference < 0 && `Du har ${Math.abs(difference)} tegn for mye`}
     </span>

--- a/packages/nav-frontend-skjema/src/textarea.tsx
+++ b/packages/nav-frontend-skjema/src/textarea.tsx
@@ -285,7 +285,7 @@ function defaultTellerTekst(antallTegn, maxLength) {
   return (
     <span
       className={tellerTekstCls(difference)}
-      aria-live={difference > 20 ? "off" : "polite"}
+      aria-live={difference < 20 ? "polite" : "off"}
     >
       {difference >= 0 && `Du har ${difference} tegn igjen`}
       {difference < 0 && `Du har ${Math.abs(difference)} tegn for mye`}


### PR DESCRIPTION
- Unngår nå at skjermleser announcer at det gjenstår 1000, 999, 998 tegn igjen etc. 
- Fikses med at aria-live bare settes til polite når det er < 20 tegn igjen 