### PR TITLE
:page_facing_up: Move font-license to /fonts & change 'licence' to 'license'

### DIFF
--- a/@navikt/aksel-icons/README.md
+++ b/@navikt/aksel-icons/README.md
@@ -63,4 +63,4 @@ declare module "*.svg" {
 
 ## License
 
-[MIT](https://github.com/navikt/aksel/blob/main/LICENCE)
+[MIT](https://github.com/navikt/aksel/blob/main/LICENSE)

--- a/@navikt/aksel/README.md
+++ b/@navikt/aksel/README.md
@@ -242,4 +242,4 @@ This codemod can only be ran once, since the size-scale will keep decreasing for
 
 ## License
 
-[MIT](https://github.com/navikt/aksel/blob/main/LICENCE)
+[MIT](https://github.com/navikt/aksel/blob/main/LICENSE)

--- a/@navikt/core/css/README.md
+++ b/@navikt/core/css/README.md
@@ -40,4 +40,4 @@ But you can import it in a .css-file
 
 ## License
 
-[MIT](https://github.com/navikt/aksel/blob/main/LICENCE)
+[MIT](https://github.com/navikt/aksel/blob/main/LICENSE)

--- a/@navikt/core/react/README.md
+++ b/@navikt/core/react/README.md
@@ -33,4 +33,4 @@ function App() {
 
 ## License
 
-[MIT](https://github.com/navikt/aksel/blob/main/LICENCE)
+[MIT](https://github.com/navikt/aksel/blob/main/LICENSE)

--- a/@navikt/core/tailwind/README.md
+++ b/@navikt/core/tailwind/README.md
@@ -26,4 +26,4 @@ module.exports = {
 
 ## License
 
-[MIT](https://github.com/navikt/aksel/blob/main/LICENCE)
+[MIT](https://github.com/navikt/aksel/blob/main/LICENSE)

--- a/@navikt/core/tokens/README.md
+++ b/@navikt/core/tokens/README.md
@@ -33,4 +33,4 @@ backgroundcolor: var(--a-surface-default);
 
 ## License
 
-[MIT](https://github.com/navikt/aksel/blob/main/LICENCE)
+[MIT](https://github.com/navikt/aksel/blob/main/LICENSE)

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,4 @@
-Font License
-
-SIL Open Font License (OFL)
-
-# The MIT License
+# MIT License
 
 Copyright 2023 NAV (Arbeids- og velferdsdirektoratet) - The Norwegian Labour and Welfare Administration
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Vi tar gjerne i mot PR-er! [CONTRIBUTING.md](https://github.com/navikt/aksel/blo
 
 ## Lisenser
 
-[MIT](https://github.com/navikt/aksel/blob/main/LICENCE)
+[MIT](https://github.com/navikt/aksel/blob/main/LICENSE)
 
 ## Codeowners
 

--- a/fonts/LICENSE
+++ b/fonts/LICENSE
@@ -1,0 +1,3 @@
+# Font License
+
+SIL Open Font License (OFL)


### PR DESCRIPTION
Description
ref: https://nav-it.slack.com/archives/C7NE7A8UF/p1692692096991049
Endrer og flytter licence-filer slik at det er en egen for fonts i /fonts og en for prosjektet som en helhet i root. Håpet er at Github skal kunne lese lisensen lettere. 

Change summary

- Laget en LICENCE-fil i /fonts
- Endret licence til license (les: c til s) overalt så det blir likt og fordi package.json krever s
