### PR TITLE
[FIX] button:disabled opacity til 0.3, tidligere 30%

### DIFF
--- a/@navikt/core/css/button.css
+++ b/@navikt/core/css/button.css
@@ -255,7 +255,7 @@
  **************************/
 
 .navds-button:disabled {
-  opacity: 30%;
+  opacity: 0.3;
   cursor: not-allowed;
   transform: none;
 }


### PR DESCRIPTION
ref slack: https://nav-it.slack.com/archives/C6HJFRRMY/p1639478644096000

https://stackoverflow.com/questions/58853844/the-opacity-value-was-changed-to-1-after-building-the-reacjs-project

Var bare i button at opacity var satt med `%`, alle form-elementer bruker `0.3`