### PR TITLE
💄 Prettier-config for CSS

### DIFF
--- a/@navikt/core/css/accordion.css
+++ b/@navikt/core/css/accordion.css
@@ -1,15 +1,9 @@
 :root,
 :host {
-  --navds-accordion-color-text-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
+  --navds-accordion-color-text-hover: var(--navds-semantic-color-interaction-primary);
   --navds-accordion-color-border: var(--navds-semantic-color-border);
-  --navds-accordion-color-border-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-accordion-color-background-open: var(
-    --navds-semantic-color-interaction-primary-hover-subtle
-  );
+  --navds-accordion-color-border-hover: var(--navds-semantic-color-interaction-primary);
+  --navds-accordion-color-background-open: var(--navds-semantic-color-interaction-primary-hover-subtle);
 }
 
 .navds-accordion__item:focus-within {
@@ -56,10 +50,7 @@
   border-bottom: 2px solid var(--navds-accordion-color-border);
 }
 
-.navds-accordion__item--open
-  > .navds-accordion__header:hover
-  + *
-  .navds-accordion__content {
+.navds-accordion__item--open > .navds-accordion__header:hover + * .navds-accordion__content {
   border-color: var(--navds-accordion-color-border-hover);
 }
 
@@ -69,9 +60,7 @@
   flex-shrink: 0;
 }
 
-.navds-accordion__item--open
-  > .navds-accordion__header
-  > .navds-accordion__expand-icon {
+.navds-accordion__item--open > .navds-accordion__header > .navds-accordion__expand-icon {
   transform: rotateZ(180deg);
 }
 
@@ -79,8 +68,7 @@
   display: none;
 }
 
-.navds-accordion__header:hover
-  > .navds-accordion__expand-icon.navds-accordion__expand-icon--filled {
+.navds-accordion__header:hover > .navds-accordion__expand-icon.navds-accordion__expand-icon--filled {
   display: inherit;
 }
 

--- a/@navikt/core/css/alert.css
+++ b/@navikt/core/css/alert.css
@@ -1,21 +1,13 @@
 :root,
 :host {
   --navds-alert-color-border: var(--navds-semantic-color-border-muted);
-  --navds-alert-color-error-border: var(
-    --navds-semantic-color-feedback-danger-border
-  );
+  --navds-alert-color-error-border: var(--navds-semantic-color-feedback-danger-border);
   --navds-alert-color-error-background: var(--navds-global-color-red-50);
-  --navds-alert-color-warning-border: var(
-    --navds-semantic-color-feedback-warning-border
-  );
+  --navds-alert-color-warning-border: var(--navds-semantic-color-feedback-warning-border);
   --navds-alert-color-warning-background: var(--navds-global-color-orange-50);
-  --navds-alert-color-info-border: var(
-    --navds-semantic-color-feedback-info-border
-  );
+  --navds-alert-color-info-border: var(--navds-semantic-color-feedback-info-border);
   --navds-alert-color-info-background: var(--navds-global-color-lightblue-50);
-  --navds-alert-color-success-border: var(
-    --navds-semantic-color-feedback-success-border
-  );
+  --navds-alert-color-success-border: var(--navds-semantic-color-feedback-success-border);
   --navds-alert-color-success-background: var(--navds-global-color-green-50);
 }
 

--- a/@navikt/core/css/button.css
+++ b/@navikt/core/css/button.css
@@ -3,79 +3,35 @@
 [data-theme="light"] {
   /* Primary */
   --navds-button-color-primary-text: var(--navds-semantic-color-text-inverted);
-  --navds-button-color-primary-border-focus: var(
-    --navds-semantic-color-text-inverted
-  );
-  --navds-button-color-primary-background: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-button-color-primary-background-hover: var(
-    --navds-semantic-color-interaction-primary-hover
-  );
-  --navds-button-color-primary-background-active: var(
-    --navds-semantic-color-interaction-primary-selected
-  );
+  --navds-button-color-primary-border-focus: var(--navds-semantic-color-text-inverted);
+  --navds-button-color-primary-background: var(--navds-semantic-color-interaction-primary);
+  --navds-button-color-primary-background-hover: var(--navds-semantic-color-interaction-primary-hover);
+  --navds-button-color-primary-background-active: var(--navds-semantic-color-interaction-primary-selected);
 
   /* Secondary */
-  --navds-button-color-secondary-text: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-button-color-secondary-text-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-button-color-secondary-text-active: var(
-    --navds-semantic-color-text-inverted
-  );
-  --navds-button-color-secondary-border: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-button-color-secondary-border-focus-active-hover: var(
-    --navds-semantic-color-component-background-light
-  );
-  --navds-button-color-secondary-background: var(
-    --navds-semantic-color-component-background-light
-  );
-  --navds-button-color-secondary-background-hover: var(
-    --navds-semantic-color-interaction-primary-hover-subtle
-  );
-  --navds-button-color-secondary-background-active: var(
-    --navds-semantic-color-interaction-primary-selected
-  );
+  --navds-button-color-secondary-text: var(--navds-semantic-color-interaction-primary);
+  --navds-button-color-secondary-text-hover: var(--navds-semantic-color-interaction-primary);
+  --navds-button-color-secondary-text-active: var(--navds-semantic-color-text-inverted);
+  --navds-button-color-secondary-border: var(--navds-semantic-color-interaction-primary);
+  --navds-button-color-secondary-border-focus-active-hover: var(--navds-semantic-color-component-background-light);
+  --navds-button-color-secondary-background: var(--navds-semantic-color-component-background-light);
+  --navds-button-color-secondary-background-hover: var(--navds-semantic-color-interaction-primary-hover-subtle);
+  --navds-button-color-secondary-background-active: var(--navds-semantic-color-interaction-primary-selected);
 
   /* Tertiary */
-  --navds-button-color-tertiary-text: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-button-color-tertiary-text-active: var(
-    --navds-semantic-color-text-inverted
-  );
-  --navds-button-color-tertiary-background-hover: var(
-    --navds-semantic-color-interaction-primary-hover-subtle
-  );
-  --navds-button-color-tertiary-border-focus: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-button-color-tertiary-border-active: var(
-    --navds-semantic-color-component-background-light
-  );
-  --navds-button-color-tertiary-background-active: var(
-    --navds-semantic-color-interaction-primary-selected
-  );
+  --navds-button-color-tertiary-text: var(--navds-semantic-color-interaction-primary);
+  --navds-button-color-tertiary-text-active: var(--navds-semantic-color-text-inverted);
+  --navds-button-color-tertiary-background-hover: var(--navds-semantic-color-interaction-primary-hover-subtle);
+  --navds-button-color-tertiary-border-focus: var(--navds-semantic-color-interaction-primary);
+  --navds-button-color-tertiary-border-active: var(--navds-semantic-color-component-background-light);
+  --navds-button-color-tertiary-background-active: var(--navds-semantic-color-interaction-primary-selected);
 
   /* Danger */
   --navds-button-color-danger-text: var(--navds-semantic-color-text-inverted);
-  --navds-button-color-danger-background: var(
-    --navds-semantic-color-interaction-danger
-  );
-  --navds-button-color-danger-background-hover: var(
-    --navds-semantic-color-interaction-danger-hover
-  );
-  --navds-button-color-danger-background-active: var(
-    --navds-semantic-color-interaction-danger-selected
-  );
-  --navds-button-color-danger-border-focus: var(
-    --navds-semantic-color-component-background-light
-  );
+  --navds-button-color-danger-background: var(--navds-semantic-color-interaction-danger);
+  --navds-button-color-danger-background-hover: var(--navds-semantic-color-interaction-danger-hover);
+  --navds-button-color-danger-background-active: var(--navds-semantic-color-interaction-danger-selected);
+  --navds-button-color-danger-border-focus: var(--navds-semantic-color-component-background-light);
 
   /* Loader */
   --navds-loader-color-on-button-background: rgb(255 255 255 / 0.3);
@@ -87,30 +43,18 @@
   --navds-button-color-primary-text: var(--navds-semantic-color-text);
   --navds-button-color-primary-border-focus: var(--navds-semantic-color-text);
   --navds-button-color-primary-background: var(--navds-global-color-blue-200);
-  --navds-button-color-primary-background-hover: var(
-    --navds-global-color-blue-300
-  );
-  --navds-button-color-primary-background-active: var(
-    --navds-global-color-blue-400
-  );
+  --navds-button-color-primary-background-hover: var(--navds-global-color-blue-300);
+  --navds-button-color-primary-background-active: var(--navds-global-color-blue-400);
 
   /* Secondary */
   --navds-button-color-secondary-text: var(--navds-global-color-white);
   --navds-button-color-secondary-text-hover: var(--navds-global-color-white);
   --navds-button-color-secondary-text-active: var(--navds-global-color-white);
   --navds-button-color-secondary-border: var(--navds-global-color-blue-200);
-  --navds-button-color-secondary-border-focus-active-hover: var(
-    --navds-semantic-color-text
-  );
-  --navds-button-color-secondary-background: var(
-    --navds-semantic-color-component-background-inverted
-  );
-  --navds-button-color-secondary-background-hover: var(
-    --navds-global-color-gray-800
-  );
-  --navds-button-color-secondary-background-active: var(
-    --navds-global-color-gray-700
-  );
+  --navds-button-color-secondary-border-focus-active-hover: var(--navds-semantic-color-text);
+  --navds-button-color-secondary-background: var(--navds-semantic-color-component-background-inverted);
+  --navds-button-color-secondary-background-hover: var(--navds-global-color-gray-800);
+  --navds-button-color-secondary-background-active: var(--navds-global-color-gray-700);
 }
 
 .navds-button {
@@ -202,8 +146,7 @@
 }
 
 .navds-button--primary:focus {
-  box-shadow: inset 0 0 0 1px var(--navds-button-color-primary-border-focus),
-    var(--navds-shadow-focus);
+  box-shadow: inset 0 0 0 1px var(--navds-button-color-primary-border-focus), var(--navds-shadow-focus);
 }
 
 .navds-button--primary:hover:where(:disabled, .navds-button--disabled),
@@ -227,8 +170,7 @@
 }
 
 .navds-button--secondary:focus {
-  box-shadow: inset 0 0 0 2px var(--navds-button-color-secondary-border),
-    var(--navds-shadow-focus);
+  box-shadow: inset 0 0 0 2px var(--navds-button-color-secondary-border), var(--navds-shadow-focus);
 }
 
 .navds-button--secondary:active {
@@ -238,9 +180,7 @@
 }
 
 .navds-button--secondary:focus:active {
-  box-shadow: inset 0 0 0 1px
-      var(--navds-button-color-secondary-border-focus-active-hover),
-    var(--navds-shadow-focus);
+  box-shadow: inset 0 0 0 1px var(--navds-button-color-secondary-border-focus-active-hover), var(--navds-shadow-focus);
 }
 
 .navds-button--secondary:where(:disabled, .navds-button--disabled),
