### PR TITLE
add close button to alert

### DIFF
--- a/.changeset/six-ducks-eat-duplicate.md
+++ b/.changeset/six-ducks-eat-duplicate.md
@@ -1,6 +1,5 @@
 ---
 "@navikt/ds-css": patch
-"@navikt/ds-react": patch
 ---
 
 - Button: Fikset outline-bug i tertiary-variant ved `:active`-state

--- a/.changeset/six-ducks-eat-duplicate.md
+++ b/.changeset/six-ducks-eat-duplicate.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-css": patch
+"@navikt/ds-react": patch
+---
+
+- Button: Fikset outline-bug i tertiary-variant ved `:active`-state

--- a/.changeset/six-ducks-eat.md
+++ b/.changeset/six-ducks-eat.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-css": minor
+"@navikt/ds-react": minor
+---
+
+:sparkles: Add close button to Alert component

--- a/.changeset/six-ducks-eat.md
+++ b/.changeset/six-ducks-eat.md
@@ -3,4 +3,4 @@
 "@navikt/ds-react": minor
 ---
 
-:sparkles: Add close button to Alert component
+- Alert: La til `closeButton`-prop

--- a/@navikt/core/css/alert.css
+++ b/@navikt/core/css/alert.css
@@ -75,9 +75,8 @@
   padding: 0;
 }
 
-.navds-alert > .navds-alert__button-wrapper {
+.navds-alert__button-wrapper {
   align-self: flex-start;
-  justify-self: flex-end;
   flex: 1;
   display: flex;
   flex-flow: row nowrap;

--- a/@navikt/core/css/alert.css
+++ b/@navikt/core/css/alert.css
@@ -73,3 +73,12 @@
   border: none;
   padding: 0;
 }
+
+.navds-alert > .navds-alert__button-wrapper {
+  align-self: flex-start;
+  justify-self: flex-end;
+  flex: 1;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-end;
+}

--- a/@navikt/core/css/alert.css
+++ b/@navikt/core/css/alert.css
@@ -24,7 +24,7 @@
   font-size: 1.5rem;
   align-self: flex-start;
   height: var(--a-font-line-height-xlarge);
-  margin: var(--ac-alert-padding-icon, var(--a-spacing-1));
+  margin: var(--a-spacing-1);
   background: radial-gradient(circle, var(--a-surface-default) 50%, 0, transparent);
 }
 

--- a/@navikt/core/css/alert.css
+++ b/@navikt/core/css/alert.css
@@ -24,6 +24,7 @@
   font-size: 1.5rem;
   align-self: flex-start;
   height: var(--a-font-line-height-xlarge);
+  margin: var(--ac-alert-padding-icon, var(--a-spacing-1));
   background: radial-gradient(circle, var(--a-surface-default) 50%, 0, transparent);
 }
 

