### PR TITLE
Bugfix/dropdown voice over bug

### DIFF
--- a/.changeset/slimy-rocks-talk.md
+++ b/.changeset/slimy-rocks-talk.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Remove tabIndex="-1" on Popover to fix VoiceOver navigation issue inside Popover

--- a/@navikt/core/react/src/popover/Popover.tsx
+++ b/@navikt/core/react/src/popover/Popover.tsx
@@ -210,7 +210,6 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         })}
         data-placement={flPlacement}
         aria-hidden={!open || !anchorEl}
-        tabIndex={-1}
         {...getFloatingProps({
           ref: floatingRef,
           style: {

--- a/@navikt/core/react/src/popover/Popover.tsx
+++ b/@navikt/core/react/src/popover/Popover.tsx
@@ -203,16 +203,6 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       left: "right",
     }[flPlacement.split("-")[0]];
 
-    const floatingProps = getFloatingProps({
-      ref: floatingRef,
-      style: {
-        position: strategy,
-        top: y ?? 0,
-        left: x ?? 0,
-      },
-    });
-    delete floatingProps.tabIndex;
-
     return (
       <div
         className={cl("navds-popover", className, {
@@ -220,7 +210,15 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         })}
         data-placement={flPlacement}
         aria-hidden={!open || !anchorEl}
-        {...floatingProps}
+        {...getFloatingProps({
+          ref: floatingRef,
+          style: {
+            position: strategy,
+            top: y ?? 0,
+            left: x ?? 0,
+          },
+          tabIndex: undefined,
+        })}
         {...rest}
       >
         {children}

--- a/@navikt/core/react/src/popover/Popover.tsx
+++ b/@navikt/core/react/src/popover/Popover.tsx
@@ -203,6 +203,16 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       left: "right",
     }[flPlacement.split("-")[0]];
 
+    const floatingProps = getFloatingProps({
+      ref: floatingRef,
+      style: {
+        position: strategy,
+        top: y ?? 0,
+        left: x ?? 0,
+      },
+    });
+    delete floatingProps.tabIndex;
+
     return (
       <div
         className={cl("navds-popover", className, {
@@ -210,14 +220,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         })}
         data-placement={flPlacement}
         aria-hidden={!open || !anchorEl}
-        {...getFloatingProps({
-          ref: floatingRef,
-          style: {
-            position: strategy,
-            top: y ?? 0,
-            left: x ?? 0,
-          },
-        })}
+        {...floatingProps}
         {...rest}
       >
         {children}


### PR DESCRIPTION
### Description

Fix VoiceOver navigation issue inside Popover (and through inheritance in Dropdown, Datepicker and Timeline)

### Change summary

- Removed tabIndex="-1" on Popover, as it seems to break something™️ without appearing to be used for anything useful.
