### PR TITLE
[FIX] Textfield: CSS-sync med figma 3.0 beta

### DIFF
--- a/@navikt/core/css/form/text-field.css
+++ b/@navikt/core/css/form/text-field.css
@@ -24,13 +24,13 @@
   padding: 0.5rem;
   background-color: var(--navds-text-field-color-background);
   border-radius: 4px;
-  border: 2px solid var(--navds-text-field-color-border);
+  border: 1px solid var(--navds-text-field-color-border);
   min-height: 48px;
   width: 100%;
 }
 
 .navds-form-field--small > .navds-text-field__input {
-  padding: 0 0.15rem;
+  padding: 0 0.25rem;
   min-height: 32px;
 }
 
@@ -52,6 +52,13 @@
 */
 .navds-text-field--error > .navds-text-field__input:not(:hover):not(:disabled) {
   border-color: var(--navds-text-field-color-border-error);
+  box-shadow: 0 0 0 1px var(--navds-text-field-color-border-error);
+}
+
+.navds-text-field--error
+  > .navds-text-field__input:focus:not(:hover):not(:disabled) {
+  box-shadow: 0 0 0 1px var(--navds-text-field-color-border-error),
+    var(--navds-shadow-focus);
 }
 
 /* Disabled handling */


### PR DESCRIPTION
- Endret tilbake til 1px border, 2px (px border 1px box-shadow) for error
- litt mer side-padding for size-small