--- a/@navikt/core/css/button.css
+++ b/@navikt/core/css/button.css
@@ -294,7 +294,6 @@
 .navds-button--tertiary:active {
   color: var(--ac-button-tertiary-active-text, var(--a-text-on-action));
   background-color: var(--ac-button-tertiary-active-bg, var(--a-surface-action-active));
-  box-shadow: inset 0 0 0 1px var(--a-surface-default);
 }
 
 .navds-button--tertiary:active:hover {
@@ -346,7 +345,6 @@
 .navds-button--tertiary-neutral:active {
   color: var(--ac-button-tertiary-neutral-active-text, var(--a-text-on-neutral));
   background-color: var(--ac-button-tertiary-neutral-active-bg, var(--a-surface-neutral-active));
-  box-shadow: inset 0 0 0 1px var(--a-surface-default);
 }
 
 .navds-button--tertiary-neutral:active:hover {

--- a/@navikt/core/css/tokens.json
+++ b/@navikt/core/css/tokens.json
@@ -11,8 +11,7 @@
     "--ac-alert-icon-info-color": "--a-icon-info",
     "--ac-alert-success-border": "--a-border-success",
     "--ac-alert-success-bg": "--a-surface-success-subtle",
-    "--ac-alert-icon-success-color": "--a-icon-success",
-    "--ac-alert-padding-icon": "--a-spacing-1"
+    "--ac-alert-icon-success-color": "--a-icon-success"
   },
   "accordion": {
     "--ac-accordion-header-bg": "--a-surface-transparent",

--- a/@navikt/core/css/tokens.json
+++ b/@navikt/core/css/tokens.json
@@ -11,7 +11,8 @@
     "--ac-alert-icon-info-color": "--a-icon-info",
     "--ac-alert-success-border": "--a-border-success",
     "--ac-alert-success-bg": "--a-surface-success-subtle",
-    "--ac-alert-icon-success-color": "--a-icon-success"
+    "--ac-alert-icon-success-color": "--a-icon-success",
+    "--ac-alert-padding-icon": "--a-spacing-1"
   },
   "accordion": {
     "--ac-accordion-header-bg": "--a-surface-transparent",

--- a/@navikt/core/react/src/alert/Alert.tsx
+++ b/@navikt/core/react/src/alert/Alert.tsx
@@ -112,7 +112,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
         {closeButton && !inline && (
           <div className="navds-alert__button-wrapper">
             <Button
-              className={cl("navds-alert__button")}
+              className="navds-alert__button"
               size="small"
               variant="tertiary-neutral"
               onClick={onClose}

--- a/@navikt/core/react/src/alert/Alert.tsx
+++ b/@navikt/core/react/src/alert/Alert.tsx
@@ -3,10 +3,12 @@ import {
   CheckmarkCircleFillIcon,
   ExclamationmarkTriangleFillIcon,
   XMarkOctagonFillIcon,
+  XMarkIcon,
 } from "@navikt/aksel-icons";
 import cl from "clsx";
 import React, { forwardRef } from "react";
 import { BodyLong } from "../typography/BodyLong";
+import { Button } from "../button";
 
 export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -32,6 +34,17 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
    * @default false
    */
   inline?: boolean;
+  /**
+   * Removes close-button(X) when false
+   * Requires onClose to be set
+   * @default true
+   */
+  closeButton?: boolean;
+  /**
+   * Callback for alert wanting to close
+   * requires closeButton to be true
+   */
+  onClose?: () => void;
 }
 
 const Icon = ({ variant, ...props }) => {
@@ -71,27 +84,45 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
       size = "medium",
       fullWidth = false,
       inline = false,
+      closeButton = false,
+      onClose,
       ...rest
     },
     ref
-  ) => (
-    <div
-      {...rest}
-      ref={ref}
-      className={cl(
-        className,
-        "navds-alert",
-        `navds-alert--${variant}`,
-        `navds-alert--${size}`,
-        { "navds-alert--full-width": fullWidth, "navds-alert--inline": inline }
-      )}
-    >
-      <Icon variant={variant} className="navds-alert__icon" />
-      <BodyLong as="div" size={size} className="navds-alert__wrapper">
-        {children}
-      </BodyLong>
-    </div>
-  )
+  ) => {
+    return (
+      <div
+        {...rest}
+        ref={ref}
+        className={cl(
+          className,
+          "navds-alert",
+          `navds-alert--${variant}`,
+          `navds-alert--${size}`,
+          {
+            "navds-alert--full-width": fullWidth,
+            "navds-alert--inline": inline,
+          }
+        )}
+      >
+        <Icon variant={variant} className="navds-alert__icon" />
+        <BodyLong as="div" size={size} className="navds-alert__wrapper">
+          {children}
+        </BodyLong>
+        {closeButton && !inline && (
+          <div className="navds-alert__button-wrapper">
+            <Button
+              className={cl("navds-alert__button")}
+              size="small"
+              variant="tertiary-neutral"
+              onClick={onClose}
+              icon={<XMarkIcon title="Lukk Alert" />}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
 );
 
 export default Alert;

--- a/@navikt/core/react/src/alert/alert.stories.tsx
+++ b/@navikt/core/react/src/alert/alert.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { Alert } from ".";
 import { BodyLong, Heading as DsHeading, Link } from "..";
+import { within, userEvent } from "@storybook/testing-library";
+import { expect } from "@storybook/jest";
 
 const meta: Meta<typeof Alert> = {
   title: "ds-react/Alert",
@@ -146,4 +148,45 @@ export const Links = () => {
       ))}
     </div>
   );
+};
+
+const CloseButton = ({ children }: { children?: React.ReactNode }) => {
+  let [show, setShow] = React.useState(true);
+
+  return (
+    show && (
+      <Alert variant="success" closeButton onClose={() => setShow(false)}>
+        {children || "Content"}
+      </Alert>
+    )
+  );
+};
+
+export const WithCloseButton: Story = {
+  render: () => {
+    return (
+      <div className="colgap">
+        <CloseButton />
+        <CloseButton>
+          <BodyLong>
+            Ullamco ullamco laborum et commodo sint culpa cupidatat culpa qui
+            laboris ex. Labore ex occaecat proident qui qui fugiat magna. Fugiat
+            sint commodo consequat eu aute.
+          </BodyLong>
+          <Link href="#">Id elit esse enim reprehenderit</Link>
+        </CloseButton>
+      </div>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const buttons = canvas.getAllByTitle("Lukk Alert");
+
+    await step("click button", async () => {
+      await userEvent.click(buttons[0]);
+    });
+
+    const buttonsAfter = canvas.getAllByTitle("Lukk Alert");
+    expect(buttonsAfter.length).toBe(1);
+  },
 };

--- a/@navikt/core/react/src/alert/alert.stories.tsx
+++ b/@navikt/core/react/src/alert/alert.stories.tsx
@@ -28,6 +28,7 @@ export const Default: Story = {
       size={props.size}
       fullWidth={props.fullWidth}
       inline={props.inline}
+      closeButton={props.closeButton}
     >
       {props.children}
     </Alert>
@@ -38,6 +39,7 @@ export const Default: Story = {
     fullWidth: false,
     variant: "info",
     size: "medium",
+    closeButton: false,
   },
   argTypes: {
     variant: {
@@ -51,6 +53,9 @@ export const Default: Story = {
         type: "radio",
       },
       options: ["medium", "small"],
+    },
+    closeButton: {
+      type: "boolean",
     },
   },
 };

--- a/@navikt/core/react/src/alert/alert.stories.tsx
+++ b/@navikt/core/react/src/alert/alert.stories.tsx
@@ -22,17 +22,7 @@ const variants: Array<"error" | "warning" | "info" | "success"> = [
 ];
 
 export const Default: Story = {
-  render: (props) => (
-    <Alert
-      variant={props.variant}
-      size={props.size}
-      fullWidth={props.fullWidth}
-      inline={props.inline}
-      closeButton={props.closeButton}
-    >
-      {props.children}
-    </Alert>
-  ),
+  render: (props) => <Alert {...props} />,
 
   args: {
     children: "Id elit esse enim reprehenderit enim nisi veniam nostrud.",
@@ -60,18 +50,33 @@ export const Default: Story = {
   },
 };
 
-export const Small = () => {
-  return (
-    <div className="colgap">
-      {variants.map((variant, i) => (
-        <Alert key={variant} variant={variant} size="small">
-          {new Array(i + 1).fill(
-            "Id elit esse enim reprehenderit enim nisi veniam nostrud."
-          )}
-        </Alert>
-      ))}
-    </div>
-  );
+export const Small = {
+  render: (props) => {
+    return (
+      <div className="colgap">
+        {variants.map((variant, i) => (
+          <Alert
+            key={variant}
+            variant={variant}
+            size="small"
+            closeButton={props.closeButton}
+          >
+            {new Array(i + 1).fill(
+              "Id elit esse enim reprehenderit enim nisi veniam nostrud."
+            )}
+          </Alert>
+        ))}
+      </div>
+    );
+  },
+  args: {
+    closeButton: false,
+  },
+  argtypes: {
+    closeButton: {
+      type: "boolean",
+    },
+  },
 };
 
 export const FullWidth = () => {
@@ -155,7 +160,7 @@ export const Links = () => {
   );
 };
 
-const CloseButton = ({ children }: { children?: React.ReactNode }) => {
+const AlertWithCloseButton = ({ children }: { children?: React.ReactNode }) => {
   let [show, setShow] = React.useState(true);
 
   return (
@@ -171,15 +176,15 @@ export const WithCloseButton: Story = {
   render: () => {
     return (
       <div className="colgap">
-        <CloseButton />
-        <CloseButton>
+        <AlertWithCloseButton />
+        <AlertWithCloseButton>
           <BodyLong>
             Ullamco ullamco laborum et commodo sint culpa cupidatat culpa qui
             laboris ex. Labore ex occaecat proident qui qui fugiat magna. Fugiat
             sint commodo consequat eu aute.
           </BodyLong>
           <Link href="#">Id elit esse enim reprehenderit</Link>
-        </CloseButton>
+        </AlertWithCloseButton>
       </div>
     );
   },

--- a/aksel.nav.no/website/pages/eksempler/alert/med-lukkeknapp.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert/med-lukkeknapp.tsx
@@ -1,0 +1,53 @@
+import { Alert, AlertProps } from "@navikt/ds-react";
+import { withDsExample } from "components/website-modules/examples/withDsExample";
+import React from "react";
+
+const AlertWithCloseButton = ({
+  children,
+  variant,
+}: {
+  children?: React.ReactNode;
+  variant: AlertProps["variant"];
+}) => {
+  const [show, setShow] = React.useState(true);
+
+  return (
+    show && (
+      <Alert variant={variant} closeButton onClose={() => setShow(false)}>
+        {children || "Content"}
+      </Alert>
+    )
+  );
+};
+
+const Example = () => {
+  return (
+    <div className="grid gap-4">
+      <AlertWithCloseButton variant="info">
+        Hvis du er mellom 62 og 67 år når du søker, må du som hovedregel ha hatt
+        en pensjonsgivende inntekt som tilsvarer x G, året før du fikk nedsatt
+        arbeidsevnen.
+      </AlertWithCloseButton>
+      <AlertWithCloseButton variant="success">
+        Søknad er sendt inn!
+      </AlertWithCloseButton>
+      <AlertWithCloseButton variant="warning">
+        Du må være registrert hos NAV for å bruke aktivitetsplanen.
+      </AlertWithCloseButton>
+      <AlertWithCloseButton variant="error">
+        Noe gikk galt! Prøv igjen om noen minutter.
+      </AlertWithCloseButton>
+    </div>
+  );
+};
+
+export default withDsExample(Example);
+
+/* Storybook story */
+export const Demo = {
+  render: Example,
+};
+
+export const args = {
+  index: 1,
+};


### PR DESCRIPTION
### Description

<!-- PR description/motivation
https://github.com/navikt/team-aksel/issues/163
-->

### Change summary

- add close button to alert
- added a storybook interaction/play for alert with close buttons
- close button state is managed outside the component, and you pass in a callback 'onClose' + set 'closeButton' props

### PR Checklist 📝 (Remove fields after check!)

#### Documentation 📝

- Add/update component-demos for component `aksel.nav.no/website/pages/eksempler`
- Create/Update documentation in sanity if needed
  Note: Props, tokens and examples only updates to sanity on merge to main
