### PR TITLE
[FIX] La til errorId i checkbox-props

### DIFF
--- a/@navikt/core/react/src/form/ConfirmationPanel.test.tsx
+++ b/@navikt/core/react/src/form/ConfirmationPanel.test.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import faker from "faker";
+import { ConfirmationPanel } from ".";
+
+test("omits error id from input", async () => {
+  const label = faker.datatype.string();
+
+  const { getByLabelText } = render(
+    <ConfirmationPanel label={label} errorId="wat"></ConfirmationPanel>
+  );
+
+  expect(getByLabelText(label).getAttribute("errorid")).toBeNull();
+});

--- a/@navikt/core/react/src/form/ConfirmationPanel.tsx
+++ b/@navikt/core/react/src/form/ConfirmationPanel.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from "react";
 import cl from "classnames";
-import { BodyLong, Checkbox, CheckboxProps, ErrorMessage } from "..";
+import { BodyLong, Checkbox, CheckboxProps, ErrorMessage, omit } from "..";
 import { useFormField } from "./useFormField";
 
 export interface ConfirmationPanelProps
@@ -53,7 +53,12 @@ export const ConfirmationPanel = forwardRef<
             {children}
           </BodyLong>
         )}
-        <Checkbox {...props} {...inputProps} error={hasError} size={size}>
+        <Checkbox
+          {...omit(props, ["errorId"])}
+          {...inputProps}
+          error={hasError}
+          size={size}
+        >
           {label}
         </Checkbox>
       </div>

--- a/@navikt/core/react/src/form/ConfirmationPanel.tsx
+++ b/@navikt/core/react/src/form/ConfirmationPanel.tsx
@@ -1,6 +1,6 @@
-import React, { forwardRef } from "react";
 import cl from "classnames";
-import { BodyLong, Checkbox, CheckboxProps, ErrorMessage, omit } from "..";
+import React, { forwardRef } from "react";
+import { BodyLong, Checkbox, CheckboxProps, ErrorMessage } from "..";
 import { useFormField } from "./useFormField";
 
 export interface ConfirmationPanelProps
@@ -53,12 +53,7 @@ export const ConfirmationPanel = forwardRef<
             {children}
           </BodyLong>
         )}
-        <Checkbox
-          {...omit(props, ["errorId"])}
-          {...inputProps}
-          error={hasError}
-          size={size}
-        >
+        <Checkbox {...props} {...inputProps} error={hasError} size={size}>
           {label}
         </Checkbox>
       </div>

--- a/@navikt/core/react/src/form/checkbox/Checkbox.test.tsx
+++ b/@navikt/core/react/src/form/checkbox/Checkbox.test.tsx
@@ -6,6 +6,10 @@ import { Checkbox, CheckboxGroup } from ".";
 
 const firstArgumentOfFirstCall = (fn: jest.Mock) => fn.mock.calls[0][0];
 
+test("checkbox with error id does not give type error", () => {
+  <Checkbox errorId="wat">child</Checkbox>;
+});
+
 test("checkbox group chains onChange calls", async () => {
   const onGroupChange = jest.fn();
   const onChange = jest.fn();

--- a/@navikt/core/react/src/form/checkbox/Checkbox.tsx
+++ b/@navikt/core/react/src/form/checkbox/Checkbox.tsx
@@ -5,13 +5,17 @@ import { FormFieldProps } from "../useFormField";
 import { BodyShort, Detail, omit } from "../..";
 
 export interface CheckboxProps
-  extends Omit<FormFieldProps, "errorId">,
+  extends FormFieldProps,
     Omit<InputHTMLAttributes<HTMLInputElement>, "size" | "value"> {
   /**
    * Adds error indication on checkbox
    * @default false
    */
   error?: boolean;
+  /**
+   * Id for error resulting in checkbox having error
+   */
+  errorId?: string;
   /**
    * Checkbox label
    */
@@ -61,6 +65,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             "description",
             "hideLabel",
             "indeterminate",
+            "errorId",
           ])}
           {...inputProps}
           type="checkbox"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3222,7 +3222,7 @@ __metadata:
   resolution: "@navikt/ds-react-internal@workspace:@navikt/internal/react"
   dependencies:
     "@navikt/ds-icons": ^0.8.18
-    "@navikt/ds-react": ^0.19.18
+    "@navikt/ds-react": ^0.19.19
     "@popperjs/core": ^2.10.1
     "@types/node": ^17.0.35
     classnames: ^2.3.1
@@ -3238,7 +3238,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@*, @navikt/ds-react@^0.19.18, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@*, @navikt/ds-react@^0.19.19, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:


### PR DESCRIPTION
ConfirmationPanel må gi Checkbox en errorId for at riktig aria-describedby skal fungere. Dette ble tidligere gjort ved å bare videresende props, noe som tryna for noen da props-valideringen ikke var gyldig.