### PR TITLE
[V6] text-width-max token i tailwind

### DIFF
--- a/@navikt/core/tailwind/src/getMaxWidth.ts
+++ b/@navikt/core/tailwind/src/getMaxWidth.ts
@@ -1,0 +1,12 @@
+import Reducer from "./reducer";
+
+/**
+ * @note This is made just for the case `--a-text-width-max` at the moment
+ */
+export const getMaxWidth = (tokens: { [key: string]: string | number }) => {
+  const widths = Reducer(tokens, ["text-width"]);
+
+  return Object.keys(widths).reduce((cur, key) => {
+    return Object.assign(cur, { [`--a-text-width-${key}`]: widths[key] });
+  }, {});
+};

--- a/@navikt/core/tailwind/src/getMaxWidth.ts
+++ b/@navikt/core/tailwind/src/getMaxWidth.ts
@@ -1,12 +1,10 @@
 import Reducer from "./reducer";
 
 /**
- * @note This is made just for the case `--a-text-width-max` at the moment
+ * @note This is hardcoded just for the case `--a-text-width-max` at the moment
  */
 export const getMaxWidth = (tokens: { [key: string]: string | number }) => {
-  const widths = Reducer(tokens, ["text-width"]);
+  const width = Reducer(tokens, ["text-width-max"]);
 
-  return Object.keys(widths).reduce((cur, key) => {
-    return Object.assign(cur, { [`--a-text-width-${key}`]: widths[key] });
-  }, {});
+  return { text: Object.values(width)[0] };
 };

--- a/@navikt/core/tailwind/src/index.ts
+++ b/@navikt/core/tailwind/src/index.ts
@@ -2,6 +2,7 @@ import { writeFileSync } from "fs";
 import * as TokensBuild from "@navikt/ds-tokens/dist/tokens";
 import { getColors } from "./colors";
 import { getBreakpoints } from "./getBreakpoints";
+import { getMaxWidth } from "./getMaxWidth";
 import kebabCase from "./kebabCase";
 import Reducer from "./reducer";
 
@@ -26,8 +27,7 @@ const config = {
       lineHeight: Reducer(tokens, ["font-line-height"]),
       fontFamily: Reducer(tokens, ["font-family"]),
       borderRadius: Reducer(tokens, ["border-radius"]),
-      // TODO: Add next major-release
-      // maxWidth: Reducer(tokens, ["text-width"]),
+      maxWidth: getMaxWidth(tokens),
     },
   },
 };


### PR DESCRIPTION
### Description

Lagt til støtte for `--a-text-width-max`-token i tailwind-config 


f.eks `max-w-text` vil nå resolve til 576px

Etter noe testing viser det seg at dette ikke er en breaking change da brukers egendefinerte config ikke vil bli overskrevet av denne, og `text` er ikke en innebygd maksbredde i tailwind fra før. Legger det til som en patch