### PR TITLE
Oppdatere skyggeskala med mykere verdier

### DIFF
--- a/@navikt/core/tokens/src/shadow.json
+++ b/@navikt/core/tokens/src/shadow.json
@@ -2,19 +2,19 @@
   "navds": {
     "shadow": {
       "xsmall": {
-        "value": "0px 2px 1px -1px rgba(0, 0, 0, 0.1), 0px 1px 3px 0px rgba(0, 0, 0, 0.1)"
+        "value": "0 1px 2px 0 rgba(0, 0, 0, 0.5)"
       },
       "small": {
-        "value": "0px 2px 4px -2px rgba(0, 0, 0, 0.1), 0px 4px 6px -1px rgba(0, 0, 0, 0.1)"
+        "value": "0 1px 2px -1px rgba(0, 0, 0, 0.05), 0 1px 3px 0 rgba(0, 0, 0, 0.1)"
       },
       "medium": {
-        "value": "0px 4px 6px -4px rgba(0, 0, 0, 0.1) ,0px 10px 15px -3px rgba(0, 0, 0, 0.1)"
+        "value": "0 2px 4px -2px rgba(0, 0, 0, 0.05), 0 4px 6px -1px rgba(0, 0, 0, 0.1)"
       },
       "large": {
-        "value": "0px 8px 10px -6px rgba(0, 0, 0, 0.1), 0px 20px 25px -5px rgba(0, 0, 0, 0.1)"
+        "value": "0 4px 6px -4px rgba(0, 0, 0, 0.05), 0 10px 15px -3px rgba(0, 0, 0, 0.1)"
       },
       "xlarge": {
-        "value": "0px 8px 10px -6px rgba(0, 0, 0, 0.1), 0px 25px 50px -12px rgba(0, 0, 0, 0.25)"
+        "value": "0 8px 10px -6px rgba(0, 0, 0, 0.05), 0 25px 50px -5px rgba(0, 0, 0, 0.1)"
       },
       "focus": {
         "value": "0 0 0 3px {navds.semantic.color.focus.@.value}"


### PR DESCRIPTION
I forbindelse med opprettelse av skyggestiler i Figma, så jeg at skyggene var litt for harde og luftige. Alle skygger er nå justert og sjekket grundigere i Figma. (Denne gangen med zoom på 100% 🙈) 

Det var også en god anledning til å erstatte `0px` med `0`.