### PR TITLE
[fix] restrict text field value to string for clarity/simplicity

### DIFF
--- a/@navikt/core/react/src/form/TextField.tsx
+++ b/@navikt/core/react/src/form/TextField.tsx
@@ -8,6 +8,14 @@ export interface TextFieldProps
   extends FormFieldProps,
     Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
   /**
+   * The current value (controlled).
+   */
+  value?: string;
+  /**
+   * The default value (uncontrolled).
+   */
+  defaultValue?: string;
+  /**
    * Expose the HTML size attribute
    */
   htmlSize?: number;


### PR DESCRIPTION
Denne endringen har ingen store konsekvenser. `value` og `defaultValue` arver denne typen: `string | ReadonlyArray<string> | number`, så denne endringen gjør det bare hakket tydeligere hva som gir mening å sende til `TextField`. ✌️