### PR TITLE
[FIX ] ikon id prefikset

### DIFF
--- a/@navikt/core/icons/template.js
+++ b/@navikt/core/icons/template.js
@@ -36,7 +36,7 @@ function defaultTemplate(
   ${interfaces}
   function ${componentName}(${props}) {
     const titleId = _titleId ?? (title ?
-      `icon-title-${v4()}` : undefined);
+      "icon-title-" + v4() : undefined);
     return ${jsx};
   }
   ${exports}`;

--- a/@navikt/core/icons/template.js
+++ b/@navikt/core/icons/template.js
@@ -36,7 +36,7 @@ function defaultTemplate(
   ${interfaces}
   function ${componentName}(${props}) {
     const titleId = _titleId ?? (title ?
-      "ikonId" + v4() : undefined);
+      `icon-title-${v4()}` : undefined);
     return ${jsx};
   }
   ${exports}`;

--- a/@navikt/core/icons/template.js
+++ b/@navikt/core/icons/template.js
@@ -35,7 +35,8 @@ function defaultTemplate(
   ${imports}
   ${interfaces}
   function ${componentName}(${props}) {
-    const titleId = _titleId ?? (title ? v4() : undefined);
+    const titleId = _titleId ?? (title ?
+      "ikonId" + v4() : undefined);
     return ${jsx};
   }
   ${exports}`;


### PR DESCRIPTION
Er ikke et problem for løsningene våre, da dette problemet er relatert til at CSS-selectorer ikke fungerer med tall først i ID. Siden idene blir autogenerert vil de ikke bli brukt med selectorer, men greit å fikse uansett

Closes https://github.com/navikt/verktoykassen/issues/28