### PR TITLE
[aksel.nav.no] :rotating_light: Ikke tillat @ts-ignore

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,7 +72,6 @@ module.exports = {
           "error",
           "aksel.nav.no/website/pages/",
         ],
-        "@typescript-eslint/ban-ts-comment": "off", // Temporary
       },
     },
     {

--- a/aksel.nav.no/website/components/sanity-modules/code-examples/parts/CodeSandbox.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/code-examples/parts/CodeSandbox.tsx
@@ -20,7 +20,7 @@ export const CodeSandbox = ({ code }: { code: string }) => {
   const parameters = getParameters({
     files: {
       "package.json": {
-        // @ts-expect-error
+        // @ts-expect-error https://github.com/codesandbox/codesandbox-importers/issues/137
         content: {
           dependencies: {
             react: "latest",

--- a/aksel.nav.no/website/sanity/schema/custom-components/InputWithCounter.tsx
+++ b/aksel.nav.no/website/sanity/schema/custom-components/InputWithCounter.tsx
@@ -13,7 +13,7 @@ export function InputWithCounter(
     <VStack gap="1">
       {props.renderDefault(props)}
       <Counter
-        // @ts-ignore
+        // @ts-expect-error - maxLength is a custom prop not officially supported
         maxLength={schemaType?.options?.maxLength}
         currentLength={value?.length ?? 0}
       />

--- a/aksel.nav.no/website/sanity/schema/documents/god-praksis/tema.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/god-praksis/tema.tsx
@@ -29,7 +29,7 @@ export const Tema = defineType({
       group: "innhold",
 
       options: {
-        // @ts-expect-error
+        // @ts-expect-error - maxLength is a custom prop not officially supported
         maxLength: 130,
       },
       validation: (Rule) =>

--- a/aksel.nav.no/website/sanity/schema/documents/presets/ingress.ts
+++ b/aksel.nav.no/website/sanity/schema/documents/presets/ingress.ts
@@ -13,7 +13,7 @@ export const ingressField = defineField({
       .max(210)
       .error("Side må ha en ingress og kortere enn 210 tegn."),
   options: {
-    //@ts-ignore
+    //@ts-expect-error - maxLength is a custom prop not officially supported
     maxLength: 210,
   },
 });

--- a/aksel.nav.no/website/sanity/schema/documents/presets/seo.ts
+++ b/aksel.nav.no/website/sanity/schema/documents/presets/seo.ts
@@ -26,7 +26,7 @@ const BaseSEOPreset = {
       description: "Erstatter ingress som OG-description og meta-tag",
       rows: 3,
       options: {
-        // @ts-expect-error
+        // @ts-expect-error - maxLength is a custom prop not officially supported
         maxLength: 160,
       },
     }),

--- a/aksel.nav.no/website/sanity/schema/documents/presets/title-field.ts
+++ b/aksel.nav.no/website/sanity/schema/documents/presets/title-field.ts
@@ -12,7 +12,7 @@ export const titleField = defineField({
     Rule.max(60).error("Sidetittel kan ikke være over 60 tegn"),
   ],
   options: {
-    //@ts-ignore
+    //@ts-expect-error - maxLength is a custom prop not officially supported
     maxLength: 60,
   },
 });

--- a/aksel.nav.no/website/sanity/schema/documents/publiseringsflyt.ts
+++ b/aksel.nav.no/website/sanity/schema/documents/publiseringsflyt.ts
@@ -14,7 +14,6 @@ export const Publiseringsflyt = defineType({
       of: [
         {
           ...block,
-          // @ts-expect-error
           styles: [...headingStyles],
         },
       ],
@@ -28,7 +27,6 @@ export const Publiseringsflyt = defineType({
       of: [
         {
           ...block,
-          // @ts-expect-error
           styles: [...headingStyles],
         },
       ],
@@ -42,7 +40,6 @@ export const Publiseringsflyt = defineType({
       of: [
         {
           ...block,
-          // @ts-expect-error
           styles: [...headingStyles],
         },
       ],

--- a/aksel.nav.no/website/sanity/schema/documents/skrivehjelp.ts
+++ b/aksel.nav.no/website/sanity/schema/documents/skrivehjelp.ts
@@ -14,7 +14,6 @@ export const Skrivehjelp = defineType({
       of: [
         {
           ...block,
-          // @ts-expect-error
           styles: [...headingStyles],
         },
       ],

--- a/aksel.nav.no/website/sanity/schema/objects/shared/riktekst.tsx
+++ b/aksel.nav.no/website/sanity/schema/objects/shared/riktekst.tsx
@@ -24,7 +24,7 @@ export const styles = [
 
 export const block = {
   title: "Block",
-  type: "block",
+  type: "block" as const,
   styles: [...styles],
   lists: [
     {


### PR DESCRIPTION
Aktiverte @typescript-eslint/ban-ts-comment for aksel.nav.no. Dvs. at man må bruke @ts-expect-error i stedet for @ts-ignore, og man må ha med en forklaring.

På det med `maxLength` så bare tippet jeg, kom gjerne med forslag til mer presis forklaring.