### PR TITLE
[FIX] parentElement prop på Modal

### DIFF
--- a/@navikt/core/react/src/modal/Modal.tsx
+++ b/@navikt/core/react/src/modal/Modal.tsx
@@ -33,6 +33,10 @@ export interface ModalProps {
    * @default true
    */
   closeButton?: boolean;
+  /**
+   * Callback for getting parent element modal will attach to
+   */
+  parentSelector?(): HTMLElement;
   "aria-labelledby"?: string;
   "aria-describedby"?: string;
   "aria-modal"?: boolean;


### PR DESCRIPTION
Gir muligheten til å mounte modal på andre elementer enn `Body`. Ønsket feature for bruk i Dekoratøren og de som jobber med shadow-dom