### PR TITLE
Search: Ekskluder 'type' fra SearchProps

### DIFF
--- a/.changeset/happy-jeans-juggle.md
+++ b/.changeset/happy-jeans-juggle.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": major
+---
+
+Search: Fjern 'type' fra SearchProps

--- a/@navikt/core/react/src/form/search/Search.tsx
+++ b/@navikt/core/react/src/form/search/Search.tsx
@@ -23,7 +23,7 @@ export type SearchClearEvent =
 
 export interface SearchProps
   extends Omit<FormFieldProps, "readOnly">,
-    Omit<InputHTMLAttributes<HTMLInputElement>, "size" | "onChange"> {
+    Omit<InputHTMLAttributes<HTMLInputElement>, "size" | "onChange" | "type"> {
   children?: React.ReactNode;
   /**
    * Search label
@@ -66,10 +66,10 @@ export interface SearchProps
    * Exposes the HTML size attribute
    */
   htmlSize?: number | string;
-    /*
+  /*
    * Exposes role attribute
    */
-  role?: string
+  role?: string;
 }
 
 interface SearchComponent
@@ -210,7 +210,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
               value={value ?? internalValue}
               onChange={(e) => handleChange(e.target.value)}
               type="search"
-              role={role ?? 'searchbox'}
+              role={role ?? "searchbox"}
               className={cl(
                 className,
                 "navds-search__input",

--- a/v6-migration.md
+++ b/v6-migration.md
@@ -108,6 +108,16 @@ Alle klasser med `.navds-content-container`-prefix er fjernet
 </Page>
 ```
 
+## Search
+
+Du vil nå få type-feil hvis du prøver å sette `type`. Internt i komponenten er `type` hardkodet til "search" og det har aldri vært mulig å endre dette med en prop.
+
+```jsx
+<Search label="Søk" type="text" />
+                    ~~~~
+                 // Property 'type' does not exist on type...
+```
+
 ## Tokens
 
 ### Z-index


### PR DESCRIPTION
I Search-komponenten blir `type` overskrevet, slik at det ikke har noen effekt å sette `type` fra brukerens side. Tenkte derfor denne burde fjernes fra SearchProps slik at folk ikke blir forvirret. Dette blir en breaking change da mange har satt `type` i dag.