### PR TITLE
:hammer: new plugin for prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,14 @@
           "printWidth": 130
         }
       }
-    ]
+    ],
+    "importOrder": [
+      "^@navikt/(.*)$",
+      "^@/(.*)$",
+      "^[./]"
+    ],
+    "importOrderSeparation": false,
+    "importOrderSortSpecifiers": true
   },
   "lint-staged": {
     "*.js": "eslint",
@@ -134,6 +141,7 @@
     "@storybook/testing-library": "^0.2.2",
     "@storybook/theming": "^7.5.3",
     "@svitejs/changesets-changelog-github-compact": "^1.1.0",
+    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@typescript-eslint/eslint-plugin": "^6.7.3",
     "@typescript-eslint/parser": "^6.7.3",
     "@whitespace/storybook-addon-html": "^5.1.6",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
       "^@/(.*)$",
       "^[./]"
     ],
-    "importOrderSeparation": false,
     "importOrderSortSpecifiers": true
   },
   "lint-staged": {


### PR DESCRIPTION
once added, let's run something like this:

```
npx prettier --write "**/*.tsx"
```

remove `organizeImports` from vscode settings (since it overlaps, and causes a flicker as they fight for control)

```
  "editor.codeActionsOnSave": {
    "source.organizeImports": "always"
  },
```