### PR TITLE
:fire: Fjernet hyphen på blogg-headings

### DIFF
--- a/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
+++ b/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
@@ -101,7 +101,7 @@ const Page = ({ blogg, morePosts, publishDate }: PageProps["props"]) => {
             <Heading
               level="1"
               size="xlarge"
-              className="text-wrap-balance mt-1 break-words text-5xl leading-[1.2] text-deepblue-800"
+              className="text-wrap-balance mt-1 hyphens-auto break-words text-5xl leading-[1.2] text-deepblue-800 md:hyphens-none"
             >
               {blogg.heading}
             </Heading>

--- a/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
+++ b/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
@@ -101,7 +101,7 @@ const Page = ({ blogg, morePosts, publishDate }: PageProps["props"]) => {
             <Heading
               level="1"
               size="xlarge"
-              className="text-wrap-balance mt-1 break-words text-5xl leading-[1.2] text-deepblue-800 [hyphens:_auto]"
+              className="text-wrap-balance mt-1 break-words text-5xl leading-[1.2] text-deepblue-800"
             >
               {blogg.heading}
             </Heading>


### PR DESCRIPTION
### Description

På request fra Team PB ønsker de at headings på blogg ikke formateres med auto-hyphen slik det er i dag
- Har gått gjennom alle blogger på Aksel og ser ikke ut til å "brekke" noen headings
- På mobil vil fortsatt hyphens automatisk bli satt for å sikre at lengre ord ikke brekker siden

Etter
![Screenshot 2024-02-07 at 12 31 00](https://github.com/navikt/aksel/assets/26967723/597bcdac-bbcc-40d6-ab32-8c8a2b114a31)

Før
![Screenshot 2024-02-07 at 12 30 56](https://github.com/navikt/aksel/assets/26967723/93431b1d-1f4a-4392-ae21-d922701c2dbe)
