### PR TITLE
Datepicker expose all props

### DIFF
--- a/@navikt/core/css/date.css
+++ b/@navikt/core/css/date.css
@@ -33,6 +33,23 @@
   border-radius: var(--a-border-radius-small);
 }
 
+.navds-date_with_week_number_click .rdp-tbody .rdp-row .rdp-cell:first-child {
+  font-size: var(--a-font-size-small);
+  padding-right: calc(var(--a-spacing-1) + var(--a-spacing-05) / 2);
+  position: relative;
+}
+
+.navds-date_with_week_number_click .rdp-tbody .rdp-row .rdp-cell:first-child button::after {
+  display: block;
+  content: "";
+  position: absolute;
+  right: 0;
+  top: -1px;
+  bottom: -1px;
+  width: var(--a-spacing-05);
+  background-color: var(--a-border-default);
+}
+
 .navds-date__caption-dropdown {
   display: flex;
   justify-content: space-between;

--- a/@navikt/core/react/src/date/datepicker/DatePicker.tsx
+++ b/@navikt/core/react/src/date/datepicker/DatePicker.tsx
@@ -49,7 +49,7 @@ export type ConditionalModeProps =
 //github.com/gpbl/react-day-picker/blob/50b6dba/packages/react-day-picker/src/types/DayPickerBase.ts#L139
 export interface DatePickerDefaultProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "onSelect">,
-    Pick<DayPickerBase, "month" | "onMonthChange" | "today" | "onDayClick"> {
+    Omit<DayPickerBase, "hidden" | "locale"> {
   /**
    * Element datepicker anchors to. Use <DatePicker.Input /> for built-in toggle, or make your own with the open/onClose props
    */

--- a/@navikt/core/react/src/date/datepicker/DatePickerStandalone.tsx
+++ b/@navikt/core/react/src/date/datepicker/DatePickerStandalone.tsx
@@ -53,6 +53,7 @@ export const DatePickerStandalone: DatePickerStandaloneType = forwardRef<
       selected,
       defaultSelected,
       onSelect,
+      onWeekNumberClick,
       fixedWeeks = true,
       ...rest
     },
@@ -100,7 +101,10 @@ export const DatePickerStandalone: DatePickerStandaloneType = forwardRef<
             Caption: dropdownCaption ? DropdownCaption : Caption,
             Head: TableHead,
           }}
-          className="navds-date"
+          className={cl(
+            "navds-date",
+            onWeekNumberClick ? "navds-date_with_week_number_click" : ""
+          )}
           classNames={{ vhidden: "navds-sr-only" }}
           disabled={(day) => {
             return (
@@ -117,6 +121,7 @@ export const DatePickerStandalone: DatePickerStandaloneType = forwardRef<
             weekend: "rdp-day__weekend",
           }}
           showWeekNumber={showWeekNumber}
+          onWeekNumberClick={onWeekNumberClick}
           fixedWeeks={fixedWeeks}
           showOutsideDays
           {...omit(rest, ["onSelect", "children", "id"])}

--- a/@navikt/core/react/src/date/datepicker/datepicker.stories.tsx
+++ b/@navikt/core/react/src/date/datepicker/datepicker.stories.tsx
@@ -150,6 +150,19 @@ export const ShowWeekNumber = () => (
   <DatePicker.Standalone showWeekNumber today={new Date("2006-07-01")} />
 );
 
+export const ClickableWeekNumber = () => (
+  <DatePicker.Standalone
+    showWeekNumber
+    today={new Date("2006-07-01")}
+    onWeekNumberClick={(ukenummer) => {
+      console.log(`Uke ${ukenummer} trykket på`);
+    }}
+    labels={{
+      labelWeekNumber: (ukenummer) => `Uke ${ukenummer}`,
+    }}
+  />
+);
+
 export const UseDatepicker = () => {
   const { datepickerProps, inputProps } = useDatepicker({
     fromDate: new Date("Aug 23 2019"),


### PR DESCRIPTION
### Description

Utvide Datepicker med mulighet for å ha klikkbare ukenumre.

### Change summary

- Eksponere alle props i react-day-picker som ikke er i konflikt med Datepicker.
- Legge til styling for når bruker har satt props onWeekNumberClick

### Comment

Jeg antar det er gjort en vurdering tidligere på å ikke eksponere alle props som react-day-picker har. Men lager en PR uansett. Alternativet til å eksponere alle kan være å eksponere `onWeekNumberClick`og `labels`props. Da vil hovedfunksjonaliteten med å ha klikkbare ukenummer med mulighet for å sette riktig `aria-label` på ukenummeret være tilgjengelig.

Layout
![image](https://github.com/navikt/aksel/assets/462494/b282f2a5-cf75-443e-9f32-075020114dc1)

