### PR TITLE
[aksel.nav.no] :bug: Fikset accumulator-bug i preview

### DIFF
--- a/aksel.nav.no/website/components/website-modules/preview/parts/resolvers.ts
+++ b/aksel.nav.no/website/components/website-modules/preview/parts/resolvers.ts
@@ -18,11 +18,14 @@ export function runResolvers({
   }
 
   return resolvers.reduce((acc, resolver) => {
+    /* Not allowed to edit accumulators directly as its readonly*/
+    const _acc = { ...acc };
     const dataFromKeys = resolver.dataKeys.map((key) =>
-      getNestedProperty(acc, key)
+      getNestedProperty(_acc, key)
     );
-    acc[resolver.key] = resolver.cb(dataFromKeys);
-    return acc;
+
+    _acc[resolver.key] = resolver.cb(dataFromKeys);
+    return _acc;
   }, data);
 }
 


### PR DESCRIPTION
### Description

Preview av enkelte sider feiler (bare i dev) siden `accumulators` i reduce er readonly. Trenger bare shallow-copy, så bruker object spread. 

