### PR TITLE
:label: Modal: Bedre type for `width`

### DIFF
--- a/.changeset/afraid-bugs-teach.md
+++ b/.changeset/afraid-bugs-teach.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+:label: Modal: Bedre type for `width`

--- a/@navikt/core/react/src/modal/Modal.tsx
+++ b/@navikt/core/react/src/modal/Modal.tsx
@@ -64,7 +64,7 @@ export interface ModalProps
   /**
    * @default fit-content (up to 700px)
    * */
-  width?: "medium" | "small" | number | string;
+  width?: "medium" | "small" | number | `${number}${string}`;
   /**
    * User defined classname for modal
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3351,7 +3351,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@^4.12.1, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
+"@navikt/aksel-icons@^5.0.1, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-icons@workspace:@navikt/aksel-icons"
   dependencies:
@@ -3378,8 +3378,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-stylelint@workspace:@navikt/aksel-stylelint"
   dependencies:
-    "@navikt/ds-css": ^4.12.1
-    "@navikt/ds-tokens": ^4.12.1
+    "@navikt/ds-css": ^5.0.1
+    "@navikt/ds-tokens": ^5.0.1
     "@types/jest": ^29.0.0
     concurrently: 7.2.1
     copyfiles: 2.4.1
@@ -3396,7 +3396,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel@workspace:@navikt/aksel"
   dependencies:
-    "@navikt/ds-css": 4.12.1
+    "@navikt/ds-css": 5.0.1
     "@types/inquirer": ^9.0.3
     "@types/jest": ^29.0.0
     axios: 1.3.6
@@ -3420,11 +3420,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@*, @navikt/ds-css@4.12.1, @navikt/ds-css@^4.12.1, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@*, @navikt/ds-css@5.0.1, @navikt/ds-css@^5.0.1, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": ^4.12.1
+    "@navikt/ds-tokens": ^5.0.1
     cssnano: 6.0.0
     fast-glob: 3.2.11
     lodash: 4.17.21
@@ -3437,12 +3437,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@*, @navikt/ds-react@4.12.1, @navikt/ds-react@^4.12.1, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@*, @navikt/ds-react@5.0.1, @navikt/ds-react@^5.0.1, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": 0.24.1
-    "@navikt/aksel-icons": ^4.12.1
+    "@navikt/aksel-icons": ^5.0.1
     "@radix-ui/react-tabs": 1.0.0
     "@radix-ui/react-toggle-group": 1.0.0
     "@testing-library/dom": 8.13.0
@@ -3476,11 +3476,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@^4.12.1, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@^5.0.1, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": ^4.12.1
+    "@navikt/ds-tokens": ^5.0.1
     "@types/jest": ^29.0.0
     color: 4.2.3
     jest: ^29.0.0
@@ -3491,7 +3491,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@^4.12.1, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@^5.0.1, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -8033,11 +8033,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/aksel-icons": ^4.12.1
-    "@navikt/ds-css": ^4.12.1
-    "@navikt/ds-react": ^4.12.1
-    "@navikt/ds-tailwind": ^4.12.1
-    "@navikt/ds-tokens": ^4.12.1
+    "@navikt/aksel-icons": ^5.0.1
+    "@navikt/ds-css": ^5.0.1
+    "@navikt/ds-react": ^5.0.1
+    "@navikt/ds-tailwind": ^5.0.1
+    "@navikt/ds-tokens": ^5.0.1
     prettier-plugin-tailwindcss: ^0.2.3
   languageName: unknown
   linkType: soft
@@ -22026,8 +22026,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "shadow-dom@workspace:examples/shadow-dom"
   dependencies:
-    "@navikt/ds-css": 4.12.1
-    "@navikt/ds-react": 4.12.1
+    "@navikt/ds-css": 5.0.1
+    "@navikt/ds-react": 5.0.1
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0
     "@vitejs/plugin-react": ^3.1.0


### PR DESCRIPTION
Gjør at "medium" og "small" nå kommer opp i dokumentasjon/tsdoc/intellisense.