### PR TITLE
[fix] Støtt React 18 via react-modal 3.15.1

### DIFF
--- a/@navikt/core/react/package.json
+++ b/@navikt/core/react/package.json
@@ -44,7 +44,7 @@
     "classnames": "^2.2.6",
     "react-collapse": "^5.1.0",
     "react-merge-refs": "^1.1.0",
-    "react-modal": "3.14.3",
+    "react-modal": "3.15.1",
     "react-popper": "^2.2.5",
     "uuid": "^8.3.2"
   },


### PR DESCRIPTION
React-modal støtter ikke React 18 som peerDependency før 3.15.1.

https://github.com/reactjs/react-modal/blob/master/CHANGELOG.md#3151---mon-11-apr-2022-222643-utc