### PR TITLE
Justering av kodeeksempler for Table

### DIFF
--- a/@navikt/core/react/src/table/Table.tsx
+++ b/@navikt/core/react/src/table/Table.tsx
@@ -57,7 +57,7 @@ export interface TableType
  *   <Table.Header>
  *     <Table.Row>
  *       <Table.HeaderCell scope="col">Navn</Table.HeaderCell>
- *       <Table.HeaderCell scope="col">Fødseslnr.</Table.HeaderCell>
+ *       <Table.HeaderCell scope="col">Fødselsnr.</Table.HeaderCell>
  *       <Table.HeaderCell scope="col">Start</Table.HeaderCell>
  *     </Table.Row>
  *   </Table.Header>

--- a/aksel.nav.no/website/components/sanity-modules/code-examples/CodeExamples.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/code-examples/CodeExamples.tsx
@@ -11,8 +11,8 @@ import { BodyLong, Button, Chips, HStack } from "@navikt/ds-react";
 import cl from "clsx";
 import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
-import { Sandbox } from "./parts/Sandbox";
 import { CodeSandbox } from "./parts/CodeSandbox";
+import { Sandbox } from "./parts/Sandbox";
 
 const iframePadding = 192;
 const iframeId = "example-iframe";
@@ -98,10 +98,10 @@ const ComponentExamples = ({ node }: CodeExamplesProps) => {
 
   return (
     <div>
-      <div className="mb-5 max-w-xl">
-        <Chips>
-          {node.dir.filer.map((fil) => {
-            return (
+      {node.dir.filer.length > 1 && (
+        <div className="mb-5 max-w-xl">
+          <Chips>
+            {node.dir.filer.map((fil) => (
               <Chips.Toggle
                 checkmark={false}
                 key={fil._key}
@@ -119,119 +119,117 @@ const ComponentExamples = ({ node }: CodeExamplesProps) => {
               >
                 {fixName(fil.title)}
               </Chips.Toggle>
-            );
+            ))}
+          </Chips>
+        </div>
+      )}
+      {node.dir.filer.map((fil) => (
+        <div
+          key={fil._key}
+          className={cl({
+            visible: active === fil.navn,
+            hidden: active !== fil.navn,
           })}
-        </Chips>
-      </div>
-      {node.dir.filer.map((fil) => {
-        return (
-          <div
-            key={fil._key}
-            className={cl({
-              visible: active === fil.navn,
-              hidden: active !== fil.navn,
-            })}
-          >
-            {fil?.description && (
-              <BodyLong className="mb-2">{fil.description}</BodyLong>
-            )}
+        >
+          {fil?.description && (
+            <BodyLong className="mb-2">{fil.description}</BodyLong>
+          )}
 
-            {active === fil.navn && (
-              <>
-                <div
+          {active === fil.navn && (
+            <>
+              <div
+                className={cl(
+                  "overflow-hidden rounded-t-lg border border-b-0 border-gray-300 ",
+                  {
+                    "relative animate-pulse": unloaded,
+                    "bg-gray-50": !unloaded,
+                  }
+                )}
+              >
+                <iframe
+                  src={`/${demoVariant}/${node.dir.title}/${fil.navn.replace(
+                    ".tsx",
+                    ""
+                  )}`}
+                  height={frameState}
+                  onLoad={() => handleExampleLoad()}
+                  id={iframeId}
+                  aria-label={`${node?.dir?.title} ${fil.navn} eksempel`}
                   className={cl(
-                    "overflow-hidden rounded-t-lg border border-b-0 border-gray-300 ",
+                    "min-w-80 block w-full max-w-full resize-x bg-white shadow-[20px_0_20px_-20px_rgba(0,0,0,0.22)]",
                     {
-                      "relative animate-pulse": unloaded,
-                      "bg-gray-50": !unloaded,
+                      invisible: unloaded,
                     }
                   )}
-                >
-                  <iframe
-                    src={`/${demoVariant}/${node.dir.title}/${fil.navn.replace(
-                      ".tsx",
-                      ""
-                    )}`}
-                    height={frameState}
-                    onLoad={() => handleExampleLoad()}
-                    id={iframeId}
-                    aria-label={`${node?.dir?.title} ${fil.navn} eksempel`}
-                    className={cl(
-                      "min-w-80 block w-full max-w-full resize-x bg-white shadow-[20px_0_20px_-20px_rgba(0,0,0,0.22)]",
-                      {
-                        invisible: unloaded,
-                      }
-                    )}
-                    title="Kode-eksempler"
-                    ref={iframeRef}
-                  />
-                  {unloaded && (
-                    <div className="absolute inset-0 mx-auto flex flex-col items-center justify-center gap-2">
-                      <div className="grid w-3/5 gap-2">
-                        <div className="bg-surface-neutral-subtle h-6 w-2/3 rounded-xl" />
-                        <div className="bg-surface-neutral-subtle h-16 w-full rounded-xl" />
-                      </div>
+                  title="Kode-eksempler"
+                  ref={iframeRef}
+                />
+                {unloaded && (
+                  <div className="absolute inset-0 mx-auto flex flex-col items-center justify-center gap-2">
+                    <div className="grid w-3/5 gap-2">
+                      <div className="bg-surface-neutral-subtle h-6 w-2/3 rounded-xl" />
+                      <div className="bg-surface-neutral-subtle h-16 w-full rounded-xl" />
                     </div>
-                  )}
-                </div>
-                <div className="mb-2 rounded-b-lg border border-gray-300 p-1">
-                  <HStack gap="4" justify="space-between">
-                    <div className="hidden sm:block">
-                      <HStack gap="2">
-                        <Button
-                          variant="tertiary-neutral"
-                          size="small"
-                          icon={
-                            <MobileSmallIcon title="Sett eksempel til mobilbredde" />
-                          }
-                          onClick={() =>
-                            (iframeRef.current.style.width = "360px")
-                          }
-                        />
-
-                        <Button
-                          variant="tertiary-neutral"
-                          size="small"
-                          icon={
-                            <LaptopIcon title="Sett eksempel til desktopbredde" />
-                          }
-                          onClick={() => (iframeRef.current.style.width = "")}
-                        />
-                      </HStack>
-                    </div>
-
+                  </div>
+                )}
+              </div>
+              <div className="mb-2 rounded-b-lg border border-gray-300 p-1">
+                <HStack gap="4" justify="space-between">
+                  <div className="hidden sm:block">
                     <HStack gap="2">
-                      {fil?.sandboxEnabled && (
-                        <Sandbox code={fil?.sandboxBase64} />
-                      )}
-                      <CodeSandbox code={fil.innhold.trim()} />
                       <Button
                         variant="tertiary-neutral"
                         size="small"
                         icon={
-                          <ExternalLinkIcon title="Åpne eksempel i nytt vindu" />
+                          <MobileSmallIcon title="Sett eksempel til mobilbredde" />
                         }
-                        target="_blank"
-                        className="si-ignore"
-                        as="a"
-                        href={`/${demoVariant}/${
-                          node.dir.title
-                        }/${fil.navn.replace(".tsx", "")}`}
+                        onClick={() =>
+                          (iframeRef.current.style.width = "360px")
+                        }
+                      />
+
+                      <Button
+                        variant="tertiary-neutral"
+                        size="small"
+                        icon={
+                          <LaptopIcon title="Sett eksempel til desktopbredde" />
+                        }
+                        onClick={() => (iframeRef.current.style.width = "")}
                       />
                     </HStack>
-                  </HStack>
-                </div>
+                  </div>
 
-                <SnippetLazy
-                  node={{
-                    code: { code: fil.innhold.trim(), language: "tsx" },
-                  }}
-                />
-              </>
-            )}
-          </div>
-        );
-      })}
+                  <HStack gap="2">
+                    {fil?.sandboxEnabled && (
+                      <Sandbox code={fil?.sandboxBase64} />
+                    )}
+                    <CodeSandbox code={fil.innhold.trim()} />
+                    <Button
+                      variant="tertiary-neutral"
+                      size="small"
+                      icon={
+                        <ExternalLinkIcon title="Åpne eksempel i nytt vindu" />
+                      }
+                      target="_blank"
+                      className="si-ignore"
+                      as="a"
+                      href={`/${demoVariant}/${
+                        node.dir.title
+                      }/${fil.navn.replace(".tsx", "")}`}
+                    />
+                  </HStack>
+                </HStack>
+              </div>
+
+              <SnippetLazy
+                node={{
+                  code: { code: fil.innhold.trim(), language: "tsx" },
+                }}
+              />
+            </>
+          )}
+        </div>
+      ))}
     </div>
   );
 };

--- a/aksel.nav.no/website/pages/eksempler/table-menu/default.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table-menu/default.tsx
@@ -1,0 +1,93 @@
+import { withDsExample } from "@/web/examples/withDsExample";
+import { MenuElipsisHorizontalCircleIcon } from "@navikt/aksel-icons";
+import { Button, Dropdown, HStack, Link, Table } from "@navikt/ds-react";
+
+const Example = () => {
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell scope="col">Navn</Table.HeaderCell>
+          <Table.HeaderCell scope="col" align="right">
+            Prosent
+          </Table.HeaderCell>
+          <Table.HeaderCell scope="col" align="right">
+            Handlinger
+          </Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {data.map(({ name, percent }, i) => (
+          <Table.Row key={i + name}>
+            <Table.HeaderCell scope="row">{name}</Table.HeaderCell>
+            <Table.DataCell align="right">{percent}&nbsp;%</Table.DataCell>
+            <Table.DataCell align="right">
+              <Dropdown defaultOpen={i === 0}>
+                <HStack justify="end">
+                  <Button
+                    as={Dropdown.Toggle}
+                    icon={<MenuElipsisHorizontalCircleIcon title="Meny" />}
+                    size="small"
+                    variant="tertiary"
+                  />
+                </HStack>
+                <Dropdown.Menu>
+                  <Dropdown.Menu.GroupedList>
+                    <Dropdown.Menu.GroupedList.Item onClick={() => {}}>
+                      Legg på vent
+                    </Dropdown.Menu.GroupedList.Item>
+                    <Dropdown.Menu.GroupedList.Item onClick={() => {}}>
+                      Meld av
+                    </Dropdown.Menu.GroupedList.Item>
+                    <Dropdown.Menu.Divider />
+                    <Dropdown.Menu.GroupedList.Item
+                      as={Link}
+                      href="#"
+                      underline={false}
+                    >
+                      Annuller
+                    </Dropdown.Menu.GroupedList.Item>
+                  </Dropdown.Menu.GroupedList>
+                </Dropdown.Menu>
+              </Dropdown>
+            </Table.DataCell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+};
+
+const data = [
+  {
+    name: "Jakobsen, Markus",
+    percent: 100,
+  },
+  {
+    name: "Halvorsen, Mari",
+    percent: 50,
+  },
+  {
+    name: "Christiansen, Mathias",
+    percent: 95,
+  },
+  {
+    name: "Fredriksen, Leah",
+    percent: 100,
+  },
+  {
+    name: "Evensen, Jonas",
+    percent: 9,
+  },
+];
+
+export default withDsExample(Example);
+
+/* Storybook story */
+export const Demo = {
+  render: Example,
+};
+
+export const args = {
+  index: 0,
+};

--- a/aksel.nav.no/website/pages/eksempler/table-menu/default.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table-menu/default.tsx
@@ -81,6 +81,7 @@ const data = [
   },
 ];
 
+// EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
 export default withDsExample(Example);
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/table-numbers/default.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table-numbers/default.tsx
@@ -63,6 +63,7 @@ const data = [
   },
 ];
 
+// EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
 export default withDsExample(Example);
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/table-numbers/default.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table-numbers/default.tsx
@@ -1,0 +1,75 @@
+import { withDsExample } from "@/web/examples/withDsExample";
+import { Table } from "@navikt/ds-react";
+
+const Example = () => {
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell scope="col">Navn</Table.HeaderCell>
+          <Table.HeaderCell scope="col" align="right">
+            Beløp
+          </Table.HeaderCell>
+          <Table.HeaderCell scope="col" align="right">
+            Prosent
+          </Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {data.map(({ name, amount, percent }, i) => (
+          <Table.Row key={i + name}>
+            <Table.HeaderCell scope="row">{name}</Table.HeaderCell>
+            <Table.DataCell align="right">
+              {formatter.format(amount)}
+            </Table.DataCell>
+            <Table.DataCell align="right">{percent}&nbsp;%</Table.DataCell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+};
+
+const formatter = new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const data = [
+  {
+    name: "Jakobsen, Markus",
+    amount: 123,
+    percent: 100,
+  },
+  {
+    name: "Halvorsen, Mari",
+    amount: 1045,
+    percent: 50,
+  },
+  {
+    name: "Christiansen, Mathias",
+    amount: 123,
+    percent: 95,
+  },
+  {
+    name: "Fredriksen, Leah",
+    amount: 940.5,
+    percent: 100,
+  },
+  {
+    name: "Evensen, Jonas",
+    amount: 1100,
+    percent: 9,
+  },
+];
+
+export default withDsExample(Example);
+
+/* Storybook story */
+export const Demo = {
+  render: Example,
+};
+
+export const args = {
+  index: 0,
+};

--- a/aksel.nav.no/website/pages/eksempler/table/expandable.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/expandable.tsx
@@ -8,7 +8,7 @@ const Example = () => {
         <Table.Row>
           <Table.HeaderCell />
           <Table.HeaderCell scope="col">Navn</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Fødseslnr.</Table.HeaderCell>
+          <Table.HeaderCell scope="col">Fødselsnr.</Table.HeaderCell>
           <Table.HeaderCell scope="col">Start</Table.HeaderCell>
         </Table.Row>
       </Table.Header>
@@ -74,4 +74,5 @@ export const Demo = {
 
 export const args = {
   index: 6,
+  desc: "Rader kan utvides for å vise ekstra informasjon. Man kan velge om knappen for å utvide/lukke vises i starten eller enden av raden.",
 };

--- a/aksel.nav.no/website/pages/eksempler/table/medium.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/medium.tsx
@@ -7,7 +7,7 @@ const Example = () => {
       <Table.Header>
         <Table.Row>
           <Table.HeaderCell scope="col">Navn</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Fødseslnr.</Table.HeaderCell>
+          <Table.HeaderCell scope="col">Fødselsnr.</Table.HeaderCell>
           <Table.HeaderCell scope="col">Start</Table.HeaderCell>
         </Table.Row>
       </Table.Header>
@@ -70,4 +70,5 @@ export const Demo = {
 
 export const args = {
   index: 0,
+  desc: "Standardstørrelsen 'medium' brukes både på eksterne og interne flater.",
 };

--- a/aksel.nav.no/website/pages/eksempler/table/pagination.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/pagination.tsx
@@ -15,7 +15,7 @@ const Example = () => {
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell scope="col">Navn</Table.HeaderCell>
-            <Table.HeaderCell scope="col">Fødseslnr.</Table.HeaderCell>
+            <Table.HeaderCell scope="col">Fødselsnr.</Table.HeaderCell>
             <Table.HeaderCell scope="col">Start</Table.HeaderCell>
           </Table.Row>
         </Table.Header>

--- a/aksel.nav.no/website/pages/eksempler/table/selectable.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/selectable.tsx
@@ -35,7 +35,7 @@ const Example = () => {
             </Table.DataCell>
 
             <Table.HeaderCell scope="col">Navn</Table.HeaderCell>
-            <Table.HeaderCell scope="col">Fødseslnr.</Table.HeaderCell>
+            <Table.HeaderCell scope="col">Fødselsnr.</Table.HeaderCell>
             <Table.HeaderCell scope="col">Start</Table.HeaderCell>
           </Table.Row>
         </Table.Header>

--- a/aksel.nav.no/website/pages/eksempler/table/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/small.tsx
@@ -7,7 +7,7 @@ const Example = () => {
       <Table.Header>
         <Table.Row>
           <Table.HeaderCell scope="col">Navn</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Fødseslnr.</Table.HeaderCell>
+          <Table.HeaderCell scope="col">Fødselsnr.</Table.HeaderCell>
           <Table.HeaderCell scope="col">Start</Table.HeaderCell>
         </Table.Row>
       </Table.Header>
@@ -70,4 +70,5 @@ export const Demo = {
 
 export const args = {
   index: 1,
+  desc: "Small brukes på interne flater der det er behov for et mer komprimert grensesnitt.",
 };

--- a/aksel.nav.no/website/pages/eksempler/table/sortable.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/sortable.tsx
@@ -46,7 +46,7 @@ const Example = () => {
             <Table.ColumnHeader sortKey="name" sortable>
               Navn
             </Table.ColumnHeader>
-            <Table.HeaderCell scope="col">Fødseslnr.</Table.HeaderCell>
+            <Table.HeaderCell scope="col">Fødselsnr.</Table.HeaderCell>
             <Table.ColumnHeader sortKey="start" sortable>
               Start
             </Table.ColumnHeader>

--- a/aksel.nav.no/website/pages/eksempler/table/with-input.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/with-input.tsx
@@ -7,7 +7,7 @@ const Example = () => {
       <Table.Header>
         <Table.Row>
           <Table.HeaderCell scope="col">Navn</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Fødseslnr.</Table.HeaderCell>
+          <Table.HeaderCell scope="col">Fødselsnr.</Table.HeaderCell>
           <Table.HeaderCell scope="col">Start</Table.HeaderCell>
         </Table.Row>
       </Table.Header>
@@ -18,7 +18,7 @@ const Example = () => {
               <Table.HeaderCell scope="row">{name}</Table.HeaderCell>
               <Table.DataCell>
                 <TextField
-                  label="Fødseslnr"
+                  label="Fødselsnr."
                   hideLabel
                   defaultValue={`${fnr.substring(0, 6)} ${fnr.substring(6)}`}
                   size="small"

--- a/aksel.nav.no/website/pages/eksempler/table/zebraStripes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/zebraStripes.tsx
@@ -7,7 +7,7 @@ const Example = () => {
       <Table.Header>
         <Table.Row>
           <Table.HeaderCell scope="col">Navn</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Fødseslnr.</Table.HeaderCell>
+          <Table.HeaderCell scope="col">Fødselsnr.</Table.HeaderCell>
           <Table.HeaderCell scope="col">Start</Table.HeaderCell>
         </Table.Row>
       </Table.Header>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3417,7 +3417,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@^5.11.1, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
+"@navikt/aksel-icons@^5.11.2, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-icons@workspace:@navikt/aksel-icons"
   dependencies:
@@ -3444,8 +3444,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-stylelint@workspace:@navikt/aksel-stylelint"
   dependencies:
-    "@navikt/ds-css": ^5.11.1
-    "@navikt/ds-tokens": ^5.11.1
+    "@navikt/ds-css": ^5.11.2
+    "@navikt/ds-tokens": ^5.11.2
     "@types/jest": ^29.0.0
     concurrently: 7.2.1
     copyfiles: 2.4.1
@@ -3463,7 +3463,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel@workspace:@navikt/aksel"
   dependencies:
-    "@navikt/ds-css": 5.11.1
+    "@navikt/ds-css": 5.11.2
     "@types/inquirer": ^9.0.3
     "@types/jest": ^29.0.0
     axios: 1.6.0
@@ -3487,11 +3487,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@*, @navikt/ds-css@5.11.1, @navikt/ds-css@^5.11.1, @navikt/ds-css@^5.9.2, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@*, @navikt/ds-css@5.11.2, @navikt/ds-css@^5.11.2, @navikt/ds-css@^5.9.2, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": ^5.11.1
+    "@navikt/ds-tokens": ^5.11.2
     cssnano: 6.0.0
     fast-glob: 3.2.11
     lodash: 4.17.21
@@ -3504,13 +3504,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@*, @navikt/ds-react@^5.11.1, @navikt/ds-react@^5.9.2, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@*, @navikt/ds-react@^5.11.2, @navikt/ds-react@^5.9.2, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": 0.25.4
-    "@navikt/aksel-icons": ^5.11.1
-    "@navikt/ds-tokens": ^5.11.1
+    "@navikt/aksel-icons": ^5.11.2
+    "@navikt/ds-tokens": ^5.11.2
     "@radix-ui/react-tabs": 1.0.0
     "@radix-ui/react-toggle-group": 1.0.0
     "@testing-library/dom": 8.13.0
@@ -3544,11 +3544,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@^5.11.1, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@^5.11.2, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": ^5.11.1
+    "@navikt/ds-tokens": ^5.11.2
     "@types/jest": ^29.0.0
     color: 4.2.3
     jest: ^29.0.0
@@ -3560,7 +3560,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@^5.11.1, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@^5.11.2, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -8812,11 +8812,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/aksel-icons": ^5.11.1
-    "@navikt/ds-css": ^5.11.1
-    "@navikt/ds-react": ^5.11.1
-    "@navikt/ds-tailwind": ^5.11.1
-    "@navikt/ds-tokens": ^5.11.1
+    "@navikt/aksel-icons": ^5.11.2
+    "@navikt/ds-css": ^5.11.2
+    "@navikt/ds-react": ^5.11.2
+    "@navikt/ds-tailwind": ^5.11.2
+    "@navikt/ds-tokens": ^5.11.2
     prettier-plugin-tailwindcss: ^0.2.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
La til separate eksempler på tabell med tall og tabell med meny, for å bruke lenger ned på dokumentasjonssiden.

Gjorde en justering i CodeExamples.tsx slik at chips ikke vises hvis det bare er ett eksempel.