### PR TITLE
:memo: Oppdatert typo-eksempler

### DIFF
--- a/aksel.nav.no/website/pages/eksempler/heading/large.tsx
+++ b/aksel.nav.no/website/pages/eksempler/heading/large.tsx
@@ -10,7 +10,9 @@ const Example = () => {
       <Divider />
       <div>
         <Descriptor>Spacing </Descriptor>
-        <Heading size="large">{lorem}</Heading>
+        <Heading size="large" spacing>
+          {lorem}
+        </Heading>
       </div>
     </VStack>
   );

--- a/aksel.nav.no/website/pages/eksempler/heading/medium.tsx
+++ b/aksel.nav.no/website/pages/eksempler/heading/medium.tsx
@@ -10,7 +10,9 @@ const Example = () => {
       <Divider />
       <div>
         <Descriptor>Spacing </Descriptor>
-        <Heading size="medium">{lorem}</Heading>
+        <Heading size="medium" spacing>
+          {lorem}
+        </Heading>
       </div>
     </VStack>
   );

--- a/aksel.nav.no/website/pages/eksempler/heading/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/heading/small.tsx
@@ -10,7 +10,9 @@ const Example = () => {
       <Divider />
       <div>
         <Descriptor>Spacing </Descriptor>
-        <Heading size="small">{lorem}</Heading>
+        <Heading size="small" spacing>
+          {lorem}
+        </Heading>
       </div>
     </VStack>
   );

--- a/aksel.nav.no/website/pages/eksempler/heading/xlarge.tsx
+++ b/aksel.nav.no/website/pages/eksempler/heading/xlarge.tsx
@@ -10,7 +10,9 @@ const Example = () => {
       <Divider />
       <div>
         <Descriptor>Spacing</Descriptor>
-        <Heading size="xlarge">{lorem}</Heading>
+        <Heading size="xlarge" spacing>
+          {lorem}
+        </Heading>
       </div>
     </VStack>
   );

--- a/aksel.nav.no/website/pages/eksempler/heading/xsmall.tsx
+++ b/aksel.nav.no/website/pages/eksempler/heading/xsmall.tsx
@@ -10,7 +10,9 @@ const Example = () => {
       <Divider />
       <div>
         <Descriptor>Spacing </Descriptor>
-        <Heading size="xsmall">{lorem}</Heading>
+        <Heading size="xsmall" spacing>
+          {lorem}
+        </Heading>
       </div>
     </VStack>
   );

--- a/aksel.nav.no/website/pages/eksempler/label/spacing-medium.tsx
+++ b/aksel.nav.no/website/pages/eksempler/label/spacing-medium.tsx
@@ -7,8 +7,12 @@ const Example = () => {
 
   return (
     <div>
-      <Label spacing>{lorem}</Label>
-      <Label spacing>{lorem}</Label>
+      <Label spacing as="p">
+        {lorem}
+      </Label>
+      <Label spacing as="p">
+        {lorem}
+      </Label>
     </div>
   );
 };

--- a/aksel.nav.no/website/pages/eksempler/label/spacing-small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/label/spacing-small.tsx
@@ -7,10 +7,10 @@ const Example = () => {
 
   return (
     <div>
-      <Label size="small" spacing>
+      <Label size="small" spacing as="p">
         {lorem}
       </Label>
-      <Label size="small" spacing>
+      <Label size="small" spacing as="p">
         {lorem}
       </Label>
     </div>


### PR DESCRIPTION
### Description

Resolves #2473

### Change summary

- Oppdatert Typo-eksempler med spacing
- `<label>` støtter ikke margin, så bruker `as`-prop der

