### PR TITLE
:bug: Bleed håndterer reflectivePadding og marginInlin=full riktig

### DIFF
--- a/.changeset/large-dragons-joke.md
+++ b/.changeset/large-dragons-joke.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Bleed: `marginInline='full'` og `reflectivePadding` kan nå brukes sammen.

--- a/@navikt/core/react/src/layout/bleed/Bleed.stories.tsx
+++ b/@navikt/core/react/src/layout/bleed/Bleed.stories.tsx
@@ -272,6 +272,19 @@ export const Full = {
             </Bleed>
           </Box>
         </Box>
+        <Box
+          className="maxWidth"
+          background="surface-alt-1-subtle"
+          padding="10"
+        >
+          <Box background="surface-alt-2-subtle" padding="10">
+            <Bleed marginInline="full" reflectivePadding asChild>
+              <Box background="surface-success-subtle">
+                <BodyLong>full + reflectivePadding</BodyLong>
+              </Box>
+            </Bleed>
+          </Box>
+        </Box>
       </VStack>
     </>
   ),

--- a/@navikt/core/react/src/layout/utilities/css.ts
+++ b/@navikt/core/react/src/layout/utilities/css.ts
@@ -44,6 +44,9 @@ const translateTokenStringToCSS = (
       if (componentProp === "margin-inline" && x === "full") {
         const width = 100 / arr.length;
         return `calc((100vw - ${width}%)/-2)`;
+      } else if (componentProp === "padding-inline" && x === "full") {
+        const width = 100 / arr.length;
+        return `calc((100vw - ${width}%)/2)`;
       }
 
       let output = `var(--a-${tokenSubgroup}-${x})`;


### PR DESCRIPTION
### Description

Bleed håndterte ikke ` <Bleed marginInline="full" reflectivePadding>` riktig og token ble satt til `full`. Settes nå til riktig verdi `calc((100vw - 100%)/2)`