### PR TITLE
force postinstall in workflow

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -30,6 +30,9 @@ jobs:
       - name: install
         if: steps.node-cache.outputs.cache-hit != 'true'
         run: yarn install
+      - name: postinstall
+        if: steps.node-cache.outputs.cache-hit == 'true'
+        run: yarn postinstall
       - name: test
         run: yarn test
       - name: Boot


### PR DESCRIPTION
Det kan se ut som testene feiler når node_modules hentes fra cache. Tipper det er fordi `install` da ikke blir kjørt, og derfor blir ikke `postinstall` kjørt heller.