### PR TITLE
[FIX] Nested token-parsing

### DIFF
--- a/@navikt/core/tokens/config.json
+++ b/@navikt/core/tokens/config.json
@@ -44,7 +44,7 @@
         },
         {
           "destination": "tokens-cjs.js",
-          "format": "javascript/module"
+          "format": "javascript/module-flat"
         }
       ]
     }

--- a/@navikt/core/tokens/figma/deepen.ts
+++ b/@navikt/core/tokens/figma/deepen.ts
@@ -1,6 +1,6 @@
 const deepen = (obj: { [key: string]: { value: string } }) => {
   const result = {};
-
+  console.log(obj);
   // For each object path (property key) in the object
   for (const objectPath in obj) {
     // Split path into component parts

--- a/@navikt/core/tokens/figma/deepen.ts
+++ b/@navikt/core/tokens/figma/deepen.ts
@@ -1,6 +1,10 @@
+import unifyNestedLevel from "./unify-nested-level";
+
 const deepen = (obj: { [key: string]: { value: string } }) => {
   const result = {};
-  console.log(obj);
+
+  unifyNestedLevel(obj);
+
   // For each object path (property key) in the object
   for (const objectPath in obj) {
     // Split path into component parts
@@ -12,7 +16,6 @@ const deepen = (obj: { [key: string]: { value: string } }) => {
       const part = parts.shift();
       target = target[part] = target[part] || {};
     }
-
     // Set value at end of path
     target[parts[0]] = obj[objectPath];
   }

--- a/@navikt/core/tokens/figma/deepen.ts
+++ b/@navikt/core/tokens/figma/deepen.ts
@@ -3,10 +3,10 @@ import unifyNestedLevel from "./unify-nested-level";
 const deepen = (obj: { [key: string]: { value: string } }) => {
   const result = {};
 
-  unifyNestedLevel(obj);
+  const workObj = unifyNestedLevel(obj);
 
   // For each object path (property key) in the object
-  for (const objectPath in obj) {
+  for (const objectPath in workObj) {
     // Split path into component parts
     const parts = objectPath.split("-");
 
@@ -17,7 +17,7 @@ const deepen = (obj: { [key: string]: { value: string } }) => {
       target = target[part] = target[part] || {};
     }
     // Set value at end of path
-    target[parts[0]] = obj[objectPath];
+    target[parts[0]] = workObj[objectPath];
   }
 
   return result;

--- a/@navikt/core/tokens/figma/tests/format-sd.test.ts
+++ b/@navikt/core/tokens/figma/tests/format-sd.test.ts
@@ -30,10 +30,10 @@ describe("Check conversion to Styled-dictionary format", () => {
           semantic: {
             color: {
               danger: {
-                value: "{navds.global.color.red.400.value}",
                 hover: {
                   value: "{navds.global.color.red.300.value}",
                 },
+                "@": { value: "{navds.global.color.red.400.value}" },
               },
             },
           },

--- a/@navikt/core/tokens/figma/tests/unify-nested-level.test.ts
+++ b/@navikt/core/tokens/figma/tests/unify-nested-level.test.ts
@@ -20,9 +20,9 @@ describe("Check unifying of nested levels", () => {
       },
     };
 
-    unifyNestedLevel(obj);
+    const newObj = unifyNestedLevel(obj);
 
-    expect(obj).toEqual({
+    expect(newObj).toEqual({
       "navds-global-color-green-50": { value: "rbga(0,1,0,0)" },
       "navds-global-color-green-500": { value: "rbga(0,2,0,0)" },
       "navds-semantic-color-primary-hover-@": {

--- a/@navikt/core/tokens/figma/tests/unify-nested-level.test.ts
+++ b/@navikt/core/tokens/figma/tests/unify-nested-level.test.ts
@@ -1,0 +1,43 @@
+import unifyNestedLevel from "../unify-nested-level";
+
+describe("Check unifying of nested levels", () => {
+  test("Check color nesting", () => {
+    const obj = {
+      "navds-global-color-green-50": { value: "rbga(0,1,0,0)" },
+      "navds-global-color-green-500": { value: "rbga(0,2,0,0)" },
+      "navds-semantic-color-primary-hover": {
+        value: "rbga(0,3,0,0)",
+      },
+      "navds-semantic-color-primary-hover-subtle": {
+        value: "rbga(0,4,0,0)",
+      },
+      "navds-semantic-color-danger": { value: "rbga(0,5,0,0)" },
+      "navds-semantic-color-danger-hover": {
+        value: "rbga(0,6,0,0)",
+      },
+      "navds-semantic-color-danger-hover-subtle": {
+        value: "rbga(0,7,0,0)",
+      },
+    };
+
+    unifyNestedLevel(obj);
+
+    expect(obj).toEqual({
+      "navds-global-color-green-50": { value: "rbga(0,1,0,0)" },
+      "navds-global-color-green-500": { value: "rbga(0,2,0,0)" },
+      "navds-semantic-color-primary-hover-@": {
+        value: "rbga(0,3,0,0)",
+      },
+      "navds-semantic-color-primary-hover-subtle": {
+        value: "rbga(0,4,0,0)",
+      },
+      "navds-semantic-color-danger-@-@": { value: "rbga(0,5,0,0)" },
+      "navds-semantic-color-danger-hover-@": {
+        value: "rbga(0,6,0,0)",
+      },
+      "navds-semantic-color-danger-hover-subtle": {
+        value: "rbga(0,7,0,0)",
+      },
+    });
+  });
+});

--- a/@navikt/core/tokens/figma/unify-nested-level.ts
+++ b/@navikt/core/tokens/figma/unify-nested-level.ts
@@ -1,6 +1,9 @@
 const unifyNestedLevel = (obj: { [key: string]: { value: string } }) => {
-  Object.keys(obj).forEach((k) => {
-    const deeperKeys = Object.keys(obj).filter(
+  // deep copy
+  const workObj = JSON.parse(JSON.stringify(obj));
+
+  Object.keys(workObj).forEach((k) => {
+    const deeperKeys = Object.keys(workObj).filter(
       (k2) => k2.startsWith(`${k}-`) && k2.length > k.length
     );
     if (deeperKeys.length > 0) {
@@ -8,11 +11,12 @@ const unifyNestedLevel = (obj: { [key: string]: { value: string } }) => {
         Math.max(...deeperKeys.map((k) => k.split("-").length)) -
         k.split("-").length;
 
-      delete Object.assign(obj, {
-        [k + "-@".repeat(neededNestedLevel)]: obj[k],
+      delete Object.assign(workObj, {
+        [k + "-@".repeat(neededNestedLevel)]: workObj[k],
       })[k];
     }
   });
+  return workObj;
 };
 
 export default unifyNestedLevel;

--- a/@navikt/core/tokens/figma/unify-nested-level.ts
+++ b/@navikt/core/tokens/figma/unify-nested-level.ts
@@ -1,0 +1,23 @@
+const unifyNestedLevel = (obj: { [key: string]: { value: string } }) => {
+  let foundDeeperValue = false;
+
+  Object.keys(obj).forEach((k) => {
+    const deeperKeys = Object.keys(obj).filter(
+      (k2) => k2.startsWith(`${k}-`) && k2.length > k.length
+    );
+    if (deeperKeys.length > 0) {
+      const neededNestedLevel =
+        Math.max(...deeperKeys.map((k) => k.split("-").length)) -
+        k.split("-").length;
+
+      delete Object.assign(obj, {
+        [k + "-@".repeat(neededNestedLevel)]: obj[k],
+      })[k];
+      foundDeeperValue = true;
+    }
+  });
+
+  foundDeeperValue && unifyNestedLevel(obj);
+};
+
+export default unifyNestedLevel;

--- a/@navikt/core/tokens/figma/unify-nested-level.ts
+++ b/@navikt/core/tokens/figma/unify-nested-level.ts
@@ -1,6 +1,4 @@
 const unifyNestedLevel = (obj: { [key: string]: { value: string } }) => {
-  let foundDeeperValue = false;
-
   Object.keys(obj).forEach((k) => {
     const deeperKeys = Object.keys(obj).filter(
       (k2) => k2.startsWith(`${k}-`) && k2.length > k.length
@@ -13,11 +11,8 @@ const unifyNestedLevel = (obj: { [key: string]: { value: string } }) => {
       delete Object.assign(obj, {
         [k + "-@".repeat(neededNestedLevel)]: obj[k],
       })[k];
-      foundDeeperValue = true;
     }
   });
-
-  foundDeeperValue && unifyNestedLevel(obj);
 };
 
 export default unifyNestedLevel;

--- a/@navikt/core/tokens/src/colors.json
+++ b/@navikt/core/tokens/src/colors.json
@@ -383,9 +383,7 @@
           }
         },
         "focus": {
-          "default": {
-            "value": "{navds.global.color.blue.800.value}"
-          },
+          "value": "{navds.global.color.blue.800.value}",
           "inverted": {
             "value": "{navds.global.color.blue.200.value}"
           }
@@ -407,12 +405,7 @@
               "value": "{navds.global.color.blue.500.value}"
             },
             "hover": {
-              "subtle": {
-                "value": "{navds.global.color.blue.50.value}"
-              },
-              "@": {
-                "value": "{navds.global.color.blue.600.value}"
-              }
+              "value": "{navds.global.color.blue.600.value}"
             },
             "selected": {
               "value": "{navds.global.color.deepblue.500.value}"
@@ -427,9 +420,7 @@
             "value": "{navds.global.color.white.value}"
           },
           "link": {
-            "default": {
-              "value": "{navds.global.color.blue.500.value}"
-            },
+            "value": "{navds.global.color.blue.500.value}",
             "visited": {
               "value": "{navds.global.color.purple.500.value}"
             }

--- a/@navikt/core/tokens/src/colors.json
+++ b/@navikt/core/tokens/src/colors.json
@@ -383,7 +383,9 @@
           }
         },
         "focus": {
-          "value": "{navds.global.color.blue.800.value}",
+          "default": {
+            "value": "{navds.global.color.blue.800.value}"
+          },
           "inverted": {
             "value": "{navds.global.color.blue.200.value}"
           }
@@ -405,7 +407,12 @@
               "value": "{navds.global.color.blue.500.value}"
             },
             "hover": {
-              "value": "{navds.global.color.blue.600.value}"
+              "subtle": {
+                "value": "{navds.global.color.blue.50.value}"
+              },
+              "@": {
+                "value": "{navds.global.color.blue.600.value}"
+              }
             },
             "selected": {
               "value": "{navds.global.color.deepblue.500.value}"
@@ -420,7 +427,9 @@
             "value": "{navds.global.color.white.value}"
           },
           "link": {
-            "value": "{navds.global.color.blue.500.value}",
+            "default": {
+              "value": "{navds.global.color.blue.500.value}"
+            },
             "visited": {
               "value": "{navds.global.color.purple.500.value}"
             }


### PR DESCRIPTION
Style-dictionary støtter ikke strukturer med nestede verdier + default verdier (https://github.com/amzn/style-dictionary/issues/643#issuecomment-857105609)
Dette gjør at eks dette oppsettet ikke fungerer og SD ignorerer subtle her.

```json
"hover": {
  "subtle": {
    "value": "{navds.global.color.blue.50.value}"
  },
   "value": "{navds.global.color.blue.600.value}"
}
```

Foreslått fix er at alle nivå over det "dypeste" blir prefikset med `@`. Så eks eksemplet over blir da:
```json
"hover": {
  "subtle": {
    "value": "{navds.global.color.blue.50.value}"
  },
  "@": {
   "value": "{navds.global.color.blue.600.value}"
  }
}
```

Style dictionary ignorerer alle special-characters og resultatet blir da
```css
--navds-global-color-interaction-hover: ...
--navds-global-color-interaction-hover-subtle : ...
```

Slipper da å rename eks `navds-global-color-interaction-primary-hover` -> ` navds-global-color-interaction-primary-hover-default` bare for å støtte parsing med SD. 
Er en litt hacky løsning som er litt kjip å måtte løse slik, så ser gjerne at vi finner en bedre måte å løse det på. Satser på at SD fikser dette i v4 etterhvert.

## Alternativ løsning

Vil også være mulig å å sjekke om en verdi er "dypere" enn en default value, for så å ikke kjøre "deepen" for den "dypere" verdien 😵‍💫  og flytter den ut et hakk. Eksemplet viser kanskje bedre (bruker første eksemplet som input):
```json
"hover": {
   "value": "{navds.global.color.blue.600.value}"
},
"hover-subtle": {
  "value": "{navds.global.color.blue.50.value}"
}
```