### PR TITLE
:bug: Forsøk på aria-live fix for button

### DIFF
--- a/.changeset/brave-bottles-scream.md
+++ b/.changeset/brave-bottles-scream.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Button: Fikset aria-live bug der knapp alltid ble lest opp av skjermleser ved render

--- a/@navikt/core/react/src/button/Button.tsx
+++ b/@navikt/core/react/src/button/Button.tsx
@@ -126,11 +126,7 @@ export const Button: OverridableComponent<ButtonProps, HTMLButtonElement> =
                 <span className="navds-button__icon">{icon}</span>
               )}
               {children && (
-                <Label
-                  as="span"
-                  size={size === "medium" ? "medium" : "small"}
-                  aria-live="polite"
-                >
+                <Label as="span" size={size === "medium" ? "medium" : "small"}>
                   {children}
                 </Label>
               )}

--- a/@navikt/core/react/src/button/button.stories.tsx
+++ b/@navikt/core/react/src/button/button.stories.tsx
@@ -1,6 +1,7 @@
 import { StarIcon } from "@navikt/aksel-icons";
-import React from "react";
+import React, { useState } from "react";
 import { Button } from "./index";
+import { Tabs, VStack } from "..";
 
 export default {
   title: "ds-react/Button",
@@ -277,4 +278,38 @@ export const LoadingWithAs = {
 
   args: { chromatic: { disableSnapshot: true } },
   chromatic: { disableSnapshot: true },
+};
+
+export const LoadingDemo = () => {
+  const [l, setL] = useState(false);
+
+  const handleLoading = () => {
+    setL(true);
+    setTimeout(() => setL(false), 2000);
+  };
+
+  return (
+    <Tabs defaultValue="logg">
+      <Tabs.List>
+        <Tabs.Tab value="logg" label="Logg" />
+        <Tabs.Tab value="inbox" label="Inbox" />
+      </Tabs.List>
+      <Tabs.Panel value="logg" className="h-24 w-full bg-gray-50 p-4">
+        <VStack gap="6">
+          <button onClick={handleLoading}>Toggle loading</button>
+          <Button loading={l} onClick={handleLoading}>
+            Testknapp 1
+          </Button>
+        </VStack>
+      </Tabs.Panel>
+      <Tabs.Panel value="inbox" className="h-24 w-full bg-gray-50 p-4">
+        <VStack gap="6">
+          <button onClick={handleLoading}>Toggle loading</button>
+          <Button loading={l} onClick={handleLoading}>
+            Testknapp 2
+          </Button>
+        </VStack>
+      </Tabs.Panel>
+    </Tabs>
+  );
 };

--- a/@navikt/core/react/src/button/button.stories.tsx
+++ b/@navikt/core/react/src/button/button.stories.tsx
@@ -1,7 +1,6 @@
 import { StarIcon } from "@navikt/aksel-icons";
-import React, { useState } from "react";
+import React from "react";
 import { Button } from "./index";
-import { Tabs, VStack } from "..";
 
 export default {
   title: "ds-react/Button",
@@ -149,8 +148,9 @@ export const Loading = {
     </div>
   ),
 
-  args: { chromatic: { disableSnapshot: true } },
-  chromatic: { disableSnapshot: true },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export const Icon = () => (
@@ -276,40 +276,7 @@ export const LoadingWithAs = {
     </div>
   ),
 
-  args: { chromatic: { disableSnapshot: true } },
-  chromatic: { disableSnapshot: true },
-};
-
-export const LoadingDemo = () => {
-  const [l, setL] = useState(false);
-
-  const handleLoading = () => {
-    setL(true);
-    setTimeout(() => setL(false), 2000);
-  };
-
-  return (
-    <Tabs defaultValue="logg">
-      <Tabs.List>
-        <Tabs.Tab value="logg" label="Logg" />
-        <Tabs.Tab value="inbox" label="Inbox" />
-      </Tabs.List>
-      <Tabs.Panel value="logg" className="h-24 w-full bg-gray-50 p-4">
-        <VStack gap="6">
-          <button onClick={handleLoading}>Toggle loading</button>
-          <Button loading={l} onClick={handleLoading}>
-            Testknapp 1
-          </Button>
-        </VStack>
-      </Tabs.Panel>
-      <Tabs.Panel value="inbox" className="h-24 w-full bg-gray-50 p-4">
-        <VStack gap="6">
-          <button onClick={handleLoading}>Toggle loading</button>
-          <Button loading={l} onClick={handleLoading}>
-            Testknapp 2
-          </Button>
-        </VStack>
-      </Tabs.Panel>
-    </Tabs>
-  );
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3496,7 +3496,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@^4.7.3, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
+"@navikt/aksel-icons@^4.9.0, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-icons@workspace:@navikt/aksel-icons"
   dependencies:
@@ -3523,8 +3523,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-stylelint@workspace:@navikt/aksel-stylelint"
   dependencies:
-    "@navikt/ds-css": ^4.7.3
-    "@navikt/ds-tokens": ^4.7.3
+    "@navikt/ds-css": ^4.9.0
+    "@navikt/ds-tokens": ^4.9.0
     "@types/jest": ^29.0.0
     concurrently: 7.2.1
     copyfiles: 2.4.1
@@ -3541,7 +3541,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel@workspace:@navikt/aksel"
   dependencies:
-    "@navikt/ds-css": 4.7.3
+    "@navikt/ds-css": 4.9.0
     "@types/inquirer": ^9.0.3
     "@types/jest": ^29.0.0
     axios: 1.3.6
@@ -3565,11 +3565,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@*, @navikt/ds-css@4.7.3, @navikt/ds-css@^4.7.3, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@*, @navikt/ds-css@4.9.0, @navikt/ds-css@^4.9.0, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": ^4.7.3
+    "@navikt/ds-tokens": ^4.9.0
     cssnano: 6.0.0
     fast-glob: 3.2.11
     lodash: 4.17.21
@@ -3582,12 +3582,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@*, @navikt/ds-react@4.7.3, @navikt/ds-react@^4.7.3, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@*, @navikt/ds-react@4.9.0, @navikt/ds-react@^4.9.0, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": 0.24.1
-    "@navikt/aksel-icons": ^4.7.3
+    "@navikt/aksel-icons": ^4.9.0
     "@radix-ui/react-tabs": 1.0.0
     "@radix-ui/react-toggle-group": 1.0.0
     "@testing-library/dom": 8.13.0
@@ -3623,11 +3623,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@^4.7.3, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@^4.9.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": ^4.7.3
+    "@navikt/ds-tokens": ^4.9.0
     "@types/jest": ^29.0.0
     color: 4.2.3
     jest: ^29.0.0
@@ -3638,7 +3638,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@^4.7.3, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@^4.9.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -7969,11 +7969,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/aksel-icons": ^4.7.3
-    "@navikt/ds-css": ^4.7.3
-    "@navikt/ds-react": ^4.7.3
-    "@navikt/ds-tailwind": ^4.7.3
-    "@navikt/ds-tokens": ^4.7.3
+    "@navikt/aksel-icons": ^4.9.0
+    "@navikt/ds-css": ^4.9.0
+    "@navikt/ds-react": ^4.9.0
+    "@navikt/ds-tailwind": ^4.9.0
+    "@navikt/ds-tokens": ^4.9.0
     prettier-plugin-tailwindcss: ^0.2.3
   languageName: unknown
   linkType: soft
@@ -21952,8 +21952,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "shadow-dom@workspace:examples/shadow-dom"
   dependencies:
-    "@navikt/ds-css": 4.7.3
-    "@navikt/ds-react": 4.7.3
+    "@navikt/ds-css": 4.9.0
+    "@navikt/ds-react": 4.9.0
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0
     "@vitejs/plugin-react": ^3.1.0


### PR DESCRIPTION
### Description

Mange brukere sliter i dag med at aria-live leser opp innholdet i knappen første gang knappen vises. Dette skjer ofte når knappen går fra å være i en container med `display: none` til synlig. Eksempelvis i Tabs.

### Change summary

- Fjernet aria-live fra Button
- Laget en story `LoadingDemo` der man kan teste loading-state i button (fjernes før merge)

