### PR TITLE
It is not possible to close combobox dropdown after clicking a chip

### DIFF
--- a/.changeset/fluffy-guests-watch.md
+++ b/.changeset/fluffy-guests-watch.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Fixes bug where combobox list could not be closed after clicking a chip

--- a/@navikt/core/react/src/form/combobox/Input/Input.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.tsx
@@ -37,6 +37,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       ariaDescribedBy,
       moveFocusToInput,
       moveFocusToEnd,
+      setFilteredOptionsIndex,
       shouldAutocomplete,
     } = useFilteredOptionsContext();
 
@@ -139,6 +140,10 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       [filteredOptions.length, onChange, toggleIsListOpen]
     );
 
+    const onBlur = () => {
+      setFilteredOptionsIndex(-1);
+    };
+
     return (
       <input
         {...rest}
@@ -148,6 +153,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         onChange={onChangeHandler}
         type="text"
         role="combobox"
+        onBlur={onBlur}
         onKeyUp={handleKeyUp}
         onKeyDown={handleKeyDown}
         aria-controls={`${inputProps.id}-filtered-options`}

--- a/@navikt/core/react/src/form/combobox/SelectedOptions/SelectedOptions.tsx
+++ b/@navikt/core/react/src/form/combobox/SelectedOptions/SelectedOptions.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Chips } from "../../..";
 import { useSelectedOptionsContext } from "./selectedOptionsContext";
+import { useInputContext } from "../Input/inputContext";
 
 interface SelectedOptionsProps {
   selectedOptions?: string[];
@@ -10,10 +11,12 @@ interface SelectedOptionsProps {
 
 const Option = ({ option }: { option: string }) => {
   const { isMultiSelect, removeSelectedOption } = useSelectedOptionsContext();
+  const { focusInput } = useInputContext();
 
   const onClick = (e) => {
     e.stopPropagation();
     removeSelectedOption(option);
+    focusInput();
   };
 
   if (!isMultiSelect) {

--- a/@navikt/core/react/src/form/combobox/combobox.stories.tsx
+++ b/@navikt/core/react/src/form/combobox/combobox.stories.tsx
@@ -365,12 +365,20 @@ export const RemoveSelectedMultiSelectTest = {
     await sleep(250);
     userEvent.keyboard("{Enter}");
     await sleep(250);
-    userEvent.keyboard("{Escape}");
-    await sleep(250);
 
     const appleSlett = canvas.getByLabelText("apple slett");
+    appleSlett.focus();
+    await sleep(250);
     userEvent.click(appleSlett);
     await sleep(250);
+    const appleOption = canvas.getByRole("option", {
+      name: "apple",
+      selected: false,
+    });
+    expect(appleOption).toBeVisible();
+    userEvent.keyboard("{Escape}");
+    await sleep(250);
+    expect(appleOption).not.toBeVisible();
 
     const bananaSlett = canvas.getByLabelText("banana slett");
     expect(bananaSlett).toBeInTheDocument();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3496,7 +3496,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@^4.10.0, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
+"@navikt/aksel-icons@^4.10.2, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-icons@workspace:@navikt/aksel-icons"
   dependencies:
@@ -3523,8 +3523,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-stylelint@workspace:@navikt/aksel-stylelint"
   dependencies:
-    "@navikt/ds-css": ^4.10.0
-    "@navikt/ds-tokens": ^4.10.0
+    "@navikt/ds-css": ^4.10.2
+    "@navikt/ds-tokens": ^4.10.2
     "@types/jest": ^29.0.0
     concurrently: 7.2.1
     copyfiles: 2.4.1
@@ -3541,7 +3541,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel@workspace:@navikt/aksel"
   dependencies:
-    "@navikt/ds-css": 4.10.0
+    "@navikt/ds-css": 4.10.2
     "@types/inquirer": ^9.0.3
     "@types/jest": ^29.0.0
     axios: 1.3.6
@@ -3565,11 +3565,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@*, @navikt/ds-css@4.10.0, @navikt/ds-css@^4.10.0, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@*, @navikt/ds-css@4.10.2, @navikt/ds-css@^4.10.2, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": ^4.10.0
+    "@navikt/ds-tokens": ^4.10.2
     cssnano: 6.0.0
     fast-glob: 3.2.11
     lodash: 4.17.21
@@ -3582,12 +3582,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@*, @navikt/ds-react@4.10.0, @navikt/ds-react@^4.10.0, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@*, @navikt/ds-react@4.10.2, @navikt/ds-react@^4.10.2, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": 0.24.1
-    "@navikt/aksel-icons": ^4.10.0
+    "@navikt/aksel-icons": ^4.10.2
     "@radix-ui/react-tabs": 1.0.0
     "@radix-ui/react-toggle-group": 1.0.0
     "@testing-library/dom": 8.13.0
@@ -3623,11 +3623,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@^4.10.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@^4.10.2, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": ^4.10.0
+    "@navikt/ds-tokens": ^4.10.2
     "@types/jest": ^29.0.0
     color: 4.2.3
     jest: ^29.0.0
@@ -3638,7 +3638,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@^4.10.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@^4.10.2, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -7969,11 +7969,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/aksel-icons": ^4.10.0
-    "@navikt/ds-css": ^4.10.0
-    "@navikt/ds-react": ^4.10.0
-    "@navikt/ds-tailwind": ^4.10.0
-    "@navikt/ds-tokens": ^4.10.0
+    "@navikt/aksel-icons": ^4.10.2
+    "@navikt/ds-css": ^4.10.2
+    "@navikt/ds-react": ^4.10.2
+    "@navikt/ds-tailwind": ^4.10.2
+    "@navikt/ds-tokens": ^4.10.2
     prettier-plugin-tailwindcss: ^0.2.3
   languageName: unknown
   linkType: soft
@@ -21952,8 +21952,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "shadow-dom@workspace:examples/shadow-dom"
   dependencies:
-    "@navikt/ds-css": 4.10.0
-    "@navikt/ds-react": 4.10.0
+    "@navikt/ds-css": 4.10.2
+    "@navikt/ds-react": 4.10.2
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0
     "@vitejs/plugin-react": ^3.1.0


### PR DESCRIPTION
Fixes bug where it is not possible to close dropdown by pressing escape or clicking outside the combobox after clicking the chips to de-select an option

### Description

In short, the focus were lost/reset when the chip disappears, but now is reset to the input instead. Also fixed issue where clicking the chip while virtual focus is in the dropdown caused a click on both the option and the chip, causing it to be de-selected and instantly re-selected.

### Change summary

- Resets focus to the input field after removing a chip
- Resets virtual focus when focus leaves the input field, but keeps the list open if focus does not leave the entire combobox
