### PR TITLE
Oppgrader wait-on-check-action for å fikse workflow

### DIFF
--- a/.github/workflows/aksel-prod.yml
+++ b/.github/workflows/aksel-prod.yml
@@ -100,7 +100,7 @@ jobs:
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Wait for e2e-tests to succeed
-        uses: lewagon/wait-on-check-action@v1.2.0
+        uses: lewagon/wait-on-check-action@v1.3.3
         with:
           ref: ${{ github.ref }}
           check-name: "Smoketest Aksel"


### PR DESCRIPTION
"Build and deploy to prod-gcp" feiler for tiden. Problemet ser ut til å ha blitt fikset i [v1.3.2](https://github.com/lewagon/wait-on-check-action/releases/tag/v1.3.2)

Vil merging av denne trigge workflowen, eller må vi gjøre en endring et sted for å trigge det?