### PR TITLE
:bug: Modal: Bedre støtte for Tooltip i Modal

### DIFF
--- a/.changeset/wise-weeks-shop.md
+++ b/.changeset/wise-weeks-shop.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+:bug: Modal: Bedre støtte for Tooltip i Modal

--- a/@navikt/core/css/modal.css
+++ b/@navikt/core/css/modal.css
@@ -23,7 +23,6 @@
 .navds-modal--polyfilled {
   top: 50%;
   transform: translate(0, -50%);
-  overflow: auto;
 
   /* From polyfill (dialog-polyfill/dist/dialog-polyfill.css): */
   left: 0;
@@ -31,6 +30,10 @@
   width: fit-content;
   height: fit-content;
   margin: auto;
+}
+
+.navds-modal--polyfilled .navds-modal--polyfilled {
+  overflow: auto;
 }
 
 .navds-modal--polyfilled:not([open]) {

--- a/@navikt/core/react/src/modal/Modal.tsx
+++ b/@navikt/core/react/src/modal/Modal.tsx
@@ -108,6 +108,11 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
       if (needPolyfill && modalRef.current && portalNode) {
         dialogPolyfill.registerDialog(modalRef.current);
       }
+      // We set autofocus on the dialog element to prevent the default behavior where first focusable element gets focus when modal is opened.
+      // This is mainly to fix an edge case where having a Tooltip as the first focusable element would make it activate when you open the modal.
+      // We have to use JS because it doesn't work to set it with a prop (React bug?)
+      // Currently doesn't seem to work in Chrome. See also Tooltip.tsx
+      if (modalRef.current && portalNode) modalRef.current.autofocus = true;
     }, [modalRef, portalNode]);
 
     useEffect(() => {
@@ -156,6 +161,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
         <ModalContext.Provider
           value={{
             closeHandler: getCloseHandler(modalRef, header, onBeforeClose),
+            ref: modalRef,
           }}
         >
           {header && (

--- a/@navikt/core/react/src/modal/ModalContext.ts
+++ b/@navikt/core/react/src/modal/ModalContext.ts
@@ -2,5 +2,6 @@ import React from "react";
 
 interface ModalContextProps {
   closeHandler?: React.MouseEventHandler<HTMLButtonElement>;
+  ref: React.RefObject<HTMLDialogElement>;
 }
 export const ModalContext = React.createContext<ModalContextProps | null>(null);

--- a/@navikt/core/react/src/modal/modal.stories.tsx
+++ b/@navikt/core/react/src/modal/modal.stories.tsx
@@ -1,6 +1,6 @@
-import React, { useRef, useState } from "react";
 import { FileIcon } from "@navikt/aksel-icons";
-import { BodyLong, Button, Heading } from "..";
+import React, { useRef, useState } from "react";
+import { BodyLong, Button, Heading, Tooltip } from "..";
 import Modal from "./Modal";
 
 export default {
@@ -165,3 +165,28 @@ export const MediumWithPortal = () => (
     <Modal.Body>Lorem ipsum dolor sit amet.</Modal.Body>
   </Modal>
 );
+
+export const WithTooltip = () => {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  return (
+    <div>
+      <Button onClick={() => ref.current?.showModal()}>Open Modal</Button>
+      <Modal
+        open={ref.current ? undefined : true /* initially open */}
+        ref={ref}
+      >
+        <Modal.Body>
+          <div style={{ marginBottom: "1rem" }}>
+            <Tooltip content="This_is_the_first_tooltip">
+              <Button>Test 1</Button>
+            </Tooltip>
+          </div>
+          <Tooltip content="This is the second tooltip">
+            <Button>Test 2</Button>
+          </Tooltip>
+        </Modal.Body>
+      </Modal>
+    </div>
+  );
+};

--- a/@navikt/core/react/src/tooltip/Tooltip.tsx
+++ b/@navikt/core/react/src/tooltip/Tooltip.tsx
@@ -1,8 +1,8 @@
 import {
-  arrow as flArrow,
-  autoUpdate,
-  flip,
   FloatingPortal,
+  autoUpdate,
+  arrow as flArrow,
+  flip,
   offset,
   safePolygon,
   shift,
@@ -14,16 +14,18 @@ import {
 } from "@floating-ui/react";
 import cl from "clsx";
 import React, {
+  HTMLAttributes,
   cloneElement,
   forwardRef,
-  HTMLAttributes,
+  useContext,
   useMemo,
   useRef,
   useState,
 } from "react";
+import { ModalContext } from "../modal/ModalContext";
+import { useProvider } from "../provider";
 import { Detail } from "../typography";
 import { mergeRefs, useId } from "../util";
-import { useProvider } from "../provider";
 
 export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -110,7 +112,11 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
   ) => {
     const [open, setOpen] = useState(defaultOpen);
     const arrowRef = useRef<HTMLDivElement | null>(null);
-    const rootElement = useProvider()?.rootElement;
+    const modalContext = useContext(ModalContext);
+    const providerRootElement = useProvider()?.rootElement;
+    const rootElement = modalContext
+      ? modalContext.ref.current
+      : providerRootElement;
 
     const {
       x,
@@ -133,7 +139,13 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
         flip({ padding: 5, fallbackPlacements: ["bottom", "top"] }),
         flArrow({ element: arrowRef, padding: 5 }),
       ],
-      whileElementsMounted: autoUpdate,
+      whileElementsMounted: modalContext
+        ? (reference, floating, update) =>
+            // Makes weird behavoir in Chrome less weird (when first focusable elm in a Modal is a Tooltip)
+            // Can be removed when autofocus starts working on <dialog> in Chrome. See also Modal.tsx
+            autoUpdate(reference, floating, update, { animationFrame: true })
+        : autoUpdate,
+      strategy: modalContext ? "fixed" : undefined,
     });
 
     const { getReferenceProps, getFloatingProps } = useInteractions([

--- a/@navikt/core/react/src/tooltip/Tooltip.tsx
+++ b/@navikt/core/react/src/tooltip/Tooltip.tsx
@@ -141,7 +141,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       ],
       whileElementsMounted: modalContext
         ? (reference, floating, update) =>
-            // Makes weird behavoir in Chrome less weird (when first focusable elm in a Modal is a Tooltip)
+            // Reduces jumping in Chrome when used in a Modal and it's the first focusable element.
             // Can be removed when autofocus starts working on <dialog> in Chrome. See also Modal.tsx
             autoUpdate(reference, floating, update, { animationFrame: true })
         : autoUpdate,


### PR DESCRIPTION
For at Tooltip skal kunne blø ut av en modal må den ha position:fixed og modalen kan ikke ha overflow:auto/scroll. For å unngå at tooltip vises når modalen åpnes og det er det første fokuserbare elementet i modalen, settes autofocus på dialog-elementet. Dette fungerer imidlertid ikke i Chrome, så `animationFrame: true` i Tooltip er for å redusere et problem med at tooltipen hopper hit og dit mens modalens åpne-animasjon kjører.