### PR TITLE
[FIX] Kan endre posisjonerings-strategi for Popover

### DIFF
--- a/@navikt/core/react/src/help-text/HelpText.tsx
+++ b/@navikt/core/react/src/help-text/HelpText.tsx
@@ -1,5 +1,4 @@
 import { Helptext as HelpTextIcon } from "@navikt/ds-icons";
-import { Placement } from "@popperjs/core";
 import cl from "classnames";
 import React, { forwardRef, useEffect, useRef, useState } from "react";
 import mergeRefs from "react-merge-refs";

--- a/@navikt/core/react/src/help-text/HelpText.tsx
+++ b/@navikt/core/react/src/help-text/HelpText.tsx
@@ -3,24 +3,27 @@ import { Placement } from "@popperjs/core";
 import cl from "classnames";
 import React, { forwardRef, useEffect, useRef, useState } from "react";
 import mergeRefs from "react-merge-refs";
-import { Popover } from "..";
+import { Popover, PopoverProps } from "..";
 
 export interface HelpTextProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    Pick<PopoverProps, "strategy" | "placement"> {
   /**
    * Component content
    */
   children: React.ReactNode;
-  /**
-   * Placement of popover
-   * @default "top"
-   */
-  placement?: Placement;
 }
 
 const HelpText = forwardRef<HTMLButtonElement, HelpTextProps>(
   (
-    { className, children, placement = "top", title = "hjelp", ...rest },
+    {
+      className,
+      children,
+      placement = "top",
+      strategy = "absolute",
+      title = "hjelp",
+      ...rest
+    },
     ref
   ) => {
     const buttonRef = useRef<HTMLButtonElement | null>(null);
@@ -64,6 +67,7 @@ const HelpText = forwardRef<HTMLButtonElement, HelpTextProps>(
           role="tooltip"
           anchorEl={buttonRef.current}
           placement={placement}
+          strategy={strategy}
         >
           <Popover.Content>{children}</Popover.Content>
         </Popover>

--- a/@navikt/core/react/src/popover/Popover.tsx
+++ b/@navikt/core/react/src/popover/Popover.tsx
@@ -44,6 +44,13 @@ export interface PopoverProps extends HTMLAttributes<HTMLDivElement> {
    * @default 16 w/arrow, 4 w/no-arrow
    */
   offset?: number;
+  /**
+   * Changes CSS position property to use
+   * You want to used "fixed" if reference element is inside a fixed container,
+   * but floating element is not
+   * @default "absolute"
+   */
+  strategy?: "absolute" | "fixed";
 }
 
 const useEventLister = (event: string, callback) =>
@@ -72,6 +79,7 @@ const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       onClose,
       placement = "right",
       offset,
+      strategy = "absolute",
       ...rest
     },
     ref
@@ -137,6 +145,7 @@ const Popover = forwardRef<HTMLDivElement, PopoverProps>(
             },
           },
         ],
+        strategy,
       }
     );
 

--- a/@navikt/core/react/src/popover/Popover.tsx
+++ b/@navikt/core/react/src/popover/Popover.tsx
@@ -46,8 +46,7 @@ export interface PopoverProps extends HTMLAttributes<HTMLDivElement> {
   offset?: number;
   /**
    * Changes CSS position property to use
-   * You want to used "fixed" if reference element is inside a fixed container,
-   * but floating element is not
+   * You want to use "fixed" if reference element is inside a fixed container, but popover is not
    * @default "absolute"
    */
   strategy?: "absolute" | "fixed";

--- a/@navikt/core/react/src/popover/Popover.tsx
+++ b/@navikt/core/react/src/popover/Popover.tsx
@@ -45,7 +45,7 @@ export interface PopoverProps extends HTMLAttributes<HTMLDivElement> {
    */
   offset?: number;
   /**
-   * Changes CSS position property to use
+   * Changes what CSS position property to use
    * You want to use "fixed" if reference element is inside a fixed container, but popover is not
    * @default "absolute"
    */


### PR DESCRIPTION
Fikser https://nav-it.slack.com/archives/C7NE7A8UF/p1642076390053500

```ts
/**
   * Changes what CSS position property to use
   * You want to use "fixed" if reference element is inside a fixed container, but popover is not
   * @default "absolute"
   */
strategy?: "absolute" | "fixed";
```

Lar bruker sette `position: fixed` om ønsket på Popover og HelpText. 

`strategy?: "absolute" | "fixed";` er samme for PopperJs og [floatingUI](https://floating-ui.com/docs/computeposition#strategy), så trenger ikke endre på funksjonaliteten når vi migrerer til floatingUi