### PR TITLE
Unpublished articles crash in preview mode, because the page does not exist

### DIFF
--- a/aksel.nav.no/website/components/layout/page-templates/AkselArtikkel.tsx
+++ b/aksel.nav.no/website/components/layout/page-templates/AkselArtikkel.tsx
@@ -23,6 +23,11 @@ const AkselArtikkelTemplate = ({
   title: string;
 }): JSX.Element => {
   if (!data.content || !data.heading) {
+    console.warn(
+      `Artikkelen har ikke ${
+        !data.content ? "innhold" : "overskrift"
+      }, så den kan ikke vises.`
+    );
     return null;
   }
 

--- a/aksel.nav.no/website/components/layout/page-templates/AkselPrinsipp.tsx
+++ b/aksel.nav.no/website/components/layout/page-templates/AkselPrinsipp.tsx
@@ -22,6 +22,11 @@ const AkselPrinsippTemplate = ({
   title: string;
 }): JSX.Element => {
   if (!data.content || !data.heading) {
+    console.warn(
+      `Artikkelen har ikke ${
+        !data.content ? "innhold" : "overskrift"
+      }, så den kan ikke vises.`
+    );
     return null;
   }
 

--- a/aksel.nav.no/website/pages/god-praksis/artikler/[slug].tsx
+++ b/aksel.nav.no/website/pages/god-praksis/artikler/[slug].tsx
@@ -83,7 +83,7 @@ export const getStaticProps = async ({
       page,
       slug,
       preview,
-      id: page?._id,
+      id: page?._id ?? "",
     },
     notFound: !page && !preview,
     revalidate: 60,


### PR DESCRIPTION
In addition to fixing the root cause, added console warning for not displaying the article if heading or content is missing