### PR TITLE
[FIX] Patchet bruk av text-align: start

### DIFF
--- a/@navikt/core/css/page-header.css
+++ b/@navikt/core/css/page-header.css
@@ -26,7 +26,7 @@
 .navds-page-header__wrapper {
   width: 100%;
   max-width: 56.5rem;
-  text-align: start;
+  text-align: left;
 }
 
 .navds-page-header__title {
@@ -38,7 +38,7 @@
 }
 
 .navds-page-header--left > .navds-page-header__wrapper {
-  text-align: start;
+  text-align: left;
 }
 
 .navds-page-header--center > .navds-page-header__wrapper {

--- a/@navikt/core/css/stepper.css
+++ b/@navikt/core/css/stepper.css
@@ -68,7 +68,7 @@
 .navds-stepper__step-label {
   margin-top: 2px;
   color: var(--navds-semantic-color-interaction-primary);
-  text-align: start;
+  text-align: left;
 }
 
 .navds-stepper__step:hover > .navds-stepper__step-label {


### PR DESCRIPTION
Parcel lager noen funky prefikser basert på browser-support + bruk av text-align:start/end 
Resolves #1524

Tenker vi patcher det denne gangen siden vi ikke har begynt å bruke logical-properties noe enda. Legger ved en anbefaling i slack-posten at vi på sikt kommer til å bruke logical-properties og anbefaler at de oppdaterer browserlist i package.json. I dette tilfellet tror vi kanskje det er `maintained node versions` som fører til prefiksingen.