### PR TITLE
:memo: Oppdatert datepicker-eksempler med formatering

### DIFF
--- a/aksel.nav.no/website/pages/eksempler/datepicker/anchor.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/anchor.tsx
@@ -1,5 +1,7 @@
 import { Button, DatePicker } from "@navikt/ds-react";
 import { withDsExample } from "components/website-modules/examples/withDsExample";
+import format from "date-fns/format";
+import nbLocale from "date-fns/locale/nb";
 import { useState } from "react";
 
 const Example = () => {
@@ -20,7 +22,9 @@ const Example = () => {
       {days && (
         <div className="pt-4">
           {days.map((x) => (
-            <div key={x.toString()}>{x.toDateString()}</div>
+            <div key={x.toString()}>
+              {format(x, "dd.MM.yyyy", { locale: nbLocale })}
+            </div>
           ))}
         </div>
       )}

--- a/aksel.nav.no/website/pages/eksempler/datepicker/input-range.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/input-range.tsx
@@ -1,5 +1,7 @@
 import { DatePicker, useRangeDatepicker } from "@navikt/ds-react";
 import { withDsExample } from "components/website-modules/examples/withDsExample";
+import format from "date-fns/format";
+import nbLocale from "date-fns/locale/nb";
 
 const Example = () => {
   const { datepickerProps, toInputProps, fromInputProps, selectedRange } =
@@ -18,8 +20,14 @@ const Example = () => {
       </DatePicker>
       {selectedRange && (
         <div className="pt-4">
-          <div>{selectedRange?.from && selectedRange.from.toDateString()}</div>
-          <div>{selectedRange?.to && selectedRange.to.toDateString()}</div>
+          <div>
+            {selectedRange?.from &&
+              format(selectedRange.from, "dd.MM.yyyy", { locale: nbLocale })}
+          </div>
+          <div>
+            {selectedRange?.to &&
+              format(selectedRange.to, "dd.MM.yyyy", { locale: nbLocale })}
+          </div>
         </div>
       )}
     </div>

--- a/aksel.nav.no/website/pages/eksempler/datepicker/input-single.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/input-single.tsx
@@ -1,5 +1,7 @@
 import { DatePicker, useDatepicker } from "@navikt/ds-react";
 import { withDsExample } from "components/website-modules/examples/withDsExample";
+import format from "date-fns/format";
+import nbLocale from "date-fns/locale/nb";
 
 const Example = () => {
   const { datepickerProps, inputProps, selectedDay } = useDatepicker({
@@ -12,7 +14,9 @@ const Example = () => {
       <DatePicker {...datepickerProps}>
         <DatePicker.Input {...inputProps} label="Velg dato" />
       </DatePicker>
-      <div className="pt-4">{selectedDay && selectedDay.toDateString()}</div>
+      <div className="pt-4">
+        {selectedDay && format(selectedDay, "dd.MM.yyyy", { locale: nbLocale })}
+      </div>
     </div>
   );
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/modal.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/modal.tsx
@@ -7,6 +7,8 @@ import {
 } from "@navikt/ds-react";
 import { withDsExample } from "components/website-modules/examples/withDsExample";
 import { useEffect, useState } from "react";
+import format from "date-fns/format";
+import nbLocale from "date-fns/locale/nb";
 
 const Example = () => {
   const [open, setOpen] = useState(false);
@@ -40,7 +42,8 @@ const Example = () => {
               <DatePicker.Input {...inputProps} label="Velg dato" />
             </DatePicker>
             <div className="pt-4">
-              {selectedDay && selectedDay.toDateString()}
+              {selectedDay &&
+                format(selectedDay, "dd.MM.yyyy", { locale: nbLocale })}
             </div>
           </div>
         </Modal.Content>

--- a/aksel.nav.no/website/pages/eksempler/datepicker/two-digit-year.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/two-digit-year.tsx
@@ -1,5 +1,7 @@
 import { DatePicker, useDatepicker } from "@navikt/ds-react";
 import { withDsExample } from "components/website-modules/examples/withDsExample";
+import format from "date-fns/format";
+import nbLocale from "date-fns/locale/nb";
 
 const Example = () => {
   const { datepickerProps, inputProps, selectedDay } = useDatepicker({
@@ -13,7 +15,9 @@ const Example = () => {
       <DatePicker {...datepickerProps}>
         <DatePicker.Input {...inputProps} label="Velg dato" />
       </DatePicker>
-      <div className="pt-4">{selectedDay && selectedDay.toDateString()}</div>
+      <div className="pt-4">
+        {selectedDay && format(selectedDay, "dd.MM.yyyy", { locale: nbLocale })}
+      </div>
     </div>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3796,7 +3796,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@^4.7.0, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
+"@navikt/aksel-icons@^4.7.2, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-icons@workspace:@navikt/aksel-icons"
   dependencies:
@@ -3823,8 +3823,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-stylelint@workspace:@navikt/aksel-stylelint"
   dependencies:
-    "@navikt/ds-css": ^4.7.0
-    "@navikt/ds-tokens": ^4.7.0
+    "@navikt/ds-css": ^4.7.2
+    "@navikt/ds-tokens": ^4.7.2
     "@types/jest": ^29.0.0
     concurrently: 7.2.1
     copyfiles: 2.4.1
@@ -3841,7 +3841,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel@workspace:@navikt/aksel"
   dependencies:
-    "@navikt/ds-css": 4.7.0
+    "@navikt/ds-css": 4.7.2
     "@types/inquirer": ^9.0.3
     "@types/jest": ^29.0.0
     axios: 1.3.6
@@ -3865,11 +3865,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@*, @navikt/ds-css@4.7.0, @navikt/ds-css@^4.7.0, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@*, @navikt/ds-css@4.7.2, @navikt/ds-css@^4.7.2, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": ^4.7.0
+    "@navikt/ds-tokens": ^4.7.2
     cssnano: 6.0.0
     fast-glob: 3.2.11
     lodash: 4.17.21
@@ -3882,12 +3882,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@*, @navikt/ds-react@4.7.0, @navikt/ds-react@^4.7.0, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@*, @navikt/ds-react@4.7.2, @navikt/ds-react@^4.7.2, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": 0.24.1
-    "@navikt/aksel-icons": ^4.7.0
+    "@navikt/aksel-icons": ^4.7.2
     "@radix-ui/react-tabs": 1.0.0
     "@radix-ui/react-toggle-group": 1.0.0
     "@testing-library/dom": 8.13.0
@@ -3923,11 +3923,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@^4.7.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@^4.7.2, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": ^4.7.0
+    "@navikt/ds-tokens": ^4.7.2
     "@types/jest": ^29.0.0
     color: 4.2.3
     jest: ^29.0.0
@@ -3938,7 +3938,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@^4.7.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@^4.7.2, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -7926,11 +7926,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/aksel-icons": ^4.7.0
-    "@navikt/ds-css": ^4.7.0
-    "@navikt/ds-react": ^4.7.0
-    "@navikt/ds-tailwind": ^4.7.0
-    "@navikt/ds-tokens": ^4.7.0
+    "@navikt/aksel-icons": ^4.7.2
+    "@navikt/ds-css": ^4.7.2
+    "@navikt/ds-react": ^4.7.2
+    "@navikt/ds-tailwind": ^4.7.2
+    "@navikt/ds-tokens": ^4.7.2
     prettier-plugin-tailwindcss: ^0.2.3
   languageName: unknown
   linkType: soft
@@ -22201,8 +22201,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "shadow-dom@workspace:examples/shadow-dom"
   dependencies:
-    "@navikt/ds-css": 4.7.0
-    "@navikt/ds-react": 4.7.0
+    "@navikt/ds-css": 4.7.2
+    "@navikt/ds-react": 4.7.2
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0
     "@vitejs/plugin-react": ^2.1.0


### PR DESCRIPTION
### Description

Eksempler formaterer nå vist valgt dato til standard norsk format

### Change summary

Eksempler kjører nå `format` fra date-fns istedenfor `toDateString()`
