### PR TITLE
Erstattet "classnames" med "clsx"

### DIFF
--- a/@navikt/core/react/package.json
+++ b/@navikt/core/react/package.json
@@ -39,7 +39,7 @@
     "@navikt/ds-icons": "^1.0.0",
     "@radix-ui/react-tabs": "0.1.5",
     "@radix-ui/react-toggle-group": "0.1.5",
-    "classnames": "^2.2.6",
+    "clsx": "^1.1.1",
     "react-collapse": "^5.1.0",
     "react-modal": "3.15.1"
   },

--- a/@navikt/core/react/src/accordion/Accordion.tsx
+++ b/@navikt/core/react/src/accordion/Accordion.tsx
@@ -1,4 +1,4 @@
-import cl from "classnames";
+import cl from "clsx";
 import React, { forwardRef } from "react";
 import AccordionItem, { AccordionItemType } from "./AccordionItem";
 import AccordionContent, { AccordionContentType } from "./AccordionContent";

--- a/@navikt/core/react/src/accordion/AccordionContent.tsx
+++ b/@navikt/core/react/src/accordion/AccordionContent.tsx
@@ -1,4 +1,4 @@
-import cl from "classnames";
+import cl from "clsx";
 import React, { forwardRef, useContext } from "react";
 import { Collapse, UnmountClosed } from "react-collapse";
 import { AccordionItemContext } from "./AccordionItem";

--- a/@navikt/core/react/src/accordion/AccordionHeader.tsx
+++ b/@navikt/core/react/src/accordion/AccordionHeader.tsx
@@ -1,5 +1,5 @@
 import { Expand, ExpandFilled } from "@navikt/ds-icons";
-import cl from "classnames";
+import cl from "clsx";
 import React, { forwardRef, useContext } from "react";
 import { AccordionItemContext } from "./AccordionItem";
 import { useClientLayoutEffect, useId } from "..";

--- a/@navikt/core/react/src/accordion/AccordionItem.tsx
+++ b/@navikt/core/react/src/accordion/AccordionItem.tsx
@@ -1,4 +1,4 @@
-import cl from "classnames";
+import cl from "clsx";
 import React, { createContext, forwardRef, useState } from "react";
 
 export interface AccordionItemProps

--- a/@navikt/core/react/src/alert/Alert.tsx
+++ b/@navikt/core/react/src/alert/Alert.tsx
@@ -4,7 +4,7 @@ import {
   SuccessColored,
   WarningColored,
 } from "@navikt/ds-icons";
-import cl from "classnames";
+import cl from "clsx";
 import React, { forwardRef } from "react";
 import { BodyLong } from "..";
 

--- a/@navikt/core/react/src/button/Button.tsx
+++ b/@navikt/core/react/src/button/Button.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { BodyShort, OverridableComponent, Loader, mergeRefs } from "../";
 import { useClientLayoutEffect } from "../util";
 

--- a/@navikt/core/react/src/chat/Bubble.tsx
+++ b/@navikt/core/react/src/chat/Bubble.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, HTMLAttributes } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { Detail } from "../typography";
 
 export interface BubbleProps extends HTMLAttributes<HTMLDivElement> {

--- a/@navikt/core/react/src/chat/Chat.tsx
+++ b/@navikt/core/react/src/chat/Chat.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, HTMLAttributes } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import Bubble, { BubbleType } from "./Bubble";
 import { BodyLong, BodyShort } from "..";
 

--- a/@navikt/core/react/src/form/ConfirmationPanel.tsx
+++ b/@navikt/core/react/src/form/ConfirmationPanel.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { BodyLong, Checkbox, CheckboxProps, ErrorMessage } from "..";
 import { useFormField } from "./useFormField";
 

