### PR TITLE
Alert: fokuserbar med Javascript ut av boksen

### DIFF
--- a/.changeset/mean-lies-invent.md
+++ b/.changeset/mean-lies-invent.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+Alert: fokuserbar med Javascript ut av boksen

--- a/@navikt/core/react/src/alert/Alert.tsx
+++ b/@navikt/core/react/src/alert/Alert.tsx
@@ -92,6 +92,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
   ) => {
     return (
       <div
+        tabIndex={-1}
         {...rest}
         ref={ref}
         className={cl(


### PR DESCRIPTION
Setter `tabIndex={-1}` på `Alert` så man kan fokusere den med Javascript ut av boksen uten å måtte sette `tabIndex` selv.

Jeg satt dette over `...rest` slik at man fortsatt kan overstyre `tabIndex` selv.