### PR TITLE
:bug: Fikset default-visning av bloggposter

### DIFF
--- a/aksel.nav.no/website/pages/produktbloggen/index.tsx
+++ b/aksel.nav.no/website/pages/produktbloggen/index.tsx
@@ -63,7 +63,7 @@ const Page = (props: PageProps["props"]) => {
     return <NotFotfund />;
   }
 
-  const remainingPosts = props?.bloggposts?.slice(4, props?.bloggposts.length);
+  const remainingPosts = props?.bloggposts?.slice(3, props?.bloggposts.length);
 
   return (
     <>


### PR DESCRIPTION
### Description

Ble `sliced` en artikkel for my fra blogg-utlistingen. Dette gjorde at hver 4-sist publiserte artikkel aldir ble vist på /produktbloggen