### PR TITLE
[FIX] :art: Fikset typer og story for CopyToClipboard

### DIFF
--- a/@navikt/internal/react/src/copy-to-clipboard/CopyToClipboard.tsx
+++ b/@navikt/internal/react/src/copy-to-clipboard/CopyToClipboard.tsx
@@ -46,6 +46,11 @@ export interface CopyToClipboardProps
    * @default children ? undefined : `Kopier ${copyText}`
    */
   title?: string;
+  /**
+   * Components i tertiary by default. Will be removed in v2.0.0
+   * @breaking v2
+   */
+  variant?: "tertiary";
 }
 
 export const CopyToClipboard = forwardRef<

--- a/@navikt/internal/react/src/copy-to-clipboard/CopyToClipboard.tsx
+++ b/@navikt/internal/react/src/copy-to-clipboard/CopyToClipboard.tsx
@@ -10,7 +10,8 @@ import {
   mergeRefs,
 } from "@navikt/ds-react";
 
-export interface CopyToClipboardProps extends Omit<ButtonProps, "children"> {
+export interface CopyToClipboardProps
+  extends Omit<ButtonProps, "children" | "variant" | "loading"> {
   /**
    * Button text
    */
@@ -45,11 +46,6 @@ export interface CopyToClipboardProps extends Omit<ButtonProps, "children"> {
    * @default children ? undefined : `Kopier ${copyText}`
    */
   title?: string;
-  /**
-   * Placement of icon
-   * @default "left"
-   */
-  iconPosition?: "left" | "right";
 }
 
 export const CopyToClipboard = forwardRef<

--- a/@navikt/internal/react/src/copy-to-clipboard/copy-to-clipboard.stories.tsx
+++ b/@navikt/internal/react/src/copy-to-clipboard/copy-to-clipboard.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta } from "@storybook/react";
 import * as React from "react";
+import { Link } from "@navikt/ds-icons";
 
 import { CopyToClipboard } from "../index";
 
@@ -91,6 +92,25 @@ export const Small = () => (
       size="small"
     >
       Kopier Pi
+    </CopyToClipboard>
+  </div>
+);
+
+export const Ikon = () => (
+  <div className="rowgap">
+    <CopyToClipboard
+      iconPosition="right"
+      popoverText="Kopierte lenke"
+      copyText="3.14"
+      icon={<Link />}
+    />
+    <CopyToClipboard
+      iconPosition="left"
+      popoverText="Kopierte lenke"
+      copyText="3.14"
+      icon={<Link />}
+    >
+      Kopier lenke
     </CopyToClipboard>
   </div>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3001,7 +3001,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": ^1.3.2
+    "@navikt/ds-tokens": ^1.3.4
     normalize.css: ^8.0.1
     postcss: ^8.3.6
     postcss-cli: ^8.3.1
@@ -3010,7 +3010,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-icons@^1.0.0, @navikt/ds-icons@^1.3.2, @navikt/ds-icons@workspace:@navikt/core/icons":
+"@navikt/ds-icons@^1.0.0, @navikt/ds-icons@^1.3.4, @navikt/ds-icons@workspace:@navikt/core/icons":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-icons@workspace:@navikt/core/icons"
   dependencies:
@@ -3041,8 +3041,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react-internal@workspace:@navikt/internal/react"
   dependencies:
-    "@navikt/ds-icons": ^1.3.2
-    "@navikt/ds-react": ^1.3.2
+    "@navikt/ds-icons": ^1.3.4
+    "@navikt/ds-react": ^1.3.4
     "@types/node": ^17.0.35
     clsx: ^1.1.1
     concurrently: 7.2.1
@@ -3059,12 +3059,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@^1.0.0, @navikt/ds-react@^1.3.2, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@^1.0.0, @navikt/ds-react@^1.3.4, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react-dom-interactions": 0.9.2
-    "@navikt/ds-icons": ^1.3.2
+    "@navikt/ds-icons": ^1.3.4
     "@radix-ui/react-tabs": 1.0.0
     "@radix-ui/react-toggle-group": 1.0.0
     "@testing-library/dom": 8.13.0
@@ -3103,7 +3103,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": ^1.3.2
+    "@navikt/ds-tokens": ^1.3.4
     "@types/jest": ^27.0.1
     "@types/node": ^17.0.35
     jest: ^27.2.0
@@ -3114,7 +3114,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@^1.3.2, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@^1.3.4, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:


### PR DESCRIPTION
Fjernet loading og variant som kommer fra ButtonProps, ønsker ikke å tilby dette i komponenten.