### PR TITLE
[FIX] Fallback på font-family i body

### DIFF
--- a/@navikt/core/css/baseline/baseline.css
+++ b/@navikt/core/css/baseline/baseline.css
@@ -24,7 +24,6 @@ html {
 [data-theme="light"] {
   --navds-shadow-focus: 0 0 0 3px var(--navds-semantic-color-focus);
 
-  font-family: var(--navds-font-family, "Source Sans Pro", Arial, sans-serif);
   color: var(--navds-semantic-color-text);
 }
 
@@ -35,6 +34,7 @@ html {
 }
 
 body {
+  font-family: var(--navds-font-family, "Source Sans Pro", Arial, sans-serif);
   line-height: 1.333;
   font-size: 1.125rem;
 }

--- a/@navikt/core/css/baseline/baseline.css
+++ b/@navikt/core/css/baseline/baseline.css
@@ -24,7 +24,7 @@ html {
 [data-theme="light"] {
   --navds-shadow-focus: 0 0 0 3px var(--navds-semantic-color-focus);
 
-  font-family: var(--navds-font-family);
+  font-family: var(--navds-font-family, "Source Sans Pro", Arial, sans-serif);
   color: var(--navds-semantic-color-text);
 }
 

--- a/@navikt/core/css/baseline/baseline.css
+++ b/@navikt/core/css/baseline/baseline.css
@@ -24,6 +24,7 @@ html {
 [data-theme="light"] {
   --navds-shadow-focus: 0 0 0 3px var(--navds-semantic-color-focus);
 
+  font-family: var(--navds-font-family);
   color: var(--navds-semantic-color-text);
 }
 
@@ -34,7 +35,6 @@ html {
 }
 
 body {
-  font-family: var(--navds-font-family);
   line-height: 1.333;
   font-size: 1.125rem;
 }


### PR DESCRIPTION
Denne PRen løser flere problemer med feil font på nav.no. Dekoratøren drar inn CSSen fra designsystemet. Der scopes «alt» utenom `body` til `.decorator-wrapper`, som gjør at følgende linjer kan skape trøbbel enkelte steder. Se skjermbilde under.

```css
body {
    font-family: var(--navds-font-family)
}
```

Fremfor å be alle apper om å hente inn designsystemet, foreslår jeg derfor å flytte `font-family` fra `body` til `:root`.

![image](https://user-images.githubusercontent.com/1032194/194284475-249a5d46-414b-4252-96eb-34215f8b82f8.png)
