### PR TITLE
[fix] Støtte for @types/react 18.0.0

### DIFF
--- a/@navikt/core/icons/package.json
+++ b/@navikt/core/icons/package.json
@@ -36,7 +36,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "@types/react": "^17.0.30",
+    "@types/react": "^17.0.30 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {

--- a/@navikt/core/react/package.json
+++ b/@navikt/core/react/package.json
@@ -66,7 +66,7 @@
     "ts-jest": "^27.1.0"
   },
   "peerDependencies": {
-    "@types/react": "^17.0.30",
+    "@types/react": "^17.0.30 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0"
   }
 }

--- a/@navikt/internal/react/package.json
+++ b/@navikt/internal/react/package.json
@@ -44,7 +44,7 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@types/react": "^17.0.30",
+    "@types/react": "^17.0.30 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0"
   }
 }


### PR DESCRIPTION
Ved kjøring av `npm install` får man en feilmelding om manglende pakke: @types/react 17.0.30

@types/react har blitt oppdatert til versjon 18.0.0

Har derfor lagt til dette i peerDependencies så man slipper å måtte kjøre `npm install --peer-legacy-deps`