### PR TITLE
:bug: Fikset typefeil introdusert i v2.0.6 for ikoner og loader

### DIFF
--- a/.changeset/nice-cows-ring.md
+++ b/.changeset/nice-cows-ring.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-icons": patch
+---
+
+Fikset @types/react v18 feil introdusert i v2.0.6

--- a/@navikt/core/react/src/guide-panel/Illustration.tsx
+++ b/@navikt/core/react/src/guide-panel/Illustration.tsx
@@ -6,11 +6,15 @@ interface SVGRProps {
   titleId?: string;
 }
 
-export const DefaultIllustration = ({
+export type DefaultIllustrationType = React.FunctionComponent<
+  SVGProps<SVGSVGElement> & SVGRProps
+>;
+
+export const DefaultIllustration: DefaultIllustrationType = ({
   title,
   titleId: _titleId,
   ...props
-}: SVGProps<SVGSVGElement> & SVGRProps) => {
+}) => {
   let titleId: string | undefined = useId();
   titleId = title ? (_titleId ? _titleId : "title-" + titleId) : undefined;
 

--- a/@navikt/core/react/src/loader/Loader.tsx
+++ b/@navikt/core/react/src/loader/Loader.tsx
@@ -33,7 +33,12 @@ export interface LoaderProps extends SVGProps<SVGSVGElement> {
   variant?: "neutral" | "interaction" | "inverted";
 }
 
-export const Loader = forwardRef<SVGSVGElement, LoaderProps>(
+/* Workaround for @types/react v17/v18 feil */
+export type LoaderType = React.ForwardRefExoticComponent<
+  LoaderProps & React.RefAttributes<SVGSVGElement>
+>;
+
+export const Loader: LoaderType = forwardRef<SVGSVGElement, LoaderProps>(
   (
     {
       children,

--- a/@navikt/icons/cleanTypes.js
+++ b/@navikt/icons/cleanTypes.js
@@ -1,0 +1,20 @@
+/**
+ * Fikser https://github.com/navikt/Designsystemet/issues/1758
+ */
+
+const fs = require("fs");
+
+const files = fs.readdirSync(`./esm`).filter((x) => x.endsWith(".d.ts"));
+
+files.forEach((file) => {
+  let data = fs.readFileSync(`./esm/${file}`).toString().split("\n");
+
+  data = data.map((x) => {
+    return x.includes("React.ForwardRefExoticComponent")
+      ? x.split(":")[0] +
+          `: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement> & SVGRProps & React.RefAttributes<SVGSVGElement>>;`
+      : x;
+  });
+
+  fs.writeFileSync(`./esm/${file}`, data.join("\n"));
+});

--- a/@navikt/icons/package.json
+++ b/@navikt/icons/package.json
@@ -32,7 +32,7 @@
     "create-package-json-pointers-to-esm": "node ../../scripts/createPackageJsonsWithESMPointers.js",
     "create-icons": "svgr --silent --out-dir src svg",
     "clean": "rimraf src cjs esm",
-    "build": "copyfiles util/* src && yarn create-icons && concurrently \"tsc\" \"tsc -p tsconfig.esm.json\" && yarn create-package-json-pointers-to-esm",
+    "build": "copyfiles util/* src && yarn create-icons && concurrently \"tsc\" \"tsc -p tsconfig.esm.json\" && node cleanTypes.js && yarn create-package-json-pointers-to-esm",
     "update": "ts-node figma/index.ts dotenv/config",
     "test": "jest"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3080,7 +3080,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/ds-codemod@^2.0.18, @navikt/ds-codemod@workspace:@navikt/codemod":
+"@navikt/ds-codemod@^2.1.0, @navikt/ds-codemod@workspace:@navikt/codemod":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-codemod@workspace:@navikt/codemod"
   dependencies:
@@ -3107,7 +3107,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css-internal@^2.0.18, @navikt/ds-css-internal@workspace:@navikt/internal/css":
+"@navikt/ds-css-internal@^2.1.0, @navikt/ds-css-internal@workspace:@navikt/internal/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css-internal@workspace:@navikt/internal/css"
   dependencies:
@@ -3118,11 +3118,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@2.0.18, @navikt/ds-css@^2.0.18, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@2.1.0, @navikt/ds-css@^2.1.0, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": ^2.0.18
+    "@navikt/ds-tokens": ^2.1.0
     normalize.css: ^8.0.1
     postcss: ^8.4.0
     postcss-cli: ^9.0.0
@@ -3131,7 +3131,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-icons@^2.0.18, @navikt/ds-icons@workspace:@navikt/icons":
+"@navikt/ds-icons@^2.1.0, @navikt/ds-icons@workspace:@navikt/icons":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-icons@workspace:@navikt/icons"
   dependencies:
@@ -3167,8 +3167,8 @@ __metadata:
     "@babel/preset-env": 7.19.4
     "@babel/preset-react": 7.18.6
     "@babel/preset-typescript": 7.18.6
-    "@navikt/ds-icons": ^2.0.18
-    "@navikt/ds-react": ^2.0.18
+    "@navikt/ds-icons": ^2.1.0
+    "@navikt/ds-react": ^2.1.0
     "@rollup/plugin-babel": 6.0.2
     "@rollup/plugin-commonjs": 23.0.2
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -3193,12 +3193,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react-internal@^2.0.18, @navikt/ds-react-internal@workspace:@navikt/internal/react":
+"@navikt/ds-react-internal@^2.1.0, @navikt/ds-react-internal@workspace:@navikt/internal/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react-internal@workspace:@navikt/internal/react"
   dependencies:
-    "@navikt/ds-icons": ^2.0.18
-    "@navikt/ds-react": ^2.0.18
+    "@navikt/ds-icons": ^2.1.0
+    "@navikt/ds-react": ^2.1.0
     clsx: ^1.1.1
     concurrently: 7.2.1
     copy-to-clipboard: ^3.3.1
@@ -3214,12 +3214,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@2.0.18, @navikt/ds-react@^2.0.18, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@2.1.0, @navikt/ds-react@^2.1.0, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": 0.17.0
-    "@navikt/ds-icons": ^2.0.18
+    "@navikt/ds-icons": ^2.1.0
     "@radix-ui/react-tabs": 1.0.0
     "@radix-ui/react-toggle-group": 1.0.0
     "@testing-library/dom": 8.13.0
@@ -3255,11 +3255,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@^2.0.18, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@^2.1.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": ^2.0.18
+    "@navikt/ds-tokens": ^2.1.0
     "@types/jest": ^29.0.0
     color: 4.2.3
     jest: ^29.0.0
@@ -3270,7 +3270,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@^2.0.18, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@^2.1.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -7763,14 +7763,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/ds-codemod": ^2.0.18
-    "@navikt/ds-css": ^2.0.18
-    "@navikt/ds-css-internal": ^2.0.18
-    "@navikt/ds-icons": ^2.0.18
-    "@navikt/ds-react": ^2.0.18
-    "@navikt/ds-react-internal": ^2.0.18
-    "@navikt/ds-tailwind": ^2.0.18
-    "@navikt/ds-tokens": ^2.0.18
+    "@navikt/ds-codemod": ^2.1.0
+    "@navikt/ds-css": ^2.1.0
+    "@navikt/ds-css-internal": ^2.1.0
+    "@navikt/ds-icons": ^2.1.0
+    "@navikt/ds-react": ^2.1.0
+    "@navikt/ds-react-internal": ^2.1.0
+    "@navikt/ds-tailwind": ^2.1.0
+    "@navikt/ds-tokens": ^2.1.0
     prettier-plugin-tailwindcss: ^0.1.13
   languageName: unknown
   linkType: soft
@@ -23898,8 +23898,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "shadow-dom@workspace:examples/shadow-dom"
   dependencies:
-    "@navikt/ds-css": 2.0.18
-    "@navikt/ds-react": 2.0.18
+    "@navikt/ds-css": 2.1.0
+    "@navikt/ds-react": 2.1.0
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0
     "@vitejs/plugin-react": ^2.1.0


### PR DESCRIPTION
React v18 har lagt til noen ekstra typer i SVGSVGElement. `tsc` velger å destrukturere props som bruker `SVGSVGElement` ved build, noe som gjør at alle ikonene våre + loader ender opp med å inneholde react 18 spesifikke typer. Dette brekker for alle som ikke bruker  `@types/react: ^18`