### PR TITLE
Add new LICENCE-file for /fonts

### DIFF
--- a/@navikt/aksel-icons/README.md
+++ b/@navikt/aksel-icons/README.md
@@ -63,4 +63,4 @@ declare module "*.svg" {
 
 ## License
 
-[MIT](https://github.com/navikt/aksel/blob/main/LICENCE)
+[MIT](https://github.com/navikt/aksel/blob/main/fonts/LICENCE)

--- a/@navikt/aksel/README.md
+++ b/@navikt/aksel/README.md
@@ -242,4 +242,4 @@ This codemod can only be ran once, since the size-scale will keep decreasing for
 
 ## License
 
-[MIT](https://github.com/navikt/aksel/blob/main/LICENCE)
+[MIT](https://github.com/navikt/aksel/blob/main/fonts/LICENCE)

--- a/@navikt/core/css/README.md
+++ b/@navikt/core/css/README.md
@@ -40,4 +40,4 @@ But you can import it in a .css-file
 
 ## License
 
-[MIT](https://github.com/navikt/aksel/blob/main/LICENCE)
+[MIT](https://github.com/navikt/aksel/blob/main/fonts/LICENCE)

--- a/@navikt/core/react/README.md
+++ b/@navikt/core/react/README.md
@@ -33,4 +33,4 @@ function App() {
 
 ## License
 
-[MIT](https://github.com/navikt/aksel/blob/main/LICENCE)
+[MIT](https://github.com/navikt/aksel/blob/main/fonts/LICENCE)

--- a/@navikt/core/tailwind/README.md
+++ b/@navikt/core/tailwind/README.md
@@ -26,4 +26,4 @@ module.exports = {
 
 ## License
 
-[MIT](https://github.com/navikt/aksel/blob/main/LICENCE)
+[MIT](https://github.com/navikt/aksel/blob/main/fonts/LICENCE)

--- a/@navikt/core/tokens/README.md
+++ b/@navikt/core/tokens/README.md
@@ -33,4 +33,4 @@ backgroundcolor: var(--a-surface-default);
 
 ## License
 
-[MIT](https://github.com/navikt/aksel/blob/main/LICENCE)
+[MIT](https://github.com/navikt/aksel/blob/main/fonts/LICENCE)

--- a/LICENCE
+++ b/LICENCE
@@ -1,15 +1,11 @@
-Font License
-
-SIL Open Font License (OFL)
-
-# The MIT License
+# MIT Licence
 
 Copyright 2023 NAV (Arbeids- og velferdsdirektoratet) - The Norwegian Labour and Welfare Administration
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
+the rights to use, copy, modify, merge, publish, distribute, sublicence,
 and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:
 

--- a/fonts/LICENCE
+++ b/fonts/LICENCE
@@ -1,0 +1,3 @@
+# Font Licence
+
+SIL Open Font Licence (OFL)


### PR DESCRIPTION
### Description
ref: https://nav-it.slack.com/archives/C7NE7A8UF/p1692692096991049
Endrer og flytter licence-filer slik at det er en egen for fonts i /fonts og en for prosjektet som en helhet i root

### Change summary

- Laget en LICENCE-fil i /fonts med font-licencing-info
- Endret andre filer som henviser til denne
- Endret license til license (s vs. c, amerikansk vs. britisk) siden filnavnene bruker c

#### Versioning 🏷️

- Run `yarn changeset` to generate a version-entry for change.
- - Bug/hotfix: Patch
- - New feature: Minor
- - Breaking change: Major
- Adding breaking changes? Consider adding a codemod for easier migration.
- Breaking changes also needs documentation under "Migration"-page on website
