### PR TITLE
[FIX] justify-self stretch for confirmation-panel

### DIFF
--- a/@navikt/core/css/form/confirmation-panel.css
+++ b/@navikt/core/css/form/confirmation-panel.css
@@ -28,6 +28,7 @@
   border: 1px solid var(--navds-confirmation-panel-color-border);
   background-color: var(--navds-confirmation-panel-color-background);
   transition: background-color linear 100ms;
+  justify-self: stretch;
 }
 
 .navds-confirmation-panel__content {


### PR DESCRIPTION
Confirmation-panel bruker nå hele bredden til container