### PR TITLE
[fix] add alert role to Alert-component

### DIFF
--- a/@navikt/core/react/src/alert/Alert.tsx
+++ b/@navikt/core/react/src/alert/Alert.tsx
@@ -61,12 +61,14 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(
       size = "medium",
       fullWidth = false,
       inline = false,
+      role = "alert",
       ...rest
     },
     ref
   ) => (
     <div
       {...rest}
+      role={role}
       ref={ref}
       className={cl(
         className,


### PR DESCRIPTION
Inspirert av MUI sine Alert-komponenter som alle har `role="alert"`

Per nå er alerten helt usynlig i fra testing-library:

```plain
    document:
    
    Name "":
    <body />
    
    --------------------------------------------------
    img:
    
    Name "error-ikon":
    <svg
      aria-labelledby="icon-title-8e17cb6c-42d8-4ad6-ba42-e30574199950"
      class="navds-alert__icon"
      fill="none"
      focusable="false"
      height="1em"
      role="img"
      viewBox="0 0 24 24"
      width="1em"
      xmlns="http://www.w3.org/2000/svg"
    />
    
    --------------------------------------------------
```