### PR TITLE
Darkreader-støtte

### DIFF
--- a/aksel.nav.no/website/components/styles/animations.css
+++ b/aksel.nav.no/website/components/styles/animations.css
@@ -1,35 +1,44 @@
 .header-animated-bg {
-  animation: animated-bg 60s ease infinite;
   z-index: 0;
+  background-color: #dccaf3;
+  animation: animated-bg 60s ease infinite;
+
+  --bg-animated-1: #dccaf3;
+  --bg-animated-2: #b2f0e4;
+}
+
+/* Allows dark-reader to show frontpage: https://nav-it.slack.com/archives/C7NE7A8UF/p1704272426011129 */
+[data-darkreader-scheme] .header-animated-bg {
+  animation: none;
 }
 
 @keyframes animated-bg {
   0% {
-    background-color: #dccaf3;
+    background-color: var(--bg-animated-1);
   }
 
   10% {
-    background-color: #dccaf3;
+    background-color: var(--bg-animated-1);
   }
 
   33% {
-    background-color: #dccaf3;
+    background-color: var(--bg-animated-1);
   }
 
   45% {
-    background-color: #b2f0e4;
+    background-color: var(--bg-animated-2);
   }
 
   60% {
-    background-color: #b2f0e4;
+    background-color: var(--bg-animated-2);
   }
 
   90% {
-    background-color: #dccaf3;
+    background-color: var(--bg-animated-1);
   }
 
   100% {
-    background-color: #dccaf3;
+    background-color: var(--bg-animated-1);
   }
 }
 

--- a/aksel.nav.no/website/components/styles/animations.css
+++ b/aksel.nav.no/website/components/styles/animations.css
@@ -1,6 +1,5 @@
 .header-animated-bg {
   z-index: 0;
-  background-color: #dccaf3;
   animation: animated-bg 60s ease infinite;
 
   --bg-animated-1: #dccaf3;


### PR DESCRIPTION
### Description

Tilpasset forside-animasjon slik at brukere av dark-reader kan lese forsiden
https://nav-it.slack.com/archives/C7NE7A8UF/p1704272426011129

Før
<img width="1436" alt="Screenshot 2024-01-04 at 10 00 10" src="https://github.com/navikt/aksel/assets/26967723/b107f6b6-952a-4757-8f1d-25a6f740707c">

Etter
<img width="1435" alt="Screenshot 2024-01-04 at 10 00 02" src="https://github.com/navikt/aksel/assets/26967723/0bd8aa45-1436-4f2d-b7db-c8bdd99d4d15">
