### PR TITLE
:memo: Modal: Oppdatert JSDoc

### DIFF
--- a/.changeset/wise-comics-smoke.md
+++ b/.changeset/wise-comics-smoke.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+:memo: Modal: Oppdatert JSDoc

--- a/@navikt/core/react/src/modal/types.ts
+++ b/@navikt/core/react/src/modal/types.ts
@@ -35,10 +35,9 @@ export interface ModalProps
   onClose?: React.ReactEventHandler<HTMLDialogElement>;
   /**
    * Called when the user tries to close the modal by one of the built-in ways.
+   * Use this if you want to ask the user for confirmation before closing.
    * @warning Will not always be called when pressing Esc. Refer to the JSDoc for `onCancel` for more info.
    * @returns Whether to close the modal
-   * @deprecated The modal should be implemented in such a way that closing it doesn't cause data loss.
-   *  Use `onClose` if you just need to know when the modal has closed.
    */
   onBeforeClose?: () => boolean | void;
   /**

--- a/@navikt/core/react/src/modal/types.ts
+++ b/@navikt/core/react/src/modal/types.ts
@@ -34,18 +34,22 @@ export interface ModalProps
    */
   onClose?: React.ReactEventHandler<HTMLDialogElement>;
   /**
-   * Called when the user wants to close the modal (clicked the close button or pressed Esc).
+   * Called when the user tries to close the modal by one of the built-in ways.
+   * @warning Will not always be called when pressing Esc. Refer to the JSDoc for `onCancel` for more info.
    * @returns Whether to close the modal
+   * @deprecated The modal should be implemented in such a way that closing it doesn't cause data loss.
+   *  Use `onClose` if you just need to know when the modal has closed.
    */
   onBeforeClose?: () => boolean | void;
   /**
-   * Called when the user presses the Esc key, unless `onBeforeClose()` returns `false`.
+   * *Sometimes** called when the user presses the Esc key, unless you return `false` in `onBeforeClose()`.
+   * @warning *Some browsers does not always trigger this event. Chrome only triggers it if you have
+   *  interacted with the modal, and will not trigger it a second time if you press Esc twice in a row.
    */
   onCancel?: React.ReactEventHandler<HTMLDialogElement>;
   /**
    * Whether to close when clicking on the backdrop.
-   *
-   * **WARNING:** Users may click outside by accident. Don't use if closing can cause data loss, or the modal contains important info.
+   * @warning Users may click outside by accident. Don't use if closing can cause data loss, or the modal contains important info.
    * @default false
    */
   closeOnBackdropClick?: boolean;

--- a/@navikt/core/react/src/modal/types.ts
+++ b/@navikt/core/react/src/modal/types.ts
@@ -36,7 +36,7 @@ export interface ModalProps
   /**
    * Called when the user tries to close the modal by one of the built-in methods.
    * Used if you want to ask the user for confirmation before closing.
-   * @warning Will not always be called when pressing Esc. Refer to the JSDoc for `onCancel` for more info.
+   * @warning Will not always be called when pressing Esc. See `onCancel` for more info.
    * @returns Whether to close the modal
    */
   onBeforeClose?: () => boolean | void;

--- a/@navikt/core/react/src/modal/types.ts
+++ b/@navikt/core/react/src/modal/types.ts
@@ -34,8 +34,8 @@ export interface ModalProps
    */
   onClose?: React.ReactEventHandler<HTMLDialogElement>;
   /**
-   * Called when the user tries to close the modal by one of the built-in ways.
-   * Use this if you want to ask the user for confirmation before closing.
+   * Called when the user tries to close the modal by one of the built-in methods.
+   * Used if you want to ask the user for confirmation before closing.
    * @warning Will not always be called when pressing Esc. Refer to the JSDoc for `onCancel` for more info.
    * @returns Whether to close the modal
    */


### PR DESCRIPTION
Oppdatert JSDoc på Modal sin `onBeforeClose` og `onCancel` ihht. endringer i Chrome.

~~Valgte også å merke `onBeforeClose` som deprecated, da jeg tenker at man kanskje bør unngå å bruke den i utgangspunktet. Er imidlertid veldig usikker, da jeg ser at 2-3 repoer har brukt den til å spørre om bekreftelse før modalen lukkes. Kanskje de ønsker å beholde det selv om det ikke alltid vil funke.~~

https://github.com/navikt/aksel/issues/2555
https://bugs.chromium.org/p/chromium/issues/detail?id=1510389#c8
https://nav-it.slack.com/archives/C039XP6GF0S/p1702894915653149?thread_ts=1702662836.468729&cid=C039XP6GF0S