### PR TITLE
[aksel.nav.no] :fire: Fjern noAmps fra InlineCode

### DIFF
--- a/aksel.nav.no/website/components/styles/utilities.css
+++ b/aksel.nav.no/website/components/styles/utilities.css
@@ -81,10 +81,6 @@ p.override-text-no-max {
   color: inherit;
 }
 
-[id] > code > .inline-code-amp {
-  display: none;
-}
-
 /* Not in tailwindcss yet: https://github.com/tailwindlabs/tailwindcss/discussions/11486 */
 .text-wrap-balance {
   text-wrap: balance;

--- a/aksel.nav.no/website/components/website-modules/InlineCode.tsx
+++ b/aksel.nav.no/website/components/website-modules/InlineCode.tsx
@@ -1,18 +1,8 @@
 const InlineCode = (
-  props: React.HTMLAttributes<HTMLElement> & { noAmps?: boolean },
+  props: Pick<React.HTMLAttributes<HTMLElement>, "children">,
 ) => (
   <code className="rounded-sm bg-surface-neutral-subtle px-1 py-05 font-mono text-sm font-semibold">
-    {!props?.noAmps && (
-      <span aria-hidden className="inline-code-amp">
-        `
-      </span>
-    )}
-    <span>{props.children}</span>
-    {!props?.noAmps && (
-      <span aria-hidden className="inline-code-amp">
-        `
-      </span>
-    )}
+    {props.children}
   </code>
 );
 

--- a/aksel.nav.no/website/components/website-modules/SanityBlockContent.tsx
+++ b/aksel.nav.no/website/components/website-modules/SanityBlockContent.tsx
@@ -118,7 +118,7 @@ const serializers: Partial<PortableTextReactComponents> = {
   },
   marks: {
     kbd: ({ text }) => <KBD>{text}</KBD>,
-    code: ({ text }) => <InlineCode noAmps>{text}</InlineCode>,
+    code: ({ text }) => <InlineCode>{text}</InlineCode>,
     link: ({ text, value: { href } }: PortableTextMarkComponentProps<any>) => {
       if (!href) {
         return <span>{text}</span>;

--- a/aksel.nav.no/website/sanity/schema/objects/shared/riktekst.tsx
+++ b/aksel.nav.no/website/sanity/schema/objects/shared/riktekst.tsx
@@ -62,7 +62,7 @@ export const block = {
         title: "Inline-Kode",
         value: "code",
         icon: () => <CodeIcon aria-label="Kode" />,
-        component: ({ children }) => <InlineCode noAmps>{children}</InlineCode>,
+        component: ({ children }) => <InlineCode>{children}</InlineCode>,
       },
       {
         title: "KBD",


### PR DESCRIPTION
InlineCode var aldri brukt uten noAmps, så da kunne det fjernes.