### PR TITLE
Modal: Ikke opphev scroll lock ved lukking av nesta modal

### DIFF
--- a/.changeset/soft-trains-clean.md
+++ b/.changeset/soft-trains-clean.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Modal: Ikke opphev scroll lock ved lukking av nesta modal (DatePicker)

--- a/@navikt/core/react/src/modal/Modal.tsx
+++ b/@navikt/core/react/src/modal/Modal.tsx
@@ -98,8 +98,8 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
     const portalNode = useFloatingPortalNode({ root: rootElement });
 
     const dateContext = useContext(DateContext);
-    const modalContext = useModalContext(false);
-    if (modalContext && !dateContext) {
+    const isNested = useModalContext(false) !== undefined;
+    if (isNested && !dateContext) {
       console.error("Modals should not be nested");
     }
 
@@ -130,7 +130,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
       }
     }, [modalRef, portalNode, open]);
 
-    useBodyScrollLock(modalRef, portalNode);
+    useBodyScrollLock(modalRef, portalNode, isNested);
 
     const isWidthPreset =
       typeof width === "string" && ["small", "medium"].includes(width);

--- a/@navikt/core/react/src/modal/ModalUtils.ts
+++ b/@navikt/core/react/src/modal/ModalUtils.ts
@@ -37,5 +37,5 @@ export function useBodyScrollLock(
       observer.disconnect();
       document.body.classList.remove(BODY_CLASS); // In case modal is unmounted before it's closed
     };
-  }, [modalRef, portalNode]);
+  }, [modalRef, portalNode, isNested]);
 }

--- a/@navikt/core/react/src/modal/ModalUtils.ts
+++ b/@navikt/core/react/src/modal/ModalUtils.ts
@@ -18,8 +18,10 @@ export const BODY_CLASS = "navds-modal__document-body";
 export function useBodyScrollLock(
   modalRef: React.RefObject<HTMLDialogElement>,
   portalNode: HTMLElement | null,
+  isNested: boolean,
 ) {
   React.useEffect(() => {
+    if (isNested) return;
     if (!modalRef.current || !portalNode) return; // We check both to avoid running this twice when not using portal
     if (modalRef.current.open) document.body.classList.add(BODY_CLASS); // In case `open` is true initially
 


### PR DESCRIPTION
Nesting av modaler er ikke offisielt støttet, men vi har gjort et unntak for DatePicker når brukt i modal. Problemet er at scroll lock oppheves når den nesta/inner modalen (DatePicker) lukkes. Denne endringen fikser dette.