### PR TITLE
Stylelint v16 bug

### DIFF
--- a/.changeset/gentle-numbers-compete.md
+++ b/.changeset/gentle-numbers-compete.md
@@ -1,0 +1,5 @@
+---
+"@navikt/aksel-stylelint": patch
+---
+
+Stylelint: Støtter nå stylelint v16

--- a/@navikt/aksel-stylelint/src/index.ts
+++ b/@navikt/aksel-stylelint/src/index.ts
@@ -5,4 +5,4 @@ const rulesPlugins = Object.keys(rules).map((ruleName) => {
   return createPlugin(`${ruleName}`, rules[ruleName]);
 });
 
-export default rulesPlugins;
+module.exports = rulesPlugins;


### PR DESCRIPTION
### Description

Stylelint v16 kom med noen breaking changes som også brakk vår stylelint-plugin
https://nav-it.slack.com/archives/C7NE7A8UF/p1704271450129559

En "hack" for å løse dette er å erstatte `export default rulesPlugins;` med `module.exports = rulesPlugins;` som unngår feilen. 

Co-authored-by: @HalvorHaugan  👏 