### PR TITLE
[FEATURE] React og @types/react til v17 i peerDep

### DIFF
--- a/@navikt/core/icons/package.json
+++ b/@navikt/core/icons/package.json
@@ -38,7 +38,8 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^17.0.0",
+    "@types/react": "^17.0.30"
   },
   "devDependencies": {
     "@svgr/cli": "^5.5.0",

--- a/@navikt/core/react/package.json
+++ b/@navikt/core/react/package.json
@@ -61,6 +61,7 @@
     "ts-jest": "^27.0.5"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^17.0.0",
+    "@types/react": "^17.0.30"
   }
 }

--- a/@navikt/internal/react/package.json
+++ b/@navikt/internal/react/package.json
@@ -44,6 +44,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^17.0.0",
+    "@types/react": "^17.0.30"
   }
 }


### PR DESCRIPTION
- Sikrer fremtidig støtte av react.
- @types/react er lagt til for å unngå typefeil i vår transpilerte versjon og brukerens @types/react

Er en bruker av react < v17 nå. De vil då få warnings i konsollen, men ingenting vil brekke for dem (basert på om de bruker npm/yarn og installasjonsmetode).