### PR TITLE
[FIX] Toggle-group fix for label

### DIFF
--- a/@navikt/core/css/toggle-group.css
+++ b/@navikt/core/css/toggle-group.css
@@ -18,6 +18,12 @@
   );
 }
 
+.navds-toggle-group__wrapper {
+  display: grid;
+  justify-items: start;
+  gap: var(--navds-spacing-2);
+}
+
 .navds-toggle-group {
   border-radius: 7px; /* Custom value OK */
   background-color: var(--navds-toggle-group-color-background);
@@ -90,8 +96,4 @@
   > .navds-toggle-group__button-inner
   > svg {
   font-size: 1.125rem;
-}
-
-.navds-toggle-group__label {
-  margin-bottom: 0.5rem;
 }

--- a/@navikt/core/react/src/toggle-group/ToggleGroup.tsx
+++ b/@navikt/core/react/src/toggle-group/ToggleGroup.tsx
@@ -98,7 +98,7 @@ export const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps>(
           size,
         }}
       >
-        <div>
+        <div className={cl("navds-toggle-group__wrapper", className)}>
           {label && (
             <Label
               size={size}
@@ -114,11 +114,7 @@ export const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps>(
             value={value ?? groupValue}
             defaultValue={defaultValue}
             ref={ref}
-            className={cl(
-              "navds-toggle-group",
-              className,
-              `navds-toggle-group--${size}`
-            )}
+            className={cl("navds-toggle-group", `navds-toggle-group--${size}`)}
             {...(describeBy && { "aria-describedby": describeBy })}
             role="radiogroup"
             type="single"


### PR DESCRIPTION
Label blir i dag inline som ikke er helt optimalt. Så over bruken på github og tror ikke denne endringen vil påvirke noen løsninger

Fix:
<img width="421" alt="Screenshot 2022-09-06 at 15 47 58" src="https://user-images.githubusercontent.com/26967723/188651863-a914f59b-7c61-435e-ac29-0d6ac7c5c15e.png">

Før:
<img width="647" alt="Screenshot 2022-09-06 at 15 47 54" src="https://user-images.githubusercontent.com/26967723/188651869-3a0fd7c2-db49-4e5f-8fec-c82d07be8eb9.png">
