### PR TITLE
:wrench: Alle pakker bruker nå npm provernance for verifisering

### DIFF
--- a/.changeset/tricky-tools-sleep.md
+++ b/.changeset/tricky-tools-sleep.md
@@ -1,0 +1,13 @@
+---
+"@navikt/aksel-icons": patch
+"@navikt/ds-codemod": patch
+"@navikt/ds-css": patch
+"@navikt/ds-react": patch
+"@navikt/ds-tailwind": patch
+"@navikt/ds-tokens": patch
+"@navikt/ds-icons": patch
+"@navikt/ds-css-internal": patch
+"@navikt/ds-react-internal": patch
+---
+
+Alle pakker implementerer nå npm provenance (beta)

--- a/@navikt/aksel-icons/package.json
+++ b/@navikt/aksel-icons/package.json
@@ -17,7 +17,8 @@
     "svg"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "sideEffects": [
     "*.svg"

--- a/@navikt/codemod/package.json
+++ b/@navikt/codemod/package.json
@@ -59,6 +59,7 @@
     "node": ">=12.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/@navikt/community/navno/package.json
+++ b/@navikt/community/navno/package.json
@@ -19,7 +19,8 @@
   "module": "./esm/index.js",
   "typings": "./esm/index.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "/css",

--- a/@navikt/core/css/package.json
+++ b/@navikt/core/css/package.json
@@ -8,7 +8,8 @@
   ],
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/@navikt/core/react/package.json
+++ b/@navikt/core/react/package.json
@@ -18,7 +18,8 @@
   "module": "./esm/index.js",
   "typings": "./esm/index.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "/cjs",

--- a/@navikt/core/tailwind/package.json
+++ b/@navikt/core/tailwind/package.json
@@ -30,5 +30,9 @@
     "ts-jest": "^29.0.0",
     "ts-node": "10.9.0",
     "typescript": "^4.8.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/@navikt/core/tokens/package.json
+++ b/@navikt/core/tokens/package.json
@@ -38,5 +38,9 @@
     "ts-jest": "^29.0.0",
     "ts-node": "10.9.0",
     "typescript": "^4.8.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/@navikt/icons/package.json
+++ b/@navikt/icons/package.json
@@ -62,5 +62,9 @@
     "ts-jest": "^29.0.0",
     "ts-node": "10.9.0",
     "typescript": "^4.8.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/@navikt/internal/css/package.json
+++ b/@navikt/internal/css/package.json
@@ -8,7 +8,8 @@
   ],
   "license": "MIT",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/@navikt/internal/react/package.json
+++ b/@navikt/internal/react/package.json
@@ -18,7 +18,8 @@
   "module": "./esm/index.js",
   "typings": "./esm/index.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "/cjs",


### PR DESCRIPTION
https://github.blog/2023-04-19-introducing-npm-package-provenance/