### PR TITLE
:bug: Fikset layout-bug i skjemakomponenter

### DIFF
--- a/.changeset/ten-hotels-tease.md
+++ b/.changeset/ten-hotels-tease.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-css": patch
+"@navikt/ds-react": patch
+---
+
+Skjema: Labels og Legends bruker nå inline-flex når readOnly er satt

--- a/@navikt/core/css/form/fieldset.css
+++ b/@navikt/core/css/form/fieldset.css
@@ -30,6 +30,10 @@
   padding: 0;
 }
 
+.navds-fieldset--readonly > :where(.navds-fieldset__legend) {
+  display: inline-flex;
+}
+
 .navds-fieldset:disabled > .navds-fieldset__legend,
 .navds-fieldset:disabled > .navds-fieldset__description {
   opacity: 0.3;

--- a/@navikt/core/css/form/form.css
+++ b/@navikt/core/css/form/form.css
@@ -37,8 +37,13 @@
   color: var(--ac-form-subdescription, var(--a-text-subtle));
 }
 
+.navds-form-field--readonly > :where(.navds-form-field__label) {
+  display: inline-flex;
+}
+
 .navds-form-field__readonly-icon {
+  margin-top: var(--a-spacing-05);
   margin-right: var(--a-spacing-2);
-  vertical-align: middle;
-  margin-bottom: 3px;
+  flex-shrink: 0;
+  align-self: flex-start;
 }

--- a/@navikt/core/css/form/radio-checkbox.css
+++ b/@navikt/core/css/form/radio-checkbox.css
@@ -254,6 +254,10 @@
   cursor: default;
 }
 
+.navds-checkbox--readonly .navds-checkbox__label-text {
+  display: inline-flex;
+}
+
 .navds-checkbox--readonly > .navds-checkbox__input:hover + .navds-checkbox__label,
 .navds-radio--readonly > .navds-radio__input:hover + .navds-radio__label {
   color: var(--a-text-default);

--- a/@navikt/core/css/form/switch.css
+++ b/@navikt/core/css/form/switch.css
@@ -197,6 +197,10 @@
   color: var(--a-text-default);
 }
 
+.navds-switch--readonly .navds-switch__label {
+  display: inline-flex;
+}
+
 .navds-switch--readonly .navds-switch__thumb {
   background-color: var(--a-surface-subtle);
   box-shadow: 0 0 0 2px var(--a-border-default);

--- a/@navikt/core/react/src/date/DateInput.tsx
+++ b/@navikt/core/react/src/date/DateInput.tsx
@@ -73,6 +73,7 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>((props, ref) => {
           "navds-date__field--error": hasError,
           "navds-form-field--disabled": !!inputProps.disabled,
           "navds-text-field--disabled": !!inputProps.disabled,
+          "navds-form-field--readonly": readOnly,
           "navds-text-field--readonly": readOnly,
           "navds-date__field--readonly": readOnly,
         }

--- a/@navikt/core/react/src/form/Select.tsx
+++ b/@navikt/core/react/src/form/Select.tsx
@@ -99,6 +99,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           `navds-form-field--${size}`,
           {
             "navds-form-field--disabled": !!inputProps.disabled,
+            "navds-form-field--readonly": readOnly,
             "navds-select--error": hasError,
             "navds-select--readonly": readOnly,
           }

--- a/@navikt/core/react/src/form/TextField.tsx
+++ b/@navikt/core/react/src/form/TextField.tsx
@@ -73,10 +73,12 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           className,
           "navds-form-field",
           `navds-form-field--${size}`,
+
           {
             "navds-text-field--error": hasError,
             "navds-text-field--disabled": !!inputProps.disabled,
             "navds-form-field--disabled": !!inputProps.disabled,
+            "navds-form-field--readonly": readOnly,
             "navds-text-field--readonly": readOnly,
           }
         )}

