### PR TITLE
[fix] remove aria-live from popover

### DIFF
--- a/@navikt/core/react/src/popover/Popover.tsx
+++ b/@navikt/core/react/src/popover/Popover.tsx
@@ -150,7 +150,6 @@ const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         className={cl("navds-popover", className, {
           "navds-popover--hidden": !open || !anchorEl,
         })}
-        aria-live="polite"
         aria-hidden={!open || !anchorEl}
         tabIndex={-1}
         {...attributes.popper}


### PR DESCRIPTION
`aria-live` skal ifølge Sarah kun brukes om innhold blir lagt til eller endres dynamisk. Det blir derfor forvirrende i komponenter som åpnes/lukkes.