### PR TITLE
Fiksar midtstilling av tekst i Select for Firefox

### DIFF
--- a/.changeset/nine-walls-camp.md
+++ b/.changeset/nine-walls-camp.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": minor
+---
+
+Fiksa sentrering av tekst i Select i Firefox

--- a/@navikt/core/css/form/select.css
+++ b/@navikt/core/css/form/select.css
@@ -25,7 +25,6 @@
   position: relative;
   display: flex;
   width: 100%;
-  align-items: center;
   color: var(--a-text-default);
 }
 
@@ -34,6 +33,7 @@
   font-size: 1rem;
   right: 0.5rem;
   pointer-events: none;
+  align-self: center;
 }
 
 .navds-form-field--small .navds-select__input {


### PR DESCRIPTION
## Fiksar problem med vertikal midtstilling i Select i Firefox.

Noko i grunnstylinga av select i Firefox gjer at teksten ikkje legg seg i midten av inputfeltet ved bruk av `align-items: center;` på container. Ved å la teksten ha sin default plassering og heller style chevron med `align-self: center;` får vi midtstilt teksten også hos Firefox.


Har testa denne stylinga i Storybook i Chrome, Safari og Firefox. Legg ved nokre skjermbilete av før og etter endring i styling:

### Før (Firefox)
<img width="196" alt="Før_firefox" src="https://user-images.githubusercontent.com/26256569/220076422-561f27fc-1a6c-4a4b-aa0e-2c56dda10f1e.png">

### Etter (Firefox)
<img width="192" alt="Screenshot 2023-02-20 at 10 29 26" src="https://user-images.githubusercontent.com/26256569/220074418-4d5a9f2a-79c1-4608-a619-6a7ecc04a709.png">

### Før (Chrome)
<img width="199" alt="Før_chrome" src="https://user-images.githubusercontent.com/26256569/220076627-d9449e30-6bdb-4255-ac37-81991fe64e23.png">

### Etter (Chrome)
<img width="196" alt="Etter_chrome" src="https://user-images.githubusercontent.com/26256569/220076682-4d660577-2dfb-4cc9-b9ed-23a997ad213e.png">

### Etter (Safari)
<img width="191" alt="Etter_safari" src="https://user-images.githubusercontent.com/26256569/220076741-489f6b85-4298-441a-a083-12b0880106b1.png">



_(Det er ikkje det same biletet 4 gonger, altså, eg lovar.)_