--- a/@navikt/core/react/src/form/Fieldset/Fieldset.tsx
+++ b/@navikt/core/react/src/form/Fieldset/Fieldset.tsx
@@ -1,4 +1,4 @@
-import cl from "classnames";
+import cl from "clsx";
 import React, { FieldsetHTMLAttributes, forwardRef, useContext } from "react";
 import { BodyShort, Detail, Label, ErrorMessage, omit } from "../..";
 import { FormFieldProps } from "../useFormField";

--- a/@navikt/core/react/src/form/Select.tsx
+++ b/@navikt/core/react/src/form/Select.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, SelectHTMLAttributes } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { Expand } from "@navikt/ds-icons";
 import { BodyShort, Label, ErrorMessage, omit, Detail } from "..";
 import { FormFieldProps, useFormField } from "./useFormField";

--- a/@navikt/core/react/src/form/Switch.tsx
+++ b/@navikt/core/react/src/form/Switch.tsx
@@ -1,4 +1,4 @@
-import cl from "classnames";
+import cl from "clsx";
 import React, {
   forwardRef,
   InputHTMLAttributes,

--- a/@navikt/core/react/src/form/TextField.tsx
+++ b/@navikt/core/react/src/form/TextField.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, InputHTMLAttributes } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { BodyShort, Detail, Label, ErrorMessage, omit } from "..";
 import { FormFieldProps, useFormField } from "./useFormField";
 

--- a/@navikt/core/react/src/form/Textarea.tsx
+++ b/@navikt/core/react/src/form/Textarea.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useState } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { BodyShort, Label, ErrorMessage, omit, Detail } from "..";
 import { FormFieldProps, useFormField } from "./useFormField";
 import { useId } from "..";

--- a/@navikt/core/react/src/form/checkbox/Checkbox.tsx
+++ b/@navikt/core/react/src/form/checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, InputHTMLAttributes } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import useCheckbox from "./useCheckbox";
 import { FormFieldProps } from "../useFormField";
 import { BodyShort, Detail, omit } from "../..";

--- a/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
+++ b/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, forwardRef, useContext, useState } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { Fieldset, FieldsetProps, FieldsetContext } from "..";
 
 export interface CheckboxGroupState {

--- a/@navikt/core/react/src/form/error-summary/ErrorSummary.tsx
+++ b/@navikt/core/react/src/form/error-summary/ErrorSummary.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, HTMLAttributes } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { Heading, BodyShort } from "../..";
 import ErrorSummaryItem, { ErrorSummaryItemType } from "./ErrorSummaryItem";
 import { useId } from "../../util";

--- a/@navikt/core/react/src/form/error-summary/ErrorSummaryItem.tsx
+++ b/@navikt/core/react/src/form/error-summary/ErrorSummaryItem.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "../..";
 
 export interface ErrorSummaryItemProps

--- a/@navikt/core/react/src/form/radio/Radio.tsx
+++ b/@navikt/core/react/src/form/radio/Radio.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, InputHTMLAttributes } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { BodyShort, Detail, omit } from "../..";
 import { FormFieldProps } from "../useFormField";
 import { useRadio } from "./useRadio";

--- a/@navikt/core/react/src/form/radio/RadioGroup.tsx
+++ b/@navikt/core/react/src/form/radio/RadioGroup.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useContext } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { Fieldset, FieldsetContext, FieldsetProps } from "..";
 import { useId } from "../..";
 

--- a/@navikt/core/react/src/form/search/Search.tsx
+++ b/@navikt/core/react/src/form/search/Search.tsx
@@ -1,5 +1,5 @@
 import { Close, Search as SearchIcon } from "@navikt/ds-icons";
