### PR TITLE
:zap: Filterer ut chromatic-snapshots for package-files

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -59,7 +59,9 @@ jobs:
           exitZeroOnChanges: false
           buildScriptName: "build:storybook"
           onlyChanged: true
+          untraced: "**/package.json|yarn.lock|**/*.md"
           externals: \@navikt/core/css/**/*.css
+          traceChanged: true
         env:
           STORYBOOK_GITHUB_SHA: ${{ github.sha }}
 


### PR DESCRIPTION
### Description

På grunn av Chromatic sine pricing-changes kan vi vurdere å være litt mer streng med hva som kjører snapshots
https://www.chromatic.com/docs/turbosnap/#pricing

Endringen gjør at alle endringer i package.json, yarn lock og md-filer ikke vil kjøre chromatic nå. By default fører dette i dag til en komplett re-run, noe som har ført til ~30 bare på main-branch denne mnd (30 * ~400= 12000 av 55,348 = ~20% av snapshots)

La også til tracing slik at vi kan undersøke hva som fører til 200+ snapshots når bare f.eks `Datepicker.tsx` er oppdatert