### PR TITLE
[FIX] Endret npm registry til https fra http

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "version": "independent",
   "command": {
     "publish": {
-      "registry": "http://registry.npmjs.org/",
+      "registry": "https://registry.npmjs.org/",
       "npmClient": "npm",
       "ignoreChanges": ["*.md", "*.mdx", "*.story.tsx", "*.stories.tsx"],
       "message": "Lerna versionbump [ci skip]"

--- a/utilities/lerna.json
+++ b/utilities/lerna.json
@@ -3,7 +3,7 @@
   "version": "independent",
   "command": {
     "publish": {
-      "registry": "http://registry.npmjs.org/",
+      "registry": "https://registry.npmjs.org/",
       "npmClient": "npm",
       "ignoreChanges": ["*.md", "*.mdx", "*.story.tsx", "*.stories.tsx"],
       "message": "Lerna versionbump [ci skip]"


### PR DESCRIPTION
> lerna notice Beginning October 4, 2021, all connections to the npm registry - including for package installation - must use TLS 1.2 or higher. You are currently using plaintext http to connect. Please visit the GitHub blog for more information: https://github.blog/2021-08-23-npm-registry-deprecating-tls-1-0-tls-1-1/