### PR TITLE
:label: Bedre typet lokal useId

### DIFF
--- a/@navikt/core/react/src/util/useId.ts
+++ b/@navikt/core/react/src/util/useId.ts
@@ -27,7 +27,7 @@ const maybeReactUseId: undefined | (() => string) = (React as any)[
  * @param idOverride
  * @returns {string}
  */
-export function useId(idOverride?: string): string | undefined {
+export function useId(idOverride?: string): string {
   if (maybeReactUseId !== undefined) {
     const reactId = maybeReactUseId();
     return idOverride ?? reactId.replace(/(:)/g, "");


### PR DESCRIPTION
### Description

`useId`-hook returnerte typen `string | undefined` selv om den i praksis bare kunne returnere `string`. Dette gjør at noe bruke av den potensielt feiler (https://github.com/navikt/aksel/pull/2562)


### Why

Returnverdi er `useGlobalId(idOverride) ?? ""`, der `useGlobalId` returnerer `string | undefined`. I det tilfellet den er `useGlobalId` vil `""` bli returnert