### PR TITLE
Utvide datePickerDefaultProps med onWeekNumberClick

### DIFF
--- a/.changeset/swift-pears-occur.md
+++ b/.changeset/swift-pears-occur.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Utvide DatePickerDefaultProps med onWeekNumberClick fra DayPickerBase.

--- a/@navikt/core/react/src/date/datepicker/DatePicker.tsx
+++ b/@navikt/core/react/src/date/datepicker/DatePicker.tsx
@@ -49,7 +49,10 @@ export type ConditionalModeProps =
 //github.com/gpbl/react-day-picker/blob/50b6dba/packages/react-day-picker/src/types/DayPickerBase.ts#L139
 export interface DatePickerDefaultProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "onSelect">,
-    Pick<DayPickerBase, "month" | "onMonthChange" | "today" | "onDayClick"> {
+    Pick<
+      DayPickerBase,
+      "month" | "onMonthChange" | "today" | "onDayClick" | "onWeekNumberClick"
+    > {
   /**
    * Element datepicker anchors to. Use <DatePicker.Input /> for built-in toggle, or make your own with the open/onClose props
    */


### PR DESCRIPTION
### Description

Utvide DatePickerDefaultProps med onWeekNumberClick fra DayPickerBase.

### Change summary

Utvide DatePickerDefaultProps med onWeekNumberClick fra DayPickerBase.

### Alternativ løsning til denne PR'en - og kanskje det som hadde vært best?
Kanskje det kan være et bedre alternativ å tilby hele DayPicker direkte, men hvor en har lagt til alle NAV tilpasningene på layout, locale, roles etc. Da vil brukere kunne bruke den med all funksjonalitet som den har, men samtidig høre til i NAV-familien.

Lagde egen PR på alternativet:
https://github.com/navikt/aksel/pull/2301
