### PR TITLE
restrict children type to string

### DIFF
--- a/@navikt/core/react/src/help-text/HelpText.tsx
+++ b/@navikt/core/react/src/help-text/HelpText.tsx
@@ -9,7 +9,7 @@ export interface HelpTextProps
   /**
    * Helptext-dialog content
    */
-  children: React.ReactNode;
+  children: string;
   /**
    * Adds a title-tooltip with the given text
    * @default "hjelp"


### PR DESCRIPTION
https://trello.com/c/KKvj7NH0

Går vekk fra `React.Children` til kun `string` for innholdet i HelpText. 

I følge Ken sin fantastiske [dependency tracker](https://dependency-tracker.dev.nav.no/ds/@navikt__ds-react) er det 38 tilfeller av HelpText ute, så sjansen er der for at noen sin kode vil brekke av dette. Hva tenker vi om det?