### PR TITLE
[fix] prop to disable expansion for expandable row

### DIFF
--- a/@navikt/core/css/table.css
+++ b/@navikt/core/css/table.css
@@ -47,7 +47,20 @@
 
 .navds-table--zebra-stripes
   .navds-table__body
-  .navds-table__row:nth-of-type(odd):not(:hover):not(.navds-table__row--selected) {
+  .navds-table__row:nth-child(odd):not(:hover):not(.navds-table__row--selected) {
+  background-color: var(--navds-table-row-color-background-zebra);
+}
+
+.navds-table--zebra-stripes
+  .navds-table__body
+  .navds-table__expandable-row:nth-child(4n
+    + 1):not(:hover):not(.navds-table__row--selected) {
+  background-color: transparent;
+}
+
+.navds-table--zebra-stripes
+  .navds-table__body
+  .navds-table__expanded-row:nth-child(4n) {
   background-color: var(--navds-table-row-color-background-zebra);
 }
 

--- a/@navikt/core/react/src/table/ExpandableRow.tsx
+++ b/@navikt/core/react/src/table/ExpandableRow.tsx
@@ -30,6 +30,11 @@ interface ExpandableRowProps extends RowProps {
    * Change handler for open
    */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * Disable expansion
+   * @default false
+   */
+  expansionDisabled?: boolean;
 }
 
 export interface ExpandableRowType
@@ -47,6 +52,7 @@ const ExpandableRow: ExpandableRowType = forwardRef(
       defaultOpen = false,
       open,
       onOpenChange,
+      expansionDisabled = false,
       ...rest
     },
     ref
@@ -71,26 +77,28 @@ const ExpandableRow: ExpandableRowType = forwardRef(
               "navds-table__toggle-expand-cell--open": isOpen,
             })}
           >
-            <button
-              className="navds-table__toggle-expand-button"
-              aria-controls={id}
-              aria-expanded={isOpen}
-              onClick={() => {
-                onOpenChange?.(!isOpen);
-                if (open === undefined) {
-                  setInternalOpen((open) => !open);
-                }
-              }}
-            >
-              <Expand
-                className="navds-table__expandable-icon"
-                title={isOpen ? "Vis mindre" : "Vis mer"}
-              />
-              <ExpandFilled
-                className="navds-table__expandable-icon navds-table__expandable-icon--filled"
-                title={isOpen ? "Vis mindre" : "Vis mer"}
-              />
-            </button>
+            {!expansionDisabled && (
+              <button
+                className="navds-table__toggle-expand-button"
+                aria-controls={id}
+                aria-expanded={isOpen}
+                onClick={() => {
+                  onOpenChange?.(!isOpen);
+                  if (open === undefined) {
+                    setInternalOpen((open) => !open);
+                  }
+                }}
+              >
+                <Expand
+                  className="navds-table__expandable-icon"
+                  title={isOpen ? "Vis mindre" : "Vis mer"}
+                />
+                <ExpandFilled
+                  className="navds-table__expandable-icon navds-table__expandable-icon--filled"
+                  title={isOpen ? "Vis mindre" : "Vis mer"}
+                />
+              </button>
+            )}
           </DataCell>
           {togglePlacement === "left" && children}
         </Row>

--- a/@navikt/core/react/src/table/stories/table-expandable.stories.tsx
+++ b/@navikt/core/react/src/table/stories/table-expandable.stories.tsx
@@ -12,7 +12,7 @@ export const Expandable = () => {
 
   return (
     <>
-      <Table>
+      <Table zebraStripes>
         <Table.Header>
           <Table.Row>
             {columns.map(({ key, name }) => (
@@ -24,6 +24,7 @@ export const Expandable = () => {
         <Table.Body>
           {data.map((data) => (
             <Table.ExpandableRow
+              expansionDisabled={data.animal === "Sel"}
               content={data.content}
               key={data.name}
               togglePlacement="right"


### PR DESCRIPTION
Denne endringen gjør at zebrastriper kan brukes i kombinasjon med ekspanderbare rader, men det krever at alle radene i tabellen er `ExpandableRow`.