### PR TITLE
[Aksel.nav.no] Fikser bug i `_id`-generering for props-tabeller

### DIFF
--- a/@navikt/core/react/src/list/List.tsx
+++ b/@navikt/core/react/src/list/List.tsx
@@ -32,7 +32,9 @@ export interface ListProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export interface ListComponent
-  extends React.ForwardRefExoticComponent<ListProps> {
+  extends React.ForwardRefExoticComponent<
+    ListProps & React.RefAttributes<HTMLDivElement>
+  > {
   /**
    * @see 🏷️ {@link ListItemProps}
    */

--- a/aksel.nav.no/website/sanity/schema/documents/komponenter/props.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/komponenter/props.tsx
@@ -78,11 +78,10 @@ export const Props = defineType({
       id: "_id",
     },
     prepare(selection) {
-      const { title, filepath, id } = selection;
-      const str = id.includes("core") ? "ds-react" : "ds-internal";
+      const { title, filepath } = selection;
       return {
         title,
-        subtitle: `${str}: ${filepath}`,
+        subtitle: `${filepath}`,
       };
     },
   },

--- a/aksel.nav.no/website/scripts/update-props.tsx
+++ b/aksel.nav.no/website/scripts/update-props.tsx
@@ -24,7 +24,7 @@ async function updateProps() {
   props.forEach((x) => transactionClient.createOrReplace(x));
 
   await transactionClient
-    .commit({ dryRun: true })
+    .commit()
     .then(() => console.log("Successfully updated prop-documentation"))
     .catch((e) => {
       throw new Error(e.message);
@@ -64,7 +64,7 @@ How to fix:
   }
 
   await transactionClient
-    .commit({ dryRun: true })
+    .commit()
     .then(() => console.log("Successfully deleted unused prop-documents"))
     .catch(() =>
       console.error(

--- a/aksel.nav.no/website/scripts/update-props.tsx
+++ b/aksel.nav.no/website/scripts/update-props.tsx
@@ -32,7 +32,7 @@ async function updateProps() {
 
   const remoteProps = await noCdnClient(token).fetch(`*[_type == "ds_props"]`);
 
-  const deletedIds: string[] = [];
+  let deletedIds: string[] = [];
   for (const prop of remoteProps) {
     if (!props.find(({ _id }) => _id === prop._id)) {
       transactionClient.delete(prop._id);
@@ -40,37 +40,36 @@ async function updateProps() {
     }
   }
 
-  if (deletedIds.length > 0) {
-    console.log("\n");
-    console.log(
-      `Found ${deletedIds.length} prop definitions no longer documented.
-This could be caused by moving file-location of prop-definition, a namechange or simply not existing anymore.
-
-How to fix:
-- Go to links provided under and try to manually delete document.
-- You will then be prompted to update referenced document before deleting.
-- After updating reference(s) and deleting document(s) there is no need to run the script again.`
-    );
-    console.log(
-      JSON.stringify(
-        deletedIds.map(
-          (x) =>
-            `https://aksel.nav.no/admin/prod/desk/admin;propsDesignsystemet;${x}`
-        ),
-        null,
-        2
-      )
-    );
-  }
-
   await transactionClient
     .commit()
     .then(() => console.log("Successfully deleted unused prop-documents"))
-    .catch(() =>
-      console.error(
-        "Failed deleting still referenced document(s). See previous warning for fix."
-      )
-    );
+    .catch((e) => {
+      /**
+       * Errormessage includes all ids that failed.
+       */
+      deletedIds = deletedIds.filter((id) => e.message.includes(id));
+
+      console.log("\n");
+      console.log(
+        `Found ${deletedIds.length} prop definitions no longer documented.
+    This could be caused by moving file-location of prop-definition, a namechange or simply not existing anymore.
+
+    How to fix:
+    - Go to links provided under and try to manually delete document.
+    - You will then be prompted to update referenced document before deleting.
+    - After updating reference(s) and deleting document(s) there is no need to run the script again.`
+      );
+      console.log(
+        JSON.stringify(
+          deletedIds.map(
+            (x) =>
+              `https://aksel.nav.no/admin/prod/desk/admin;propsDesignsystemet;${x}`
+          ),
+          null,
+          2
+        )
+      );
+    });
 }
 
 function propList() {

--- a/aksel.nav.no/website/scripts/update-props.tsx
+++ b/aksel.nav.no/website/scripts/update-props.tsx
@@ -4,6 +4,7 @@ import dotenv from "dotenv";
 import { noCdnClient } from "../sanity/interface/client.server";
 
 dotenv.config();
+dotenv.config({ path: `.env.local` });
 
 updateProps();
 
@@ -42,7 +43,7 @@ async function updateProps() {
   if (deletedIds.length > 0) {
     console.log("\n");
     console.log(
-      `Found prop ${deletedIds.length} definitions no longer documented.
+      `Found ${deletedIds.length} prop definitions no longer documented.
 This could be caused by moving file-location of prop-definition, a namechange or simply not existing anymore.
 
 How to fix:

--- a/aksel.nav.no/website/scripts/update-props.tsx
+++ b/aksel.nav.no/website/scripts/update-props.tsx
@@ -25,7 +25,9 @@ async function updateProps() {
   await transactionClient
     .commit({ dryRun: true })
     .then(() => console.log("Successfully updated prop-documentation"))
-    .catch((e) => console.error(e.message));
+    .catch((e) => {
+      throw new Error(e.message);
+    });
 
   const remoteProps = await noCdnClient(token).fetch(`*[_type == "ds_props"]`);
 

--- a/aksel.nav.no/website/scripts/update-props.tsx
+++ b/aksel.nav.no/website/scripts/update-props.tsx
@@ -69,6 +69,9 @@ async function updateProps() {
           2
         )
       );
+      throw new Error(
+        "Failed when deleting old prop-documentation from sanity, see warning above."
+      );
     });
 }
 

--- a/aksel.nav.no/website/scripts/update-props.tsx
+++ b/aksel.nav.no/website/scripts/update-props.tsx
@@ -42,8 +42,9 @@ async function updateProps() {
   if (deletedIds.length > 0) {
     console.log("\n");
     console.log(
-      `Found prop definitions no longer documented.
-This could be caused by moving file-locations of prop-definition or a namechange.
+      `Found prop ${deletedIds.length} definitions no longer documented.
+This could be caused by moving file-location of prop-definition, a namechange or simply not existing anymore.
+
 How to fix:
 - Go to links provided under and try to manually delete document.
 - You will then be prompted to update referenced document before deleting.
@@ -107,6 +108,6 @@ function hashString(str: string) {
   return output;
 }
 
-function checkIfDuplicateExists(arr) {
+function checkIfDuplicateExists(arr: string[]) {
   return new Set(arr).size !== arr.length;
 }


### PR DESCRIPTION
### Description

_id er er nå unik basert på navn + filepath
```
`${hashString(prop.displayName)}_${hashString(prop.filePath)}`
```

Ulemper:
- Flytting av filer vil endre _id, og referanse må oppdateres
- Endring av Propnavn endrer _id og referanse må oppdateres

Begge av disse skjer svært sjelden, så tror ikke det vil være et stort problem. Fordelene er at det nå er lettere å fikse + oppdage feil hvis det skulle hende.

### Change summary

- _id er er nå unik basert på navn + filepath
- Bedre feilhåndtering av prop-dokumentering
- Bedre feilmeldinger


Eks på feilmelding ved oppdaget avvik:

<img width="956" alt="Screenshot 2023-10-10 at 17 57 01" src="https://github.com/navikt/aksel/assets/26967723/7f449e5d-4d17-4b3a-ac83-89364ee8f28c">

## TODO:
- Etter review og testing, slette `{dryRun: true}` fra transaction-commit