### PR TITLE
:memo: Dropdown: Better Item examples

### DIFF
--- a/aksel.nav.no/website/pages/eksempler/dropdown/default.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dropdown/default.tsx
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import { Button } from "@navikt/ds-react";
 import { Dropdown } from "@navikt/ds-react";
 import { withDsExample } from "components/website-modules/examples/withDsExample";
+import Link from "next/link";
 
 const Example = () => {
   return (
@@ -12,17 +14,25 @@ const Example = () => {
             <Dropdown.Menu.GroupedList.Heading>
               Systemer og oppslagsverk
             </Dropdown.Menu.GroupedList.Heading>
-            <Dropdown.Menu.GroupedList.Item>
+            <Dropdown.Menu.GroupedList.Item onClick={() => {}}>
               Gosys
             </Dropdown.Menu.GroupedList.Item>
-            <Dropdown.Menu.GroupedList.Item>
+            <Dropdown.Menu.GroupedList.Item as="a" href="https://nav.no">
               Infotrygd
             </Dropdown.Menu.GroupedList.Item>
           </Dropdown.Menu.GroupedList>
           <Dropdown.Menu.Divider />
           <Dropdown.Menu.List>
-            <Dropdown.Menu.List.Item>Gosys</Dropdown.Menu.List.Item>
-            <Dropdown.Menu.List.Item>Infotrygd</Dropdown.Menu.List.Item>
+            <Dropdown.Menu.List.Item as={Link} href="https://nav.no">
+              Kontakt
+            </Dropdown.Menu.List.Item>
+            <Dropdown.Menu.List.Item
+              as={Link}
+              href="https://nav.no"
+              target="_blank"
+            >
+              Hjelp (åpner i en ny fane)
+            </Dropdown.Menu.List.Item>
           </Dropdown.Menu.List>
         </Dropdown.Menu>
       </Dropdown>


### PR DESCRIPTION
Forslag til forbedring (?) av kode-eksempelet for Dropdown.

Det virker som at ikke alle får meg seg at `Dropdown.Menu.GroupedList.Item` er en `<button>` som standard, og at man derfor ikke kan ha lenker inni den. (Det står under Props, men mange kopierer sikkert bare eksempel-koden.) Har derfor oppdatert eksempelet slik at de trolig vanligste brukstilfellene kommer fram.

https://nav-it.slack.com/archives/C7NE7A8UF/p1687430929786099