### PR TITLE
:art: Fikset hardkodet border-radius i diverse komponenter

### DIFF
--- a/.changeset/plenty-cobras-give.md
+++ b/.changeset/plenty-cobras-give.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Border-radius: Fikset hardkodet border-radius i Datepicker, ToggleGroup og Combobox.

--- a/@navikt/aksel-icons/figma-plugin/src/ui/app.css
+++ b/@navikt/aksel-icons/figma-plugin/src/ui/app.css
@@ -58,7 +58,7 @@
 .icon-button {
   min-height: 3rem;
   min-width: 3rem;
-  border-radius: 2px;
+  border-radius: var(--a-border-radius-small);
   display: grid;
   place-content: center;
   background-color: var(--a-surface-default);

--- a/@navikt/core/css/date.css
+++ b/@navikt/core/css/date.css
@@ -233,7 +233,7 @@
   text-decoration: none;
   border: none;
   background: none;
-  border-radius: 3px;
+  border-radius: calc(var(--a-border-radius-medium) - 1px);
   padding: var(--a-spacing-3);
   align-items: center;
   justify-content: center;

--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -283,7 +283,7 @@
 
 .navds-combobox__list-item__new-option--focus {
   box-shadow: var(--a-shadow-focus) inset, var(--a-border-action) 0 0 0 5px inset;
-  border-radius: 3px;
+  border-radius: calc(var(--a-border-radius-medium) - 1px);
 }
 
 /* Mobile */

--- a/@navikt/core/css/toggle-group.css
+++ b/@navikt/core/css/toggle-group.css
@@ -34,7 +34,7 @@
   cursor: pointer;
   background-color: var(--ac-toggle-group-button-bg, var(--a-surface-transparent));
   color: var(--ac-toggle-group-button-text, var(--a-text-default));
-  border-radius: 2px;
+  border-radius: var(--a-border-radius-small);
   min-width: fit-content;
   font-weight: var(--a-font-weight-regular);
 }

--- a/aksel.nav.no/website/styles/utilities.css
+++ b/aksel.nav.no/website/styles/utilities.css
@@ -30,7 +30,7 @@ p.override-text-no-max {
   position: absolute;
   width: 8px;
   height: 8px;
-  border-radius: 2px;
+  border-radius: var(--a-border-radius-small);
   background-color: var(--a-deepblue-500);
   transform: translateY(10px) translateX(2px) rotate(45deg);
   left: 0;


### PR DESCRIPTION
### Description

Resolves #2158

Noe bruk av border-radius var hardkodet da vi ikke hadde tokens for dem (f.eks `3px`). Dette gjorde at overskriving av border-radius tokens ikke passet ved bruk av disse. 
Fiksen er å bruke tokens + calc for å dynamiskt justere border-radius ved endring.