### PR TITLE
Fiks lint-kommandoer i Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "chromatic": "npx chromatic --only-changed --project-token x3xqdfgkujg --build-script-name build:storybook",
     "build:storybook": "storybook build",
     "test": "yarn workspaces foreach -p run test",
-    "lint": "yarn eslint --rule \"import/no-cycle:error\" . && yarn stylelint @navikt/**/*.css",
-    "lint:css": "yarn stylelint @navikt/**/*.css",
+    "lint": "yarn eslint --rule \"import/no-cycle:error\" . && yarn stylelint '@navikt/**/*.css'",
+    "lint:css": "yarn stylelint '@navikt/**/*.css'",
     "changeset": "changeset",
     "version": "changeset version && yarn changelog",
     "release": "yarn boot && yarn docgen && changeset publish"


### PR DESCRIPTION
Kommandoene fungerte ikke i Windows lenger fordi `@navikt/**/*.css` ekspanderte til for mange filer slik at kommandoen ble for lang. Med fnutter så fungerer det. Regner med det gjør at strengen sendes videre uten ekspandering.