### PR TITLE
[FIX] Modal: optional closebutton, button variant="tertiary"

### DIFF
--- a/@navikt/core/react/src/modal/Modal.tsx
+++ b/@navikt/core/react/src/modal/Modal.tsx
@@ -28,6 +28,11 @@ export interface ModalProps {
    * User defined classname for modal
    */
   className?: string;
+  /**
+   * Toggles addition of a X-button on modal
+   * @default true
+   */
+  closeButton?: boolean;
 }
 
 interface ModalComponent
@@ -50,6 +55,7 @@ const Modal = forwardRef<ReactModal, ModalProps>(
       onClose,
       className,
       shouldCloseOnOverlayClick = true,
+      closeButton = true,
       ...rest
     },
     ref
@@ -77,18 +83,20 @@ const Modal = forwardRef<ReactModal, ModalProps>(
         onRequestClose={(e) => onModalCloseRequest(e)}
       >
         {children}
-        <Button
-          className={cl("navds-modal__button", {
-            "navds-modal__button--shake": shouldCloseOnOverlayClick,
-          })}
-          size="small"
-          variant="secondary"
-          ref={buttonRef}
-          aria-label="lukk modalvindu"
-          onClick={onClose}
-        >
-          <Close title="X-ikon for å lukke modal" />
-        </Button>
+        {closeButton && (
+          <Button
+            className={cl("navds-modal__button", {
+              "navds-modal__button--shake": shouldCloseOnOverlayClick,
+            })}
+            size="small"
+            variant="tertiary"
+            ref={buttonRef}
+            aria-label="lukk modalvindu"
+            onClick={onClose}
+          >
+            <Close aria-hidden />
+          </Button>
+        )}
       </ReactModal>
     );
   }

--- a/@navikt/core/react/src/modal/Modal.tsx
+++ b/@navikt/core/react/src/modal/Modal.tsx
@@ -91,10 +91,9 @@ const Modal = forwardRef<ReactModal, ModalProps>(
             size="small"
             variant="tertiary"
             ref={buttonRef}
-            aria-label="lukk modalvindu"
             onClick={onClose}
           >
-            <Close aria-hidden />
+            <Close title="Lukk modalvindu" />
           </Button>
         )}
       </ReactModal>

--- a/@navikt/core/react/src/modal/stories/modal.stories.tsx
+++ b/@navikt/core/react/src/modal/stories/modal.stories.tsx
@@ -11,6 +11,7 @@ Modal.setAppElement("#root");
 export const All = () => {
   const [open, setOpen] = useState(true);
   const [openTwo, setOpenTwo] = useState(false);
+  const [openThree, setOpenThree] = useState(false);
 
   return (
     <>
@@ -44,6 +45,21 @@ export const All = () => {
             minim exercitation id irure velit sit dolor aliquip velit esse.
             Excepteur sint non minim nulla excepteur labore non magna eu.
           </p>
+        </Modal.Content>
+      </Modal>
+      <button onClick={() => setOpenThree(true)}>
+        Open modal without x-button
+      </button>
+      <Modal
+        open={openThree}
+        closeButton={false}
+        onClose={() => setOpenThree(false)}
+      >
+        <Modal.Content>
+          <h1>Header</h1>
+          <h2>subheader</h2>
+          <p>Cupidatat irure ipsum veniam ad in esse.</p>
+          <p>Cillum tempor pariatur amet ut laborum Lorem enim enim.</p>
         </Modal.Content>
       </Modal>
     </>


### PR DESCRIPTION
- Kan nå fjerne x-knapp ved å sette `closeButton={false}`
- Endret Button-variant til tertiary som er det Figma 2.1 biblioteket bruker.
- Satt aria-hidden på button-ikon, da selve knappen har en aira-label