@@ -263,8 +203,7 @@
 }
 
 .navds-button--tertiary:focus {
-  box-shadow: inset 0 0 0 2px var(--navds-button-color-tertiary-border-focus),
-    var(--navds-shadow-focus);
+  box-shadow: inset 0 0 0 2px var(--navds-button-color-tertiary-border-focus), var(--navds-shadow-focus);
 }
 
 .navds-button--tertiary:active {
@@ -278,8 +217,7 @@
 }
 
 .navds-button--tertiary:active:focus {
-  box-shadow: inset 0 0 0 1px var(--navds-button-color-tertiary-border-active),
-    var(--navds-shadow-focus);
+  box-shadow: inset 0 0 0 1px var(--navds-button-color-tertiary-border-active), var(--navds-shadow-focus);
 }
 
 .navds-button--tertiary:where(:disabled, .navds-button--disabled),
@@ -309,8 +247,7 @@
 }
 
 .navds-button--danger:focus {
-  box-shadow: inset 0 0 0 1px var(--navds-button-color-danger-border-focus),
-    var(--navds-shadow-focus);
+  box-shadow: inset 0 0 0 1px var(--navds-button-color-danger-border-focus), var(--navds-shadow-focus);
 }
 
 .navds-button--danger:active:where(:disabled, .navds-button--disabled),

--- a/@navikt/core/css/chat.css
+++ b/@navikt/core/css/chat.css
@@ -2,9 +2,7 @@
 :host {
   --navds-chat-color-background: var(--navds-semantic-color-canvas-background);
   --navds-chat-color-avatar: var(--navds-semantic-color-text);
-  --navds-chat-color-avatar-background: var(
-    --navds-semantic-color-canvas-background
-  );
+  --navds-chat-color-avatar-background: var(--navds-semantic-color-canvas-background);
 }
 
 .navds-chat {

--- a/@navikt/core/css/date.css
+++ b/@navikt/core/css/date.css
@@ -61,14 +61,12 @@
 
 .navds-date .rdp-day_range_start {
   border-radius: 12px 2px 2px 12px;
-  border-radius: var(--navds-border-radius-xlarge)
-    var(--navds-border-radius-small) var(--navds-border-radius-small)
+  border-radius: var(--navds-border-radius-xlarge) var(--navds-border-radius-small) var(--navds-border-radius-small)
     var(--navds-border-radius-xlarge);
 }
 
 .navds-date .rdp-day_range_end:not(.rdp-day_range_start) {
-  border-radius: var(--navds-border-radius-small)
-    var(--navds-border-radius-xlarge) var(--navds-border-radius-xlarge)
+  border-radius: var(--navds-border-radius-small) var(--navds-border-radius-xlarge) var(--navds-border-radius-xlarge)
     var(--navds-border-radius-small);
 }
 
@@ -77,15 +75,13 @@
 }
 
 .navds-date .rdp-button:not(.rdp-day_selected):not([disabled]):focus,
