### PR TITLE
:bug: move internal token definition to a larger scope

### DIFF
--- a/.changeset/brave-impalas-agree.md
+++ b/.changeset/brave-impalas-agree.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+:bug: fix missing accordion bottom box-shadow on last element (when opened)

--- a/@navikt/core/css/accordion.css
+++ b/@navikt/core/css/accordion.css
@@ -1,3 +1,7 @@
+.navds-accordion {
+  --__ac-accordion-header-shadow-color: var(--ac-accordion-header-border, var(--a-border-divider));
+}
+
 .navds-accordion__item:focus-within {
   position: relative;
 }
@@ -6,7 +10,6 @@
  * Header *
  *************************/
 .navds-accordion__header {
-  --__ac-accordion-header-shadow-color: var(--ac-accordion-header-border, var(--a-border-divider));
   --__ac-accordion-header-shadow: inset 2px 0 0 0 var(--a-transparent), inset -2px 0 0 0 var(--a-transparent),
     inset 0 2px 0 0 var(--__ac-accordion-header-shadow-color);
 


### PR DESCRIPTION
when the scope only covered the __header, the __item could not use the same token, and it was undefined. Setting this on a shared parent (the topmost accordion) fixes this.

### Description

fixes https://github.com/navikt/team-aksel/issues/257

### Change summary

move internal token definition to a higher scope.