### PR TITLE
:tada: Fikset regresjon ved bruk av portal i tooltip

### DIFF
--- a/.changeset/happy-trees-join.md
+++ b/.changeset/happy-trees-join.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Tooltip: Fikset regresjon der bruk av Tooltip ga hydration-error i nextjs

--- a/@navikt/core/react/src/tooltip/Tooltip.tsx
+++ b/@navikt/core/react/src/tooltip/Tooltip.tsx
@@ -189,7 +189,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
               : children?.props["aria-describedby"],
           }),
         )}
-        <Portal rootElement={rootElement}>
+        <Portal rootElement={rootElement} asChild>
           {_open && (
             <div
               {...getFloatingProps({


### PR DESCRIPTION
### Description

Siden globalThis bare er tilgjengelig for client vil dom ikke matche server og client. En enkel løsning for nå er å bruke "asChild" slik at portal ikke rendres før tooltip åpnes. En fremtidig løsning vil være å sjekke om portal er i ssr-context før man rendrer.
