### PR TITLE
Checkbox any value

### DIFF
--- a/@navikt/core/react/src/form/checkbox/Checkbox.tsx
+++ b/@navikt/core/react/src/form/checkbox/Checkbox.tsx
@@ -6,7 +6,7 @@ import { BodyShort, Detail, omit } from "../..";
 
 export interface CheckboxProps
   extends Omit<FormFieldProps, "errorId">,
-    Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
+    Omit<InputHTMLAttributes<HTMLInputElement>, "size" | "value"> {
   /**
    * Checkbox has error
    * @default false
@@ -23,7 +23,7 @@ export interface CheckboxProps
   /**
    * The value of the HTML element.
    */
-  value?: any;
+  value?: string | number | boolean;
   /**
    * Specify whether the Checkbox is in an indeterminate state
    * @default false

--- a/@navikt/core/react/src/form/checkbox/Checkbox.tsx
+++ b/@navikt/core/react/src/form/checkbox/Checkbox.tsx
@@ -23,7 +23,7 @@ export interface CheckboxProps
   /**
    * The value of the HTML element.
    */
-  value?: string;
+  value?: any;
   /**
    * Specify whether the Checkbox is in an indeterminate state
    * @default false

--- a/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
+++ b/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
@@ -3,9 +3,9 @@ import cl from "classnames";
 import { Fieldset, FieldsetProps, FieldsetContext } from "..";
 
 export interface CheckboxGroupState {
-  readonly defaultValue?: readonly string[];
-  readonly value?: readonly string[];
-  toggleValue(value: string): void;
+  readonly defaultValue?: readonly any[];
+  readonly value?: readonly any[];
+  toggleValue(value: any): void;
 }
 
 export const CheckboxGroupContext = createContext<CheckboxGroupState | null>(
@@ -21,15 +21,15 @@ export interface CheckboxGroupProps
   /**
    * Controlled state for group
    */
-  value?: string[];
+  value?: any;
   /**
    * Default checked checkboxes on render
    */
-  defaultValue?: string[];
+  defaultValue?: any;
   /**
    * Returns current checked checkboxes in group
    */
-  onChange?: (value: string[]) => void;
+  onChange?: (value: any) => void;
 }
 
 const CheckboxGroup = forwardRef<HTMLFieldSetElement, CheckboxGroupProps>(
@@ -39,9 +39,9 @@ const CheckboxGroup = forwardRef<HTMLFieldSetElement, CheckboxGroupProps>(
   ) => {
     const fieldset = useContext(FieldsetContext);
 
-    const [state, setState] = useState<string[]>(defaultValue ?? []);
+    const [state, setState] = useState<any[]>(defaultValue ?? []);
 
-    const toggleValue = (v: string) => {
+    const toggleValue = (v: any) => {
       const newValue = value ?? state;
       const newState = newValue.includes(v)
         ? newValue.filter((x) => x !== v)

--- a/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
+++ b/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
@@ -39,7 +39,7 @@ const CheckboxGroup = forwardRef<HTMLFieldSetElement, CheckboxGroupProps>(
   ) => {
     const fieldset = useContext(FieldsetContext);
 
-    const [state, setState] = useState<string[]>([]);
+    const [state, setState] = useState<string[]>(defaultValue ?? []);
 
     const handleChange = (v: string) => {
       const newValue = value ? value : state;

--- a/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
+++ b/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
@@ -41,8 +41,8 @@ const CheckboxGroup = forwardRef<HTMLFieldSetElement, CheckboxGroupProps>(
 
     const [state, setState] = useState<string[]>(defaultValue ?? []);
 
-    const handleChange = (v: string) => {
-      const newValue = value ? value : state;
+    const toggleValue = (v: string) => {
+      const newValue = value ?? state;
       const newState = newValue.includes(v)
         ? newValue.filter((x) => x !== v)
         : [...newValue, v];
@@ -65,7 +65,7 @@ const CheckboxGroup = forwardRef<HTMLFieldSetElement, CheckboxGroupProps>(
           value={{
             value,
             defaultValue,
-            toggleValue: (value: string) => handleChange(value),
+            toggleValue,
           }}
         >
           <div className="navds-checkboxes">{children}</div>

--- a/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
+++ b/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
@@ -3,9 +3,9 @@ import cl from "classnames";
 import { Fieldset, FieldsetProps, FieldsetContext } from "..";
 
 export interface CheckboxGroupState {
-  readonly defaultValue?: readonly any[];
-  readonly value?: readonly any[];
-  toggleValue(value: any): void;
+  readonly defaultValue?: ReadonlyArray<string | number | boolean>;
+  readonly value?: ReadonlyArray<string | number | boolean>;
+  toggleValue(value: string | number | boolean): void;
 }
 
 export const CheckboxGroupContext = createContext<CheckboxGroupState | null>(
@@ -13,7 +13,10 @@ export const CheckboxGroupContext = createContext<CheckboxGroupState | null>(
 );
 
 export interface CheckboxGroupProps
-  extends Omit<FieldsetProps, "onChange" | "errorPropagation"> {
+  extends Omit<
+    FieldsetProps,
+    "onChange" | "errorPropagation" | "defaultValue"
+  > {
   /**
    * Checkboxes
    */
@@ -21,15 +24,15 @@ export interface CheckboxGroupProps
   /**
    * Controlled state for group
    */
-  value?: any;
+  value?: Array<string | number | boolean>;
   /**
    * Default checked checkboxes on render
    */
-  defaultValue?: any;
+  defaultValue?: Array<string | number | boolean>;
   /**
    * Returns current checked checkboxes in group
    */
-  onChange?: (value: any) => void;
+  onChange?: (value: Array<string | number | boolean>) => void;
 }
 
 const CheckboxGroup = forwardRef<HTMLFieldSetElement, CheckboxGroupProps>(
@@ -39,9 +42,11 @@ const CheckboxGroup = forwardRef<HTMLFieldSetElement, CheckboxGroupProps>(
   ) => {
     const fieldset = useContext(FieldsetContext);
 
-    const [state, setState] = useState<any[]>(defaultValue ?? []);
+    const [state, setState] = useState<Array<string | number | boolean>>(
+      defaultValue ?? []
+    );
 
-    const toggleValue = (v: any) => {
+    const toggleValue = (v: string | number | boolean) => {
       const newValue = value ?? state;
       const newState = newValue.includes(v)
         ? newValue.filter((x) => x !== v)

--- a/@navikt/core/react/src/form/checkbox/stories/checkbox.stories.tsx
+++ b/@navikt/core/react/src/form/checkbox/stories/checkbox.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Checkbox, CheckboxGroup } from "../../index";
 import { Meta } from "@storybook/react/types-6-0";
+import { CheckboxGroupProps } from "..";
 export default {
   title: "ds-react/form/checkbox",
   component: Checkbox,
@@ -37,13 +38,15 @@ export const Indeterminate = () => {
 };
 
 export const All = () => {
-  const Checkboxes = (props) => (
+  const Checkboxes = (
+    props: Omit<CheckboxGroupProps, "legend" | "description" | "children">
+  ) => (
     <CheckboxGroup
       legend="Mollit eiusmod"
       description="Exercitation do labore"
       {...props}
     >
-      <Checkbox value="Apple">Apple</Checkbox>
+      <Checkbox value={1}>Apple</Checkbox>
       <Checkbox value="Orange" description="Laborum ad">
         Orange
       </Checkbox>
@@ -60,7 +63,7 @@ export const All = () => {
       <h2>Single checkbox</h2>
       <Checkbox value="Apple">Apple</Checkbox>
       <h3>Desription</h3>
-      <Checkbox value="Apple" description="Laborum ad" defaultChecked>
+      <Checkbox value={1} description="Laborum ad" defaultChecked>
         Apple
       </Checkbox>
       <h3>Error</h3>
@@ -98,7 +101,7 @@ export const All = () => {
       <h3>Small + error</h3>
       <Checkboxes size="small" error="Dette er en feilmelding" />
       <h3>Default value</h3>
-      <Checkboxes defaultValue={["Orange", "Melon"]} />
+      <Checkboxes defaultValue={[1, "Melon"]} />
       <h3>Disabled</h3>
       <Checkboxes disabled />
     </>

--- a/@navikt/core/react/src/form/checkbox/useCheckbox.ts
+++ b/@navikt/core/react/src/form/checkbox/useCheckbox.ts
@@ -33,14 +33,14 @@ const useCheckbox = ({ children, ...props }: CheckboxProps) => {
     inputProps: {
       ...inputProps,
       checked: checkboxGroup?.value
-        ? checkboxGroup.value.includes(props.value as string)
+        ? checkboxGroup.value.includes(props.value)
         : props.checked,
       defaultChecked: checkboxGroup?.defaultValue
-        ? checkboxGroup.defaultValue.includes(props.value as string)
+        ? checkboxGroup.defaultValue.includes(props.value)
         : props.defaultChecked,
       onChange: (e) => {
         props.onChange && props.onChange(e);
-        checkboxGroup && checkboxGroup.toggleValue(props.value as string);
+        checkboxGroup && checkboxGroup.toggleValue(props.value);
       },
     },
   };

--- a/@navikt/core/react/src/form/checkbox/useCheckbox.ts
+++ b/@navikt/core/react/src/form/checkbox/useCheckbox.ts
@@ -28,19 +28,21 @@ const useCheckbox = ({ children, ...props }: CheckboxProps) => {
     }
   }
 
+  const value = props.value as string | number | boolean;
+
   return {
     ...rest,
     inputProps: {
       ...inputProps,
       checked: checkboxGroup?.value
-        ? checkboxGroup.value.includes(props.value)
+        ? checkboxGroup.value.includes(value)
         : props.checked,
       defaultChecked: checkboxGroup?.defaultValue
-        ? checkboxGroup.defaultValue.includes(props.value)
+        ? checkboxGroup.defaultValue.includes(value)
         : props.defaultChecked,
       onChange: (e) => {
         props.onChange && props.onChange(e);
-        checkboxGroup && checkboxGroup.toggleValue(props.value);
+        checkboxGroup && checkboxGroup.toggleValue(value);
       },
     },
   };

--- a/@navikt/core/react/src/form/radio/Radio.tsx
+++ b/@navikt/core/react/src/form/radio/Radio.tsx
@@ -6,7 +6,7 @@ import { useRadio } from "./useRadio";
 
 export interface RadioProps
   extends Omit<FormFieldProps, "error" | "errorId">,
-    Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
+    Omit<InputHTMLAttributes<HTMLInputElement>, "size" | "value"> {
   /**
    * Label for radio
    */
@@ -14,7 +14,7 @@ export interface RadioProps
   /**
    * The value of the HTML element
    */
-  value: any;
+  value: string | number | boolean;
 }
 
 const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {

--- a/@navikt/core/react/src/form/radio/Radio.tsx
+++ b/@navikt/core/react/src/form/radio/Radio.tsx
@@ -14,7 +14,7 @@ export interface RadioProps
   /**
    * The value of the HTML element
    */
-  value: string;
+  value: any;
 }
 
 const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {

--- a/@navikt/core/react/src/form/radio/RadioGroup.tsx
+++ b/@navikt/core/react/src/form/radio/RadioGroup.tsx
@@ -5,9 +5,9 @@ import { useId } from "../..";
 
 export interface RadioGroupContextProps {
   name: string;
-  defaultValue?: any;
-  value?: any;
-  onChange: (value: any) => void;
+  defaultValue?: string | number | boolean;
+  value?: string | number | boolean;
+  onChange: (value: string | number | boolean) => void;
   required?: boolean;
 }
 
@@ -16,7 +16,10 @@ export const RadioGroupContext = React.createContext<RadioGroupContextProps | nu
 );
 
 export interface RadioGroupProps
-  extends Omit<FieldsetProps, "onChange" | "errorPropagation"> {
+  extends Omit<
+    FieldsetProps,
+    "onChange" | "errorPropagation" | "defaultValue"
+  > {
   /**
    * Collection of <Radio>-elements
    */
@@ -28,15 +31,15 @@ export interface RadioGroupProps
   /**
    * Default checked radiobutton
    */
-  defaultValue?: any;
+  defaultValue?: string | number | boolean;
   /**
    * Controlled state for Radiobutton
    */
-  value?: any;
+  value?: string | number | boolean;
   /**
    * Returns current checked radiobutton in group
    */
-  onChange?: (value: any) => void;
+  onChange?: (value: string | number | boolean) => void;
   /**
    * Tells Fieldset if group is required
    */

--- a/@navikt/core/react/src/form/radio/RadioGroup.tsx
+++ b/@navikt/core/react/src/form/radio/RadioGroup.tsx
@@ -5,9 +5,9 @@ import { useId } from "../..";
 
 export interface RadioGroupContextProps {
   name: string;
-  defaultValue?: string;
-  value?: string;
-  onChange: (value: string) => void;
+  defaultValue?: any;
+  value?: any;
+  onChange: (value: any) => void;
   required?: boolean;
 }
 
@@ -28,15 +28,15 @@ export interface RadioGroupProps
   /**
    * Default checked radiobutton
    */
-  defaultValue?: string;
+  defaultValue?: any;
   /**
    * Controlled state for Radiobutton
    */
-  value?: string;
+  value?: any;
   /**
    * Returns current checked radiobutton in group
    */
-  onChange?: (value: string) => void;
+  onChange?: (value: any) => void;
   /**
    * Tells Fieldset if group is required
    */

--- a/@navikt/core/react/src/form/radio/stories/radio.stories.tsx
+++ b/@navikt/core/react/src/form/radio/stories/radio.stories.tsx
@@ -1,23 +1,21 @@
 import React from "react";
 import { Meta } from "@storybook/react/types-6-0";
 import { RadioGroup, Radio } from "../index";
+import { RadioGroupProps } from "../RadioGroup";
 export default {
   title: "ds-react/form/radio",
   component: RadioGroup,
 } as Meta;
 
 export const All = () => {
-  const Radios = (props) => (
+  const Radios = (props: Omit<RadioGroupProps, "legend" | "children">) => (
     <RadioGroup
       legend="Mollit eiusmod"
       description={<div>"Exercitation do labore"</div>}
       {...props}
     >
-      <Radio value="Apple">Apple</Radio>
-      <Radio value="Orange" description="Laborum ad">
-        Orange
-      </Radio>
-      <Radio value="Orange" description={<div>Laborum ad</div>}>
+      <Radio value={1}>Apple</Radio>
+      <Radio value={false} description={<div>Laborum ad</div>}>
         Orange
       </Radio>
       <Radio value="Melon">Melon</Radio>
@@ -35,13 +33,13 @@ export const All = () => {
       <h2>Small + error</h2>
       <Radios size="small" error="Dette er en feilmelding" />
       <h2>Default value</h2>
-      <Radios defaultValue="Orange" />
+      <Radios defaultValue={1} />
       <h2>Disabled</h2>
       <RadioGroup legend="Mollit eiusmod" description="Exercitation do labore">
         <Radio value="Apple" disabled>
           Apple
         </Radio>
-        <Radio value="Orange" description="Laborum ad" disabled>
+        <Radio value={false} description="Laborum ad" disabled>
           Orange
         </Radio>
         <Radio value="Melon">Melon</Radio>


### PR DESCRIPTION
Dette er for å gjøre så Checkbox og RadioGroup kan ta f.eks. `false` og `1` som value. Jeg er litt usikker på om det egentlig er en god ide, men jeg ser at material-ui gjør det: https://mui.com/api/radio-group/#props

@taniaholst ønsket en sånn endring