### PR TITLE
[FIX] loading-state på Switch bli nå disabled

### DIFF
--- a/@navikt/core/css/form/switch.css
+++ b/@navikt/core/css/form/switch.css
@@ -210,7 +210,7 @@
   appearance: none;
 }
 
-.navds-switch--disabled {
+.navds-switch--disabled:not(.navds-switch--loading) {
   opacity: 0.3;
 }
 

--- a/@navikt/core/react/src/form/Switch.tsx
+++ b/@navikt/core/react/src/form/Switch.tsx
@@ -89,13 +89,15 @@ const Switch = forwardRef<HTMLInputElement, SwitchProps>((props, ref) => {
         `navds-switch--${size}`,
         `navds-switch--${position}`,
         {
-          "navds-switch--disabled": inputProps.disabled,
+          "navds-switch--loading": loading,
+          "navds-switch--disabled": inputProps.disabled || loading,
         }
       )}
     >
       <input
         {...omit(rest, ["size"])}
         {...omit(inputProps, ["aria-invalid", "aria-describedby"])}
+        disabled={inputProps.disabled || loading}
         checked={checkedProp}
         defaultChecked={defaultChecked}
         ref={ref}
@@ -106,7 +108,7 @@ const Switch = forwardRef<HTMLInputElement, SwitchProps>((props, ref) => {
       <span className="navds-switch__track">
         <span className="navds-switch__thumb">
           {loading ? (
-            <Loader size="xsmall" />
+            <Loader size="xsmall" aria-live="polite" />
           ) : checked ? (
             <SelectedIcon />
           ) : null}

--- a/@navikt/core/react/src/form/Switch.tsx
+++ b/@navikt/core/react/src/form/Switch.tsx
@@ -90,14 +90,14 @@ const Switch = forwardRef<HTMLInputElement, SwitchProps>((props, ref) => {
         `navds-switch--${position}`,
         {
           "navds-switch--loading": loading,
-          "navds-switch--disabled": inputProps.disabled || loading,
+          "navds-switch--disabled": inputProps.disabled ?? loading,
         }
       )}
     >
       <input
         {...omit(rest, ["size"])}
         {...omit(inputProps, ["aria-invalid", "aria-describedby"])}
-        disabled={inputProps.disabled || loading}
+        disabled={inputProps.disabled ?? loading}
         checked={checkedProp}
         defaultChecked={defaultChecked}
         ref={ref}

--- a/@navikt/core/react/src/form/stories/switch.stories.tsx
+++ b/@navikt/core/react/src/form/stories/switch.stories.tsx
@@ -91,6 +91,9 @@ export const All = () => {
       <Switch disabled loading>
         Label text
       </Switch>
+      <Switch disabled loading checked>
+        Label text
+      </Switch>
     </div>
   );
 };

--- a/@navikt/core/react/src/form/stories/switch.stories.tsx
+++ b/@navikt/core/react/src/form/stories/switch.stories.tsx
@@ -9,6 +9,7 @@ export default {
 
 export const All = () => {
   const [checked, setChecked] = useState(false);
+  const [loadingState, setLoadingState] = useState(false);
   return (
     <div style={{ width: "fit-content" }}>
       <h1>Switch</h1>
@@ -91,9 +92,13 @@ export const All = () => {
       <Switch disabled loading>
         Label text
       </Switch>
-      <Switch disabled loading checked>
+      <Switch checked loading>
         Label text
       </Switch>
+      <button onClick={() => setLoadingState(!loadingState)}>
+        Toggle loading
+      </button>
+      <Switch loading={loadingState}>Label text</Switch>
     </div>
   );
 };


### PR DESCRIPTION
- disabled blir satt på input-element
- cursor: not-allowed, men ikke opacity: 0.3

Skjermleser:
- Når man toggler loading vil "title" på <Loader/> bli lest opp. Så for switch blir det "venter..."