### PR TITLE
:bug: aksel-icons: justere "copy-svg"-kommandoen slik at den fungerer på både Win og Unix

### DIFF
--- a/@navikt/aksel-icons/package.json
+++ b/@navikt/aksel-icons/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "create-icons": "svgr --silent --index-template config/index-template.js --out-dir src icons",
     "copy-util": "copyfiles util/* src",
-    "copy-svg": "copyfiles -f icons/*.svg dist/svg/",
+    "copy-svg": "copyfiles -f 'icons/*.svg' dist/svg/",
     "copy": "yarn copy-util && yarn copy-svg",
     "update-metadata": "node config/metadata.js",
     "build": "yarn copy && yarn create-icons && concurrently \"tsc\" \"tsc -p tsconfig.esm.json\" && node config/cleanTypes.js && yarn update-metadata",


### PR DESCRIPTION
Den opprinnelige kommandoen fungerer ikke i Windows, tilsynelatende fordi * ekspanderes til hver enkelt fil, slik at kommandoen blir for lang. Ved å legge til single quotes rundt "icons/*.svg" ser det ut til at den virker i både Windows og Unix-baserte systemer.