-.navds-date
-  .navds-date__month-button:not(.rdp-day_selected):not([disabled]):focus {
+.navds-date .navds-date__month-button:not(.rdp-day_selected):not([disabled]):focus {
   box-shadow: var(--navds-shadow-focus);
 }
 
 .navds-date .rdp-button.rdp-day_selected:not([disabled]):focus,
 .navds-date .navds-date__month-button.rdp-day_selected:not([disabled]):focus {
-  box-shadow: inset 0 0 0 1px var(--navds-global-color-white),
-    0 0 0 3px var(--navds-global-color-blue-800);
+  box-shadow: inset 0 0 0 1px var(--navds-global-color-white), 0 0 0 3px var(--navds-global-color-blue-800);
 }
 
 /* Monthpicker */

--- a/@navikt/core/css/form/confirmation-panel.css
+++ b/@navikt/core/css/form/confirmation-panel.css
@@ -1,23 +1,11 @@
 :root,
 :host {
-  --navds-confirmation-panel-color-background: var(
-    --navds-global-color-orange-50
-  );
-  --navds-confirmation-panel-color-background-checked: var(
-    --navds-global-color-green-50
-  );
-  --navds-confirmation-panel-color-background-error: var(
-    --navds-global-color-red-50
-  );
-  --navds-confirmation-panel-color-border: var(
-    --navds-semantic-color-feedback-warning-border
-  );
-  --navds-confirmation-panel-color-border-checked: var(
-    --navds-semantic-color-feedback-success-border
-  );
-  --navds-confirmation-panel-color-border-error: var(
-    --navds-semantic-color-feedback-danger-border
-  );
+  --navds-confirmation-panel-color-background: var(--navds-global-color-orange-50);
+  --navds-confirmation-panel-color-background-checked: var(--navds-global-color-green-50);
+  --navds-confirmation-panel-color-background-error: var(--navds-global-color-red-50);
+  --navds-confirmation-panel-color-border: var(--navds-semantic-color-feedback-warning-border);
+  --navds-confirmation-panel-color-border-checked: var(--navds-semantic-color-feedback-success-border);
+  --navds-confirmation-panel-color-border-error: var(--navds-semantic-color-feedback-danger-border);
 }
 
 .navds-confirmation-panel__inner {

--- a/@navikt/core/css/form/error-summary.css
+++ b/@navikt/core/css/form/error-summary.css
@@ -1,11 +1,7 @@
 :root,
 :host {
-  --navds-error-summary-color-background: var(
-    --navds-semantic-color-component-background-light
-  );
-  --navds-error-summary-color-border: var(
-    --navds-semantic-color-feedback-danger-border
-  );
+  --navds-error-summary-color-background: var(--navds-semantic-color-component-background-light);
+  --navds-error-summary-color-border: var(--navds-semantic-color-feedback-danger-border);
 }
 
 .navds-error-summary {

--- a/@navikt/core/css/form/radio-checkbox.css
+++ b/@navikt/core/css/form/radio-checkbox.css
@@ -1,28 +1,14 @@
 :root,
 :host {
-  --navds-radio-checkbox-color-background: var(
-    --navds-semantic-color-component-background-light
-  );
+  --navds-radio-checkbox-color-background: var(--navds-semantic-color-component-background-light);
   --navds-radio-checkbox-color-text: var(--navds-semantic-color-text);
-  --navds-radio-checkbox-color-background-hover: var(
-    --navds-semantic-color-interaction-primary-hover-subtle
-  );
-  --navds-radio-checkbox-color-background-checked: var(
-    --navds-semantic-color-interaction-primary
-  );
+  --navds-radio-checkbox-color-background-hover: var(--navds-semantic-color-interaction-primary-hover-subtle);
+  --navds-radio-checkbox-color-background-checked: var(--navds-semantic-color-interaction-primary);
   --navds-radio-checkbox-color-shadow: var(--navds-semantic-color-border);
-  --navds-radio-checkbox-color-shadow-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-radio-checkbox-color-shadow-checked: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-radio-checkbox-color-shadow-error: var(
-    --navds-semantic-color-interaction-danger
-  );
-  --navds-radio-checkbox-color-label-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
+  --navds-radio-checkbox-color-shadow-hover: var(--navds-semantic-color-interaction-primary);
+  --navds-radio-checkbox-color-shadow-checked: var(--navds-semantic-color-interaction-primary);
+  --navds-radio-checkbox-color-shadow-error: var(--navds-semantic-color-interaction-danger);
+  --navds-radio-checkbox-color-label-hover: var(--navds-semantic-color-interaction-primary);
 }
 
 .navds-checkbox,
@@ -94,14 +80,12 @@
 
 .navds-checkbox__input:focus + .navds-checkbox__label::before,
 .navds-radio__input:focus + .navds-radio__label::before {
-  box-shadow: inset 0 0 0 2px var(--navds-radio-checkbox-color-shadow),
-    var(--navds-shadow-focus);
+  box-shadow: inset 0 0 0 2px var(--navds-radio-checkbox-color-shadow), var(--navds-shadow-focus);
 }
 
 .navds-checkbox__input:hover:focus + .navds-checkbox__label::before,
 .navds-radio__input:hover:focus + .navds-radio__label::before {
-  box-shadow: inset 0 0 0 2px var(--navds-radio-checkbox-color-shadow-hover),
-    var(--navds-shadow-focus);
+  box-shadow: inset 0 0 0 2px var(--navds-radio-checkbox-color-shadow-hover), var(--navds-shadow-focus);
 }
 
 .navds-checkbox__input:indeterminate + .navds-checkbox__label::before {
@@ -121,9 +105,7 @@
   flex-shrink: 0;
 }
 
-.navds-checkbox--small
-  .navds-checkbox__input:indeterminate
-  + .navds-checkbox__label::after {
+.navds-checkbox--small .navds-checkbox__input:indeterminate + .navds-checkbox__label::after {
   transform: translate(0.25rem, -50%);
 }
 
@@ -136,9 +118,7 @@
   background-color: var(--navds-radio-checkbox-color-background-checked);
 }
 
-.navds-checkbox--small
-  > .navds-checkbox__input:checked
-  + .navds-checkbox__label::before {
+.navds-checkbox--small > .navds-checkbox__input:checked + .navds-checkbox__label::before {
   background-position: 4px center;
 }
 
@@ -148,14 +128,12 @@
 }
 
 .navds-radio__input:checked + .navds-radio__label::before {
-  box-shadow: inset 0 0 0 2px var(--navds-radio-checkbox-color-shadow-checked),
-    inset 0 0 0 4px #fff;
+  box-shadow: inset 0 0 0 2px var(--navds-radio-checkbox-color-shadow-checked), inset 0 0 0 4px #fff;
   background-color: var(--navds-radio-checkbox-color-background-checked);
 }
 
 .navds-radio__input:checked:focus + .navds-radio__label::before {
-  box-shadow: inset 0 0 0 2px var(--navds-radio-checkbox-color-shadow-checked),
-    inset 0 0 0 4px #fff, var(--navds-shadow-focus);
+  box-shadow: inset 0 0 0 2px var(--navds-radio-checkbox-color-shadow-checked), inset 0 0 0 4px #fff, var(--navds-shadow-focus);
 }
 
 .navds-checkbox__input:hover:not(:disabled) + .navds-checkbox__label,
@@ -163,17 +141,13 @@
   color: var(--navds-radio-checkbox-color-label-hover);
 }
 
-.navds-checkbox__input:hover:not(:disabled):not(:checked):not(:indeterminate):not(:focus)
-  + .navds-checkbox__label::before,
-.navds-radio__input:hover:not(:disabled):not(:checked):not(:focus)
-  + .navds-radio__label::before {
+.navds-checkbox__input:hover:not(:disabled):not(:checked):not(:indeterminate):not(:focus) + .navds-checkbox__label::before,
+.navds-radio__input:hover:not(:disabled):not(:checked):not(:focus) + .navds-radio__label::before {
   box-shadow: inset 0 0 0 2px var(--navds-radio-checkbox-color-shadow-hover);
 }
 
-.navds-checkbox__input:hover:not(:disabled):not(:checked):not(:indeterminate)
-  + .navds-checkbox__label::before,
-.navds-radio__input:hover:not(:disabled):not(:checked)
-  + .navds-radio__label::before {
+.navds-checkbox__input:hover:not(:disabled):not(:checked):not(:indeterminate) + .navds-checkbox__label::before,
+.navds-radio__input:hover:not(:disabled):not(:checked) + .navds-radio__label::before {
   background-color: var(--navds-radio-checkbox-color-background-hover);
 }
 
@@ -192,8 +166,7 @@
 .navds-radio--error
   > .navds-radio__input:focus:not(:hover):not(:disabled):not(:checked):not(:indeterminate)
   + .navds-radio__label::before {
-  box-shadow: inset 0 0 0 2px var(--navds-radio-checkbox-color-shadow-error),
-    var(--navds-shadow-focus);
+  box-shadow: inset 0 0 0 2px var(--navds-radio-checkbox-color-shadow-error), var(--navds-shadow-focus);
 }
 
 .navds-checkbox--disabled,

--- a/@navikt/core/css/form/search.css
+++ b/@navikt/core/css/form/search.css
@@ -3,9 +3,7 @@
 [data-theme="light"] {
   --navds-search-color-text: var(--navds-semantic-color-text);
   --navds-search-color-border: var(--navds-semantic-color-border);
-  --navds-search-color-border-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
+  --navds-search-color-border-hover: var(--navds-semantic-color-interaction-primary);
   --navds-search-color-clear-hover: var(--navds-global-color-blue-500);
   --navds-search-color-border-error: var(--navds-global-color-red-500);
 }
@@ -121,32 +119,26 @@
 }
 
 .navds-search__button-search.navds-button--secondary {
-  box-shadow: -1px 0 0 0 var(--navds-search-color-border) inset,
-    0 1px 0 0 var(--navds-search-color-border) inset,
+  box-shadow: -1px 0 0 0 var(--navds-search-color-border) inset, 0 1px 0 0 var(--navds-search-color-border) inset,
     0 -1px 0 0 var(--navds-search-color-border) inset;
 }
 
 .navds-search__button-search.navds-button--secondary:hover {
-  box-shadow: -1px 0 0 0 var(--navds-search-color-border-hover) inset,
-    0 1px 0 0 var(--navds-search-color-border-hover) inset,
-    0 -1px 0 0 var(--navds-search-color-border-hover) inset,
-    -1px 0 0 0 var(--navds-search-color-border-hover);
+  box-shadow: -1px 0 0 0 var(--navds-search-color-border-hover) inset, 0 1px 0 0 var(--navds-search-color-border-hover) inset,
+    0 -1px 0 0 var(--navds-search-color-border-hover) inset, -1px 0 0 0 var(--navds-search-color-border-hover);
   z-index: 1;
 }
 
-.navds-search__wrapper-inner:focus-within
-  + .navds-search__button-search.navds-button--secondary:hover {
+.navds-search__wrapper-inner:focus-within + .navds-search__button-search.navds-button--secondary:hover {
   z-index: auto;
 }
 
 .navds-search__button-search.navds-button--secondary:focus {
-  box-shadow: 0 0 0 1px var(--navds-search-color-border) inset,
-    var(--navds-shadow-focus);
+  box-shadow: 0 0 0 1px var(--navds-search-color-border) inset, var(--navds-shadow-focus);
 }
 
 .navds-search__button-search.navds-button--secondary:focus:hover {
-  box-shadow: 0 0 0 1px var(--navds-search-color-border-hover) inset,
-    var(--navds-shadow-focus);
+  box-shadow: 0 0 0 1px var(--navds-search-color-border-hover) inset, var(--navds-shadow-focus);
 }
 
 .navds-search__button-search.navds-button--secondary:focus:active {
@@ -160,8 +152,7 @@
 }
 
 .navds-search--error .navds-search__input:focus:not(:hover):not(:disabled) {
-  box-shadow: inset 0 0 0 1px var(--navds-search-color-border-error),
-    var(--navds-shadow-focus);
+  box-shadow: inset 0 0 0 1px var(--navds-search-color-border-error), var(--navds-shadow-focus);
 }
 
 /* Focus layering */

--- a/@navikt/core/css/form/select.css
+++ b/@navikt/core/css/form/select.css
@@ -1,22 +1,12 @@
 :root,
 :host {
-  --navds-select-color-background: var(
-    --navds-semantic-color-component-background-light
-  );
+  --navds-select-color-background: var(--navds-semantic-color-component-background-light);
   --navds-select-color-border: var(--navds-semantic-color-border);
-  --navds-select-color-border-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-select-color-border-error: var(
-    --navds-semantic-color-interaction-danger
-  );
-  --navds-select-color-shadow-error: var(
-    --navds-semantic-color-interaction-danger
-  );
+  --navds-select-color-border-hover: var(--navds-semantic-color-interaction-primary);
+  --navds-select-color-border-error: var(--navds-semantic-color-interaction-danger);
+  --navds-select-color-shadow-error: var(--navds-semantic-color-interaction-danger);
   --navds-select-color-border-disabled: var(--navds-global-color-gray-400);
-  --navds-select-color-background-disabled: var(
-    --navds-semantic-color-component-background-alternate
-  );
+  --navds-select-color-background-disabled: var(--navds-semantic-color-component-background-alternate);
 }
 
 .navds-select__input {

--- a/@navikt/core/css/form/switch.css
+++ b/@navikt/core/css/form/switch.css
@@ -1,32 +1,16 @@
 :root,
 :host {
   --navds-switch-color-label: var(--navds-semantic-color-text);
-  --navds-switch-color-label-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
+  --navds-switch-color-label-hover: var(--navds-semantic-color-interaction-primary);
   --navds-switch-color-track-background: var(--navds-semantic-color-text-muted);
-  --navds-switch-color-track-background-checked: var(
-    --navds-semantic-color-feedback-success-border
-  );
-  --navds-switch-color-track-background-hover: var(
-    --navds-global-color-gray-800
-  );
-  --navds-switch-color-track-background-hover-checked: var(
-    --navds-semantic-color-feedback-success-icon
-  );
-  --navds-switch-color-track-shadow-inner-focus: var(
-    --navds-semantic-color-component-background-light
-  );
-  --navds-switch-color-thumb: var(
-    --navds-semantic-color-component-background-light
-  );
+  --navds-switch-color-track-background-checked: var(--navds-semantic-color-feedback-success-border);
+  --navds-switch-color-track-background-hover: var(--navds-global-color-gray-800);
+  --navds-switch-color-track-background-hover-checked: var(--navds-semantic-color-feedback-success-icon);
+  --navds-switch-color-track-shadow-inner-focus: var(--navds-semantic-color-component-background-light);
+  --navds-switch-color-thumb: var(--navds-semantic-color-component-background-light);
   --navds-switch-color-thumb-icon: var(--navds-semantic-color-text-muted);
-  --navds-switch-color-thumb-icon-checked: var(
-    --navds-semantic-color-feedback-success-border
-  );
-  --navds-switch-color-thumb-loader-checked: var(
-    --navds-semantic-color-feedback-success-border
-  );
+  --navds-switch-color-thumb-icon-checked: var(--navds-semantic-color-feedback-success-border);
+  --navds-switch-color-thumb-loader-checked: var(--navds-semantic-color-feedback-success-border);
 }
 
 .navds-switch {
@@ -78,21 +62,15 @@
 }
 
 .navds-switch--small > .navds-switch__label-wrapper > .navds-switch__content {
-  padding: calc(var(--navds-spacing-2) - 2px) 0
-    calc(var(--navds-spacing-2) - 2px) 3.25rem;
+  padding: calc(var(--navds-spacing-2) - 2px) 0 calc(var(--navds-spacing-2) - 2px) 3.25rem;
 }
 
-.navds-switch--right.navds-switch--small
-  > .navds-switch__label-wrapper
-  > .navds-switch__content {
-  padding: calc(var(--navds-spacing-2) - 2px) 3.25rem
-    calc(var(--navds-spacing-2) - 2px) 0;
+.navds-switch--right.navds-switch--small > .navds-switch__label-wrapper > .navds-switch__content {
+  padding: calc(var(--navds-spacing-2) - 2px) 3.25rem calc(var(--navds-spacing-2) - 2px) 0;
 }
 
 .navds-switch--with-description,
-.navds-switch--small
-  > .navds-switch__label-wrapper
-  > .navds-switch--with-description {
+.navds-switch--small > .navds-switch__label-wrapper > .navds-switch--with-description {
   padding-bottom: 0;
 }
 
@@ -148,8 +126,7 @@
 }
 
 .navds-switch__input:focus ~ .navds-switch__track {
-  box-shadow: 0 0 0 1px var(--navds-switch-color-track-shadow-inner-focus),
-    var(--navds-shadow-focus);
+  box-shadow: 0 0 0 1px var(--navds-switch-color-track-shadow-inner-focus), var(--navds-shadow-focus);
 }
 
 /* Thumb */
@@ -179,30 +156,21 @@
     transform: translateX(2px);
   }
 
-  .navds-switch__input:checked:hover
-    ~ .navds-switch__track
-    > .navds-switch__thumb {
+  .navds-switch__input:checked:hover ~ .navds-switch__track > .navds-switch__thumb {
     transform: translateX(18px);
   }
 }
 
-.navds-switch__input:disabled:hover
-  ~ .navds-switch__track
-  > .navds-switch__thumb {
+.navds-switch__input:disabled:hover ~ .navds-switch__track > .navds-switch__thumb {
   transform: translateX(0);
 }
 
-.navds-switch__input:checked:disabled:hover
-  ~ .navds-switch__track
-  > .navds-switch__thumb {
+.navds-switch__input:checked:disabled:hover ~ .navds-switch__track > .navds-switch__thumb {
   transform: translateX(20px);
 }
 
 /* Loader */
-.navds-switch__input:checked
-  ~ .navds-switch__track
-  > .navds-switch__thumb
-  .navds-loader__foreground {
+.navds-switch__input:checked ~ .navds-switch__track > .navds-switch__thumb .navds-loader__foreground {
   stroke: var(--navds-switch-color-thumb-loader-checked);
 }
 

--- a/@navikt/core/css/form/text-field.css
+++ b/@navikt/core/css/form/text-field.css
@@ -2,34 +2,20 @@
 :host,
 [data-theme="light"] {
   --navds-text-field-color-text: var(--navds-semantic-color-text);
-  --navds-text-field-color-background: var(
-    --navds-semantic-color-component-background-light
-  );
+  --navds-text-field-color-background: var(--navds-semantic-color-component-background-light);
   --navds-text-field-color-border: var(--navds-semantic-color-border);
-  --navds-text-field-color-border-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-text-field-color-border-error: var(
-    --navds-semantic-color-interaction-danger
-  );
-  --navds-text-field-color-shadow-error: var(
-    --navds-semantic-color-interaction-danger
-  );
+  --navds-text-field-color-border-hover: var(--navds-semantic-color-interaction-primary);
+  --navds-text-field-color-border-error: var(--navds-semantic-color-interaction-danger);
+  --navds-text-field-color-shadow-error: var(--navds-semantic-color-interaction-danger);
   --navds-text-field-color-border-disabled: var(--navds-global-color-gray-400);
-  --navds-text-field-color-background-disabled: var(
-    --navds-semantic-color-component-background-alternate
-  );
+  --navds-text-field-color-background-disabled: var(--navds-semantic-color-component-background-alternate);
   --navds-text-field-color-text-disabled: var(--navds-semantic-color-text);
-  --navds-text-field-color-placeholder-text: var(
-    --navds-semantic-color-text-muted
-  );
+  --navds-text-field-color-placeholder-text: var(--navds-semantic-color-text-muted);
 }
 
 [data-theme="dark"] {
   --navds-text-field-color-text: var(--navds-semantic-color-text-inverted);
-  --navds-text-field-color-background: var(
-    --navds-semantic-color-component-background-inverted
-  );
+  --navds-text-field-color-background: var(--navds-semantic-color-component-background-inverted);
   --navds-text-field-color-border: var(--navds-semantic-color-border-inverted);
   --navds-text-field-color-border-hover: var(--navds-global-color-blue-200);
   --navds-text-field-color-placeholder-text: var(--navds-global-color-gray-500);
@@ -76,10 +62,8 @@
   box-shadow: 0 0 0 1px var(--navds-text-field-color-border-error);
 }
 
-.navds-text-field--error
-  > .navds-text-field__input:focus:not(:hover):not(:disabled) {
-  box-shadow: 0 0 0 1px var(--navds-text-field-color-border-error),
-    var(--navds-shadow-focus);
+.navds-text-field--error > .navds-text-field__input:focus:not(:hover):not(:disabled) {
+  box-shadow: 0 0 0 1px var(--navds-text-field-color-border-error), var(--navds-shadow-focus);
 }
 
 /* Disabled handling */

--- a/@navikt/core/css/form/textarea.css
+++ b/@navikt/core/css/form/textarea.css
@@ -1,27 +1,15 @@
 :root,
 :host {
-  --navds-textarea-color-background: var(
-    --navds-semantic-color-component-background-light
-  );
+  --navds-textarea-color-background: var(--navds-semantic-color-component-background-light);
   --navds-textarea-color-border: var(--navds-semantic-color-border);
-  --navds-textarea-color-border-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-textarea-color-border-error: var(
-    --navds-semantic-color-interaction-danger
-  );
-  --navds-textarea-color-shadow-error: var(
-    --navds-semantic-color-interaction-danger
-  );
+  --navds-textarea-color-border-hover: var(--navds-semantic-color-interaction-primary);
+  --navds-textarea-color-border-error: var(--navds-semantic-color-interaction-danger);
+  --navds-textarea-color-shadow-error: var(--navds-semantic-color-interaction-danger);
   --navds-textarea-color-counter-text: var(--navds-semantic-color-text-muted);
-  --navds-textarea-color-counter-text-error: var(
-    --navds-semantic-color-interaction-danger
-  );
+  --navds-textarea-color-counter-text-error: var(--navds-semantic-color-interaction-danger);
   --navds-textarea-color-text-disabled: var(--navds-semantic-color-text);
   --navds-textarea-color-border-disabled: var(--navds-global-color-gray-400);
-  --navds-textarea-color-background-disabled: var(
-    --navds-semantic-color-component-background-alternate
-  );
+  --navds-textarea-color-background-disabled: var(--navds-semantic-color-component-background-alternate);
 }
 
 .navds-textarea__wrapper {
@@ -84,8 +72,7 @@
 /**
   Error handling
 */
-.navds-textarea--error
-  .navds-textarea__input:not(:hover):not(:focus):not(:disabled) {
+.navds-textarea--error .navds-textarea__input:not(:hover):not(:focus):not(:disabled) {
   box-shadow: 0 0 0 1px var(--navds-textarea-color-shadow-error);
   border-color: var(--navds-textarea-color-border-error);
 }

--- a/@navikt/core/css/guide-panel.css
+++ b/@navikt/core/css/guide-panel.css
@@ -1,12 +1,8 @@
 :root,
 :host {
-  --navds-guide-panel-color-background: var(
-    --navds-semantic-color-component-background-light
-  );
+  --navds-guide-panel-color-background: var(--navds-semantic-color-component-background-light);
   --navds-guide-panel-color-border: var(--navds-global-color-blue-400);
-  --navds-guide-panel-color-illustration-background: var(
-    --navds-global-color-blue-200
-  );
+  --navds-guide-panel-color-illustration-background: var(--navds-global-color-blue-200);
 }
 
 /**

--- a/@navikt/core/css/help-text.css
+++ b/@navikt/core/css/help-text.css
@@ -1,24 +1,12 @@
 :root,
 :host {
   --navds-help-text-color: var(--navds-semantic-color-interaction-primary);
-  --navds-help-text-color-hover: var(
-    --navds-semantic-color-component-background-light
-  );
-  --navds-help-text-color-focus: var(
-    --navds-semantic-color-component-background-light
-  );
-  --navds-help-text-color-background-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-help-text-color-background-focus: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-help-text-color-shadow-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-help-text-color-popover-background: var(
-    --navds-semantic-color-feedback-info-background
-  );
+  --navds-help-text-color-hover: var(--navds-semantic-color-component-background-light);
+  --navds-help-text-color-focus: var(--navds-semantic-color-component-background-light);
+  --navds-help-text-color-background-hover: var(--navds-semantic-color-interaction-primary);
+  --navds-help-text-color-background-focus: var(--navds-semantic-color-interaction-primary);
+  --navds-help-text-color-shadow-hover: var(--navds-semantic-color-interaction-primary);
+  --navds-help-text-color-popover-background: var(--navds-semantic-color-feedback-info-background);
 }
 
 .navds-help-text__button {
@@ -37,8 +25,7 @@
 
 .navds-help-text__button:focus {
   outline: none;
-  box-shadow: 0 0 0 1px var(--navds-global-color-white),
-    0 0 0 4px var(--navds-semantic-color-focus);
+  box-shadow: 0 0 0 1px var(--navds-global-color-white), 0 0 0 4px var(--navds-semantic-color-focus);
 }
 
 .navds-help-text__icon {
@@ -60,12 +47,10 @@
   display: none;
 }
 
-.navds-help-text__button:where(:hover, :focus, [aria-expanded="true"])
-  > .navds-help-text__icon {
+.navds-help-text__button:where(:hover, :focus, [aria-expanded="true"]) > .navds-help-text__icon {
   display: none;
 }
 
-.navds-help-text__button:where(:hover, :focus, [aria-expanded="true"])
-  > .navds-help-text__icon--filled {
+.navds-help-text__button:where(:hover, :focus, [aria-expanded="true"]) > .navds-help-text__icon--filled {
   display: inherit;
 }

--- a/@navikt/core/css/link-panel.css
+++ b/@navikt/core/css/link-panel.css
@@ -1,9 +1,7 @@
 :root,
 :host {
   --navds-link-panel-color-text: var(--navds-semantic-color-text);
-  --navds-link-panel-color-border-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
+  --navds-link-panel-color-border-hover: var(--navds-semantic-color-interaction-primary);
   --navds-link-panel-color-title-hover: var(--navds-semantic-color-link);
 }
 

--- a/@navikt/core/css/loader.css
+++ b/@navikt/core/css/loader.css
@@ -3,9 +3,7 @@
   --navds-loader-color-foreground: var(--navds-global-color-gray-400);
   --navds-loader-color-background: rgb(0 0 0 / 0.05);
   --navds-loader-color-neutral-foreground: var(--navds-global-color-gray-400);
-  --navds-loader-color-interaction-foreground: var(
-    --navds-global-color-blue-500
-  );
+  --navds-loader-color-interaction-foreground: var(--navds-global-color-blue-500);
   --navds-loader-color-inverted-foreground: var(--navds-global-color-white);
   --navds-loader-color-inverted-background: rgb(255 255 255 / 0.25);
   --navds-loader-color-transparent-background: transparent;

--- a/@navikt/core/css/modal.css
+++ b/@navikt/core/css/modal.css
@@ -1,8 +1,6 @@
 :root,
 :host {
-  --navds-modal-color-background: var(
-    --navds-semantic-color-component-background-light
-  );
+  --navds-modal-color-background: var(--navds-semantic-color-component-background-light);
   --navds-modal-color-overlay: rgb(38 38 38 / 0.7);
 }
 

--- a/@navikt/core/css/pagination.css
+++ b/@navikt/core/css/pagination.css
@@ -1,11 +1,7 @@
 :root,
 :host {
-  --navds-pagination-color-background-selected: var(
-    --navds-semantic-color-interaction-primary-selected
-  );
-  --navds-pagination-color-text-selected: var(
-    --navds-semantic-color-text-inverted
-  );
+  --navds-pagination-color-background-selected: var(--navds-semantic-color-interaction-primary-selected);
+  --navds-pagination-color-text-selected: var(--navds-semantic-color-text-inverted);
 }
 
 .navds-pagination__list {
@@ -46,8 +42,7 @@
 }
 
 .navds-pagination__item[aria-current="true"]:focus {
-  box-shadow: inset 0 0 0 1px var(--navds-button-color-tertiary-border-active),
-    var(--navds-shadow-focus);
+  box-shadow: inset 0 0 0 1px var(--navds-button-color-tertiary-border-active), var(--navds-shadow-focus);
 }
 
 .navds-pagination__prev-next {
@@ -56,14 +51,12 @@
   gap: var(--navds-spacing-1);
 }
 
-.navds-pagination--small
-  .navds-pagination__prev-next:where(.navds-pagination--prev-next--with-text) {
+.navds-pagination--small .navds-pagination__prev-next:where(.navds-pagination--prev-next--with-text) {
   padding-left: 0.375rem;
   padding-right: 0.375rem;
 }
 
-.navds-pagination--xsmall
-  .navds-pagination__prev-next:where(.navds-pagination--prev-next--with-text) {
+.navds-pagination--xsmall .navds-pagination__prev-next:where(.navds-pagination--prev-next--with-text) {
   padding-left: 0.125rem;
   padding-right: 0.125rem;
 }

--- a/@navikt/core/css/panel.css
+++ b/@navikt/core/css/panel.css
@@ -1,8 +1,6 @@
 :root,
 :host {
-  --navds-panel-color-background: var(
-    --navds-semantic-color-component-background-light
-  );
+  --navds-panel-color-background: var(--navds-semantic-color-component-background-light);
   --navds-panel-color-border: var(--navds-semantic-color-border-muted);
 }
 

--- a/@navikt/core/css/popover.css
+++ b/@navikt/core/css/popover.css
@@ -1,8 +1,6 @@
 :root,
 :host {
-  --navds-popover-color-background: var(
-    --navds-semantic-color-component-background-light
-  );
+  --navds-popover-color-background: var(--navds-semantic-color-component-background-light);
   --navds-popover-color-border: var(--navds-semantic-color-border-muted);
 }
 

--- a/@navikt/core/css/read-more.css
+++ b/@navikt/core/css/read-more.css
@@ -8,8 +8,7 @@
   gap: 0.125rem;
   color: var(--navds-semantic-color-link);
   border-radius: var(--navds-border-radius-small);
-  padding: var(--navds-spacing-1) var(--navds-spacing-1) var(--navds-spacing-1)
-    2px;
+  padding: var(--navds-spacing-1) var(--navds-spacing-1) var(--navds-spacing-1) 2px;
   text-align: start;
 }
 
@@ -47,9 +46,7 @@
   height: 1.25rem;
 }
 
-.navds-read-more--open
-  > .navds-read-more__button
-  > .navds-read-more__expand-icon {
+.navds-read-more--open > .navds-read-more__button > .navds-read-more__expand-icon {
   transform: rotate(-180deg);
 }
 
@@ -57,8 +54,7 @@
   display: none;
 }
 
-.navds-read-more__button:hover
-  > .navds-read-more__expand-icon.navds-read-more__expand-icon--filled {
+.navds-read-more__button:hover > .navds-read-more__expand-icon.navds-read-more__expand-icon--filled {
   display: inherit;
 }
 

--- a/@navikt/core/css/stepper.css
+++ b/@navikt/core/css/stepper.css
@@ -36,8 +36,7 @@
   grid-column: 1;
 }
 
-.navds-stepper__step--behind.navds-stepper__step--completed
-  + .navds-stepper__line {
+.navds-stepper__step--behind.navds-stepper__step--completed + .navds-stepper__line {
   background-color: var(--navds-global-color-blue-500);
 }
 
@@ -64,8 +63,7 @@
   text-decoration: none;
   cursor: pointer;
   padding: var(--navds-stepper-border-width);
-  margin: calc(var(--navds-stepper-border-width) * -1)
-    calc(var(--navds-stepper-border-width) * -1) 1.75rem;
+  margin: calc(var(--navds-stepper-border-width) * -1) calc(var(--navds-stepper-border-width) * -1) 1.75rem;
 }
 
 button.navds-stepper__step {
@@ -117,9 +115,7 @@ button.navds-stepper__step {
 :where(.navds-stepper--horizontal) .navds-stepper__item {
   flex: 1 1 100%;
   grid-template-columns:
-    [line-1-start] 1fr [step-start] auto [line-1-end] var(
-      --navds-stepper-circle-size
-    )
+    [line-1-start] 1fr [step-start] auto [line-1-end] var(--navds-stepper-circle-size)
     [line-2-start] auto [step-end] 1fr [line-2-end];
   grid-template-rows: var(--navds-stepper-circle-size) auto;
 }
@@ -141,10 +137,8 @@ button.navds-stepper__step {
   grid-column: line-2;
 }
 
-:where(.navds-stepper--horizontal .navds-stepper__item:first-of-type)
-  .navds-stepper__line--1,
-:where(.navds-stepper--horizontal .navds-stepper__item:last-of-type)
-  .navds-stepper__line--2 {
+:where(.navds-stepper--horizontal .navds-stepper__item:first-of-type) .navds-stepper__line--1,
+:where(.navds-stepper--horizontal .navds-stepper__item:last-of-type) .navds-stepper__line--2 {
   visibility: hidden;
 }
 
@@ -181,8 +175,7 @@ button.navds-stepper__step {
   text-decoration: underline;
 }
 
-:where(.navds-stepper__step--non-interactive:hover, .navds-stepper__step--active:hover)
-  .navds-stepper__content {
+:where(.navds-stepper__step--non-interactive:hover, .navds-stepper__step--active:hover) .navds-stepper__content {
   text-decoration: none;
 }
 
@@ -192,26 +185,20 @@ button.navds-stepper__step {
   color: var(--navds-semantic-color-text-inverted);
 }
 
-:where(.navds-stepper__step:not(.navds-stepper__step--active):hover)
-  .navds-stepper__circle {
-  background-color: var(
-    --navds-semantic-color-interaction-primary-hover-subtle
-  );
+:where(.navds-stepper__step:not(.navds-stepper__step--active):hover) .navds-stepper__circle {
+  background-color: var(--navds-semantic-color-interaction-primary-hover-subtle);
 }
 
 /* Non-interactive */
-:where(.navds-stepper__step--non-interactive.navds-stepper__step--active)
-  .navds-stepper__content {
+:where(.navds-stepper__step--non-interactive.navds-stepper__step--active) .navds-stepper__content {
   color: var(--navds-global-color-gray-900);
 }
 
-.navds-stepper__step--non-interactive.navds-stepper__step--behind.navds-stepper__step--completed
-  + .navds-stepper__line {
+.navds-stepper__step--non-interactive.navds-stepper__step--behind.navds-stepper__step--completed + .navds-stepper__line {
   background-color: var(--navds-global-color-gray-600);
 }
 
-:where(.navds-stepper__step--non-interactive.navds-stepper__step--active)
-  .navds-stepper__circle {
+:where(.navds-stepper__step--non-interactive.navds-stepper__step--active) .navds-stepper__circle {
   background-color: var(--navds-global-color-gray-900);
   border-color: var(--navds-global-color-gray-900);
   color: var(--navds-global-color-white);
@@ -221,18 +208,15 @@ button.navds-stepper__step {
   background-color: transparent;
 }
 
-:where(.navds-stepper__step--non-interactive.navds-stepper__step--active:hover)
-  .navds-stepper__circle {
+:where(.navds-stepper__step--non-interactive.navds-stepper__step--active:hover) .navds-stepper__circle {
   background-color: var(--navds-global-color-gray-900);
 }
 
-:where(.navds-stepper__step--completed.navds-stepper__step--active)
-  .navds-stepper__circle {
+:where(.navds-stepper__step--completed.navds-stepper__step--active) .navds-stepper__circle {
   background-color: inherit;
   color: var(--navds-global-color-deepblue-500);
 }
 
-:where(.navds-stepper__step--completed.navds-stepper__step--active.navds-stepper__step--non-interactive)
-  .navds-stepper__circle {
+:where(.navds-stepper__step--completed.navds-stepper__step--active.navds-stepper__step--non-interactive) .navds-stepper__circle {
   color: var(--navds-global-color-gray-900);
 }

--- a/@navikt/core/css/table.css
+++ b/@navikt/core/css/table.css
@@ -1,18 +1,10 @@
 :root,
 :host {
   --navds-table-cell-color-border: var(--navds-semantic-color-border-muted);
-  --navds-table-row-color-background-hover: var(
-    --navds-semantic-color-canvas-background
-  );
-  --navds-table-row-color-background-selected: var(
-    --navds-semantic-color-interaction-primary-hover-subtle
-  );
-  --navds-table-row-color-background-selected-hover: var(
-    --navds-global-color-blue-100
-  );
-  --navds-table-row-color-background-zebra: var(
-    --navds-semantic-color-component-background-alternate
-  );
+  --navds-table-row-color-background-hover: var(--navds-semantic-color-canvas-background);
+  --navds-table-row-color-background-selected: var(--navds-semantic-color-interaction-primary-hover-subtle);
+  --navds-table-row-color-background-selected-hover: var(--navds-global-color-blue-100);
+  --navds-table-row-color-background-zebra: var(--navds-semantic-color-component-background-alternate);
   --navds-table-cell-color-border-hover: var(--navds-semantic-color-border);
 }
 
@@ -42,27 +34,21 @@
   background-color: var(--navds-table-row-color-background-selected);
 }
 
-.navds-table__body
-  .navds-table__row--shade-on-hover.navds-table__row--selected:hover {
+.navds-table__body .navds-table__row--shade-on-hover.navds-table__row--selected:hover {
   background-color: var(--navds-table-row-color-background-selected-hover);
 }
 
-.navds-table--zebra-stripes
-  .navds-table__body
-  :where(.navds-table__row:nth-child(odd):not(.navds-table__row--selected)) {
+.navds-table--zebra-stripes .navds-table__body :where(.navds-table__row:nth-child(odd):not(.navds-table__row--selected)) {
   background-color: var(--navds-table-row-color-background-zebra);
 }
 
 .navds-table--zebra-stripes
   .navds-table__body
-  :where(.navds-table__expandable-row:nth-child(4n
-      + 1):not(.navds-table__row--selected)) {
+  :where(.navds-table__expandable-row:nth-child(4n + 1):not(.navds-table__row--selected)) {
   background-color: transparent;
 }
 
-.navds-table--zebra-stripes
-  .navds-table__body
-  .navds-table__expanded-row:nth-child(4n) {
+.navds-table--zebra-stripes .navds-table__body .navds-table__expanded-row:nth-child(4n) {
   background-color: var(--navds-table-row-color-background-zebra);
 }
 
@@ -89,10 +75,8 @@
   text-align: center;
 }
 
-:where(.navds-table__body .navds-table__row--shade-on-hover:hover)
-  .navds-table__header-cell,
-:where(.navds-table__body .navds-table__row--shade-on-hover:hover)
-  .navds-table__data-cell {
+:where(.navds-table__body .navds-table__row--shade-on-hover:hover) .navds-table__header-cell,
+:where(.navds-table__body .navds-table__row--shade-on-hover:hover) .navds-table__data-cell {
   border-color: var(--navds-table-cell-color-border-hover);
 }
 
@@ -168,8 +152,7 @@
   flex-shrink: 0;
 }
 
-.navds-table__expandable-row:not(.navds-table__expandable-row--open)
-  .navds-table__data-cell {
+.navds-table__expandable-row:not(.navds-table__expandable-row--open) .navds-table__data-cell {
   transition: border-bottom-color 190ms cubic-bezier(0.6, 0.04, 0.98, 0.335);
 }
 

--- a/@navikt/core/css/tag.css
+++ b/@navikt/core/css/tag.css
@@ -1,33 +1,15 @@
 :root,
 :host {
   --navds-tag-color-border: var(--navds-semantic-color-border-muted);
-  --navds-tag-color-background: var(
-    --navds-semantic-color-component-background-alternate
-  );
-  --navds-tag-color-info-background: var(
-    --navds-semantic-color-feedback-info-background
-  );
-  --navds-tag-color-info-border: var(
-    --navds-semantic-color-feedback-info-border
-  );
-  --navds-tag-color-warning-background: var(
-    --navds-semantic-color-feedback-warning-background
-  );
-  --navds-tag-color-warning-border: var(
-    --navds-semantic-color-feedback-warning-border
-  );
-  --navds-tag-color-success-background: var(
-    --navds-semantic-color-feedback-success-background
-  );
-  --navds-tag-color-success-border: var(
-    --navds-semantic-color-feedback-success-border
-  );
-  --navds-tag-color-error-background: var(
-    --navds-semantic-color-feedback-danger-background
-  );
-  --navds-tag-color-error-border: var(
-    --navds-semantic-color-feedback-danger-border
-  );
+  --navds-tag-color-background: var(--navds-semantic-color-component-background-alternate);
+  --navds-tag-color-info-background: var(--navds-semantic-color-feedback-info-background);
+  --navds-tag-color-info-border: var(--navds-semantic-color-feedback-info-border);
+  --navds-tag-color-warning-background: var(--navds-semantic-color-feedback-warning-background);
+  --navds-tag-color-warning-border: var(--navds-semantic-color-feedback-warning-border);
+  --navds-tag-color-success-background: var(--navds-semantic-color-feedback-success-background);
+  --navds-tag-color-success-border: var(--navds-semantic-color-feedback-success-border);
+  --navds-tag-color-error-background: var(--navds-semantic-color-feedback-danger-background);
+  --navds-tag-color-error-border: var(--navds-semantic-color-feedback-danger-border);
 }
 
 .navds-tag {

--- a/@navikt/core/css/toggle-group.css
+++ b/@navikt/core/css/toggle-group.css
@@ -1,22 +1,12 @@
 :root,
 :host {
-  --navds-toggle-group-color-background: var(
-    --navds-semantic-color-component-background-light
-  );
+  --navds-toggle-group-color-background: var(--navds-semantic-color-component-background-light);
   --navds-toggle-group-color-text: var(--navds-semantic-color-text);
   --navds-toggle-group-color-border: var(--navds-semantic-color-divider);
-  --navds-toggle-group-color-background-hover: var(
-    --navds-semantic-color-interaction-primary-hover-subtle
-  );
-  --navds-toggle-group-color-text-hover: var(
-    --navds-semantic-color-interaction-primary
-  );
-  --navds-toggle-group-color-background-pressed: var(
-    --navds-semantic-color-interaction-primary-selected
-  );
-  --navds-toggle-group-color-text-pressed: var(
-    --navds-semantic-color-text-inverted
-  );
+  --navds-toggle-group-color-background-hover: var(--navds-semantic-color-interaction-primary-hover-subtle);
+  --navds-toggle-group-color-text-hover: var(--navds-semantic-color-interaction-primary);
+  --navds-toggle-group-color-background-pressed: var(--navds-semantic-color-interaction-primary-selected);
+  --navds-toggle-group-color-text-pressed: var(--navds-semantic-color-text-inverted);
 }
 
 .navds-toggle-group__wrapper {
@@ -57,13 +47,11 @@
 
 .navds-toggle-group__button:focus {
   outline: none;
-  box-shadow: 0 0 0 1px var(--navds-toggle-group-color-background),
-    0 0 0 4px var(--navds-semantic-color-focus);
+  box-shadow: 0 0 0 1px var(--navds-toggle-group-color-background), 0 0 0 4px var(--navds-semantic-color-focus);
 }
 
 .navds-toggle-group__button:focus:hover[aria-pressed="false"] {
-  box-shadow: 0 0 0 1px var(--navds-toggle-group-color-background-hover),
-    0 0 0 4px var(--navds-semantic-color-focus);
+  box-shadow: 0 0 0 1px var(--navds-toggle-group-color-background-hover), 0 0 0 4px var(--navds-semantic-color-focus);
 }
 
 .navds-toggle-group__button-inner {
@@ -92,9 +80,6 @@
   font-size: 1.5rem;
 }
 
-.navds-toggle-group--small
-  > .navds-toggle-group__button
-  > .navds-toggle-group__button-inner
-  > svg {
+.navds-toggle-group--small > .navds-toggle-group__button > .navds-toggle-group__button-inner > svg {
   font-size: 1.125rem;
 }

--- a/@navikt/core/css/tooltip.css
+++ b/@navikt/core/css/tooltip.css
@@ -15,8 +15,7 @@
   border-radius: var(--navds-border-radius-small);
   padding: 0 var(--navds-spacing-2);
   align-items: center;
-  filter: drop-shadow(0 2px 4px rgba(0 0 0 / 0.1))
-    drop-shadow(0 4px 6px rgba(0 0 0 / 0.1));
+  filter: drop-shadow(0 2px 4px rgba(0 0 0 / 0.1)) drop-shadow(0 4px 6px rgba(0 0 0 / 0.1));
   display: flex;
   flex-direction: column;
   animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);

--- a/@navikt/core/css/typography.css
+++ b/@navikt/core/css/typography.css
@@ -1,9 +1,7 @@
 :root,
 :host,
 [data-theme="light"] {
-  --navds-error-message-color-text: var(
-    --navds-semantic-color-feedback-danger-text
-  );
+  --navds-error-message-color-text: var(--navds-semantic-color-feedback-danger-text);
 }
 
 [data-theme="dark"] {

--- a/@navikt/internal/css/dropdown.css
+++ b/@navikt/internal/css/dropdown.css
@@ -2,12 +2,8 @@
 :host {
   --navds-dropdown-menu-color: var(--navds-semantic-color-text);
   --navdsi-dropdown-item-color-text: var(--navds-semantic-color-link);
-  --navdsi-dropdown-item-color-background-hover: var(
-    --navds-semantic-color-interaction-primary-hover-subtle
-  );
-  --navdsi-dropdown-item-color-background-active: var(
-    --navds-global-color-blue-200
-  );
+  --navdsi-dropdown-item-color-background-hover: var(--navds-semantic-color-interaction-primary-hover-subtle);
+  --navdsi-dropdown-item-color-background-active: var(--navds-global-color-blue-200);
   --navds-dropdown-item-color-focus: var(--navds-semantic-color-focus);
 }
 
@@ -27,8 +23,7 @@
   border-bottom: 1px solid var(--navds-semantic-color-divider);
 }
 
-.navdsi-dropdown__menu
-  > :not(.navdsi-dropdown__divider):not(.navdsi-dropdown__list) {
+.navdsi-dropdown__menu > :not(.navdsi-dropdown__divider):not(.navdsi-dropdown__list) {
   margin: 0 var(--navds-spacing-4) var(--navds-spacing-3);
 }
 

--- a/@navikt/internal/css/header.css
+++ b/@navikt/internal/css/header.css
@@ -1,9 +1,7 @@
 :root,
 :host {
   --navdsi-header-color-text: var(--navds-semantic-color-text-inverted);
-  --navdsi-header-color-background: var(
-    --navds-semantic-color-component-background-inverted
-  );
+  --navdsi-header-color-background: var(--navds-semantic-color-component-background-inverted);
   --navdsi-header-color-border: var(--navds-semantic-color-border);
   --navdsi-header-focus: inset 0 0 0 2px var(--navds-global-color-blue-100);
   --navdsi-header-color-hover: var(--navds-global-color-gray-800);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,16 @@
     "@navikt/codemod",
     "examples/*"
   ],
-  "prettier": {},
+  "prettier": {
+    "overrides": [
+      {
+        "files": "**/*.css",
+        "options": {
+          "printWidth": 130
+        }
+      }
+    ]
+  },
   "eslintConfig": {
     "extends": [
       "react-app"


### PR DESCRIPTION
Overskrevet print-width for css 

Gjør CSSen lettere å lese og se gjennom. I tillegg blir tokens mer lesbare både i kode og devtools uten linjeskift

Css-selektorer som eks dette 
```
.navds-accordion__item--open
  > .navds-accordion__header:hover
  + *
  .navds-accordion__content
```
er nå mer lesbar
```
.navds-accordion__item--open > .navds-accordion__header:hover + * .navds-accordion__content
```

Css-tokens som

```
background-color: var(
  --navds-button-background-hover,
  var(--navds-global-color-blue-500)
);
```
blir
```
background-color: var(--navds-button-background-hover, var(--navds-global-color-blue-500));
```

Dette er mer et problem fremover da nye token-oppsettet blir vanskelig å lese
```
Før
.navds-chips__removable--neutral:hover {
  --__a-chip-icon-bg: var(
    --a-chip-removable-neutral-icon-hover,
    var(--navds-global-color-gray-400)
  );

  background-color: var(
    --a-chip-removable-action-bg-hover,
    var(--navds-global-color-gray-200)
  );
}

Etter
.navds-chips__removable--neutral:hover {
  --__a-chip-icon-bg: var(--a-chip-removable-neutral-icon-hover, var(--navds-global-color-gray-400));
  
  background-color: var(--a-chip-removable-action-bg-hover, var(--navds-global-color-gray-200));
}
```