### PR TITLE
🐛 fix: Combobox , SingleSelect: allow custom options

### DIFF
--- a/.changeset/poor-buckets-collect.md
+++ b/.changeset/poor-buckets-collect.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+:bug: Combobox, SingleSelect: fix adding custom options

--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -253,6 +253,11 @@
   padding-left: calc(var(--a-spacing-3) - 4px);
 }
 
+.navds-form-field--small .navds-combobox__list-item--focus,
+.navds-form-field--small .navds-combobox__list-item:hover {
+  padding-left: calc(var(--a-spacing-2) - 4px);
+}
+
 .navds-combobox__list-item--selected {
   background-color: var(--ac-combobox-list-item-selected-bg, var(--a-surface-selected));
 }

--- a/@navikt/core/react/src/form/combobox/SelectedOptions/selectedOptionsContext.tsx
+++ b/@navikt/core/react/src/form/combobox/SelectedOptions/selectedOptionsContext.tsx
@@ -69,7 +69,7 @@ export const SelectedOptionsProvider = ({
         .includes(option?.toLowerCase?.());
       if (isCustomOption) {
         allowNewValues && addCustomOption(option);
-        setSelectedOptions([]);
+        !isMultiSelect && setSelectedOptions([]);
       } else if (isMultiSelect) {
         setSelectedOptions((prevSelectedOptions) => [
           ...prevSelectedOptions,

--- a/@navikt/core/react/src/form/combobox/SelectedOptions/selectedOptionsContext.tsx
+++ b/@navikt/core/react/src/form/combobox/SelectedOptions/selectedOptionsContext.tsx
@@ -42,8 +42,12 @@ export const SelectedOptionsProvider = ({
   >;
 }) => {
   const { clearInput, focusInput } = useInputContext();
-  const { customOptions, removeCustomOption, addCustomOption } =
-    useCustomOptionsContext();
+  const {
+    customOptions,
+    removeCustomOption,
+    addCustomOption,
+    setCustomOptions,
+  } = useCustomOptionsContext();
   const {
     allowNewValues,
     isMultiSelect,
@@ -65,6 +69,7 @@ export const SelectedOptionsProvider = ({
         .includes(option?.toLowerCase?.());
       if (isAddedByUser) {
         allowNewValues && addCustomOption(option);
+        setSelectedOptions([]);
       } else if (isMultiSelect) {
         setSelectedOptions((prevSelectedOptions) => [
           ...prevSelectedOptions,
@@ -72,10 +77,18 @@ export const SelectedOptionsProvider = ({
         ]);
       } else {
         setSelectedOptions([option]);
+        setCustomOptions([]);
       }
       onToggleSelected?.(option, true, isAddedByUser);
     },
-    [addCustomOption, allowNewValues, isMultiSelect, onToggleSelected, options]
+    [
+      addCustomOption,
+      allowNewValues,
+      isMultiSelect,
+      onToggleSelected,
+      options,
+      setCustomOptions,
+    ]
   );
 
   const removeSelectedOption = useCallback(

--- a/@navikt/core/react/src/form/combobox/customOptionsContext.tsx
+++ b/@navikt/core/react/src/form/combobox/customOptionsContext.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useCallback, createContext, useContext } from "react";
 import { useInputContext } from "./Input/inputContext";
+import { useSelectedOptionsContext } from "./SelectedOptions/selectedOptionsContext";
 
 type CustomOptionsContextType = {
   customOptions: string[];
   removeCustomOption: (option: string) => void;
   addCustomOption: (option: string) => void;
+  setCustomOptions: React.Dispatch<React.SetStateAction<string[]>>;
 };
 
 const CustomOptionsContext = createContext<CustomOptionsContextType>(
@@ -14,6 +16,7 @@ const CustomOptionsContext = createContext<CustomOptionsContextType>(
 export const CustomOptionsProvider = ({ children }) => {
   const [customOptions, setCustomOptions] = useState<string[]>([]);
   const { focusInput } = useInputContext();
+  const { isMultiSelect } = useSelectedOptionsContext();
 
   const removeCustomOption = useCallback(
     (option) => {
@@ -27,16 +30,21 @@ export const CustomOptionsProvider = ({ children }) => {
 
   const addCustomOption = useCallback(
     (option) => {
-      setCustomOptions((prevOptions) => [...prevOptions, option]);
+      if (isMultiSelect) {
+        setCustomOptions((prevOptions) => [...prevOptions, option]);
+      } else {
+        setCustomOptions([option]);
+      }
       focusInput();
     },
-    [focusInput, setCustomOptions]
+    [focusInput, isMultiSelect, setCustomOptions]
   );
 
   const customOptionsState = {
     customOptions,
     removeCustomOption,
     addCustomOption,
+    setCustomOptions,
   };
 
   return (


### PR DESCRIPTION
### Description

<!-- PR description/motivation
add links to project-tasks, slack discussions etc here
-->

### Change summary

- fix: SingleSelect didn't properly allow for custom options, now does
- fix: Adding a custom option _and_ listed option didn't remove the other, so you had chosen two options. Now fixed. 
