### PR TITLE
Ikke rendre child som ikke er valid element i ErrorSummary

### DIFF
--- a/.changeset/tall-wolves-tie.md
+++ b/.changeset/tall-wolves-tie.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+ErrorSummary: Gjør det mulig å rendre ErrorSummary.Item conditionally

--- a/@navikt/core/react/src/form/error-summary/ErrorSummary.tsx
+++ b/@navikt/core/react/src/form/error-summary/ErrorSummary.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, HTMLAttributes } from "react";
+import React, { forwardRef, HTMLAttributes, isValidElement } from "react";
 import cl from "clsx";
 import { Heading, BodyShort } from "../../typography";
 import ErrorSummaryItem, { ErrorSummaryItemType } from "./ErrorSummaryItem";
@@ -100,7 +100,10 @@ export const ErrorSummary = forwardRef<HTMLDivElement, ErrorSummaryProps>(
         </Heading>
         <BodyShort as="ul" size={size} className="navds-error-summary__list">
           {React.Children.map(children, (child) => {
-            return <li key={child?.toString()}>{child}</li>;
+            if (!isValidElement(child)) {
+              return null;
+            }
+            return <li key={child.toString()}>{child}</li>;
           })}
         </BodyShort>
       </section>


### PR DESCRIPTION
### Description

Hvis man i dag prøver å rendre noe conditionally i `ErrorSummary` vil man se et listepunkt (aka bullet point) selvom conditionen evaluerer til false. Eksempel:
![image](https://github.com/navikt/aksel/assets/3830142/e96f6ca1-58e7-4c49-a631-75e4edc3cbfd)

Denne fiksen gjør det mulig å conditionally rendre barn i `ErrorSummary`. For eksempel kan man nå gjøre:

```
const shouldShow = false

return (
  <ErrorSummary>
    {shouldShow && <ErrorSummary.Item href="#id1">Jeg er en feilmelding, men vises ikke</ErrorSummary.Item>}
    <ErrorSummary.Item href="#id2">Jeg er en feilmelding som vises!</ErrorSummary.Item>
  </ErrorSummary>
)
```

### Change summary
- Fikset bug slik at man kan conditionally rendre ting i `ErrorSummary`