### PR TITLE
:bug: Legg på onClose på Popover-eksempler

### DIFF
--- a/aksel.nav.no/website/pages/eksempler/popover/no-flip.tsx
+++ b/aksel.nav.no/website/pages/eksempler/popover/no-flip.tsx
@@ -18,7 +18,7 @@ const Example = () => {
 
       <Popover
         open={openState}
-        onClose={() => {}}
+        onClose={() => setOpenState(false)}
         anchorEl={buttonRef.current}
         flip={false}
         placement="right"

--- a/aksel.nav.no/website/pages/eksempler/popover/no-offset.tsx
+++ b/aksel.nav.no/website/pages/eksempler/popover/no-offset.tsx
@@ -18,7 +18,7 @@ const Example = () => {
 
       <Popover
         open={openState}
-        onClose={() => {}}
+        onClose={() => setOpenState(false)}
         anchorEl={buttonRef.current}
         offset={0}
         arrow={false}


### PR DESCRIPTION
Tror det er best at alle eksemplene har riktig implementert onClose slik at folk ikke glemmer å implementere det når de copy-paster koden.