### PR TITLE
[fix] make popover anchor element more generic

### DIFF
--- a/@navikt/core/react/src/popover/Popover.tsx
+++ b/@navikt/core/react/src/popover/Popover.tsx
@@ -16,7 +16,7 @@ export interface PopoverProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Element popover anchors to
    */
-  anchorEl: HTMLElement | null;
+  anchorEl: Element | null;
   /**
    * Open state
    */


### PR DESCRIPTION
SVGSVGElement is not an HTMLElement, but both are Element