### PR TITLE
[fix] Label react node

### DIFF
--- a/@navikt/core/react/src/form/ConfirmationPanel.tsx
+++ b/@navikt/core/react/src/form/ConfirmationPanel.tsx
@@ -10,7 +10,7 @@ export interface ConfirmationPanelProps extends Partial<CheckboxProps> {
   /**
    * Checkbox label
    */
-  label: string;
+  label: React.ReactNode;
   /**
    * Checked state for checkbox
    */

--- a/@navikt/core/react/src/form/Select.tsx
+++ b/@navikt/core/react/src/form/Select.tsx
@@ -19,7 +19,7 @@ export interface SelectProps
   /**
    * Label for select
    */
-  label: string;
+  label: React.ReactNode;
   /**
    * If enabled shows the label and description for screenreaders only
    */


### PR DESCRIPTION
Ref https://nav-it.slack.com/archives/C7NE7A8UF/p1648051909209449

Checkbox `children` er `ReactNode`, så da tenker jeg ConfirmationPanel sin `label` også kan være det.