### PR TITLE
[fix] add "children" field to Dropdown-prop-type

### DIFF
--- a/@navikt/internal/react/src/dropdown/Dropdown.tsx
+++ b/@navikt/internal/react/src/dropdown/Dropdown.tsx
@@ -1,8 +1,12 @@
-import React, { createContext, useState, ReactNode } from "react";
+import React, { createContext, useState } from "react";
 import Toggle, { ToggleType } from "./Toggle";
 import Menu, { MenuType } from "./Menu";
 
-export interface DropdownType extends React.FC<{ children: ReactNode }> {
+export interface DropdownProps {
+  children: React.ReactNode;
+}
+
+export interface DropdownType extends React.FC<DropdownProps> {
   Toggle: ToggleType;
   Menu: MenuType;
 }

--- a/@navikt/internal/react/src/dropdown/Dropdown.tsx
+++ b/@navikt/internal/react/src/dropdown/Dropdown.tsx
@@ -1,8 +1,8 @@
-import React, { createContext, useState } from "react";
+import React, { createContext, useState, ReactNode } from "react";
 import Toggle, { ToggleType } from "./Toggle";
 import Menu, { MenuType } from "./Menu";
 
-export interface DropdownType extends React.FC {
+export interface DropdownType extends React.FC<{ children: ReactNode }> {
   Toggle: ToggleType;
   Menu: MenuType;
 }


### PR DESCRIPTION
Hei! Hvis jeg forstår denne komponenten riktig så mangler den typingen til "children" hvis man bruker den i React 18. I React 18 så er ikke children feltet lenger en del av React.FC-props typen og man kan ikke lenger gi Dropdown noe children ifølge Typescript 😢 (Men det vet dere sikkert bedre enn meg som lager designsystemet 😄) Dette er bare et naivt forsøk på å fikse, mulig dette ikke skal inn hit (master) eller ikke bør gjøres i hele tatt av en eller annen grunn