### PR TITLE
flex: 'start' and 'end' have mixed support

### DIFF
--- a/@navikt/core/css/table.css
+++ b/@navikt/core/css/table.css
@@ -148,7 +148,7 @@
 }
 
 .navds-table__header-cell--align-right .navds-table__sort-button {
-  justify-content: end;
+  justify-content: flex-end;
 }
 
 .navds-table__header-cell--align-center .navds-table__sort-button {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,16 @@
       "function-url-quotes": null,
       "property-no-vendor-prefix": null,
       "alpha-value-notation": "number",
+      "declaration-property-value-disallowed-list": {
+        "justify-content": [
+          "start",
+          "end"
+        ],
+        "align-items": [
+          "start",
+          "end"
+        ]
+      },
       "value-keyword-case": [
         "lower",
         {


### PR DESCRIPTION
Creating rule to avoid their use, and using 'flex-end' and 'flex-start' where appropriate