### PR TITLE
:memo: add aria roles example to Alert

### DIFF
--- a/aksel.nav.no/website/pages/eksempler/alert/med-aria-roles.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert/med-aria-roles.tsx
@@ -1,0 +1,36 @@
+import { Alert } from "@navikt/ds-react";
+import { withDsExample } from "components/website-modules/examples/withDsExample";
+
+const Example = () => {
+  return (
+    <div className="grid gap-4">
+      <Alert variant="info">
+        Hvilken aria-role og hvilken Alert-variant man bruker er knyttet til
+        viktigheten av innholdet. I Info-varianten bør det ikke være nødvendig å
+        bruke aria-roles. Bruk role=&quot;status&quot; ved unntak.
+      </Alert>
+      <Alert role="status" variant="success">
+        Du gjorde noe rett! I Success-varianten kan du bruke
+        role=&quot;status&quot;.
+      </Alert>
+      <Alert role="status" variant="warning">
+        Det er noe som ikke stemmer! I Warning-varianten kan du bruke
+        role=&quot;status&quot;
+      </Alert>
+      <Alert role="alert" variant="error">
+        Kritisk feil! I Error-varianten kan du bruke role=&quot;alert&quot;
+      </Alert>
+    </div>
+  );
+};
+
+export default withDsExample(Example);
+
+/* Storybook story */
+export const Demo = {
+  render: Example,
+};
+
+export const args = {
+  index: 0,
+};


### PR DESCRIPTION
### Description

Legger til et eksempel med `role="status"` på `success`- og `warning`-variantene og `role="alert"` på `error`-varianten

Har også oppdatert dokumentasjonen så den reflekterer dette. 
