### PR TITLE
:lipstick: DatePicker: Litt smalere inputfelt

### DIFF
--- a/.changeset/giant-countries-relax.md
+++ b/.changeset/giant-countries-relax.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+:lipstick: DatePicker: Litt smalere inputfelt

--- a/@navikt/core/react/src/date/DateInput.tsx
+++ b/@navikt/core/react/src/date/DateInput.tsx
@@ -115,7 +115,7 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>((props, ref) => {
             "navds-body-short",
             `navds-body-short--${size}`
           )}
-          size={14}
+          size={isDatepickerVariant ? 10 : 14}
         />
         <button
           disabled={inputProps.disabled || readOnly}


### PR DESCRIPTION
Reduserer size ned til 10 på DateInput når den brukes i DatePicker da 14 er unødvendig bredt (en dato er 10 tegn). Det gjør det bittelitt enklere å få plass til to datofelt ved siden av hverandre (feks. ved range-modus) og imo ser det litt penere ut. Må imidlertid beholde 14 i MonthPicker siden måned skrives med bokstaver ("september 2023" er 14 tegn).

Det viser seg forresten at inputen blir smalere i Firefox enn Chrome ved samme size (eller width i em for den del). Prøvde først size=8 (og 12 på monthpicker), men det ble bare akkurat bredt nok på Firefox, så tenkte det var best å være på den sikre siden og ha litt å gå på.