### PR TITLE
Migrate Modal-component to native HTML dialog element

### DIFF
--- a/.changeset/heavy-pumpkins-think.md
+++ b/.changeset/heavy-pumpkins-think.md
@@ -1,0 +1,23 @@
+---
+"@navikt/ds-css": major
+"@navikt/ds-react": major
+---
+
+Migrerer `Modal`-komponenten til å bruke HTML `<dialog>`-elementet
+
+- `Modal`-komponenten bruker nå HTML `<dialog>`-elementet i stedet for `react-modal`-pakken.
+- Flere props er fjernet ved migreringen:
+  - `overlayClassName`: Bruk `className::backdrop`-pseudoelementet i stedet.
+  - `style`: Style `Modal`-komponentene direkte i stedet.
+  - `parentSelector`: Ikke lenger nødvendig.
+  - `tabIndex`: Er nå ikke lov å sette. [Ref. MDN.](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)
+- `Modal.setAppElement` er fjernet. Ikke lenger nødvendig.
+- Flere props arves nå fra `HTMLDialogElement`:
+  - `onClose`
+  - `className`
+  - `children`
+  - `aria-*`
+- Flere CSS-klasser er fjernet.
+  - `navds-modal__overlay`
+  - `navds-modal--focus`
+  - `navds-modal__button--shake`

--- a/@navikt/aksel-stylelint/src/deprecations.ts
+++ b/@navikt/aksel-stylelint/src/deprecations.ts
@@ -25,4 +25,14 @@ export const deprecations: DeprecatedList = [
     message:
       "In v4.1.0 Chips. Toggle no longer handles special alignment for checkmark-icon, thus removing this class",
   },
+  {
+    classes: ["navds-modal__overlay"],
+    message:
+      "Removed in v5.0.0 - `Modal` is migrated to HTML `<dialog>`. Traget the `::backdrop` pseudo-element instead.",
+  },
+  {
+    classes: ["navds-modal__button--shake", "navds-modal--focus"],
+    message:
+      "Removed in v5.0.0 - `Modal` is migrated to HTML `<dialog>`. No longer needed.",
+  },
 ];

