### PR TITLE
:bug: Fikset kalkulering av fromDate/toDate

### DIFF
--- a/.changeset/witty-nails-behave.md
+++ b/.changeset/witty-nails-behave.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+MonthPicker: Fikset kalkulering av fromDate/toDate

--- a/@navikt/aksel-stylelint/package.json
+++ b/@navikt/aksel-stylelint/package.json
@@ -41,11 +41,11 @@
     "concurrently": "7.2.1",
     "copyfiles": "2.4.1",
     "jest": "^29.0.0",
-    "ts-jest": "^29.0.0",
     "jest-preset-stylelint": "^6.1.0",
     "postcss-selector-parser": "^6.0.13",
     "postcss-value-parser": "^4.2.0",
     "stylelint": "^14.8.5",
+    "ts-jest": "^29.0.0",
     "typescript": "^5.1.6"
   },
   "jest": {

--- a/@navikt/core/react/src/date/monthpicker/MonthButton.tsx
+++ b/@navikt/core/react/src/date/monthpicker/MonthButton.tsx
@@ -1,7 +1,8 @@
 import cl from "clsx";
 import format from "date-fns/format";
 import isSameMonth from "date-fns/isSameMonth";
-import isSameYear from "date-fns/isSameYear";
+import compareAsc from "date-fns/compareAsc";
+import compareDesc from "date-fns/compareDesc";
 import setYear from "date-fns/setYear";
 import React, { useEffect, useRef } from "react";
 import { useDayPicker } from "react-day-picker";
@@ -20,13 +21,13 @@ interface MonthType {
 const disableMonth = (month: Date, fromDate?: Date, toDate?: Date) => {
   if (fromDate && toDate) {
     return (
-      (isSameMonth(month, fromDate) && isSameYear(month, fromDate)) ||
-      (isSameMonth(month, toDate) && isSameYear(month, toDate))
+      (compareAsc(month, fromDate) === -1 && !isSameMonth(month, fromDate)) ||
+      (compareDesc(month, toDate) === -1 && !isSameMonth(month, toDate))
     );
   } else if (fromDate) {
-    return isSameMonth(month, fromDate) && isSameYear(month, fromDate);
+    return compareAsc(month, fromDate) === -1 && !isSameMonth(month, fromDate);
   } else if (toDate) {
-    return isSameMonth(month, toDate) && isSameYear(month, toDate);
+    return compareDesc(month, toDate) === -1 && !isSameMonth(month, toDate);
   }
   return false;
 };

--- a/@navikt/core/react/src/date/monthpicker/monthpicker.stories.tsx
+++ b/@navikt/core/react/src/date/monthpicker/monthpicker.stories.tsx
@@ -46,7 +46,7 @@ export const dropdownCaption = () => {
   return (
     <MonthPicker.Standalone
       dropdownCaption
-      fromDate={new Date("Jan 1 2019")}
+      fromDate={new Date("Feb 10 2019")}
       toDate={new Date("Sep 27 2032")}
     />
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3603,7 +3603,7 @@ __metadata:
     lodash.startcase: 4.4.0
     react: ^18.0.0
     rehype-parse: 8.0.4
-    typescript: ^4.8.0
+    typescript: ^5.1.6
     unified: 10.1.2
   languageName: unknown
   linkType: soft
@@ -3622,7 +3622,8 @@ __metadata:
     postcss-selector-parser: ^6.0.13
     postcss-value-parser: ^4.2.0
     stylelint: ^14.8.5
-    typescript: ^4.8.0
+    ts-jest: ^29.0.0
+    typescript: ^5.1.6
   languageName: unknown
   linkType: soft
 
@@ -3648,7 +3649,7 @@ __metadata:
     react-scanner: ^1.1.0
     rimraf: 3.0.2
     ts-jest: ^29.0.0
-    typescript: ^4.8.0
+    typescript: ^5.1.6
   bin:
     aksel: ./dist/index.js
   languageName: unknown
@@ -3699,8 +3700,8 @@ __metadata:
     rimraf: 3.0.2
     swr: ^1.1.2
     ts-jest: ^29.0.0
-    ts-node: 10.9.0
-    typescript: ^4.8.0
+    ts-node: ^10.9.1
+    typescript: ^5.1.6
   peerDependencies:
     "@types/react": ^17.0.30 || ^18.0.0
     react: ^17.0.0 || ^18.0.0
@@ -3720,8 +3721,8 @@ __metadata:
     jest: ^29.0.0
     lodash: ^4.17.21
     ts-jest: ^29.0.0
-    ts-node: 10.9.0
-    typescript: ^4.8.0
+    ts-node: ^10.9.1
+    typescript: ^5.1.6
   languageName: unknown
   linkType: soft
 
@@ -3736,8 +3737,8 @@ __metadata:
     nodemon: ^3.0.1
     style-dictionary: ^3.0.2
     ts-jest: ^29.0.0
-    ts-node: 10.9.0
-    typescript: ^4.8.0
+    ts-node: ^10.9.1
+    typescript: ^5.1.6
   languageName: unknown
   linkType: soft
 
@@ -8644,7 +8645,7 @@ __metadata:
     postcss-url: ^10.1.3
     react: ^18.0.0
     react-dom: ^18.0.0
-    typescript: ^4.8.0
+    typescript: ^5.1.6
     vite: ^4.2.0
     vite-plugin-singlefile: ^0.13.3
     vite-plugin-svgr: ^2.4.0
@@ -23791,7 +23792,7 @@ __metadata:
     "@vitejs/plugin-react": ^3.1.0
     react: ^18.0.0
     react-dom: ^18.0.0
-    typescript: ^4.8.0
+    typescript: ^5.1.6
     vite: ^4.2.0
   languageName: unknown
   linkType: soft
@@ -25731,9 +25732,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-node@npm:10.9.0":
-  version: 10.9.0
-  resolution: "ts-node@npm:10.9.0"
+"ts-node@npm:^10.9.1":
+  version: 10.9.1
+  resolution: "ts-node@npm:10.9.1"
   dependencies:
     "@cspotcode/source-map-support": ^0.8.0
     "@tsconfig/node10": ^1.0.7
@@ -25765,7 +25766,7 @@ __metadata:
     ts-node-script: dist/bin-script.js
     ts-node-transpile-only: dist/bin-transpile.js
     ts-script: dist/bin-script-deprecated.js
-  checksum: 2d75769e595a2ee1b7382c0d9a1cd5fbff14245b3022c3701f52146e148d91c495d71f0e2ba810e92482a36b88efb5e8c487d1fbeeb7fa75dd509c1e98894029
+  checksum: 090adff1302ab20bd3486e6b4799e90f97726ed39e02b39e566f8ab674fd5bd5f727f43615debbfc580d33c6d9d1c6b1b3ce7d8e3cca3e20530a145ffa232c35
   languageName: node
   linkType: hard
 
@@ -26043,6 +26044,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.1.6":
+  version: 5.2.2
+  resolution: "typescript@npm:5.2.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@4.6.3#~builtin<compat/typescript>":
   version: 4.6.3
   resolution: "typescript@patch:typescript@npm%3A4.6.3#~builtin<compat/typescript>::version=4.6.3&hash=7ad353"
@@ -26060,6 +26071,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 2eee5c37cad4390385db5db5a8e81470e42e8f1401b0358d7390095d6f681b410f2c4a0c496c6ff9ebd775423c7785cdace7bcdad76c7bee283df3d9718c0f20
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^5.1.6#~builtin<compat/typescript>":
+  version: 5.2.2
+  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=7ad353"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
   languageName: node
   linkType: hard
 
@@ -27036,8 +27057,8 @@ __metadata:
     tailwindcss: ^3.3.3
     tinycolor2: ^1.6.0
     ts-jest: ^29.0.0
-    ts-node: 10.9.0
-    typescript: ^4.8.0
+    ts-node: ^10.9.1
+    typescript: ^5.1.6
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

Fikser regression introdusert i #2231
MonthPicker kalkulerer nå disabledMonths riktig


Merger denne som en hotfix da brukere som har oppdatert til 5.3.1 eller nyere nå har en monthpicker der "ulovlige" perioder kan velges (potensielt).


