### PR TITLE
Sandbox: allow-modals

### DIFF
--- a/aksel.nav.no/playroom/playroom.config.js
+++ b/aksel.nav.no/playroom/playroom.config.js
@@ -19,7 +19,7 @@ module.exports = {
   useScope: path.resolve("./src/useScope.tsx"),
   openBrowser: false,
   paramType: "search", // default is 'hash'
-  iframeSandbox: "allow-scripts allow-same-origin",
+  iframeSandbox: "allow-scripts allow-same-origin allow-modals",
   exampleCode: `
   <Heading>This is a sandbox!</Heading>
   <HStack gap="10">


### PR DESCRIPTION
Følgende fungerer ikke i sandbox:
```
<Modal
  onClose={() => confirm("Bekreft")}
  (...)
>
```
Konsollen sier `Ignored call to 'confirm()'. The document is sandboxed, and the 'allow-modals' keyword is not set.`
Så antar denne endringen fikser det, men får ikke testet lokalt.