### PR TITLE
Text-wrap: balance på blog og god-praksis heading

### DIFF
--- a/aksel.nav.no/website/components/styles/utilities.css
+++ b/aksel.nav.no/website/components/styles/utilities.css
@@ -83,9 +83,7 @@ p.override-text-no-max {
   display: none;
 }
 
-/* Not in tailwindcss yet
-   https://github.com/tailwindlabs/tailwindcss/discussions/11486
-*/
+/* Not in tailwindcss yet: https://github.com/tailwindlabs/tailwindcss/discussions/11486 */
 .text-wrap-balance {
   text-wrap: balance;
 }

--- a/aksel.nav.no/website/components/styles/utilities.css
+++ b/aksel.nav.no/website/components/styles/utilities.css
@@ -82,3 +82,10 @@ p.override-text-no-max {
 [id] > code > .inline-code-amp {
   display: none;
 }
+
+/* Not in tailwindcss yet
+   https://github.com/tailwindlabs/tailwindcss/discussions/11486
+*/
+.text-wrap-balance {
+  text-wrap: balance;
+}

--- a/aksel.nav.no/website/pages/god-praksis/artikler/[slug].tsx
+++ b/aksel.nav.no/website/pages/god-praksis/artikler/[slug].tsx
@@ -1,3 +1,8 @@
+import NextLink from "next/link";
+import { GetStaticPaths, GetStaticProps } from "next/types";
+import { Suspense, lazy } from "react";
+import { ChevronRightIcon } from "@navikt/aksel-icons";
+import { BodyLong, BodyShort, Detail, Heading, Label } from "@navikt/ds-react";
 import ArtikkelCard from "@/cms/cards/ArtikkelCard";
 import Footer from "@/layout/footer/Footer";
 import Header from "@/layout/header/Header";
@@ -22,11 +27,6 @@ import { abbrName, dateStr, generateTableOfContents } from "@/utils";
 import { BreadCrumbs } from "@/web/BreadCrumbs";
 import { SEO } from "@/web/seo/SEO";
 import TableOfContents from "@/web/toc/TableOfContents";
-import { ChevronRightIcon } from "@navikt/aksel-icons";
-import { BodyLong, BodyShort, Detail, Heading, Label } from "@navikt/ds-react";
-import NextLink from "next/link";
-import { GetStaticPaths, GetStaticProps } from "next/types";
-import { Suspense, lazy } from "react";
 import NotFotfund from "../../404";
 
 type PageProps = NextPageT<{
@@ -185,7 +185,7 @@ const Page = ({
               <Heading
                 level="1"
                 size="large"
-                className="text-deepblue-800 mt-4 md:text-5xl"
+                className="text-deepblue-800 mt-4 md:text-5xl text-wrap-balance"
               >
                 {data.heading}
               </Heading>

--- a/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
+++ b/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
@@ -101,7 +101,7 @@ const Page = ({ blogg, morePosts, publishDate }: PageProps["props"]) => {
             <Heading
               level="1"
               size="xlarge"
-              className="text-deepblue-800 mt-1 break-words balance text-5xl leading-[1.2] [hyphens:_auto] text-wrap-balance"
+              className="text-deepblue-800 mt-1 break-words text-5xl leading-[1.2] [hyphens:_auto] text-wrap-balance"
             >
               {blogg.heading}
             </Heading>

--- a/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
+++ b/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
@@ -1,3 +1,7 @@
+import Image from "next/legacy/image";
+import { GetServerSideProps } from "next/types";
+import { Suspense, lazy } from "react";
+import { BodyLong, BodyShort, Detail, Heading } from "@navikt/ds-react";
 import BloggCard from "@/cms/cards/BloggCard";
 import Footer from "@/layout/footer/Footer";
 import Header from "@/layout/header/Header";
@@ -15,10 +19,6 @@ import { abbrName, dateStr, getImage } from "@/utils";
 import { BloggAd } from "@/web/BloggAd";
 import { AkselCubeStatic } from "@/web/aksel-cube/AkselCube";
 import { SEO } from "@/web/seo/SEO";
-import { BodyLong, BodyShort, Detail, Heading } from "@navikt/ds-react";
-import Image from "next/legacy/image";
-import { GetServerSideProps } from "next/types";
-import { Suspense, lazy } from "react";
 import NotFotfund from "../404";
 
 type PageProps = NextPageT<{
@@ -101,7 +101,7 @@ const Page = ({ blogg, morePosts, publishDate }: PageProps["props"]) => {
             <Heading
               level="1"
               size="xlarge"
-              className="text-deepblue-800 mt-1 break-words text-5xl leading-[1.2] [hyphens:_auto]"
+              className="text-deepblue-800 mt-1 break-words balance text-5xl leading-[1.2] [hyphens:_auto] text-wrap-balance"
             >
               {blogg.heading}
             </Heading>


### PR DESCRIPTION
### Description

Før
<img width="765" alt="Screenshot 2023-12-07 at 11 03 54" src="https://github.com/navikt/aksel/assets/26967723/902fd8b5-00cb-464f-aec1-17cf28c148bc">
Etter
<img width="704" alt="Screenshot 2023-12-07 at 11 03 06" src="https://github.com/navikt/aksel/assets/26967723/f0fb0ec4-1af1-49d0-9127-b65c22be1f8c">


`balance` er ikke så godt støttet, men konsekvensen er bare css-attributten blir fjernet i den nettleseren
https://caniuse.com/?search=balance
