### PR TITLE
:bug: Modal: Sett riktig tekstfarge

### DIFF
--- a/.changeset/wet-comics-destroy.md
+++ b/.changeset/wet-comics-destroy.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+:bug: Modal: Sett riktig tekstfarge

--- a/@navikt/core/css/modal.css
+++ b/@navikt/core/css/modal.css
@@ -11,6 +11,7 @@
   position: fixed;
   max-height: 100%;
   max-width: 100%;
+  color: var(--a-text-default);
 }
 
 .navds-modal[open] {


### PR DESCRIPTION
Sett `color` eksplisitt for å overstyre user agent stylesheet som setter `dialog { color: canvastext; }`

Resolves #2337