--- a/@navikt/core/react/src/form/Textarea.tsx
+++ b/@navikt/core/react/src/form/Textarea.tsx
@@ -117,6 +117,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           `navds-form-field--${size}`,
           {
             "navds-form-field--disabled": !!inputProps.disabled,
+            "navds-form-field--readonly": readOnly,
             "navds-textarea--readonly": readOnly,
             "navds-textarea--error": hasError,
             "navds-textarea--resize": resize,

--- a/@navikt/core/react/src/form/checkbox/Checkbox.tsx
+++ b/@navikt/core/react/src/form/checkbox/Checkbox.tsx
@@ -91,7 +91,11 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
               "navds-sr-only": props.hideLabel,
             })}
           >
-            <BodyShort as="span" size={size}>
+            <BodyShort
+              as="span"
+              size={size}
+              className="navds-checkbox__label-text"
+            >
               {!nested && (
                 <ReadOnlyIcon readOnly={readOnly} nativeReadOnly={false} />
               )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3787,7 +3787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@^4.5.0, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
+"@navikt/aksel-icons@^4.6.0, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-icons@workspace:@navikt/aksel-icons"
   dependencies:
@@ -3814,8 +3814,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-stylelint@workspace:@navikt/aksel-stylelint"
   dependencies:
-    "@navikt/ds-css": ^4.5.0
-    "@navikt/ds-tokens": ^4.5.0
+    "@navikt/ds-css": ^4.6.0
+    "@navikt/ds-tokens": ^4.6.0
     "@types/jest": ^29.0.0
     concurrently: 7.2.1
     copyfiles: 2.4.1
@@ -3832,7 +3832,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel@workspace:@navikt/aksel"
   dependencies:
-    "@navikt/ds-css": 4.5.0
+    "@navikt/ds-css": 4.6.0
     "@types/inquirer": ^9.0.3
     "@types/jest": ^29.0.0
     axios: 1.3.6
@@ -3856,11 +3856,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@*, @navikt/ds-css@4.5.0, @navikt/ds-css@^4.5.0, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@*, @navikt/ds-css@4.6.0, @navikt/ds-css@^4.6.0, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": ^4.5.0
+    "@navikt/ds-tokens": ^4.6.0
     cssnano: 6.0.0
     fast-glob: 3.2.11
     lodash: 4.17.21
@@ -3873,12 +3873,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@*, @navikt/ds-react@4.5.0, @navikt/ds-react@^4.5.0, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@*, @navikt/ds-react@4.6.0, @navikt/ds-react@^4.6.0, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": 0.24.1
-    "@navikt/aksel-icons": ^4.5.0
+    "@navikt/aksel-icons": ^4.6.0
     "@radix-ui/react-tabs": 1.0.0
     "@radix-ui/react-toggle-group": 1.0.0
     "@testing-library/dom": 8.13.0
@@ -3914,11 +3914,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@^4.5.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@^4.6.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": ^4.5.0
+    "@navikt/ds-tokens": ^4.6.0
     "@types/jest": ^29.0.0
     color: 4.2.3
     jest: ^29.0.0
@@ -3929,7 +3929,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@^4.5.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@^4.6.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -7996,11 +7996,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/aksel-icons": ^4.5.0
-    "@navikt/ds-css": ^4.5.0
-    "@navikt/ds-react": ^4.5.0
-    "@navikt/ds-tailwind": ^4.5.0
-    "@navikt/ds-tokens": ^4.5.0
+    "@navikt/aksel-icons": ^4.6.0
+    "@navikt/ds-css": ^4.6.0
+    "@navikt/ds-react": ^4.6.0
+    "@navikt/ds-tailwind": ^4.6.0
+    "@navikt/ds-tokens": ^4.6.0
     prettier-plugin-tailwindcss: ^0.2.3
   languageName: unknown
   linkType: soft
@@ -22408,8 +22408,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "shadow-dom@workspace:examples/shadow-dom"
   dependencies:
-    "@navikt/ds-css": 4.5.0
-    "@navikt/ds-react": 4.5.0
+    "@navikt/ds-css": 4.6.0
+    "@navikt/ds-react": 4.6.0
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0
     "@vitejs/plugin-react": ^2.1.0


### PR DESCRIPTION
### Description

Layout brakk hvis legend/label er lengre enn parent-box. Fikset ved å sette elementet til `inline-flex`

### Change summary

Alle legend/label instanser bruker nå `inline-flex` når readOnly er satt.