### PR TITLE
[V6] SortState i Table får "none" tilgjengelig

### DIFF
--- a/.changeset/ninety-bulldogs-swim.md
+++ b/.changeset/ninety-bulldogs-swim.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": major
+---
+
+Table: SortState.direction har nå `none` tilgjengelig: `"ascending" | "descending" | "none"`

--- a/@navikt/core/react/src/table/types.ts
+++ b/@navikt/core/react/src/table/types.ts
@@ -1,4 +1,4 @@
 export interface SortState {
   orderBy: string;
-  direction: "ascending" | "descending";
+  direction: "ascending" | "descending" | "none";
 }

--- a/v6-migration.md
+++ b/v6-migration.md
@@ -119,3 +119,14 @@ For brukere av vår tailwind-config vil dette også si at `screen` er oppdatert.
   "2xl": "1440px"
 },
 ```
+
+### Table
+
+SortState.direction har nå `"none"` tilgjengelig, gir lettere type-håndtering for bruker.
+
+```
+export interface SortState {
+  orderBy: string;
+  direction: "ascending" | "descending" | "none";
+}
+```


### PR DESCRIPTION
### Description

Resolves #2725

I praksis vil ikke dette påvirke intern logikk i `Table`-komponenten, men vil være enkler for brukere av Table å lage godt typede komponenter.

Endringen i seg selv vil ikke funksjonelt påvirke koden til noen, men vil kunne påvirke typer til en del og da kreve en oppdatering (breaking)
https://github.com/search?type=code&q=org%3Anavikt+SortState