### PR TITLE
[Tokens] Breakpoint-tokens

### DIFF
--- a/.changeset/gorgeous-emus-exercise.md
+++ b/.changeset/gorgeous-emus-exercise.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-tailwind": minor
+"@navikt/ds-tokens": minor
+---
+
+Breakpoint-tokens for ds-tokens og ds-tailwind

--- a/@navikt/core/tailwind/src/getBreakpoints.ts
+++ b/@navikt/core/tailwind/src/getBreakpoints.ts
@@ -1,0 +1,11 @@
+import Reducer from "./reducer";
+
+export const getBreakpoints = (tokens: { [key: string]: string | number }) => {
+  const breakpoints = Reducer(tokens, ["breakpoint"]);
+
+  return Object.keys(breakpoints)
+    .filter((key) => !key.includes("xs") && !key.includes("-down"))
+    .reduce((cur, key) => {
+      return Object.assign(cur, { [key]: breakpoints[key] });
+    }, {});
+};

--- a/@navikt/core/tailwind/src/index.ts
+++ b/@navikt/core/tailwind/src/index.ts
@@ -2,6 +2,7 @@
 import * as TokensBuild from "@navikt/ds-tokens/dist/tokens";
 import { writeFileSync } from "fs";
 import { getColors } from "./colors";
+import { getBreakpoints } from "./getBreakpoints";
 import kebabCase from "./kebabCase";
 import Reducer from "./reducer";
 
