### PR TITLE
Forhindre at SVG-ikoner i Link krymper

### DIFF
--- a/@navikt/core/css/link.css
+++ b/@navikt/core/css/link.css
@@ -49,6 +49,7 @@
 
 .navds-link svg {
   color: var(--navds-link-color-icon);
+  flex-shrink: 0;
 }
 
 .navds-link:focus svg {


### PR DESCRIPTION
Denne endringen gjør at SVG-ikoner ikke krymper når lenketekst går over flere linjer.