### PR TITLE
[FIX] :art: Helptext med riktekst

### DIFF
--- a/@navikt/core/react/src/help-text/HelpText.tsx
+++ b/@navikt/core/react/src/help-text/HelpText.tsx
@@ -6,10 +6,7 @@ import { Popover, PopoverProps, mergeRefs } from "..";
 export interface HelpTextProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     Pick<PopoverProps, "strategy" | "placement"> {
-  /**
-   * Helptext-dialog content
-   */
-  children: string;
+  children: React.ReactNode;
   /**
    * Adds a title-tooltip with the given text
    * @default "hjelp"


### PR DESCRIPTION
Endrer HelpText tilbake til å kunne ha riktekst.

Resolves #1661 