-import cl from "classnames";
+import cl from "clsx";
 import React, {
   forwardRef,
   InputHTMLAttributes,

--- a/@navikt/core/react/src/form/search/SearchButton.tsx
+++ b/@navikt/core/react/src/form/search/SearchButton.tsx
@@ -1,5 +1,5 @@
 import { Search } from "@navikt/ds-icons";
-import cl from "classnames";
+import cl from "clsx";
 import React, { forwardRef, useContext } from "react";
 import { Button, ButtonProps } from "../..";
 import { SearchContext } from "./Search";

--- a/@navikt/core/react/src/form/search/useSearch.ts
+++ b/@navikt/core/react/src/form/search/useSearch.ts
@@ -1,4 +1,4 @@
-import cl from "classnames";
+import cl from "clsx";
 import { useContext } from "react";
 import { useId } from "../../index";
 import { FieldsetContext } from "../index";

--- a/@navikt/core/react/src/form/useFormField.ts
+++ b/@navikt/core/react/src/form/useFormField.ts
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { FieldsetContext } from "./index";
 import { useId } from "../index";
 

--- a/@navikt/core/react/src/grid/Cell.tsx
+++ b/@navikt/core/react/src/grid/Cell.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, HTMLAttributes } from "react";
-import cl from "classnames";
+import cl from "clsx";
 
 type Column = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 export interface CellProps extends HTMLAttributes<HTMLDivElement> {

--- a/@navikt/core/react/src/grid/ContentContainer.tsx
+++ b/@navikt/core/react/src/grid/ContentContainer.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, HTMLAttributes } from "react";
-import cl from "classnames";
+import cl from "clsx";
 
 export interface ContentContainerProps extends HTMLAttributes<HTMLDivElement> {
   /**

--- a/@navikt/core/react/src/grid/Grid.tsx
+++ b/@navikt/core/react/src/grid/Grid.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, HTMLAttributes } from "react";
-import cl from "classnames";
+import cl from "clsx";
 
 export interface GridProps extends HTMLAttributes<HTMLDivElement> {
   /**

--- a/@navikt/core/react/src/guide-panel/Guide.tsx
+++ b/@navikt/core/react/src/guide-panel/Guide.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, HTMLAttributes } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { DefaultIllustration } from "./Illustration";
 export interface GuideProps
   extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {

--- a/@navikt/core/react/src/guide-panel/GuidePanel.tsx
+++ b/@navikt/core/react/src/guide-panel/GuidePanel.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, HTMLAttributes } from "react";
 import Guide from "./Guide";
-import cl from "classnames";
+import cl from "clsx";
 
 export interface GuidePanelProps extends HTMLAttributes<HTMLDivElement> {
   /**

--- a/@navikt/core/react/src/help-text/HelpText.tsx
+++ b/@navikt/core/react/src/help-text/HelpText.tsx
@@ -1,5 +1,5 @@
 import { Helptext as HelpTextIcon } from "@navikt/ds-icons";
-import cl from "classnames";
+import cl from "clsx";
 import React, { forwardRef, useRef, useState } from "react";
 import { Popover, PopoverProps, mergeRefs } from "..";
 

--- a/@navikt/core/react/src/link-panel/LinkPanel.tsx
+++ b/@navikt/core/react/src/link-panel/LinkPanel.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from "react";
 import { Panel, OverridableComponent } from "..";
 import { Next } from "@navikt/ds-icons";
-import cl from "classnames";
+import cl from "clsx";
 import { LinkPanelTitle, LinkPanelTitleType } from "./LinkPanelTitle";
 import {
   LinkPanelDescription,

--- a/@navikt/core/react/src/link-panel/LinkPanelDescription.tsx
+++ b/@navikt/core/react/src/link-panel/LinkPanelDescription.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { BodyLong } from "..";
 
 interface LinkPanelDescriptionProps

--- a/@navikt/core/react/src/link-panel/LinkPanelTitle.tsx
+++ b/@navikt/core/react/src/link-panel/LinkPanelTitle.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "..";
 
 interface LinkPanelTitleProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/@navikt/core/react/src/link/Link.tsx
+++ b/@navikt/core/react/src/link/Link.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "..";
 
 export interface LinkProps

--- a/@navikt/core/react/src/loader/Loader.tsx
+++ b/@navikt/core/react/src/loader/Loader.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, SVGProps } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { useId } from "..";
 
 export interface LoaderProps extends SVGProps<SVGSVGElement> {

--- a/@navikt/core/react/src/modal/Modal.tsx
+++ b/@navikt/core/react/src/modal/Modal.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import ReactModal from "react-modal";
 import { Close } from "@navikt/ds-icons";
 import { Button, mergeRefs } from "..";

--- a/@navikt/core/react/src/modal/ModalContent.tsx
+++ b/@navikt/core/react/src/modal/ModalContent.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 
 export interface ModalContentProps
   extends React.HTMLAttributes<HTMLDivElement> {

--- a/@navikt/core/react/src/pagination/Pagination.tsx
+++ b/@navikt/core/react/src/pagination/Pagination.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { Back, Next } from "@navikt/ds-icons";
 import { BodyShort } from "..";
 import PaginationItem, {

--- a/@navikt/core/react/src/pagination/PaginationItem.tsx
+++ b/@navikt/core/react/src/pagination/PaginationItem.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { Button, OverridableComponent } from "..";
 
 export interface PaginationItemProps

--- a/@navikt/core/react/src/panel/Panel.tsx
+++ b/@navikt/core/react/src/panel/Panel.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "..";
 
 export interface PanelProps extends React.HTMLAttributes<HTMLElement> {

--- a/@navikt/core/react/src/popover/Popover.tsx
+++ b/@navikt/core/react/src/popover/Popover.tsx
@@ -9,7 +9,7 @@ import {
   useFloating,
   useInteractions,
 } from "@floating-ui/react-dom-interactions";
-import cl from "classnames";
+import cl from "clsx";
 import React, {
   forwardRef,
   HTMLAttributes,

--- a/@navikt/core/react/src/popover/PopoverContent.tsx
+++ b/@navikt/core/react/src/popover/PopoverContent.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 
 export interface PopoverContentProps
   extends React.HTMLAttributes<HTMLDivElement> {

--- a/@navikt/core/react/src/read-more/ReadMore.tsx
+++ b/@navikt/core/react/src/read-more/ReadMore.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useState } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { Collapse, UnmountClosed } from "react-collapse";
 import { Expand } from "@navikt/ds-icons";
 import { BodyLong } from "../typography";

--- a/@navikt/core/react/src/stepper/Step.tsx
+++ b/@navikt/core/react/src/stepper/Step.tsx
@@ -1,4 +1,4 @@
-import cl from "classnames";
+import cl from "clsx";
 import React, { forwardRef, useContext } from "react";
 import { StepperContext } from "./Stepper";
 import { Label, OverridableComponent } from "..";

--- a/@navikt/core/react/src/stepper/Stepper.tsx
+++ b/@navikt/core/react/src/stepper/Stepper.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import Step, { StepperStepProps, StepperStepType } from "./Step";
 
 export interface StepperProps extends React.HTMLAttributes<HTMLOListElement> {

--- a/@navikt/core/react/src/table/Body.tsx
+++ b/@navikt/core/react/src/table/Body.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 
 export interface BodyProps
   extends React.HTMLAttributes<HTMLTableSectionElement> {}

--- a/@navikt/core/react/src/table/DataCell.tsx
+++ b/@navikt/core/react/src/table/DataCell.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useContext } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { BodyShort } from "..";
 import { TableContext } from "./Table";
 

--- a/@navikt/core/react/src/table/ExpandableRow.tsx
+++ b/@navikt/core/react/src/table/ExpandableRow.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useState } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import Row, { RowProps } from "./Row";
 import DataCell from "./DataCell";
 import { UnmountClosed } from "react-collapse";

--- a/@navikt/core/react/src/table/Header.tsx
+++ b/@navikt/core/react/src/table/Header.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 
 export interface HeaderProps
   extends React.HTMLAttributes<HTMLTableSectionElement> {}

--- a/@navikt/core/react/src/table/HeaderCell.tsx
+++ b/@navikt/core/react/src/table/HeaderCell.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useContext } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { Label } from "..";
 import { TableContext } from "./Table";
 

--- a/@navikt/core/react/src/table/Row.tsx
+++ b/@navikt/core/react/src/table/Row.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 
 export interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   /**

--- a/@navikt/core/react/src/table/Table.tsx
+++ b/@navikt/core/react/src/table/Table.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import Header, { HeaderType } from "./Header";
 import Body, { BodyType } from "./Body";
 import Row, { RowType } from "./Row";

--- a/@navikt/core/react/src/tabs/Tab.tsx
+++ b/@navikt/core/react/src/tabs/Tab.tsx
@@ -1,5 +1,5 @@
 import * as RadixTabs from "@radix-ui/react-tabs";
-import cl from "classnames";
+import cl from "clsx";
 import React, { forwardRef, useContext } from "react";
 import { BodyShort, OverridableComponent } from "..";
 import { TabsContext } from "./Tabs";

--- a/@navikt/core/react/src/tabs/TabList.tsx
+++ b/@navikt/core/react/src/tabs/TabList.tsx
@@ -1,6 +1,6 @@
 import { Back, Next } from "@navikt/ds-icons";
 import { TabsList } from "@radix-ui/react-tabs";
-import cl from "classnames";
+import cl from "clsx";
 import React, {
   forwardRef,
   useContext,

--- a/@navikt/core/react/src/tabs/TabPanel.tsx
+++ b/@navikt/core/react/src/tabs/TabPanel.tsx
@@ -1,5 +1,5 @@
 import { TabsContent } from "@radix-ui/react-tabs";
-import cl from "classnames";
+import cl from "clsx";
 import React, { forwardRef } from "react";
 
 export interface TabPanelProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/@navikt/core/react/src/tabs/Tabs.tsx
+++ b/@navikt/core/react/src/tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import cl from "classnames";
+import cl from "clsx";
 import React, { createContext, forwardRef, HTMLAttributes } from "react";
 import * as RadixTabs from "@radix-ui/react-tabs";
 import Tab, { TabType } from "./Tab";

--- a/@navikt/core/react/src/tag/Tag.tsx
+++ b/@navikt/core/react/src/tag/Tag.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, HTMLAttributes } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { BodyShort, Detail } from "..";
 
 export interface TagProps extends HTMLAttributes<HTMLSpanElement> {

--- a/@navikt/core/react/src/toggle-group/ToggleGroup.tsx
+++ b/@navikt/core/react/src/toggle-group/ToggleGroup.tsx
@@ -1,4 +1,4 @@
-import cl from "classnames";
+import cl from "clsx";
 import React, {
   createContext,
   forwardRef,

--- a/@navikt/core/react/src/toggle-group/ToggleItem.tsx
+++ b/@navikt/core/react/src/toggle-group/ToggleItem.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useContext } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { Label } from "..";
 import * as RadixToggleGroup from "@radix-ui/react-toggle-group";
 import { ToggleGroupContext } from "./ToggleGroup";

--- a/@navikt/core/react/src/tooltip/Tooltip.tsx
+++ b/@navikt/core/react/src/tooltip/Tooltip.tsx
@@ -12,7 +12,7 @@ import {
   useHover,
   useInteractions,
 } from "@floating-ui/react-dom-interactions";
-import cl from "classnames";
+import cl from "clsx";
 import React, {
   cloneElement,
   forwardRef,

--- a/@navikt/core/react/src/typography/BodyLong.tsx
+++ b/@navikt/core/react/src/typography/BodyLong.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "..";
 
 export interface BodyLongProps

--- a/@navikt/core/react/src/typography/BodyShort.tsx
+++ b/@navikt/core/react/src/typography/BodyShort.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "..";
 
 export interface BodyShortProps

--- a/@navikt/core/react/src/typography/Detail.tsx
+++ b/@navikt/core/react/src/typography/Detail.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "..";
 
 export interface DetailProps

--- a/@navikt/core/react/src/typography/ErrorMessage.tsx
+++ b/@navikt/core/react/src/typography/ErrorMessage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { Label } from "..";
 
 export interface ErrorMessageProps

--- a/@navikt/core/react/src/typography/Heading.tsx
+++ b/@navikt/core/react/src/typography/Heading.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "..";
 
 export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {

--- a/@navikt/core/react/src/typography/Ingress.tsx
+++ b/@navikt/core/react/src/typography/Ingress.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "..";
 
 export interface IngressProps

--- a/@navikt/core/react/src/typography/Label.tsx
+++ b/@navikt/core/react/src/typography/Label.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "..";
 
 export interface LabelProps extends React.HTMLAttributes<HTMLParagraphElement> {

--- a/@navikt/internal/react/package.json
+++ b/@navikt/internal/react/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@navikt/ds-icons": "^1.0.0",
     "@navikt/ds-react": "^1.0.0",
-    "classnames": "^2.3.1",
+    "clsx": "^1.1.1",
     "copy-to-clipboard": "^3.3.1"
   },
   "devDependencies": {

--- a/@navikt/internal/react/src/copy-to-clipboard/CopyToClipboard.tsx
+++ b/@navikt/internal/react/src/copy-to-clipboard/CopyToClipboard.tsx
@@ -1,5 +1,5 @@
 import { Copy } from "@navikt/ds-icons";
-import cl from "classnames";
+import cl from "clsx";
 import copy from "copy-to-clipboard";
 import React, { forwardRef, useEffect, useRef, useState } from "react";
 import {

--- a/@navikt/internal/react/src/dropdown/Menu/Divider.tsx
+++ b/@navikt/internal/react/src/dropdown/Menu/Divider.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 
 export type DividerType = React.ForwardRefExoticComponent<
   React.HTMLAttributes<HTMLHRElement> & React.RefAttributes<HTMLHRElement>

--- a/@navikt/internal/react/src/dropdown/Menu/GroupedList/Heading.tsx
+++ b/@navikt/internal/react/src/dropdown/Menu/GroupedList/Heading.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 
 export interface GroupedHeadingProps
   extends React.HTMLAttributes<HTMLDetailsElement> {

--- a/@navikt/internal/react/src/dropdown/Menu/GroupedList/Item.tsx
+++ b/@navikt/internal/react/src/dropdown/Menu/GroupedList/Item.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "@navikt/ds-react";
 
 export interface GroupedItemProps

--- a/@navikt/internal/react/src/dropdown/Menu/GroupedList/index.tsx
+++ b/@navikt/internal/react/src/dropdown/Menu/GroupedList/index.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import GroupedHeading, { GroupedHeadingType } from "./Heading";
 import GroupedItem, { GroupedItemType } from "./Item";
 

--- a/@navikt/internal/react/src/dropdown/Menu/List/Item.tsx
+++ b/@navikt/internal/react/src/dropdown/Menu/List/Item.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "@navikt/ds-react";
 
 export interface ListItemProps

--- a/@navikt/internal/react/src/dropdown/Menu/List/index.tsx
+++ b/@navikt/internal/react/src/dropdown/Menu/List/index.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import ListItem, { ListItemType } from "./Item";
 
 export interface ListProps extends React.HTMLAttributes<HTMLUListElement> {

--- a/@navikt/internal/react/src/dropdown/Menu/index.tsx
+++ b/@navikt/internal/react/src/dropdown/Menu/index.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useContext } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { Popover } from "@navikt/ds-react";
 import List, { ListType } from "./List";
 import GroupedList, { GroupedListType } from "./GroupedList";

--- a/@navikt/internal/react/src/dropdown/Toggle.tsx
+++ b/@navikt/internal/react/src/dropdown/Toggle.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useContext } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { DropdownContext } from ".";
 
 export interface ToggleProps

--- a/@navikt/internal/react/src/header/Header.tsx
+++ b/@navikt/internal/react/src/header/Header.tsx
@@ -3,7 +3,7 @@ import HeaderTitle, { HeaderTitleType } from "./HeaderTitle";
 import HeaderUser, { HeaderUserType } from "./HeaderUser";
 import HeaderButton, { HeaderButtonType } from "./HeaderButton";
 import HeaderUserButton, { HeaderUserButtonType } from "./HeaderUserButton";
-import cl from "classnames";
+import cl from "clsx";
 
 export interface HeaderProps extends HTMLAttributes<HTMLElement> {
   /**

--- a/@navikt/internal/react/src/header/HeaderButton.tsx
+++ b/@navikt/internal/react/src/header/HeaderButton.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "@navikt/ds-react";
 
 export interface HeaderButtonProps

--- a/@navikt/internal/react/src/header/HeaderTitle.tsx
+++ b/@navikt/internal/react/src/header/HeaderTitle.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "@navikt/ds-react";
 
 export interface HeaderTitleProps

--- a/@navikt/internal/react/src/header/HeaderUser.tsx
+++ b/@navikt/internal/react/src/header/HeaderUser.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, HTMLAttributes } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { BodyShort, Detail } from "@navikt/ds-react";
 
 export interface HeaderUserProps extends HTMLAttributes<HTMLDivElement> {

--- a/@navikt/internal/react/src/header/HeaderUserButton.tsx
+++ b/@navikt/internal/react/src/header/HeaderUserButton.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from "react";
-import cl from "classnames";
+import cl from "clsx";
 import { OverridableComponent } from "@navikt/ds-react";
 import { BodyShort, Detail } from "@navikt/ds-react";
 import { Expand } from "@navikt/ds-icons";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3043,7 +3043,7 @@ __metadata:
     "@navikt/ds-icons": ^1.0.0
     "@navikt/ds-react": ^1.0.0
     "@types/node": ^17.0.35
-    classnames: ^2.3.1
+    clsx: ^1.1.1
     concurrently: 7.2.1
     copy-to-clipboard: ^3.3.1
     rimraf: ^3.0.2
@@ -3074,7 +3074,7 @@ __metadata:
     "@types/jest": ^27.0.1
     "@types/node": ^17.0.35
     "@types/react-modal": ^3.13.1
-    classnames: ^2.2.6
+    clsx: ^1.1.1
     concurrently: 7.2.1
     copyfiles: ^2.4.1
     faker: 5.5.3
@@ -8580,13 +8580,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:^2.2.6, classnames@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "classnames@npm:2.3.1"
-  checksum: 14db8889d56c267a591f08b0834989fe542d47fac659af5a539e110cc4266694e8de86e4e3bbd271157dbd831361310a8293e0167141e80b0f03a0f175c80960
-  languageName: node
-  linkType: hard
-
 "clean-css@npm:^4.2.3":
   version: 4.2.4
   resolution: "clean-css@npm:4.2.4"
@@ -8699,6 +8692,13 @@ __metadata:
   version: 1.0.4
   resolution: "clone@npm:1.0.4"
   checksum: d06418b7335897209e77bdd430d04f882189582e67bd1f75a04565f3f07f5b3f119a9d670c943b6697d0afb100f03b866b3b8a1f91d4d02d72c4ecf2bb64b5dd
+  languageName: node
+  linkType: hard
+
+"clsx@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "clsx@npm:1.1.1"
+  checksum: ff052650329773b9b245177305fc4c4dc3129f7b2be84af4f58dc5defa99538c61d4207be7419405a5f8f3d92007c954f4daba5a7b74e563d5de71c28c830063
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://www.npmjs.com/package/clsx

Clsx er mer fleksibel på hvordan man definerer klasser. Er også mindre (222B) og over 2x raskere (ikke at det har mye å si i vår case).