### PR TITLE
[FIX] Fjernet tabindex fra ikoner

### DIFF
--- a/@navikt/core/icons/.svgrrc.js
+++ b/@navikt/core/icons/.svgrrc.js
@@ -8,7 +8,6 @@ module.exports = {
   svgProps: {
     focusable: false,
     role: "img",
-    tabIndex: -1,
   },
   replaceAttrValues: {
     "#262626": "currentColor",


### PR DESCRIPTION
tabIndex={-1} gjør at ikoner nå "capturer" museklikk og får fokus. 

Case i modal der ikonet får fokus ved klikk:

![Screenshot 2021-10-29 at 14 48 29](https://user-images.githubusercontent.com/26967723/139437243-ca85e3f2-cc07-4233-9079-d85d3aca7196.png)
