### PR TITLE
use noAmps for InlineCode in SanityBlockContent

### DIFF
--- a/aksel.nav.no/website/components/website-modules/SanityBlockContent.tsx
+++ b/aksel.nav.no/website/components/website-modules/SanityBlockContent.tsx
@@ -118,7 +118,7 @@ const serializers: Partial<PortableTextReactComponents> = {
   },
   marks: {
     kbd: ({ text }) => <KBD>{text}</KBD>,
-    code: ({ text }) => <InlineCode>{text}</InlineCode>,
+    code: ({ text }) => <InlineCode noAmps>{text}</InlineCode>,
     link: ({ text, value: { href } }: PortableTextMarkComponentProps<any>) => {
       if (!href) {
         return <span>{text}</span>;


### PR DESCRIPTION
I en brukertest av Golden Path for frontend skapte fnuttene forvirring i inline code. Jeg tror det beste er å bare fjerne de.