### PR TITLE
:bug: Fikset tastaturnavigasjon i monthpicker

### DIFF
--- a/.changeset/new-ways-check.md
+++ b/.changeset/new-ways-check.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+MonthPicker: Fikset tastaturnavigasjon

--- a/@navikt/core/react/src/date/monthpicker/MonthButton.tsx
+++ b/@navikt/core/react/src/date/monthpicker/MonthButton.tsx
@@ -1,8 +1,8 @@
 import cl from "clsx";
-import format from "date-fns/format";
-import isSameMonth from "date-fns/isSameMonth";
 import compareAsc from "date-fns/compareAsc";
 import compareDesc from "date-fns/compareDesc";
+import format from "date-fns/format";
+import isSameMonth from "date-fns/isSameMonth";
 import setYear from "date-fns/setYear";
 import React, { useEffect, useRef } from "react";
 import { useDayPicker } from "react-day-picker";

--- a/@navikt/core/react/src/date/monthpicker/MonthSelector.tsx
+++ b/@navikt/core/react/src/date/monthpicker/MonthSelector.tsx
@@ -62,9 +62,9 @@ export const MonthSelector = () => {
   return (
     <BodyShort as="table" className="rdp-table">
       <tbody className="rdp-tbody">
-        {tableMonths.map((months, i) => (
+        {tableMonths.map((tableRow, i) => (
           <tr className="rdp-row" key={i}>
-            {months.map((month: Date) => {
+            {tableRow.map((month: Date) => {
               return (
                 <td key={month.toDateString()} className="rdp-cell">
                   <MonthButton

--- a/yarn.lock
+++ b/yarn.lock
@@ -3453,7 +3453,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@^5.6.5, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
+"@navikt/aksel-icons@^5.7.0, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-icons@workspace:@navikt/aksel-icons"
   dependencies:
@@ -3480,8 +3480,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-stylelint@workspace:@navikt/aksel-stylelint"
   dependencies:
-    "@navikt/ds-css": ^5.6.5
-    "@navikt/ds-tokens": ^5.6.5
+    "@navikt/ds-css": ^5.7.0
+    "@navikt/ds-tokens": ^5.7.0
     "@types/jest": ^29.0.0
     concurrently: 7.2.1
     copyfiles: 2.4.1
@@ -3499,7 +3499,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel@workspace:@navikt/aksel"
   dependencies:
-    "@navikt/ds-css": 5.6.5
+    "@navikt/ds-css": 5.7.0
     "@types/inquirer": ^9.0.3
     "@types/jest": ^29.0.0
     axios: 1.3.6
@@ -3523,11 +3523,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@*, @navikt/ds-css@5.6.5, @navikt/ds-css@^5.6.5, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@*, @navikt/ds-css@5.7.0, @navikt/ds-css@^5.7.0, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": ^5.6.5
+    "@navikt/ds-tokens": ^5.7.0
     cssnano: 6.0.0
     fast-glob: 3.2.11
     lodash: 4.17.21
@@ -3540,13 +3540,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@*, @navikt/ds-react@^5.6.5, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@*, @navikt/ds-react@^5.7.0, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": 0.25.4
-    "@navikt/aksel-icons": ^5.6.5
-    "@navikt/ds-tokens": ^5.6.5
+    "@navikt/aksel-icons": ^5.7.0
+    "@navikt/ds-tokens": ^5.7.0
     "@radix-ui/react-tabs": 1.0.0
     "@radix-ui/react-toggle-group": 1.0.0
     "@testing-library/dom": 8.13.0
@@ -3580,11 +3580,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@^5.6.5, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@^5.7.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": ^5.6.5
+    "@navikt/ds-tokens": ^5.7.0
     "@types/jest": ^29.0.0
     color: 4.2.3
     jest: ^29.0.0
@@ -3595,7 +3595,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@^5.6.5, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@^5.7.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -8490,11 +8490,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/aksel-icons": ^5.6.5
-    "@navikt/ds-css": ^5.6.5
-    "@navikt/ds-react": ^5.6.5
-    "@navikt/ds-tailwind": ^5.6.5
-    "@navikt/ds-tokens": ^5.6.5
+    "@navikt/aksel-icons": ^5.7.0
+    "@navikt/ds-css": ^5.7.0
+    "@navikt/ds-react": ^5.7.0
+    "@navikt/ds-tailwind": ^5.7.0
+    "@navikt/ds-tokens": ^5.7.0
     prettier-plugin-tailwindcss: ^0.2.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### Description

Resolves #2367 

[Bug ble introdusert i ESLint refactor](https://github.com/navikt/aksel/blame/7d675373bf070b44d12b34eb0a46e5b21362f054/%40navikt/core/react/src/date/monthpicker/MonthSelector.tsx#L65-L67)

### Change summary

- MonthButton får nå riktig liste med "months" for å velge mellom i tastaturnavigasjon


TODO: 
- Vurdere å skrive noen tester (storybook play-tester?) på dette
