### PR TITLE
[Table] DataCell og HeaderCell støtter nå `size`-prop for font-size

### DIFF
--- a/.changeset/new-dolphins-sleep.md
+++ b/.changeset/new-dolphins-sleep.md
@@ -1,5 +1,0 @@
----
-"@navikt/ds-react": minor
----
-
-Table: Table.DataCell og Table.HeaderCell har nå `textSize`-prop for å justere font-size mellom 18px og 16px

--- a/.changeset/new-dolphins-sleep.md
+++ b/.changeset/new-dolphins-sleep.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+Table: Table.DataCell og Table.HeaderCell har nå `size`-prop for å justere font-size mellom 18px og 16px

--- a/.changeset/new-dolphins-sleep.md
+++ b/.changeset/new-dolphins-sleep.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": minor
 ---
 
-Table: Table.DataCell og Table.HeaderCell har nå `size`-prop for å justere font-size mellom 18px og 16px
+Table: Table.DataCell og Table.HeaderCell har nå `textSize`-prop for å justere font-size mellom 18px og 16px

--- a/.changeset/young-lizards-kick.md
+++ b/.changeset/young-lizards-kick.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+Table: Table.DataCell og Table.HeaderCell har nå `textSize`-prop for å justere font-size mellom 18px og 16px.

--- a/@navikt/core/react/src/table/DataCell.tsx
+++ b/@navikt/core/react/src/table/DataCell.tsx
@@ -1,6 +1,6 @@
 import cl from "clsx";
 import React, { forwardRef } from "react";
-import { BodyShort, BodyShortProps } from "../typography";
+import { BodyShort } from "../typography";
 
 export interface DataCellProps
   extends React.TdHTMLAttributes<HTMLTableCellElement> {
@@ -12,7 +12,7 @@ export interface DataCellProps
   /**
    * Adjust font-size
    */
-  size?: BodyShortProps["size"];
+  size?: "medium" | "small";
 }
 
 export interface DataCellType

--- a/@navikt/core/react/src/table/DataCell.tsx
+++ b/@navikt/core/react/src/table/DataCell.tsx
@@ -10,7 +10,7 @@ export interface DataCellProps
    */
   align?: "left" | "center" | "right";
   /**
-   * Adjust font-size
+   * Adjusts font-size
    */
   textSize?: "medium" | "small";
 }

--- a/@navikt/core/react/src/table/DataCell.tsx
+++ b/@navikt/core/react/src/table/DataCell.tsx
@@ -12,7 +12,7 @@ export interface DataCellProps
   /**
    * Adjust font-size
    */
-  size?: "medium" | "small";
+  textSize?: "medium" | "small";
 }
 
 export interface DataCellType
