### PR TITLE
[FIX] Bedre width for search

### DIFF
--- a/@navikt/core/css/form/search.css
+++ b/@navikt/core/css/form/search.css
@@ -8,10 +8,12 @@
 .navds-search {
   display: flex;
   flex-direction: column;
+  width: 100%;
 }
 
 .navds-search__wrapper-inner {
   position: relative;
+  width: 100%;
 }
 
 .navds-search__wrapper {

--- a/@navikt/core/react/src/form/search/search.stories.tsx
+++ b/@navikt/core/react/src/form/search/search.stories.tsx
@@ -10,20 +10,23 @@ export default {
 export const All = () => {
   const [value, setValue] = useState("");
   return (
-    <div style={{ maxWidth: 300 }}>
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        flexDirection: "column",
+        maxWidth: 400,
+      }}
+    >
       <h1>Search</h1>
-      <div>
-        <Search
-          label="Søk alle sider om X og Y"
-          onSearch={console.log}
-        ></Search>
-        <br />
-        <Search
-          label="Søk alle sider om X og Y"
-          onSearch={console.log}
-          variant="primary"
-        ></Search>
-      </div>
+
+      <Search label="Søk alle sider om X og Y" onSearch={console.log}></Search>
+      <h2>Primary search</h2>
+      <Search
+        label="Søk alle sider om X og Y"
+        onSearch={console.log}
+        variant="primary"
+      ></Search>
 
       <h2>Search small</h2>
       <Search


### PR DESCRIPTION
Akkurat nå er det ikke mulig å gjøre søkefeltet bredere uten å lage en wrapper slik: 
```
<div className="wrapper">
  <Search/>
</div>

.wrapper > div, .wrapper > div > div {
	width: 100%;
}
```
Dette er da en fix for dette