### PR TITLE
[aksel.nav.no] Lagt til muligheten til å ikke ha "Send innspill" modul på komponent-artikler

### DIFF
--- a/aksel.nav.no/website/components/sanity-modules/ComponentOverview.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/ComponentOverview.tsx
@@ -1,10 +1,10 @@
-import { Heading } from "@navikt/ds-react";
-import Nextlink from "next/link";
-import cl from "clsx";
-import Image from "next/legacy/image";
-import { StatusTag } from "components/website-modules/StatusTag";
-import { ArticleListT } from "@/types";
 import { urlFor } from "@/sanity/interface";
+import { ArticleListT } from "@/types";
+import { Heading } from "@navikt/ds-react";
+import cl from "clsx";
+import { StatusTag } from "components/website-modules/StatusTag";
+import Image from "next/legacy/image";
+import Nextlink from "next/link";
 
 const ComponentOverview = ({ node }: { node: ArticleListT }) => {
   if (!node || node.length === 0) {
@@ -25,6 +25,16 @@ const ComponentOverview = ({ node }: { node: ArticleListT }) => {
         return 1;
       } else if (b?.status?.tag === "deprecated") {
         return -1;
+      }
+
+      if (a.sidebarindex !== null || b.sidebarindex !== null) {
+        if (a.sidebarindex !== null && b.sidebarindex !== null) {
+          return a.sidebarindex - b.sidebarindex;
+        } else if (a.sidebarindex !== null) {
+          return -1;
+        } else {
+          return 1;
+        }
       }
       return a?.heading?.localeCompare(b?.heading);
     });

--- a/aksel.nav.no/website/pages/grunnleggende/index.tsx
+++ b/aksel.nav.no/website/pages/grunnleggende/index.tsx
@@ -26,7 +26,7 @@ type PageProps = NextPageT<{
 
 export const query = `{${sidebarQuery}, ${landingPageQuery(
   "grunnleggende"
-)}, "links": *[_type == "ds_artikkel" && defined(kategori)]{_id,heading,"slug": slug,status,kategori}}`;
+)}, "links": *[_type == "ds_artikkel" && defined(kategori)]{_id,heading,"slug": slug,status,kategori,"sidebarindex": sidebarindex}}`;
 
 export const getStaticProps: GetStaticProps = async ({
   preview = false,

--- a/aksel.nav.no/website/pages/komponenter/[...slug].tsx
+++ b/aksel.nav.no/website/pages/komponenter/[...slug].tsx
@@ -27,9 +27,9 @@ import IntroSeksjon from "components/sanity-modules/IntroSeksjon";
 import { SEO } from "components/website-modules/seo/SEO";
 import { StatusTag } from "components/website-modules/StatusTag";
 import { SuggestionBlock } from "components/website-modules/suggestionblock";
+import { GetStaticPaths, GetStaticProps } from "next/types";
 import { lazy, Suspense } from "react";
 import NotFotfund from "../404";
-import { GetStaticPaths, GetStaticProps } from "next/types";
 
 const kodepakker = {
   "ds-react": {
@@ -303,7 +303,7 @@ const Page = ({
           />
         )}
         <IntroSeksjon node={page?.intro} internal={internal} />
-        {page?.status?.tag === "ready" && (
+        {page?.status?.tag === "ready" && !page?.hide_feedback && (
           <SuggestionBlock
             variant="komponent"
             reference={`<${page?.heading} />`}

--- a/aksel.nav.no/website/pages/komponenter/index.tsx
+++ b/aksel.nav.no/website/pages/komponenter/index.tsx
@@ -36,7 +36,7 @@ type PageProps = NextPageT<{
 
 export const query = `{${sidebarQuery}, ${landingPageQuery(
   "komponenter"
-)}, "links": *[_type == "komponent_artikkel" && defined(kategori)]{_id,heading,"slug": slug,status,kategori}}`;
+)}, "links": *[_type == "komponent_artikkel" && defined(kategori)]{_id,heading,"slug": slug,status,kategori, "sidebarindex": sidebarindex}}`;
 
 export const getStaticProps: GetStaticProps = async ({
   preview = false,

--- a/aksel.nav.no/website/sanity/schema/documents/komponenter/artikkel.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/komponenter/artikkel.tsx
@@ -1,10 +1,11 @@
 import { defineField, defineType } from "sanity";
 import { komponentKategorier } from "../../../config";
+import { devsOnly } from "../../../util";
 import { artikkelPreview } from "../presets/artikkel-preview";
-import { oppdateringsvarsel } from "../presets/oppdateringsvarsel";
 import { editorField } from "../presets/editors";
 import { groups } from "../presets/groups";
 import { hiddenFields } from "../presets/hidden-fields";
+import { oppdateringsvarsel } from "../presets/oppdateringsvarsel";
 import { SEOFields } from "../presets/seo";
 import { kategoriSlug } from "../presets/slug";
 import { titleField } from "../presets/title-field";
@@ -91,6 +92,14 @@ export const KomponentArtikkel = defineType({
       name: "sidebarindex",
       type: "number",
       group: "settings",
+    }),
+    defineField({
+      title: "Ikke vis 'Send innspill'-modul på siden",
+      name: "hide_feedback",
+      type: "boolean",
+      initialValue: false,
+      group: "settings",
+      hidden: devsOnly,
     }),
     defineField({
       name: "intro",

--- a/aksel.nav.no/website/sanity/util.tsx
+++ b/aksel.nav.no/website/sanity/util.tsx
@@ -1,3 +1,8 @@
+export const devsOnly = ({ currentUser }) =>
+  !currentUser.roles.find(({ name }) =>
+    ["developer", "administrator"].includes(name)
+  );
+
 export const getTemplates = (restTemplates: any[] = []) => {
   const templates = {
     profil: [

--- a/aksel.nav.no/website/types/sanity-schema.ts
+++ b/aksel.nav.no/website/types/sanity-schema.ts
@@ -155,6 +155,7 @@ export type ArticleListT = Array<{
     unsafe?: boolean;
     bilde?: any;
   };
+  sidebarindex?: number;
 }>;
 
 export type LandingPageTypeT<T extends string> = `${T}_landingsside`;

--- a/aksel.nav.no/website/types/sanity-schema.ts
+++ b/aksel.nav.no/website/types/sanity-schema.ts
@@ -109,6 +109,7 @@ export interface AkselKomponentDocT
     brukes_til: string[];
     brukes_ikke_til?: string[];
   };
+  hide_feedback?: boolean;
   content: any[];
   kodepakker?: string[];
   figma_link?: string;


### PR DESCRIPTION
### Description

Lagt til muligheten til å ikke ha "Send innspill" modul på komponent-artikler.

### Change summary

- Oversikts sidene på /komponenter, /grunnleggende er nå riktig sortert
