### PR TITLE
[FIX] Fjernet aria-haspopup fra toggle-button

### DIFF
--- a/@navikt/internal/react/src/dropdown/Toggle.tsx
+++ b/@navikt/internal/react/src/dropdown/Toggle.tsx
@@ -35,7 +35,6 @@ const Toggle: ToggleType = forwardRef(
           onClick && onClick(e);
         }}
         aria-expanded={isOpen}
-        aria-haspopup="menu"
         className={cl("navdsi-dropdown__toggle", className)}
       />
     );


### PR DESCRIPTION
> Fjern aria-haspopup="menu" fra menyknappen. Den gir implikasjonen at headeren har en meny-widget interaksjonsmønster (at man tabber til den, bruker pil inn i den, og tabber ut). Det er tilstrekkelig med bare aria-expanded i dette tilfellet.


https://www.w3.org/TR/wai-aria-practices-1.1/examples/menu-button/menu-button-links.html

Closes https://github.com/navikt/verktoykassen/issues/25