### PR TITLE
:wheelchair: Textarea: Skjermleser-spesifikk tekst leses opp sammenhengende

### DIFF
--- a/.changeset/smooth-hornets-try.md
+++ b/.changeset/smooth-hornets-try.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+:wheelchair: Textarea: Skjermleser-spesifikk tekst leses opp sammenhengende

--- a/@navikt/core/react/src/form/Textarea.tsx
+++ b/@navikt/core/react/src/form/Textarea.tsx
@@ -171,7 +171,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           {hasMaxLength && (
             <>
               <span id={maxLengthId} className="navds-sr-only">
-                Tekstområde med plass til {maxLength} tegn.
+                {`Tekstområde med plass til ${maxLength} tegn.`}
               </span>
               <Counter
                 maxLength={maxLength}


### PR DESCRIPTION
Closes https://github.com/navikt/aksel/issues/1975

Gjelder VoiceOver (Mac)