### PR TITLE
[FIX] charset utf-8 i css

### DIFF
--- a/@navikt/core/css/baseline/baseline.css
+++ b/@navikt/core/css/baseline/baseline.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 @import "@navikt/ds-tokens";
 @import "normalize.css";
 @import "Source-Sans-Pro-regular.css";

--- a/@navikt/core/css/baseline/baseline.css
+++ b/@navikt/core/css/baseline/baseline.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @import "@navikt/ds-tokens";
 @import "normalize.css";
 @import "Source-Sans-Pro-regular.css";

--- a/@navikt/core/css/index.css
+++ b/@navikt/core/css/index.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @import "baseline/baseline.css";
 @import "typography.css";
 @import "grid.css";


### PR DESCRIPTION
> It tells the browser to read the css file as UTF-8. This is handy if your CSS contains unicode characters and not only ASCII.

https://developer.mozilla.org/en-US/docs/Web/CSS/@charset

![Screenshot 2022-02-22 at 13 50 51](https://user-images.githubusercontent.com/26967723/155140933-810ce889-49d3-483a-b0f3-63ab390be97f.png)

Problemet er vist her der liste-stilen før error-meldingen ikke blir vist riktig