### PR TITLE
Fix issue where clicking Combobox.FilteredOptions after scrolling caused the wrong element to be selected

### DIFF
--- a/.changeset/honest-feet-sparkle.md
+++ b/.changeset/honest-feet-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Fix issue where clicking in Combobox.FilteredOptions after scrolling selected the wrong element

--- a/@navikt/core/react/src/form/combobox/Input/Input.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.tsx
@@ -168,10 +168,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       [filteredOptions.length, virtualFocus, onChange, toggleIsListOpen]
     );
 
-    const onBlur = () => {
-      virtualFocus.moveFocusToTop();
-    };
-
     return (
       <input
         {...rest}
@@ -181,7 +177,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         onChange={onChangeHandler}
         type="text"
         role="combobox"
-        onBlur={onBlur}
         onKeyUp={handleKeyUp}
         onKeyDown={handleKeyDown}
         aria-controls={filteredOptionsUtil.getFilteredOptionsId(inputProps.id)}


### PR DESCRIPTION
### Description

https://nav-it.slack.com/archives/C7NE7A8UF/p1701437323067429

When clicking an element in Combobox.FilteredOptions after scrolling, the list scrolled to the top and the new element under the cursor was selected.

This onBlur triggered when clicking items in FilteredOptions, causing the virtual focus to be moved and the list to scroll to the top.

### Change summary

Removed an onBlur that did not really have any use, but caused the mentioned bug.
