### PR TITLE
Set breidda til accordion-header-content til 100%

### DIFF
--- a/@navikt/core/css/accordion.css
+++ b/@navikt/core/css/accordion.css
@@ -28,6 +28,7 @@
 }
 
 .navds-accordion__header-content {
+  width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
Dette gjer det mogleg å høgrestille innhald i accordion-header-content.

Alternativt ynskjer vi tilgang til å style elementet som wrappar header-innhaldet