@@ -21,7 +21,7 @@ export interface DataCellType
   > {}
 
 export const DataCell: DataCellType = forwardRef(
-  ({ className, children = "", align, ...rest }, ref) => {
+  ({ className, children = "", align, textSize, ...rest }, ref) => {
     return (
       <BodyShort
         as="td"
@@ -29,6 +29,7 @@ export const DataCell: DataCellType = forwardRef(
         className={cl("navds-table__data-cell", className, {
           [`navds-table__data-cell--align-${align}`]: align,
         })}
+        size={textSize}
         {...rest}
       >
         {children}

--- a/@navikt/core/react/src/table/DataCell.tsx
+++ b/@navikt/core/react/src/table/DataCell.tsx
@@ -1,6 +1,6 @@
 import cl from "clsx";
 import React, { forwardRef } from "react";
-import { BodyShort } from "../typography";
+import { BodyShort, BodyShortProps } from "../typography";
 
 export interface DataCellProps
   extends React.TdHTMLAttributes<HTMLTableCellElement> {
@@ -9,6 +9,10 @@ export interface DataCellProps
    * @default "left"
    */
   align?: "left" | "center" | "right";
+  /**
+   * Adjust font-size
+   */
+  size?: BodyShortProps["size"];
 }
 
 export interface DataCellType

--- a/@navikt/core/react/src/table/HeaderCell.tsx
+++ b/@navikt/core/react/src/table/HeaderCell.tsx
@@ -1,5 +1,6 @@
 import cl from "clsx";
 import React, { forwardRef } from "react";
+import { LabelProps } from "../typography";
 
 export interface HeaderCellProps
   extends React.ThHTMLAttributes<HTMLTableCellElement> {
@@ -9,6 +10,10 @@ export interface HeaderCellProps
    * @default "left"
    */
   align?: "left" | "center" | "right";
+  /**
+   * Adjust font-size
+   */
+  size?: LabelProps["size"];
 }
 
 export interface HeaderCellType
@@ -17,12 +22,13 @@ export interface HeaderCellType
   > {}
 
 export const HeaderCell: HeaderCellType = forwardRef(
-  ({ className, children, align, ...rest }, ref) => {
+  ({ className, children, align, size, ...rest }, ref) => {
     return (
       <th
         ref={ref}
         className={cl("navds-table__header-cell", "navds-label", className, {
           [`navds-table__header-cell--align-${align}`]: align,
+          "navds-label--small": size === "small",
         })}
         {...rest}
       >

--- a/@navikt/core/react/src/table/HeaderCell.tsx
+++ b/@navikt/core/react/src/table/HeaderCell.tsx
@@ -12,7 +12,7 @@ export interface HeaderCellProps
   /**
    * Adjust font-size
    */
-  size?: "medium" | "small";
+  textSize?: "medium" | "small";
 }
 
 export interface HeaderCellType
@@ -21,13 +21,13 @@ export interface HeaderCellType
   > {}
 
 export const HeaderCell: HeaderCellType = forwardRef(
-  ({ className, children, align, size, ...rest }, ref) => {
+  ({ className, children, align, textSize, ...rest }, ref) => {
     return (
       <th
         ref={ref}
         className={cl("navds-table__header-cell", "navds-label", className, {
           [`navds-table__header-cell--align-${align}`]: align,
-          "navds-label--small": size === "small",
+          "navds-label--small": textSize === "small",
         })}
         {...rest}
       >

--- a/@navikt/core/react/src/table/HeaderCell.tsx
+++ b/@navikt/core/react/src/table/HeaderCell.tsx
@@ -10,7 +10,7 @@ export interface HeaderCellProps
    */
   align?: "left" | "center" | "right";
   /**
-   * Adjust font-size
+   * Adjusts font-size
    */
   textSize?: "medium" | "small";
 }

--- a/@navikt/core/react/src/table/HeaderCell.tsx
+++ b/@navikt/core/react/src/table/HeaderCell.tsx
@@ -1,6 +1,5 @@
 import cl from "clsx";
 import React, { forwardRef } from "react";
-import { LabelProps } from "../typography";
 
 export interface HeaderCellProps
   extends React.ThHTMLAttributes<HTMLTableCellElement> {
@@ -13,7 +12,7 @@ export interface HeaderCellProps
   /**
    * Adjust font-size
    */
-  size?: LabelProps["size"];
+  size?: "medium" | "small";
 }
 
 export interface HeaderCellType

--- a/@navikt/core/react/src/table/stories/table.stories.tsx
+++ b/@navikt/core/react/src/table/stories/table.stories.tsx
@@ -14,8 +14,8 @@ const TableComponent = (props) => (
         {props.button && <Table.HeaderCell>Action</Table.HeaderCell>}
         <Table.HeaderCell>ID</Table.HeaderCell>
         <Table.HeaderCell>Fornavn</Table.HeaderCell>
-        <Table.HeaderCell>Etternavn</Table.HeaderCell>
-        <Table.HeaderCell>Rolle</Table.HeaderCell>
+        <Table.HeaderCell size="medium">Etternavn</Table.HeaderCell>
+        <Table.HeaderCell size="small">Rolle</Table.HeaderCell>
       </Table.Row>
     </Table.Header>
     <Table.Body>
@@ -64,8 +64,8 @@ const TableComponent = (props) => (
         )}
         <Table.HeaderCell>3</Table.HeaderCell>
         <Table.DataCell>Geordi</Table.DataCell>
-        <Table.DataCell>La Forge</Table.DataCell>
-        <Table.DataCell>Sjefsingeniør</Table.DataCell>
+        <Table.DataCell size="medium">La Forge</Table.DataCell>
+        <Table.DataCell size="small">Sjefsingeniør</Table.DataCell>
       </Table.Row>
     </Table.Body>
   </Table>

--- a/@navikt/core/react/src/table/stories/table.stories.tsx
+++ b/@navikt/core/react/src/table/stories/table.stories.tsx
@@ -14,8 +14,8 @@ const TableComponent = (props) => (
         {props.button && <Table.HeaderCell>Action</Table.HeaderCell>}
         <Table.HeaderCell>ID</Table.HeaderCell>
         <Table.HeaderCell>Fornavn</Table.HeaderCell>
-        <Table.HeaderCell size="medium">Etternavn</Table.HeaderCell>
-        <Table.HeaderCell size="small">Rolle</Table.HeaderCell>
+        <Table.HeaderCell textSize="medium">Etternavn</Table.HeaderCell>
+        <Table.HeaderCell textSize="small">Rolle</Table.HeaderCell>
       </Table.Row>
     </Table.Header>
     <Table.Body>
@@ -64,8 +64,8 @@ const TableComponent = (props) => (
         )}
         <Table.HeaderCell>3</Table.HeaderCell>
         <Table.DataCell>Geordi</Table.DataCell>
-        <Table.DataCell size="medium">La Forge</Table.DataCell>
-        <Table.DataCell size="small">Sjefsingeniør</Table.DataCell>
+        <Table.DataCell textSize="medium">La Forge</Table.DataCell>
+        <Table.DataCell textSize="small">Sjefsingeniør</Table.DataCell>
       </Table.Row>
     </Table.Body>
   </Table>


### PR DESCRIPTION
### Description

Resolves #2551

### Change summary

- Lagt til `textSize?: "medium" | "small";` på HeaderCell og TableCell.
- Oppdatert story som tester medium og small-size. 