### PR TITLE
[aksel.nav.no] :loud_sound: Logger redirects i middleware

### DIFF
--- a/aksel.nav.no/website/middleware.ts
+++ b/aksel.nav.no/website/middleware.ts
@@ -1,22 +1,29 @@
+import { noCdnClient, sanityClient } from "@/sanity/client.server";
+import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getClient } from "@/sanity/client.server";
 
-export async function middleware(req) {
+export async function middleware(req: NextRequest) {
   try {
-    const redirects = await getClient().fetch(`
-  *[_type == 'redirect'] {
+    const redirect = await sanityClient.fetch(
+      `
+  *[_type == 'redirect' && source == $source][0] {
+    _id,
     destination,
-    source,
-    permanent
+    redirects
   }
-`);
-
-    const redirect = redirects.find(
-      (redirect) =>
-        decodeURIComponent(req.nextUrl.pathname) === redirect?.source
+`,
+      { source: decodeURIComponent(req.nextUrl.pathname) }
     );
 
     if (redirect) {
+      const token = process.env.SANITY_WRITE_KEY;
+      if (token) {
+        noCdnClient(token)
+          .patch(redirect._id)
+          .set({ redirects: 1 + (redirect.redirects ?? 0) })
+          .commit();
+      }
+
       if (redirect.destination.startsWith("http")) {
         return NextResponse.redirect(new URL(redirect.destination));
       }

--- a/aksel.nav.no/website/sanity/schema/documents/redirects.ts
+++ b/aksel.nav.no/website/sanity/schema/documents/redirects.ts
@@ -34,6 +34,7 @@ export const Redirect = defineType({
       title: "Redirects (siden Sept 2023)",
       type: "number",
       initialValue: 0,
+      readOnly: true,
     }),
   ],
   __experimental_omnisearch_visibility: false,

--- a/aksel.nav.no/website/sanity/schema/documents/redirects.ts
+++ b/aksel.nav.no/website/sanity/schema/documents/redirects.ts
@@ -29,6 +29,12 @@ export const Redirect = defineType({
       type: "boolean",
       initialValue: () => true,
     }),
+    defineField({
+      name: "redirects",
+      title: "Redirects (siden Sept 2023)",
+      type: "number",
+      initialValue: 0,
+    }),
   ],
   __experimental_omnisearch_visibility: false,
 });

--- a/aksel.nav.no/website/scripts/migrations/slug.ts
+++ b/aksel.nav.no/website/scripts/migrations/slug.ts
@@ -30,13 +30,6 @@ const main = async () => {
     transactionClient.patch(data._id, (p) => p.unset(["slug_v2"]));
   });
 
-  /* transactionClient.create({
-    _type: "redirect",
-    source: `/designsystem`,
-    destination: `/`,
-    permanent: true,
-  }); */
-
   await transactionClient
     .commit({ autoGenerateArrayKeys: true, dryRun: true })
     .then((a) => console.log(`Updated! \n${JSON.stringify(a, null, 2)}`))


### PR DESCRIPTION
### Description

Manglet oversikt over hvilken url-er som ble redirected fra. Ved å logge antall redirects fra hver url kan vi enklere se hvilken som kan fjernes, eller om noen "kritiske" lenker bør oppdateres til oppdatert versjon på sikt

⚡ Henter nå også bare en (eller ingen) redirects dokumenter ved fetch fra sanity, ikke alle.