--- a/@navikt/core/css/modal.css
+++ b/@navikt/core/css/modal.css
@@ -1,58 +1,16 @@
-.ReactModal__Body--open {
-  overflow: hidden;
-}
-
 .navds-modal {
   background-color: var(--ac-modal-bg, var(--a-surface-default));
   border-radius: var(--a-border-radius-medium);
-  display: block;
-  position: relative;
-  overflow: auto;
-  max-height: 100%;
   box-shadow: var(--a-shadow-xlarge);
+  padding: 0;
+}
+
+.navds-modal::backdrop {
+  background-color: var(--ac-modal-backdrop, var(--a-surface-backdrop));
 }
 
 .navds-modal__content {
   padding: var(--a-spacing-4);
-}
-
-.navds-modal:focus-visible,
-.navds-modal--focus {
-  box-shadow: var(--a-shadow-focus);
-  outline: none;
-}
-
-@supports not selector(:focus-visible) {
-  .navds-modal:focus,
-  .navds-modal--focus {
-    box-shadow: var(--a-shadow-focus);
-    outline: none;
-  }
-}
-
-.navds-modal__overlay {
-  position: fixed;
-  z-index: var(--a-z-index-modal);
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background-color: var(--ac-modal-backdrop, var(--a-surface-backdrop));
-  padding: var(--a-spacing-4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.navds-modal__button--shake {
-  transform: rotate(0deg);
-  transition: transform 100ms cubic-bezier(0.82, 2, 1, 0.3);
-}
-
-/* prettier-ignore */
-.navds-modal__overlay:active > .navds-modal:not(:active) > .navds-modal__button--shake {
-  transform: rotate(10deg);
-  transition: transform 100ms cubic-bezier(0.82, -2, 1, 0.3);
 }
 
 .navds-modal__button {
@@ -61,9 +19,4 @@
   right: var(--a-spacing-4);
   display: flex;
   padding: var(--a-spacing-2);
-}
-
-.navds-modal__button svg {
-  height: 1.5rem;
-  width: 1.5rem;
 }

--- a/@navikt/core/react/src/modal/modal.stories.tsx
+++ b/@navikt/core/react/src/modal/modal.stories.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import React, { useEffect, useState } from "react";
+import React, { useRef, useState } from "react";
 import { BodyLong, Button, Heading } from "..";
-import Modal from "./Modal";
+import Modal, { ModalProps } from "./Modal";
 
 export default {
   title: "ds-react/Modal",
@@ -12,31 +12,27 @@ export default {
 };
 
 export const Default = {
-  render: (props) => {
+  render: (props: ModalProps) => {
     const [open, setOpen] = useState(false);
-
-    useEffect(() => {
-      Modal.setAppElement?.("#root");
-    }, []);
 
     return (
       <>
         <Button onClick={() => setOpen(true)}>Open Modal</Button>
         <Modal
+          {...props}
           open={open}
           onClose={() => setOpen(false)}
           aria-labelledby="header123"
-          {...props}
         >
           <Modal.Content>
             <Heading spacing id="header123" level="1" size="large">
-              Header
+              Default modal
             </Heading>
             <Heading spacing level="2" size="medium">
-              Header
+              May be closed in three different ways:
             </Heading>
             <BodyLong>
-              Voluptate laboris mollit dolore qui. Magna elit.
+              Close button, clicking outside of this modal, or pressing Escape.
             </BodyLong>
           </Modal.Content>
         </Modal>
@@ -45,40 +41,73 @@ export const Default = {
   },
 
   args: {
+    shouldCloseOnEsc: true,
     shouldCloseOnOverlayClick: true,
     closeButton: true,
   },
 };
 
-export const ParentSelector = () => {
-  const [open, setOpen] = useState(true);
+export const OnlyCloseButton = {
+  render: (props: ModalProps) => {
+    const [open, setOpen] = useState(false);
 
-  useEffect(() => {
-    Modal.setAppElement?.("#root");
-  }, []);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open Modal</Button>
+        <Modal
+          {...props}
+          open={open}
+          onClose={() => setOpen(false)}
+          aria-labelledby="header123"
+        >
+          <Modal.Content>
+            <Heading spacing id="header123" level="1" size="large">
+              Force the close button
+            </Heading>
+            <BodyLong>
+              Try clicking outside of this modal or pressing Escape.
+            </BodyLong>
+            <BodyLong>
+              To close this modal, you must click the close button.
+            </BodyLong>
+          </Modal.Content>
+        </Modal>
+      </>
+    );
+  },
 
-  const parentEl = document.getElementById("custom-container");
+  args: {
+    shouldCloseOnEsc: false,
+    shouldCloseOnOverlayClick: false,
+    closeButton: true,
+  },
+};
 
-  return (
-    <>
-      <div id="custom-container" />
-      <Button onClick={() => setOpen(true)}>Open Modal</Button>
-      <Modal
-        open={open}
-        onClose={() => setOpen(false)}
-        aria-labelledby="header123"
-        parentSelector={parentEl ? () => parentEl : undefined}
-      >
-        <Modal.Content>
-          <Heading spacing id="header123" level="1" size="large">
-            Header
-          </Heading>
-          <Heading spacing level="2" size="medium">
-            Header
-          </Heading>
-          <BodyLong>Voluptate laboris mollit dolore qui. Magna elit.</BodyLong>
-        </Modal.Content>
-      </Modal>
-    </>
-  );
+export const OpenWithRef = {
+  render: (props: ModalProps) => {
+    const ref = useRef<HTMLDialogElement>(null);
+
+    return (
+      <>
+        <Button onClick={() => ref.current?.showModal()}>Open Modal</Button>
+        <Modal {...props} aria-labelledby="header123" ref={ref}>
+          <Modal.Content>
+            <Heading spacing id="header123" level="1" size="large">
+              Modal opened via ref
+            </Heading>
+            <BodyLong>
+              This modal was opened by calling ref.showModal().
+            </BodyLong>
+            <BodyLong>Using the "open" prop is recommended.</BodyLong>
+          </Modal.Content>
+        </Modal>
+      </>
+    );
+  },
+
+  args: {
+    shouldCloseOnEsc: true,
+    shouldCloseOnOverlayClick: true,
+    closeButton: true,
+  },
 };

--- a/aksel.nav.no/website/pages/eksempler/modal/default.tsx
+++ b/aksel.nav.no/website/pages/eksempler/modal/default.tsx
@@ -1,21 +1,17 @@
 import { BodyLong, Button, Heading, Modal } from "@navikt/ds-react";
 import { withDsExample } from "components/website-modules/examples/withDsExample";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 const Example = () => {
   const [open, setOpen] = useState(false);
-
-  useEffect(() => {
-    Modal.setAppElement("#__next");
-  }, []);
 
   return (
     <>
       <Button onClick={() => setOpen(true)}>Åpne modal</Button>
       <Modal
         open={open}
+        onClose={() => setOpen((o) => !o)}
         aria-label="Modal demo"
-        onClose={() => setOpen((x) => !x)}
         aria-labelledby="modal-heading"
       >
         <Modal.Content>

--- a/aksel.nav.no/website/pages/eksempler/modal/imperative.tsx
+++ b/aksel.nav.no/website/pages/eksempler/modal/imperative.tsx
@@ -1,20 +1,14 @@
 import { BodyLong, Button, Heading, Modal } from "@navikt/ds-react";
 import { withDsExample } from "components/website-modules/examples/withDsExample";
-import { useState } from "react";
+import { useRef } from "react";
 
 const Example = () => {
-  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDialogElement>(null);
 
   return (
     <>
-      <Button onClick={() => setOpen(true)}>Åpne modal</Button>
-      <Modal
-        open={open}
-        onClose={() => setOpen((o) => !o)}
-        closeButton={false}
-        aria-label="Modal demo"
-        aria-labelledby="modal-heading"
-      >
+      <Button onClick={() => ref.current?.showModal()}>Åpne modal</Button>
+      <Modal aria-label="Modal demo" aria-labelledby="modal-heading" ref={ref}>
         <Modal.Content>
           <Heading spacing level="1" size="large" id="modal-heading">
             Laborum proident id ullamco

--- a/aksel.nav.no/website/pages/eksempler/modal/only-closebutton.tsx
+++ b/aksel.nav.no/website/pages/eksempler/modal/only-closebutton.tsx
@@ -11,7 +11,8 @@ const Example = () => {
       <Modal
         open={open}
         onClose={() => setOpen((o) => !o)}
-        closeButton={false}
+        shouldCloseOnOverlayClick={false}
+        shouldCloseOnEsc={false}
         aria-label="Modal demo"
         aria-labelledby="modal-heading"
       >


### PR DESCRIPTION
# Migrerer `Modal`-komponenten til [HTML `<dialog>`-elementet](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)

> Oppretter denne som draft PR før jeg ev. legger mer arbeid i dette. Punktene nederst her om Sanity, codemod og migreringer er ikke gjort noe med ennå.

`Modal`-komponenten er i dag avhengig av `react-modal`-pakken, som har sin egen implementasjon av modal.
Denne PRen migrerer `Modal`-komponenten helt vekk fra `react-modal` og til HTML `<dialog>`-elementet.

`react-modal` [har diskutert](https://github.com/reactjs/react-modal/discussions/985) å bruke `<dialog>`-elementet, men interessen er laber og diskusjonen ser ut til å ha stoppet opp i 2022. Ingen konkrete planer eller PRer etter hva jeg kan se.

Tenker dette er en god mulighet til å migrere vekk fra en ekstern avhengighet og til vår egen wrapper rundt native funksjonalitet.

## Er `<dialog>`-elementet klart for prod?

Ifølge [Can I Use](https://caniuse.com/dialog) er `<dialog>`-elementet godt støttet.
Testet OK i Chrome og Firefox.

## Hva med de andre komponentene som bruker `react-modal`?

Det er flere komponenter som bruker `react-modal`. Om retningen denne PRen går er ønskelig, tenker jeg det er naturlig å migrere de andre komponentene også. Kanskje ved å utvide denne PRen til å omfange de komponentene.

## Oppsummering

- `Modal`-komponenten bruker nå HTML `<dialog>`-elementet i stedet for `react-modal`-pakken.
- Flere props er fjernet ved migreringen:
  - `overlayClassName`: Bruk `className::backdrop`-pseudoelementet i stedet.
  - `style`: Style `Modal`-komponentene direkte i stedet.
  - `parentSelector`: Ikke lenger nødvendig.
  - `tabIndex`: Er nå ikke lov å sette. [Ref. MDN.](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)
- `Modal.setAppElement` er fjernet. Ikke lenger nødvendig.
- Native props arves nå fra `HTMLDialogElement`:
  - `onClose`
  - `className`
  - `children`
  - `aria-*`
- Noen CSS-klasser er fjernet.
  - `navds-modal__overlay`
  - `navds-modal--focus`
  - `navds-modal__button--shake`

`navds-modal__button--shake` er fjernet til fordel for `HTMLButtonElement.animate()`.
Knappen animeres hver gang man forsøker å lukke modalen på en måte som er skrudd av med `shouldCloseOnEsc` og/eller `shouldCloseOnOverlayClick`. Dette er i hvert fall det jeg tolket intensjonen med klassen til.

`navds-modal__overlay` er ikke lenger relevant da `<dialog>`-elementet benytter pseudo-elementet `::backdrop`.

`navds-modal--focus` er også fjernet da `<dialog>`-elementet ikke kan få fokus og uansett fanger bruker i modalen.

### Documentation 📝

- Create/Update documentation in sanity if needed
  Note: Props, tokens and examples only updates to sanity on merge to main

#### Versioning 🏷️

- Adding breaking changes? Consider adding a codemod for easier migration.
- Breaking changes also needs documentation under "Migration"-page on website
