### PR TITLE
:bug: Fikset datepicker-bug for dynamsik oppdatering av 'month'

### DIFF
--- a/.changeset/early-queens-happen.md
+++ b/.changeset/early-queens-happen.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Datepicker: Fikset bug ved bruk dynamisk oppdatering av minDate. Vist `month` vil nå alltid være oppdatert når datepicker åpnes

--- a/@navikt/core/react/src/date/hooks/useDatepicker.tsx
+++ b/@navikt/core/react/src/date/hooks/useDatepicker.tsx
@@ -166,8 +166,7 @@ export const useDatepicker = (
   const handleOpen = useCallback(
     (open: boolean) => {
       setOpen(open);
-      !open &&
-        setMonth(selectedDay ?? defaultSelected ?? defaultMonth ?? today);
+      open && setMonth(selectedDay ?? defaultSelected ?? defaultMonth ?? today);
     },
     [defaultMonth, defaultSelected, selectedDay, today]
   );

--- a/@navikt/core/react/src/date/hooks/useMonthPicker.tsx
+++ b/@navikt/core/react/src/date/hooks/useMonthPicker.tsx
@@ -163,8 +163,7 @@ export const useMonthpicker = (
   const handleOpen = useCallback(
     (open: boolean) => {
       setOpen(open);
-      !open &&
-        setYear(selectedMonth ?? defaultSelected ?? defaultYear ?? today);
+      open && setYear(selectedMonth ?? defaultSelected ?? defaultYear ?? today);
     },
     [defaultSelected, defaultYear, selectedMonth, today]
   );


### PR DESCRIPTION
### Description

`month` ble bare oppdatert når datepicker lukkes. Dette førte til feil visning når data ble oppdatert dynamiskt og datepicker måtte åpnes + lukkes for at endringene skulle oppdaterte `month`. 

### Change summary

Kjører nå `setMonth` når datepicker åpnes (før når den lukkes). Up-to-date verdier vil nå alltid synkes når datepicker åpnes.