@@ -16,6 +17,7 @@ const tokens = Object.entries(TokensBuild).reduce(
 const config = {
   theme: {
     colors: getColors(tokens),
+    screen: getBreakpoints(tokens),
     extend: {
       spacing: Reducer(tokens, ["spacing"]),
       zIndex: Reducer(tokens, ["z-index"]),

--- a/@navikt/core/tokens/docs.json
+++ b/@navikt/core/tokens/docs.json
@@ -1,4 +1,15 @@
 {
+  "breakpoints": [
+    { "name": "--a-breakpoint-xs", "value": "0" },
+    { "name": "--a-breakpoint-sm", "value": "480px" },
+    { "name": "--a-breakpoint-sm-down", "value": "479px" },
+    { "name": "--a-breakpoint-md", "value": "768px" },
+    { "name": "--a-breakpoint-md-down", "value": "767px" },
+    { "name": "--a-breakpoint-lg", "value": "1024px" },
+    { "name": "--a-breakpoint-lg-down", "value": "1023px" },
+    { "name": "--a-breakpoint-xl", "value": "1280px" },
+    { "name": "--a-breakpoint-xl-down", "value": "1279px" }
+  ],
   "font": [
     {
       "name": "--a-font-family",

--- a/@navikt/core/tokens/src/index.js
+++ b/@navikt/core/tokens/src/index.js
@@ -3,6 +3,17 @@ const getFontSize = (size) => `${size / baseFontSize}rem`;
 
 module.exports = {
   a: {
+    breakpoint: {
+      xs: { value: "0" },
+      sm: { value: "480px" },
+      "sm-down": { value: "479px" },
+      md: { value: "768px" },
+      "md-down": { value: "767px" },
+      lg: { value: "1024px" },
+      "lg-down": { value: "1023px" },
+      xl: { value: "1280px" },
+      "xl-down": { value: "1279px" },
+    },
     font: {
       family: { value: '"Source Sans Pro", Arial, sans-serif' },
       line: {

--- a/aksel.nav.no/website/components/layout/header/Hamburger.tsx
+++ b/aksel.nav.no/website/components/layout/header/Hamburger.tsx
@@ -63,7 +63,7 @@ export const Hamburger = () => {
           aria={{ modal: true }}
           overlayClassName="header-modal__overlay"
           contentLabel="Meny"
-          className="bg-surface-default xs:max-w-[90%] xs:right-6 xs:left-auto xs:w-96 absolute left-4 top-0 right-4 block rounded py-14 px-11 md:hidden"
+          className="bg-surface-default absolute left-4 top-0 right-4 block rounded py-14 px-11 sm:right-6 sm:left-auto sm:w-96 sm:max-w-[90%] md:hidden"
         >
           <nav aria-label="hovedmeny">
             <ul>

--- a/aksel.nav.no/website/components/layout/header/Header.tsx
+++ b/aksel.nav.no/website/components/layout/header/Header.tsx
@@ -55,7 +55,7 @@ export const Header = ({
         })}
       >
         <div className="mx-auto flex h-full max-w-screen-2xl items-center  pr-4 pt-3 lg:pr-6">
-          <div className="xs:pr-6 xs:pl-4 flex h-11 items-center pr-4 pl-4">
+          <div className="flex h-11 items-center pr-4 pl-4 sm:pr-6 sm:pl-4">
             <Link
               href="/"
               passHref

--- a/aksel.nav.no/website/components/layout/page-templates/AkselPrinsipp.tsx
+++ b/aksel.nav.no/website/components/layout/page-templates/AkselPrinsipp.tsx
@@ -73,7 +73,7 @@ const AkselPrinsippTemplate = ({
       >
         <article className="overflow-x-clip">
           <div
-            className={cl("max-w-aksel xs:w-[90%] mx-auto px-4", {
+            className={cl("max-w-aksel mx-auto px-4 sm:w-[90%]", {
               "pb-32": mainPage,
             })}
           >
@@ -123,7 +123,7 @@ const AkselPrinsippTemplate = ({
               "bg-gray-100": mainPage,
             })}
           >
-            <div className="max-w-aksel xs:w-[90%] mx-auto px-4">
+            <div className="max-w-aksel mx-auto px-4 sm:w-[90%]">
               <div className="pb-16 md:pb-32">
                 <div className="relative mx-auto mt-4 max-w-prose lg:ml-0 lg:grid lg:max-w-none lg:grid-flow-row-dense lg:grid-cols-3 lg:items-start lg:gap-x-12">
                   <TableOfContents
@@ -135,7 +135,7 @@ const AkselPrinsippTemplate = ({
                     {data?.hero_bilde && (
                       <Bilde
                         node={data.hero_bilde as any}
-                        className="xs:-mt-72 -mt-36 mb-10"
+                        className="-mt-36 mb-10 sm:-mt-72"
                       />
                     )}
                     <SanityBlockContent

--- a/aksel.nav.no/website/components/layout/page-templates/WithSidebar.tsx
+++ b/aksel.nav.no/website/components/layout/page-templates/WithSidebar.tsx
@@ -77,7 +77,7 @@ export const WithSidebar = ({
             <main
               tabIndex={-1}
               id="hovedinnhold"
-              className="min-h-screen-header md:max-w-screen-sidebar xs:pl-6 xs:pr-6 relative w-full px-4 focus:outline-none md:pl-0"
+              className="min-h-screen-header md:max-w-screen-sidebar relative w-full px-4 focus:outline-none sm:pl-6 sm:pr-6 md:pl-0"
             >
               <div
                 className={cl(
@@ -145,12 +145,12 @@ export const WithSidebar = ({
                   </div>
                 )}
                 {variant === "landingPage" && (
-                  <div className="xs:block pointer-events-none absolute top-0 right-0 hidden">
+                  <div className="pointer-events-none absolute top-0 right-0 hidden sm:block">
                     <HeaderCube className="text-deepblue-300 z-0 max-h-full" />
                   </div>
                 )}
               </div>
-              <div className={cl("xs:px-6 md:px-10", { flex: withToc })}>
+              <div className={cl("sm:px-6 md:px-10", { flex: withToc })}>
                 {withToc && (
                   <TableOfContentsv2
                     changedState={pageProps["content"]}

--- a/aksel.nav.no/website/components/layout/page-templates/wrappers/NoSidebar.tsx
+++ b/aksel.nav.no/website/components/layout/page-templates/wrappers/NoSidebar.tsx
@@ -19,7 +19,7 @@ export const NoSidebarLayout = ({
         id="hovedinnhold"
         className="aksel-artikkel bg-gray-50 pt-4 focus:outline-none"
       >
-        <div className="max-w-aksel xs:w-[90%] mx-auto px-4">
+        <div className="max-w-aksel mx-auto px-4 sm:w-[90%]">
           <article className="pt-12 pb-16 md:pb-32">{children}</article>
         </div>
         {aside}

--- a/aksel.nav.no/website/components/sanity-modules/DoDont.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/DoDont.tsx
@@ -43,7 +43,7 @@ const Element = ({
   return (
     <figure
       className={cl(
-        "flex min-w-full flex-1 flex-col rounded-t sm:min-w-[440px]",
+        "flex min-w-full flex-1 flex-col rounded-t sm:min-w-[320px]",
         {
           "basis-full": block?.fullwidth,
           "max-w-sm": !block?.fullwidth,

--- a/aksel.nav.no/website/components/sanity-modules/bilde/Bilde.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/bilde/Bilde.tsx
@@ -28,7 +28,7 @@ const Bilde = ({
     <>
       <figure
         className={cl("m-0 mb-8 flex flex-col", style.figure, className, {
-          "sm:max-w-text": node?.small,
+          "md:max-w-text": node?.small,
         })}
       >
         <div

--- a/aksel.nav.no/website/components/sanity-modules/cards/InnholdsKort.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/cards/InnholdsKort.tsx
@@ -15,7 +15,7 @@ const InnholdsKort = ({
   }
 
   return (
-    <article className="shadow-small last-of-type:mb-18 focus-within:ring-border-focus hover:shadow-medium xs:p-8 group relative mb-7 rounded-lg bg-white p-4 ring-1 ring-gray-900/10 focus-within:ring">
+    <article className="shadow-small last-of-type:mb-18 focus-within:ring-border-focus hover:shadow-medium group relative mb-7 rounded-lg bg-white p-4 ring-1 ring-gray-900/10 focus-within:ring sm:p-8">
       <Heading
         spacing
         size="small"

--- a/aksel.nav.no/website/components/sanity-modules/cards/RelatertInnhold.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/cards/RelatertInnhold.tsx
@@ -27,7 +27,7 @@ const RelatertInnhold = ({
       className={cl(
         "relatedCard",
         "mb-8 max-w-4xl gap-4",
-        "xs:grid-cols-2 grid w-full"
+        "grid w-full sm:grid-cols-2"
       )}
     >
       {node.lenker.map((x) => (

--- a/aksel.nav.no/website/components/sanity-modules/code-examples/Examples.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/code-examples/Examples.tsx
@@ -116,7 +116,7 @@ const ComponentExamples = ({
                     title="Kode-eksempler"
                   />
                 </div>
-                <div className="xs:justify-end mb-2 flex justify-center gap-2 rounded-b border border-gray-300 px-2 py-1 text-base ">
+                <div className="mb-2 flex justify-center gap-2 rounded-b border border-gray-300 px-2 py-1 text-base sm:justify-end ">
                   <CodeSandbox code={fil.innhold.trim()} />
                   <Link
                     href={`/eksempler/${node.dir.title}/${fil.navn.replace(

--- a/aksel.nav.no/website/components/sanity-modules/icon-search/ModalContent.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/icon-search/ModalContent.tsx
@@ -74,7 +74,7 @@ import ${icon} from "@navikt/ds-icons/svg/${icon}.svg";`,
 
   return (
     <div className="flex min-w-[300px] max-w-xl shrink flex-col">
-      <div className="xs:flex-row mr-16 inline-flex flex-col justify-between gap-4">
+      <div className="mr-16 inline-flex flex-col justify-between gap-4 sm:flex-row">
         <div>
           <Heading
             spacing

--- a/aksel.nav.no/website/components/sanity-modules/tips/index.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/tips/index.tsx
@@ -17,7 +17,7 @@ const Tips = ({ node }: { node: SanityT.Schema.tips }): JSX.Element => {
       <div
         className={cl(
           style.tips,
-          "linear xs:px-8 my-8 max-w-2xl rounded-r border-l-[6px] border-l-green-200 bg-white px-4 py-4"
+          "linear my-8 max-w-2xl rounded-r border-l-[6px] border-l-green-200 bg-white px-4 py-4 sm:px-8"
         )}
       >
         <Detail
@@ -71,7 +71,7 @@ const Tips = ({ node }: { node: SanityT.Schema.tips }): JSX.Element => {
     <div
       className={cl(
         style.tips,
-        "xs:px-6 my-7 max-w-2xl px-4 py-3 shadow-[inset_5px_0_0_0_var(--a-gray-500),inset_0_0_0_1px_var(--a-gray-200)]"
+        "my-7 max-w-2xl px-4 py-3 shadow-[inset_5px_0_0_0_var(--a-gray-500),inset_0_0_0_1px_var(--a-gray-200)] sm:px-6"
       )}
     >
       <Detail

--- a/aksel.nav.no/website/components/website-modules/TOCv2.tsx
+++ b/aksel.nav.no/website/components/website-modules/TOCv2.tsx
@@ -131,7 +131,7 @@ export function TableOfContentsv2({
   return (
     <aside
       className={cl(
-        "algolia-ignore-index xs:-mr-6 sticky top-20 z-[1] order-1 my-0 ml-6 mb-16 mr-auto h-full w-full max-w-[160px] flex-col items-start md:-mr-10",
+        "algolia-ignore-index sticky top-20 z-[1] order-1 my-0 ml-6 mb-16 mr-auto h-full w-full max-w-[160px] flex-col items-start sm:-mr-6 md:-mr-10",
         {
           hidden: !renderToc,
           "hidden xl:flex": renderToc,

--- a/aksel.nav.no/website/pages/god-praksis/[slug].tsx
+++ b/aksel.nav.no/website/pages/god-praksis/[slug].tsx
@@ -115,7 +115,7 @@ const Page = ({ tema: page }: PageProps): JSX.Element => {
                 />
                 <div
                   className={cl(
-                    "max-w xs:w-96 relative z-10 mb-2 h-fit xl:mt-[10px]",
+                    "max-w relative z-10 mb-2 h-fit sm:w-96 xl:mt-[10px]",
                     { invisible: !hasAnsvarlig }
                   )}
                   aria-hidden={!hasAnsvarlig}

--- a/aksel.nav.no/website/pages/index.tsx
+++ b/aksel.nav.no/website/pages/index.tsx
@@ -111,7 +111,7 @@ const introcards = [
 
 const IntroCards = () => {
   return (
-    <ul className="centered-layout xs:mb-36 mb-40 grid w-full max-w-screen-md grid-cols-2 gap-4 md:gap-6">
+    <ul className="centered-layout mb-40 grid w-full max-w-screen-md grid-cols-2 gap-4 sm:mb-36 md:gap-6">
       {introcards.map(({ icon: Icon, title, desc, href }) => (
         <li key={title} className="grid">
           <Link
@@ -126,7 +126,7 @@ const IntroCards = () => {
               )
             }
           >
-            <span className="xs:flex items-center gap-2">
+            <span className="items-center gap-2 sm:flex">
               <Icon aria-hidden className="shrink-0 text-2xl" role="img" />
               <span className="text-xl font-semibold group-hover:underline">
                 {title}
@@ -175,7 +175,7 @@ const GetStarted = ({
         style={{
           gridTemplateColumns: `repeat(${links.length}, minmax(0, 1fr))`,
         }}
-        className="xs:grid mx-auto mt-6 flex w-fit flex-col place-items-center justify-evenly gap-4 md:gap-8"
+        className="mx-auto mt-6 flex w-fit flex-col place-items-center justify-evenly gap-4 sm:grid md:gap-8"
       >
         {links.map((x) => (
           <li key={x.title}>
@@ -270,11 +270,11 @@ const Forside = ({
 
         <main tabIndex={-1} id="hovedinnhold" className="focus:outline-none">
           <div className="z-20 pb-8">
-            <div className="centered-layout xs:mt-36 xs:mb-18 xs:max-w-screen-xs relative mb-16 mt-20 grid max-w-xs place-items-center text-center">
+            <div className="centered-layout sm:mb-18 sm:max-w-screen-xs relative mb-16 mt-20 grid max-w-xs place-items-center text-center sm:mt-36">
               <Heading
                 level="1"
                 size="xlarge"
-                className="text-deepblue-800 xs:text-[3.5rem] leading-[1.2]"
+                className="text-deepblue-800 leading-[1.2] sm:text-[3.5rem]"
               >
                 {page.title}
               </Heading>
@@ -291,7 +291,7 @@ const Forside = ({
                 <Heading
                   level="2"
                   size="xlarge"
-                  className="text-deepblue-800 xs:text-[3.25rem] mb-8 text-center"
+                  className="text-deepblue-800 mb-8 text-center sm:text-[3.25rem]"
                 >
                   God praksis
                 </Heading>

--- a/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
+++ b/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
@@ -88,7 +88,7 @@ const Page = ({
       <main
         tabIndex={-1}
         id="hovedinnhold"
-        className="aksel-artikkel xs:pb-32 #FEFCE9 overflow-hidden bg-[#FEFCE9] pt-[8vw] pb-16 focus:outline-none"
+        className="aksel-artikkel #FEFCE9 overflow-hidden bg-[#FEFCE9] pt-[8vw] pb-16 focus:outline-none sm:pb-32"
       >
         <div className="px-4">
           <div className="dynamic-wrapper-prose text-center">
@@ -195,7 +195,7 @@ const Page = ({
               <Heading level="2" size="large">
                 Flere blogginnlegg
               </Heading>
-              <ul className="mt-12 grid gap-x-6 gap-y-6 sm:grid-cols-2 sm:gap-y-10 md:gap-x-6 lg:grid-cols-3">
+              <ul className="mt-12 grid gap-x-6 gap-y-6 md:grid-cols-2 md:gap-y-10 md:gap-x-6 lg:grid-cols-3">
                 {morePosts.map((post) => (
                   <BloggCard key={post._id} blog={post} />
                 ))}

--- a/aksel.nav.no/website/pages/produktbloggen/index.tsx
+++ b/aksel.nav.no/website/pages/produktbloggen/index.tsx
@@ -72,7 +72,7 @@ const Page = (props: PageProps): JSX.Element => {
                 <Heading level="2" size="xlarge" className="text-deepblue-800">
                   Flere blogginnlegg
                 </Heading>
-                <ul className="mt-12 grid gap-x-3 gap-y-6 sm:grid-cols-2 sm:gap-y-10 md:gap-x-6 lg:grid-cols-3">
+                <ul className="mt-12 grid gap-x-3 gap-y-6 md:grid-cols-2 md:gap-y-10 md:gap-x-6 lg:grid-cols-3">
                   {remainingPosts.map((blog) => (
                     <BloggCard key={blog._id} blog={blog} />
                   ))}

--- a/aksel.nav.no/website/pages/side/[slug].tsx
+++ b/aksel.nav.no/website/pages/side/[slug].tsx
@@ -41,7 +41,7 @@ const Page = ({
       <main
         tabIndex={-1}
         id="hovedinnhold"
-        className="aksel-artikkel xs:pb-32 bg-gray-50 pt-[8vw] pb-16 focus:outline-none"
+        className="aksel-artikkel bg-gray-50 pt-[8vw] pb-16 focus:outline-none sm:pb-32"
       >
         <div className="px-4">
           <div className="dynamic-wrapper-prose">

--- a/aksel.nav.no/website/styles/layout.css
+++ b/aksel.nav.no/website/styles/layout.css
@@ -7,13 +7,13 @@
 }
 
 .content-box {
-  @apply max-w-content-w-padding xs:mx-auto xs:px-6 w-full px-4 pb-4 md:mx-0 md:mr-auto md:px-12;
+  @apply max-w-content-w-padding w-full px-4 pb-4 sm:mx-auto sm:px-6 md:mx-0 md:mr-auto md:px-12;
 }
 
 .content-box--full {
-  @apply xs:mx-auto xs:px-6 w-full px-4 pb-4 md:mx-0 md:mr-auto md:px-12;
+  @apply w-full px-4 pb-4 sm:mx-auto sm:px-6 md:mx-0 md:mr-auto md:px-12;
 }
 
 .centered-layout {
-  @apply xs:px-6 mx-auto w-full px-4;
+  @apply mx-auto w-full px-4 sm:px-6;
 }

--- a/aksel.nav.no/website/styles/utilities.css
+++ b/aksel.nav.no/website/styles/utilities.css
@@ -15,23 +15,23 @@ p.override-text-no-max {
 }
 
 .dynamic-wrapper {
-  @apply max-w-aksel xs:w-[90%] mx-auto;
+  @apply max-w-aksel mx-auto sm:w-[90%];
 }
 
 .dynamic-wrapper-prose {
-  @apply xs:w-[90%] mx-auto max-w-prose;
+  @apply mx-auto max-w-prose sm:w-[90%];
 }
 
 .dynamic-wrapper-left {
-  @apply xs:w-[90%] max-w-prose;
+  @apply max-w-prose sm:w-[90%];
 }
 
 .dynamic-wrapper-2xl {
-  @apply xs:w-[90%] mx-auto max-w-2xl;
+  @apply mx-auto max-w-2xl sm:w-[90%];
 }
 
 .card-grid-3-1 {
-  @apply grid gap-3 sm:grid-cols-2 md:gap-6 lg:grid-cols-3;
+  @apply grid gap-3 md:grid-cols-2 md:gap-6 lg:grid-cols-3;
 }
 
 .card-grid-2-1 {

--- a/aksel.nav.no/website/tailwind.config.js
+++ b/aksel.nav.no/website/tailwind.config.js
@@ -8,15 +8,6 @@ module.exports = {
     "./stories/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    /* Flytt ut fra extend og refactor bruk av screen */
-    screens: {
-      xs: "480px",
-      sm: "648px",
-      md: "768px",
-      lg: "1024px",
-      xl: "1280px",
-      "2xl": "1440px",
-    },
     extend: {
       colors: {
         pink: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3351,7 +3351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/ds-codemod@^2.4.0, @navikt/ds-codemod@workspace:@navikt/codemod":
+"@navikt/ds-codemod@^2.4.3, @navikt/ds-codemod@workspace:@navikt/codemod":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-codemod@workspace:@navikt/codemod"
   dependencies:
@@ -3378,7 +3378,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css-internal@^2.4.0, @navikt/ds-css-internal@workspace:@navikt/internal/css":
+"@navikt/ds-css-internal@^2.4.3, @navikt/ds-css-internal@workspace:@navikt/internal/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css-internal@workspace:@navikt/internal/css"
   dependencies:
@@ -3389,11 +3389,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@2.4.0, @navikt/ds-css@^2.4.0, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@2.4.3, @navikt/ds-css@^2.4.3, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": ^2.4.0
+    "@navikt/ds-tokens": ^2.4.3
     normalize.css: ^8.0.1
     postcss: ^8.4.0
     postcss-cli: ^9.0.0
@@ -3402,7 +3402,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-icons@^2.4.0, @navikt/ds-icons@workspace:@navikt/icons":
+"@navikt/ds-icons@^2.4.3, @navikt/ds-icons@workspace:@navikt/icons":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-icons@workspace:@navikt/icons"
   dependencies:
@@ -3438,8 +3438,8 @@ __metadata:
     "@babel/preset-env": 7.19.4
     "@babel/preset-react": 7.18.6
     "@babel/preset-typescript": 7.18.6
-    "@navikt/ds-icons": ^2.4.0
-    "@navikt/ds-react": ^2.4.0
+    "@navikt/ds-icons": ^2.4.3
+    "@navikt/ds-react": ^2.4.3
     "@rollup/plugin-babel": 6.0.2
     "@rollup/plugin-commonjs": 23.0.2
     "@rollup/plugin-node-resolve": ^15.0.1
@@ -3464,12 +3464,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react-internal@^2.4.0, @navikt/ds-react-internal@workspace:@navikt/internal/react":
+"@navikt/ds-react-internal@^2.4.3, @navikt/ds-react-internal@workspace:@navikt/internal/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react-internal@workspace:@navikt/internal/react"
   dependencies:
-    "@navikt/ds-icons": ^2.4.0
-    "@navikt/ds-react": ^2.4.0
+    "@navikt/ds-icons": ^2.4.3
+    "@navikt/ds-react": ^2.4.3
     clsx: ^1.1.1
     concurrently: 7.2.1
     copy-to-clipboard: ^3.3.1
@@ -3485,12 +3485,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@2.4.0, @navikt/ds-react@^2.4.0, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@2.4.3, @navikt/ds-react@^2.4.3, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": 0.17.0
-    "@navikt/ds-icons": ^2.4.0
+    "@navikt/ds-icons": ^2.4.3
     "@radix-ui/react-tabs": 1.0.0
     "@radix-ui/react-toggle-group": 1.0.0
     "@testing-library/dom": 8.13.0
@@ -3526,11 +3526,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@^2.4.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@^2.4.3, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": ^2.4.0
+    "@navikt/ds-tokens": ^2.4.3
     "@types/jest": ^29.0.0
     color: 4.2.3
     jest: ^29.0.0
@@ -3541,7 +3541,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@^2.4.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@^2.4.3, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -7390,14 +7390,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/ds-codemod": ^2.4.0
-    "@navikt/ds-css": ^2.4.0
-    "@navikt/ds-css-internal": ^2.4.0
-    "@navikt/ds-icons": ^2.4.0
-    "@navikt/ds-react": ^2.4.0
-    "@navikt/ds-react-internal": ^2.4.0
-    "@navikt/ds-tailwind": ^2.4.0
-    "@navikt/ds-tokens": ^2.4.0
+    "@navikt/ds-codemod": ^2.4.3
+    "@navikt/ds-css": ^2.4.3
+    "@navikt/ds-css-internal": ^2.4.3
+    "@navikt/ds-icons": ^2.4.3
+    "@navikt/ds-react": ^2.4.3
+    "@navikt/ds-react-internal": ^2.4.3
+    "@navikt/ds-tailwind": ^2.4.3
+    "@navikt/ds-tokens": ^2.4.3
     prettier-plugin-tailwindcss: ^0.2.3
   languageName: unknown
   linkType: soft
@@ -21749,8 +21749,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "shadow-dom@workspace:examples/shadow-dom"
   dependencies:
-    "@navikt/ds-css": 2.4.0
-    "@navikt/ds-react": 2.4.0
+    "@navikt/ds-css": 2.4.3
+    "@navikt/ds-react": 2.4.3
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0
     "@vitejs/plugin-react": ^2.1.0


### PR DESCRIPTION
- [ ] Oppdatere bruk av breakpoints på aksel.nav.no, bruker nå egen config (gjelder bare `sm`)

Down-variant er ment for bruk i "desktop-first" løsninger, eks `max-width: 1279px` eller løsninger der man ønsker et spesifikt brekkpunkt `min-width: 1024px and max-width: 1279px`.

Har valgt å gå for `px` verdier for enklere implementasjon vs `rem, em` da sistnevnte har problemer med browser-støtte (spesielt safari).

```
--a-breakpoint-xl-down: 1279px;
--a-breakpoint-xl: 1280px;
--a-breakpoint-lg-down: 1023px;
--a-breakpoint-lg: 1024px;
--a-breakpoint-md-down: 767px;
--a-breakpoint-md: 768px;
--a-breakpoint-sm-down: 479px;
--a-breakpoint-sm: 480px;
--a-breakpoint-xs: 0;
```

### Tailwind-config

Med unntak av `sm` er alle tokens de samme som tailwind tilbyr som default. I NAV er det 3 prosjekt som bruker `sm` i koden sin og vår tailwind pakke, noe som vil være en breaking change. Men de er ikke på v2 enda, så legger bare til dokumentasjon om breaking change og noe i migreringsguiden slik at det ikke blir et problem

```
"screen": {
  "sm": "480px",
  "md": "768px",
  "lg": "1024px",
  "xl": "1280px"
},
```