### PR TITLE
🎨 Skeleton as-prop

### DIFF
--- a/.changeset/rotten-badgers-breathe.md
+++ b/.changeset/rotten-badgers-breathe.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+Skeleton: Lagt til as-prop for inline brk av Skeleton med span

--- a/@navikt/core/css/skeleton.css
+++ b/@navikt/core/css/skeleton.css
@@ -1,5 +1,4 @@
 .navds-skeleton {
-  display: block;
   background-color: var(--ac-skeleton-bg, var(--a-surface-neutral-moderate));
   height: 1.3em;
   animation: akselSkeletonAnimation 0.8s linear infinite alternate;

--- a/@navikt/core/react/src/skeleton/Skeleton.tsx
+++ b/@navikt/core/react/src/skeleton/Skeleton.tsx
@@ -15,6 +15,11 @@ export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
    * When not inferring width from children, you must specify width
    */
   width?: number | string;
+  /**
+   * Overrides html-tag
+   * @default "div"
+   */
+  as?: "div" | "span";
 }
 
 /**
@@ -28,11 +33,20 @@ export interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
  */
 export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
   (
-    { className, children, height, width, style, variant = "text", ...rest },
+    {
+      className,
+      children,
+      height,
+      width,
+      style,
+      variant = "text",
+      as: As = "div",
+      ...rest
+    },
     ref
   ) => {
     return (
-      <div
+      <As
         {...rest}
         ref={ref}
         className={cl(
@@ -49,7 +63,7 @@ export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(
         aria-hidden
       >
         {children}
-      </div>
+      </As>
     );
   }
 );

--- a/@navikt/core/react/src/skeleton/skeleton.stories.tsx
+++ b/@navikt/core/react/src/skeleton/skeleton.stories.tsx
@@ -116,3 +116,14 @@ export const NativeText = {
     </div>
   ),
 };
+
+export const InlineText = {
+  render: () => (
+    <BodyLong>
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur
+      voluptas sint dolore <Skeleton as="div">omnis quia consequatur</Skeleton>{" "}
+      beatae vero cum officia debitis. Quidem debitis omnis reprehenderit nobis
+      rerum. Nulla, magnam? Saepe, eveniet? Test
+    </BodyLong>
+  ),
+};

--- a/@navikt/core/react/src/skeleton/skeleton.stories.tsx
+++ b/@navikt/core/react/src/skeleton/skeleton.stories.tsx
@@ -121,7 +121,7 @@ export const InlineText = {
   render: () => (
     <BodyLong>
       Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur
-      voluptas sint dolore <Skeleton as="div">omnis quia consequatur</Skeleton>{" "}
+      voluptas sint dolore <Skeleton as="span">omnis quia consequatur</Skeleton>{" "}
       beatae vero cum officia debitis. Quidem debitis omnis reprehenderit nobis
       rerum. Nulla, magnam? Saepe, eveniet? Test
     </BodyLong>

--- a/@navikt/core/react/src/skeleton/skeleton.stories.tsx
+++ b/@navikt/core/react/src/skeleton/skeleton.stories.tsx
@@ -102,7 +102,7 @@ export const NativeText = {
           Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur
           voluptas sint dolore omnis quia consequatur beatae vero cum officia
           debitis. Quidem debitis omnis reprehenderit nobis rerum. Nulla,
-          magnam? Saepe, eveniet? Test
+          magnam? Saepe, eveniet?
         </Skeleton>
       </h1>
       <Skeleton>
@@ -110,7 +110,7 @@ export const NativeText = {
           Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur
           voluptas sint dolore omnis quia consequatur beatae vero cum officia
           debitis. Quidem debitis omnis reprehenderit nobis rerum. Nulla,
-          magnam? Saepe, eveniet? Test
+          magnam? Saepe, eveniet?
         </p>
       </Skeleton>
     </div>
@@ -123,7 +123,7 @@ export const InlineText = {
       Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur
       voluptas sint dolore <Skeleton as="span">omnis quia consequatur</Skeleton>{" "}
       beatae vero cum officia debitis. Quidem debitis omnis reprehenderit nobis
-      rerum. Nulla, magnam? Saepe, eveniet? Test
+      rerum. Nulla, magnam? Saepe, eveniet?
     </BodyLong>
   ),
 };


### PR DESCRIPTION
### Description

Resolves #2233

Skeleton kan i dag ikke bli brukt inline i tekst på grunn av `display: block` og ugyldig dom-validering med p -> div. 

### Change summary

- Fjernet display: block fra CSS. Nettleser setter dette som default. Span får da automatisk display: inline
- La til `as`-prop med `"div" | "span"`

![Screenshot 2023-09-05 at 10 37 47](https://github.com/navikt/aksel/assets/26967723/526915d3-86d8-46e1-bd43-5254a630b250)

