### PR TITLE
Missing Combobox.onClear when clearing the input field programatically

### DIFF
--- a/.changeset/heavy-cats-jog.md
+++ b/.changeset/heavy-cats-jog.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Trigger Combobox.onChange callback in addition to onClear when clearing the value programmatically

--- a/@navikt/core/react/src/form/combobox/Input/inputContext.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/inputContext.tsx
@@ -80,10 +80,11 @@ export const InputContextProvider = ({ children, value: props }) => {
   const clearInput = useCallback(
     (event: React.PointerEvent | React.KeyboardEvent) => {
       onClear?.(event);
+      externalOnChange?.(null, "");
       setValue("");
       setSearchTerm("");
     },
-    [onClear, setSearchTerm, setValue]
+    [externalOnChange, onClear, setValue]
   );
 
   const focusInput = useCallback(() => {

--- a/@navikt/core/react/src/form/combobox/combobox.stories.tsx
+++ b/@navikt/core/react/src/form/combobox/combobox.stories.tsx
@@ -479,6 +479,6 @@ export const TestThatCallbacksOnlyFireWhenExpected = {
     await sleep(250);
     expect(args.onClear.mock.calls).toHaveLength(1);
     expect(args.onToggleSelected.mock.calls).toHaveLength(1);
-    expect(args.onChange.mock.calls).toHaveLength(searchWord.length);
+    expect(args.onChange.mock.calls).toHaveLength(searchWord.length + 1);
   },
 };

--- a/@navikt/core/react/src/form/combobox/types.ts
+++ b/@navikt/core/react/src/form/combobox/types.ts
@@ -66,7 +66,10 @@ export interface ComboboxProps
    * @param event
    * @returns
    */
-  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (
+    event: ChangeEvent<HTMLInputElement> | null,
+    value?: string
+  ) => void;
   /**
    * Callback function triggered whenever the input field is cleared
    *


### PR DESCRIPTION

### Description

We fire onChange anytime the user edits the text or deletes text using backspace. However, if clearing the field through the clear button or when selecting an option in the dropdown, only the onClear callback is triggered. To allow users to use onChange consistently to track the value, we need to trigger onChange in these cases as well.

### Change summary

- Trigger the Combobox.onChange callback when clearing the input value, similar to if the user removed the text manually (e.g. backspace)