### PR TITLE
[FIX] allow passing aria props to react-modal in modal

### DIFF
--- a/@navikt/core/react/src/modal/Modal.tsx
+++ b/@navikt/core/react/src/modal/Modal.tsx
@@ -33,6 +33,9 @@ export interface ModalProps {
    * @default true
    */
   closeButton?: boolean;
+  "aria-labelledby"?: string;
+  "aria-describedby"?: string;
+  "aria-modal"?: boolean;
 }
 
 interface ModalComponent
@@ -56,6 +59,9 @@ const Modal = forwardRef<ReactModal, ModalProps>(
       className,
       shouldCloseOnOverlayClick = true,
       closeButton = true,
+      "aria-describedby": ariaDescribedBy,
+      "aria-labelledby": ariaLabelledBy,
+      "aria-modal": ariaModal,
       ...rest
     },
     ref
@@ -81,6 +87,11 @@ const Modal = forwardRef<ReactModal, ModalProps>(
         overlayClassName="navds-modal__overlay"
         shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
         onRequestClose={(e) => onModalCloseRequest(e)}
+        aria={{
+          describedby: ariaDescribedBy,
+          labelledby: ariaLabelledBy,
+          modal: ariaModal,
+        }}
       >
         {children}
         {closeButton && (


### PR DESCRIPTION
En av to mulige løsninger på dette.

1. Type opp `aria` spesifikt, da den allerede passes videre til `react-modal`.

Alternativ: #1413 

Type opp alle rest-props som passes til `react-modal`.