### PR TITLE
✨ Støtte for 'yy'-format i datepicker/monthpicker

### DIFF
--- a/@navikt/core/react/src/date/hooks/useDatepicker.tsx
+++ b/@navikt/core/react/src/date/hooks/useDatepicker.tsx
@@ -50,7 +50,7 @@ export interface UseDatepickerOptions
    */
   onValidate?: (val: DateValidationT) => void;
   /**
-   * Allows input of yy-format.
+   * Allows input of with 'yy' year format.
    * @default false
    * @Note Decision between 20th and 21st century is based on before(todays year - 80) ? 21st : 20th.
    * In 2023 this equals to 1943 - 2042

--- a/@navikt/core/react/src/date/hooks/useDatepicker.tsx
+++ b/@navikt/core/react/src/date/hooks/useDatepicker.tsx
@@ -49,6 +49,13 @@ export interface UseDatepickerOptions
    * validation-callback
    */
   onValidate?: (val: DateValidationT) => void;
+  /**
+   * Allows input of yy-format.
+   * @default false
+   * @Note Decision between 20th and 21st century is based on before(todays year - 80) ? 21st : 20th.
+   * In 2023 this equals to 1943 - 2042
+   */
+  allowTwoDigitYear?: boolean;
 }
 
 interface UseDatepickerValue {
@@ -112,6 +119,7 @@ export const useDatepicker = (
     inputFormat,
     onValidate,
     defaultMonth,
+    allowTwoDigitYear = true,
   } = opt;
 
   const locale = getLocaleFromString(_locale);
@@ -188,7 +196,13 @@ export const useDatepicker = (
 
   const handleFocus: React.FocusEventHandler<HTMLInputElement> = (e) => {
     !open && setOpen(true);
-    let day = parseDate(e.target.value, today, locale, "date");
+    let day = parseDate(
+      e.target.value,
+      today,
+      locale,
+      "date",
+      allowTwoDigitYear
+    );
     if (isValidDate(day)) {
       setMonth(day);
       setInputValue(formatDateForInput(day, locale, "date", inputFormat));
@@ -196,7 +210,13 @@ export const useDatepicker = (
   };
 
   const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
-    let day = parseDate(e.target.value, today, locale, "date");
+    let day = parseDate(
+      e.target.value,
+      today,
+      locale,
+      "date",
+      allowTwoDigitYear
+    );
     isValidDate(day) &&
       setInputValue(formatDateForInput(day, locale, "date", inputFormat));
   };
@@ -227,7 +247,13 @@ export const useDatepicker = (
   // the calendar’s month.
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     setInputValue(e.target.value);
-    const day = parseDate(e.target.value, today, locale, "date");
+    const day = parseDate(
+      e.target.value,
+      today,
+      locale,
+      "date",
+      allowTwoDigitYear
+    );
 
     const isBefore =
       fromDate && day && differenceInCalendarDays(fromDate, day) > 0;

--- a/@navikt/core/react/src/date/hooks/useMonthPicker.tsx
+++ b/@navikt/core/react/src/date/hooks/useMonthPicker.tsx
@@ -36,7 +36,7 @@ export interface UseMonthPickerOptions
    */
   defaultYear?: Date;
   /**
-   * Allows input of yy-format.
+   * Allows input of with 'yy' year format.
    * @default false
    * @Note Decision between 20th and 21st century is based on before(todays year - 80) ? 21st : 20th.
    * In 2023 this equals to 1943 - 2042

--- a/@navikt/core/react/src/date/hooks/useMonthPicker.tsx
+++ b/@navikt/core/react/src/date/hooks/useMonthPicker.tsx
@@ -35,6 +35,13 @@ export interface UseMonthPickerOptions
    * Default shown year
    */
   defaultYear?: Date;
+  /**
+   * Allows input of yy-format.
+   * @default false
+   * @Note Decision between 20th and 21st century is based on before(todays year - 80) ? 21st : 20th.
+   * In 2023 this equals to 1943 - 2042
+   */
+  allowTwoDigitYear?: boolean;
 }
 
 interface UseMonthPickerValue {
@@ -94,6 +101,7 @@ export const useMonthpicker = (
     inputFormat,
     onValidate,
     defaultYear,
+    allowTwoDigitYear = false,
   } = opt;
 
   const [defaultSelected, setDefaultSelected] = useState(_defaultSelected);
@@ -171,7 +179,13 @@ export const useMonthpicker = (
 
   const handleFocus: React.FocusEventHandler<HTMLInputElement> = (e) => {
     !open && setOpen(true);
-    let day = parseDate(e.target.value, today, locale, "month");
+    let day = parseDate(
+      e.target.value,
+      today,
+      locale,
+      "month",
+      allowTwoDigitYear
+    );
     if (isValidDate(day)) {
       setYear(day);
       setInputValue(formatDateForInput(day, locale, "month", inputFormat));
@@ -179,7 +193,13 @@ export const useMonthpicker = (
   };
 
   const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
-    let day = parseDate(e.target.value, today, locale, "month");
+    let day = parseDate(
+      e.target.value,
+      today,
+      locale,
+      "month",
+      allowTwoDigitYear
+    );
     isValidDate(day) &&
       setInputValue(formatDateForInput(day, locale, "month", inputFormat));
   };
@@ -209,7 +229,13 @@ export const useMonthpicker = (
   // the calendar’s month.
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     setInputValue(e.target.value);
-    const month = parseDate(e.target.value, today, locale, "month");
+    const month = parseDate(
+      e.target.value,
+      today,
+      locale,
+      "month",
+      allowTwoDigitYear
+    );
 
     const isBefore =
       fromDate &&

--- a/@navikt/core/react/src/date/hooks/useRangeDatepicker.tsx
+++ b/@navikt/core/react/src/date/hooks/useRangeDatepicker.tsx
@@ -202,6 +202,7 @@ export const useRangeDatepicker = (
     inputFormat,
     onValidate,
     defaultMonth,
+    allowTwoDigitYear = false,
   } = opt;
 
   const locale = getLocaleFromString(_locale);
@@ -322,7 +323,13 @@ export const useRangeDatepicker = (
 
   const handleFocus = (e, src: RangeT) => {
     !open && setOpen(true);
-    let day = parseDate(e.target.value, today, locale, "date");
+    let day = parseDate(
+      e.target.value,
+      today,
+      locale,
+      "date",
+      allowTwoDigitYear
+    );
     if (isValidDate(day)) {
       setMonth(day);
       src === RANGE.FROM
@@ -334,7 +341,13 @@ export const useRangeDatepicker = (
   };
 
   const handleBlur = (e, src: RangeT) => {
-    let day = parseDate(e.target.value, today, locale, "date");
+    let day = parseDate(
+      e.target.value,
+      today,
+      locale,
+      "date",
+      allowTwoDigitYear
+    );
     if (!isValidDate(day)) {
       return;
     }
@@ -426,7 +439,13 @@ export const useRangeDatepicker = (
     }
 
     if (toInputValue && !selectedRange?.to) {
-      const toDay = parseDate(toInputValue, today, locale, "date");
+      const toDay = parseDate(
+        toInputValue,
+        today,
+        locale,
+        "date",
+        allowTwoDigitYear
+      );
       if (validateDay(toDay)) {
         updateRange({ from: day, to: toDay });
         setMonth(day);
@@ -489,7 +508,13 @@ export const useRangeDatepicker = (
 
   /* live-update datepicker based on changes in inputfields */
   const handleChange = (e, src: RangeT) => {
-    const day = parseDate(e.target.value, today, locale, "date");
+    const day = parseDate(
+      e.target.value,
+      today,
+      locale,
+      "date",
+      allowTwoDigitYear
+    );
     const isBefore = fromDate && differenceInCalendarDays(fromDate, day) > 0;
     const isAfter = toDate && differenceInCalendarDays(day, toDate) > 0;
 

--- a/@navikt/core/react/src/date/utils/__tests__/format-dates.test.ts
+++ b/@navikt/core/react/src/date/utils/__tests__/format-dates.test.ts
@@ -2,7 +2,7 @@ import { parseDate } from "../parse-date";
 import nb from "date-fns/locale/nb";
 import { formatDateForInput } from "../format-date";
 
-const parse = (inp: string) => parseDate(inp, new Date(), nb, "date");
+const parse = (inp: string) => parseDate(inp, new Date(), nb, "date", false);
 
 describe("Format date to correct output", () => {
   test("formatDateForInput", () => {

--- a/@navikt/core/react/src/date/utils/__tests__/format-dates.test.ts
+++ b/@navikt/core/react/src/date/utils/__tests__/format-dates.test.ts
@@ -3,6 +3,8 @@ import nb from "date-fns/locale/nb";
 import { formatDateForInput } from "../format-date";
 
 const parse = (inp: string) => parseDate(inp, new Date(), nb, "date", false);
+const parseTwoDigit = (inp: string) =>
+  parseDate(inp, new Date(), nb, "date", true);
 
 describe("Format date to correct output", () => {
   test("formatDateForInput", () => {
@@ -17,6 +19,14 @@ describe("Format date to correct output", () => {
     );
     expect(formatDateForInput(parse("15/5/2022"), nb, "date")).toEqual(
       "15.05.2022"
+    );
+  });
+  test("formatDateForInput with twoDigitYears", () => {
+    expect(formatDateForInput(parseTwoDigit("15/05/22"), nb, "date")).toEqual(
+      "15.05.2022"
+    );
+    expect(formatDateForInput(parseTwoDigit("1/5/95"), nb, "date")).toEqual(
+      "01.05.1995"
     );
   });
 });

--- a/@navikt/core/react/src/date/utils/__tests__/parse-dates.test.ts
+++ b/@navikt/core/react/src/date/utils/__tests__/parse-dates.test.ts
@@ -4,9 +4,9 @@ import nb from "date-fns/locale/nb";
 import getMonth from "date-fns/getMonth";
 
 const check = (inp: string) =>
-  expect(isValidDate(parseDate(inp, new Date(), nb, "date")));
+  expect(isValidDate(parseDate(inp, new Date(), nb, "date", false)));
 
-const parse = (inp: string) => parseDate(inp, new Date(), nb, "date");
+const parse = (inp: string) => parseDate(inp, new Date(), nb, "date", false);
 
 describe("Parse date-inputs", () => {
   test("No spaces", () => {

--- a/@navikt/core/react/src/date/utils/__tests__/parse-dates.test.ts
+++ b/@navikt/core/react/src/date/utils/__tests__/parse-dates.test.ts
@@ -6,9 +6,12 @@ import getMonth from "date-fns/getMonth";
 const check = (inp: string) =>
   expect(isValidDate(parseDate(inp, new Date(), nb, "date", false)));
 
+const checkTwoDigit = (inp: string) =>
+  expect(isValidDate(parseDate(inp, new Date(), nb, "date", true)));
+
 const parse = (inp: string) => parseDate(inp, new Date(), nb, "date", false);
 
-describe("Parse date-inputs", () => {
+describe("Parse date-inputs with 4-digit years", () => {
   test("No spaces", () => {
     check("11052022").toBeTruthy();
     check("15052022").toBeTruthy();
@@ -31,6 +34,44 @@ describe("Parse date-inputs", () => {
     check("10-5-2022").toBeTruthy();
     check("1-05-2022").toBeTruthy();
     check("10-05-2022").toBeTruthy();
+  });
+});
+
+describe("Parse date-inputs with 2-digit years", () => {
+  test("No spaces", () => {
+    checkTwoDigit("110522").toBeTruthy();
+    checkTwoDigit("150522").toBeTruthy();
+  });
+
+  test(". divider", () => {
+    checkTwoDigit("1.5.22").toBeTruthy();
+    checkTwoDigit("11.05.22").toBeTruthy();
+  });
+
+  test("/ divider", () => {
+    checkTwoDigit("1/5/22").toBeTruthy();
+    checkTwoDigit("10/5/22").toBeTruthy();
+    checkTwoDigit("1/05/22").toBeTruthy();
+    checkTwoDigit("10/05/22").toBeTruthy();
+  });
+
+  test("- divider", () => {
+    checkTwoDigit("1-5-22").toBeTruthy();
+    checkTwoDigit("10-5-22").toBeTruthy();
+    checkTwoDigit("1-05-22").toBeTruthy();
+    checkTwoDigit("10-05-22").toBeTruthy();
+  });
+
+  test("Dissallow 1 and 3 digit years", () => {
+    checkTwoDigit("11052").toBeFalsy();
+    checkTwoDigit("1105222").toBeFalsy();
+    checkTwoDigit("1105999").toBeFalsy();
+  });
+
+  test("Dissallow date before year 1000", () => {
+    checkTwoDigit("11050999").toBeFalsy();
+    checkTwoDigit("11050010").toBeFalsy();
+    checkTwoDigit("11051000").toBeTruthy();
   });
 });
 

--- a/@navikt/core/react/src/date/utils/check-dates.ts
+++ b/@navikt/core/react/src/date/utils/check-dates.ts
@@ -10,7 +10,7 @@ export const dateIsInCurrentMonth = (
 
 /** @private */
 export function isValidDate(day: Date): boolean {
-  return !isNaN(day.getTime());
+  return day && !isNaN(day?.getTime()) && day.getFullYear() > 999;
 }
 
 export const hasNextYear = (year: Date, years: Date[], val: any): boolean => {

--- a/@navikt/core/react/src/date/utils/parse-date.ts
+++ b/@navikt/core/react/src/date/utils/parse-date.ts
@@ -1,4 +1,6 @@
 import parse from "date-fns/parse";
+import isBefore from "date-fns/isBefore";
+import sub from "date-fns/sub";
 import { isValidDate } from ".";
 
 export const INPUT_DATE_STRING_FORMAT_DATE = "dd.MM.yyyy";
@@ -22,18 +24,6 @@ const ALLOWED_INPUT_FORMATS_MONTH = [
   ...ALLOWED_INPUT_FORMATS_DATE,
 ];
 
-const isTwoDigitYear = (dateString, today, locale, formats) => {
-  let parsed;
-  const newFormat = formats.map((x) => x.replace("yyyy", "yy"));
-  for (const format of newFormat) {
-    parsed = parse(dateString, format, today, { locale });
-    if (isValidDate(parsed)) {
-      return true;
-    }
-  }
-  return false;
-};
-
 export const parseDate = (
   date: string,
   today: Date,
@@ -43,14 +33,106 @@ export const parseDate = (
   let parsed;
   const ALLOWED_FORMATS =
     type === "date" ? ALLOWED_INPUT_FORMATS_DATE : ALLOWED_INPUT_FORMATS_MONTH;
-  for (const format of ALLOWED_FORMATS) {
-    parsed = parse(date, format, today, { locale });
-    if (
-      isValidDate(parsed) &&
-      !isTwoDigitYear(date, today, locale, ALLOWED_FORMATS)
-    ) {
-      return parsed;
+
+  const allowTwoDigit = true;
+  if (allowTwoDigit) {
+    for (const format of ALLOWED_FORMATS) {
+      parsed = parse(date, format, today, { locale });
+      if (
+        isValidDate(parsed) &&
+        !isTwoDigitYear(date, today, locale, ALLOWED_FORMATS)
+      ) {
+        console.log("OK 4-digit:", new Date(parsed).getFullYear());
+
+        return parsed;
+      }
+    }
+    for (const format of [
+      ...ALLOWED_FORMATS.map((x) => x.replace("yyyy", "yy")),
+    ]) {
+      parsed = parse(date, format, today, { locale });
+      if (
+        isValidDate(parsed) &&
+        isTwoDigitYear(date, today, locale, ALLOWED_FORMATS)
+      ) {
+        const convertedDate = assignCenturyToDate(date, format, today, locale);
+
+        if (isValidDate(new Date(convertedDate))) {
+          console.log("OK 2-digit:", new Date(convertedDate).getFullYear());
+          return new Date(convertedDate);
+        } else {
+          return new Date("Invalid date");
+        }
+      }
+    }
+    return new Date("Invalid date");
+  } else {
+    for (const format of ALLOWED_FORMATS) {
+      parsed = parse(date, format, today, { locale });
+      if (
+        isValidDate(parsed) &&
+        !isTwoDigitYear(date, today, locale, ALLOWED_FORMATS)
+      ) {
+        return parsed;
+      }
+    }
+    return new Date("Invalid date");
+  }
+};
+
+function isTwoDigitYear(dateString, today, locale, formats) {
+  let parsed;
+  const newFormat = formats.map((x) => x.replace("yyyy", "yy"));
+  for (const format of newFormat) {
+    parsed = parse(dateString, format, today, { locale });
+    if (isValidDate(parsed)) {
+      return true;
     }
   }
+  return false;
+}
+
+function assignCenturyToDate(
+  dateStr: string,
+  format: string,
+  today: Date,
+  locale: Locale
+) {
+  const date20Century = parse(
+    appendCenturyToTwoYearDigitDateString(dateStr, "19"),
+    format.replace("yy", "yyyy"),
+    today,
+    { locale }
+  );
+
+  const date21Century = parse(
+    appendCenturyToTwoYearDigitDateString(dateStr, "20"),
+    format.replace("yy", "yyyy"),
+    today,
+    { locale }
+  );
+
+  if (isValidDate(date20Century) && isValidDate(date21Century)) {
+    return isBefore(
+      date20Century,
+      sub(new Date(), {
+        years: 80,
+      })
+    )
+      ? date21Century
+      : date20Century;
+  }
+
   return new Date("Invalid date");
-};
+}
+
+function appendCenturyToTwoYearDigitDateString(
+  dateString: string,
+  century: "19" | "20"
+) {
+  const twoDigitYear = dateString.slice(-2);
+  return `${dateString.slice(
+    0,
+    dateString.length - 2
+  )}${century}${twoDigitYear}`;
+}

--- a/@navikt/core/react/src/date/utils/parse-date.ts
+++ b/@navikt/core/react/src/date/utils/parse-date.ts
@@ -28,14 +28,14 @@ export const parseDate = (
   date: string,
   today: Date,
   locale: Locale,
-  type: "date" | "month"
+  type: "date" | "month",
+  allowTwoDigitYear: boolean
 ): Date => {
   let parsed;
   const ALLOWED_FORMATS =
     type === "date" ? ALLOWED_INPUT_FORMATS_DATE : ALLOWED_INPUT_FORMATS_MONTH;
 
-  const allowTwoDigit = true;
-  if (allowTwoDigit) {
+  if (allowTwoDigitYear) {
     for (const format of ALLOWED_FORMATS) {
       parsed = parse(date, format, today, { locale });
       if (

--- a/@navikt/core/react/src/date/utils/parse-date.ts
+++ b/@navikt/core/react/src/date/utils/parse-date.ts
@@ -42,8 +42,6 @@ export const parseDate = (
         isValidDate(parsed) &&
         !isTwoDigitYear(date, today, locale, ALLOWED_FORMATS)
       ) {
-        console.log("OK 4-digit:", new Date(parsed).getFullYear());
-
         return parsed;
       }
     }
@@ -58,7 +56,6 @@ export const parseDate = (
         const convertedDate = assignCenturyToDate(date, format, today, locale);
 
         if (isValidDate(new Date(convertedDate))) {
-          console.log("OK 2-digit:", new Date(convertedDate).getFullYear());
           return new Date(convertedDate);
         } else {
           return new Date("Invalid date");

--- a/aksel.nav.no/website/pages/eksempler/datepicker/modal.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/modal.tsx
@@ -52,6 +52,6 @@ const Example = () => {
 export default withDsExample(Example);
 
 export const args = {
-  index: 10,
+  index: 11,
   desc: "Ved bruk av datepicker i Modal er det viktig at 'Escape' ikke lukker selve modalen hvis datepicker er åpen. Bruk 'shouldCloseOnEsc' for å toggle dette når datepicker er åpen.",
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/two-digit-year.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/two-digit-year.tsx
@@ -1,0 +1,26 @@
+import { UNSAFE_DatePicker, UNSAFE_useDatepicker } from "@navikt/ds-react";
+import { withDsExample } from "components/website-modules/examples/withDsExample";
+
+const Example = () => {
+  const { datepickerProps, inputProps, selectedDay } = UNSAFE_useDatepicker({
+    fromDate: new Date("Aug 23 2019"),
+    onDateChange: console.log,
+    allowTwoDigitYear: true,
+  });
+
+  return (
+    <div className="min-h-96">
+      <UNSAFE_DatePicker {...datepickerProps}>
+        <UNSAFE_DatePicker.Input {...inputProps} label="Velg dato" />
+      </UNSAFE_DatePicker>
+      <div className="pt-4">{selectedDay && selectedDay.toDateString()}</div>
+    </div>
+  );
+};
+
+export default withDsExample(Example);
+
+export const args = {
+  index: 10,
+  desc: "Prop allowTwoDigitYear legger til støtte for 'yy'-format. Tilgjengelig year-range vil være fra 1943-2042 (2023).",
+};


### PR DESCRIPTION
https://nav-it.slack.com/archives/C03UJKBR1EW/p1670328185572389

Date-fns støtter yy/yyyy-format på litt uventede måter, eks 10/10/1 -> 2001 og 10/10/201 -> 2010.
Får å løse dette støttes det nå bare datoer med 4-digit og 2-digit år, så eks 201 er ugyldig. Som konsekvens fungerer ikke datoer <1000, men tror ikke det skal være noe problem for Nav sin bruk.

For å støtte 'yy'-format brukes Navs [gamle datepicker](https://github.com/navikt/ds-datepicker/blob/master/src/datepicker/utils/dateFormatUtils.ts#L68) sin løsning for dette problemet. Gyldige 'yy'-år vil da være fra 1943-2042 i 2023 (2023 - 80 år).

Har valgt å gjøre det til en prop som toggler om man skal tillate yy-format, men bør kanskje bare være standard? Og om det ikke er standard, bør det være default at man støtter yy-format, eller opt-in(er opt-in nå)?