### PR TITLE
[FIX] Flyttet contentcontainer max-width ut i token

### DIFF
--- a/@navikt/core/css/content-container.css
+++ b/@navikt/core/css/content-container.css
@@ -1,7 +1,11 @@
+:root {
+  --navds-content-container-max-width: 79.5rem;
+}
+
 .navds-content-container {
   margin-left: auto;
   margin-right: auto;
-  max-width: 79.5rem;
+  max-width: var(--navds-content-container-max-width);
   padding: var(--navds-spacing-4);
 }
 


### PR DESCRIPTION
https://nav-it.slack.com/archives/C7NE7A8UF/p1649249579767839

Ser også flere repo i nav har brukt denne token `--navds-content-container-max-width` for å overskrive max-bredde, så fikser det for dem også da. https://cs.github.com/?scope=org%3Anavikt&scopeName=navikt&q=--navds-content-container-max-width