### PR TITLE
:bug: fiks createPackageJsonsWithESMPointers i Windows

### DIFF
--- a/scripts/createPackageJsonsWithESMPointers.js
+++ b/scripts/createPackageJsonsWithESMPointers.js
@@ -21,7 +21,7 @@ const createPackageJsonsWithESMPointers = async () => {
         "package.json"
       );
 
-      const depth = (packageJsonPath.match(/\//g) || []).length;
+      const depth = packageJsonPath.split(path.sep).length - 1;
       const esmDir = `../`.repeat(depth) + "esm";
 
       const packageJson = {


### PR DESCRIPTION
createPackageJsonsWithESMPointers virket ikke i Windows fordi directory separator var hardkodet til `/`, mens Windows bruker `\`.