### PR TITLE
Fiks Aksel Storybook der withDsExample går over flere linjer

### DIFF
--- a/aksel.nav.no/website/.storybook/main.ts
+++ b/aksel.nav.no/website/.storybook/main.ts
@@ -22,10 +22,7 @@ const config: StorybookConfig = {
     const exampleIndexer = async (fileName: string, opts) => {
       let code = readFileSync(fileName, "utf-8").toString();
 
-      code = code.replace(
-        /^\s*export default withDsExample\(Example[\s\S]*?;\s*/gm,
-        ""
-      );
+      code = code.replace(/export default withDsExample\([^;]+;/, "");
 
       code = code.replace("export const args =", "const args =");
 


### PR DESCRIPTION
Dette gjør at `yarn storybook:aksel` virker igjen.