### PR TITLE
Textarea: Teller flyttet ut

### DIFF
--- a/.changeset/nasty-files-know.md
+++ b/.changeset/nasty-files-know.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+:wheelchair: Textarea: Byttet fra `aria-live` til `role=status` på telleren for bedre semantikk

--- a/.changeset/real-wasps-kiss.md
+++ b/.changeset/real-wasps-kiss.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+:bug: Textarea: Teller flyttet ut av tekstfeltet for å unngå overlapp og misforståelser

--- a/@navikt/core/css/form/textarea.css
+++ b/@navikt/core/css/form/textarea.css
@@ -22,7 +22,6 @@
 
 .navds-textarea__wrapper {
   position: relative;
-  width: 100%;
 }
 
 .navds-textarea__input {
@@ -35,10 +34,6 @@
   width: 100%;
   display: block;
   color: var(--ac-textarea-text, var(--__ac-textarea-text, var(--a-text-default)));
-}
-
-.navds-textarea--counter {
-  padding-bottom: var(--a-spacing-8);
 }
 
 .navds-textarea__input::placeholder {
@@ -65,19 +60,9 @@
   padding: var(--a-spacing-1-alt);
 }
 
-.navds-form-field--small .navds-textarea--counter.navds-textarea__input {
-  padding-bottom: var(--a-spacing-7);
-}
-
 .navds-textarea__counter {
-  pointer-events: none;
+  margin-top: var(--a-spacing-05);
   color: var(--ac-textarea-counter-text, var(--__ac-textarea-counter-text, var(--a-text-subtle)));
-  font-style: italic;
-  position: absolute;
-  text-align: left;
-  left: 0.0625rem;
-  bottom: 0.0625rem;
-  padding: var(--a-spacing-1) var(--a-spacing-2);
 }
 
 .navds-textarea__counter--error {

--- a/@navikt/core/css/form/textarea.css
+++ b/@navikt/core/css/form/textarea.css
@@ -22,6 +22,7 @@
 
 .navds-textarea__wrapper {
   position: relative;
+  width: 100%;
 }
 
 .navds-textarea__input {

--- a/@navikt/core/react/src/form/Textarea.tsx
+++ b/@navikt/core/react/src/form/Textarea.tsx
@@ -4,6 +4,7 @@ import { BodyShort, ErrorMessage, Label } from "../typography";
 import { omit, useId } from "../util";
 import TextareaAutosize from "../util/TextareaAutoSize";
 import { ReadOnlyIcon } from "./ReadOnlyIcon";
+import Counter from "./TextareaCounter";
 import { FormFieldProps, useFormField } from "./useFormField";
 
 /**
@@ -193,29 +194,5 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     );
   }
 );
-
-interface CounterProps {
-  maxLength: number;
-  currentLength: number;
-  size: TextareaProps["size"];
-  i18n: TextareaProps["i18n"];
-}
-const Counter = ({ maxLength, currentLength, size, i18n }: CounterProps) => {
-  const difference = maxLength - currentLength;
-
-  return (
-    <BodyShort
-      className={cl("navds-textarea__counter", {
-        "navds-textarea__counter--error": difference < 0,
-      })}
-      role={difference < 20 ? "status" : undefined}
-      size={size}
-    >
-      {difference < 0
-        ? `${Math.abs(difference)} ${i18n?.counterTooMuch ?? "tegn for mye"}`
-        : `${difference} ${i18n?.counterLeft ?? "tegn igjen"}`}
-    </BodyShort>
-  );
-};
 
 export default Textarea;

--- a/@navikt/core/react/src/form/Textarea.tsx
+++ b/@navikt/core/react/src/form/Textarea.tsx
@@ -1,10 +1,10 @@
 import cl from "clsx";
 import React, { forwardRef, useState } from "react";
 import { BodyShort, ErrorMessage, Label } from "../typography";
-import TextareaAutosize from "../util/TextareaAutoSize";
-import { FormFieldProps, useFormField } from "./useFormField";
-import { ReadOnlyIcon } from "./ReadOnlyIcon";
 import { omit, useId } from "../util";
+import TextareaAutosize from "../util/TextareaAutoSize";
+import { ReadOnlyIcon } from "./ReadOnlyIcon";
+import { FormFieldProps, useFormField } from "./useFormField";
 
 /**
  * TODO: Mulighet for lokalisering av sr-only/counter text
@@ -27,7 +27,6 @@ export interface TextareaProps
   defaultValue?: string;
   /**
    * Maximum number of character rows to display.
-   * @bug Internal scrolling with `maxLength` scrolls over maxLength-text
    */
   maxRows?: number;
   /**
@@ -50,7 +49,7 @@ export interface TextareaProps
    * i18n-translations for counter-text
    */
   i18n?: {
-    /** @default Antall tegn igjen */
+    /** @default tegn igjen */
     counterLeft?: string;
     /** @default tegn for mye */
     counterTooMuch?: string;
@@ -162,14 +161,11 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             className={cl(
               "navds-textarea__input",
               "navds-body-short",
-              `navds-body-short--${size ?? "medium"}`,
-              {
-                "navds-textarea--counter": hasMaxLength,
-              }
+              `navds-body-short--${size ?? "medium"}`
             )}
             {...(describedBy ? { "aria-describedby": describedBy } : {})}
           />
-          {hasMaxLength && (
+          {hasMaxLength && !readOnly && !inputProps.disabled && (
             <>
               <span id={maxLengthId} className="navds-sr-only">
                 {`Tekstområde med plass til ${maxLength} tegn.`}
@@ -198,7 +194,13 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   }
 );
 
-export const Counter = ({ maxLength, currentLength, size, i18n }) => {
+interface CounterProps {
+  maxLength: number;
+  currentLength: number;
+  size: TextareaProps["size"];
+  i18n: TextareaProps["i18n"];
+}
+const Counter = ({ maxLength, currentLength, size, i18n }: CounterProps) => {
   const difference = maxLength - currentLength;
 
   return (
@@ -206,7 +208,7 @@ export const Counter = ({ maxLength, currentLength, size, i18n }) => {
       className={cl("navds-textarea__counter", {
         "navds-textarea__counter--error": difference < 0,
       })}
-      aria-live={difference < 20 ? "polite" : "off"}
+      role={difference < 20 ? "status" : undefined}
       size={size}
     >
       {difference < 0

--- a/@navikt/core/react/src/form/TextareaCounter.tsx
+++ b/@navikt/core/react/src/form/TextareaCounter.tsx
@@ -1,0 +1,31 @@
+import cl from "clsx";
+import React from "react";
+import { BodyShort } from "../typography";
+import { TextareaProps } from "./Textarea";
+
+interface Props {
+  maxLength: number;
+  currentLength: number;
+  size: TextareaProps["size"];
+  i18n: TextareaProps["i18n"];
+}
+
+const TextareaCounter = ({ maxLength, currentLength, size, i18n }: Props) => {
+  const difference = maxLength - currentLength;
+
+  return (
+    <BodyShort
+      className={cl("navds-textarea__counter", {
+        "navds-textarea__counter--error": difference < 0,
+      })}
+      role={difference < 20 ? "status" : undefined}
+      size={size}
+    >
+      {difference < 0
+        ? `${Math.abs(difference)} ${i18n?.counterTooMuch ?? "tegn for mye"}`
+        : `${difference} ${i18n?.counterLeft ?? "tegn igjen"}`}
+    </BodyShort>
+  );
+};
+
+export default TextareaCounter;

--- a/@navikt/core/react/src/form/TextareaCounter.tsx
+++ b/@navikt/core/react/src/form/TextareaCounter.tsx
@@ -1,7 +1,7 @@
 import cl from "clsx";
 import React from "react";
 import { BodyShort } from "../typography";
-import { TextareaProps } from "./Textarea";
+import type { TextareaProps } from "./Textarea";
 
 interface Props {
   maxLength: number;

--- a/@navikt/core/react/src/form/index.ts
+++ b/@navikt/core/react/src/form/index.ts
@@ -1,15 +1,20 @@
 export {
+  default as ConfirmationPanel,
+  type ConfirmationPanelProps,
+} from "./ConfirmationPanel";
+export { Fieldset, FieldsetContext, type FieldsetProps } from "./Fieldset";
+export { default as Select, type SelectProps } from "./Select";
+export { default as Switch, type SwitchProps } from "./Switch";
+export { default as TextField, type TextFieldProps } from "./TextField";
+export { default as Textarea, type TextareaProps } from "./Textarea";
+export {
   Checkbox,
   CheckboxGroup,
   type CheckboxGroupProps,
   type CheckboxProps,
 } from "./checkbox";
-export {
-  type ConfirmationPanelProps,
-  default as ConfirmationPanel,
-} from "./ConfirmationPanel";
+export { Combobox as UNSAFE_Combobox, type ComboboxProps } from "./combobox";
 export { ErrorSummary, type ErrorSummaryProps } from "./error-summary";
-export { Fieldset, FieldsetContext, type FieldsetProps } from "./Fieldset";
 export {
   Radio,
   RadioGroup,
@@ -17,8 +22,3 @@ export {
   type RadioProps,
 } from "./radio";
 export { Search, type SearchClearEvent, type SearchProps } from "./search";
-export { Combobox as UNSAFE_Combobox, type ComboboxProps } from "./combobox";
-export { default as Select, type SelectProps } from "./Select";
-export { default as Switch, type SwitchProps } from "./Switch";
-export { Counter, default as Textarea, type TextareaProps } from "./Textarea";
-export { default as TextField, type TextFieldProps } from "./TextField";

--- a/@navikt/core/react/src/form/stories/textarea.stories.tsx
+++ b/@navikt/core/react/src/form/stories/textarea.stories.tsx
@@ -67,6 +67,20 @@ export const Error = () => {
         error="Consectetur labore velit eiusmod Lorem ut nostrud mollit labore ullamco laboris laboris in."
         size="small"
       />
+
+      <Textarea
+        label="Ipsum enim quis culpa"
+        error="Consectetur labore velit eiusmod Lorem ut nostrud mollit labore ullamco laboris laboris in."
+        maxLength={20}
+      />
+
+      <Textarea
+        label="Ipsum enim quis culpa"
+        error="Consectetur labore velit eiusmod Lorem ut nostrud mollit labore ullamco laboris laboris in."
+        value="Sed dignissim sollicitudin porta."
+        maxLength={20}
+        size="small"
+      />
     </div>
   );
 };

--- a/@navikt/core/react/src/form/stories/textarea.stories.tsx
+++ b/@navikt/core/react/src/form/stories/textarea.stories.tsx
@@ -14,7 +14,7 @@ export const Default: StoryObj<typeof Textarea> = {
   },
 
   args: {
-    maxLength: 100,
+    maxLength: 0,
     label: "Ipsum enim quis culpa",
     resize: false,
   },
@@ -28,6 +28,7 @@ export const Default: StoryObj<typeof Textarea> = {
     error: { type: "string" },
     hideLabel: { type: "boolean" },
     disabled: { type: "boolean" },
+    readOnly: { type: "boolean" },
     maxRows: { type: "number" },
     minRows: { type: "number" },
   },

--- a/aksel.nav.no/website/pages/eksempler/textarea/resizable.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textarea/resizable.tsx
@@ -1,0 +1,17 @@
+import { withDsExample } from "@/web/examples/withDsExample";
+import { Textarea } from "@navikt/ds-react";
+
+const Example = () => {
+  return <Textarea label="Har du noen tilbakemeldinger?" resize />;
+};
+
+export default withDsExample(Example);
+
+/* Storybook story */
+export const Demo = {
+  render: Example,
+};
+
+export const args = {
+  index: 6,
+};


### PR DESCRIPTION
(Ekstrahert fra PR https://github.com/navikt/aksel/pull/2457 som nå bare tar for seg autoScrollbar.)

https://github.com/navikt/team-aksel/issues/332
https://github.com/navikt/aksel/issues/2326
https://github.com/navikt/aksel/issues/2224
https://github.com/navikt/aksel/issues/2341

### Endringer:

- Flyttet teller ut av selve tekstfeltet.
- Byttet fra `aria-live` til `role=status` på telleren av semantiske grunner. Ser ut til å funke like bra.
- Fjernet eksport av Counter.
- La til kodeeksempel med `resize`.