### PR TITLE
FileUpload: display:none på input

### DIFF
--- a/@navikt/core/css/form/file-upload.css
+++ b/@navikt/core/css/form/file-upload.css
@@ -8,8 +8,9 @@
 }
 
 /**
- * Dropzone
+ * FileUpload.Dropzone
  */
+
 .navds-dropzone__area {
   --__ac-dropzone-background: var(--a-surface-subtle);
   --__ac-dropzone-text-color: var(--a-text-default);
@@ -34,6 +35,7 @@
   background-color: var(--__ac-dropzone-background);
   color: var(--__ac-dropzone-text-color);
   transition: background-color var(--__ac-dropzone-animation-length-short) var(--__ac-dropzone-animation-ease-out);
+  cursor: pointer;
 }
 
 .navds-dropzone__area:hover {
@@ -72,7 +74,6 @@
   box-shadow: inset 0 2px 7px 3px rgb(11 11 11/ 0.1);
   border-radius: var(--a-border-radius-large);
   animation: akselDropzoneDragoverAnimation var(--__ac-dropzone-animation-length-short) var(--__ac-dropzone-animation-ease-out);
-  pointer-events: none;
 }
 
 @keyframes akselDropzoneDragoverAnimation {
@@ -130,24 +131,6 @@
     inset 0 0 0 1px
       var(--ac-button-secondary-active-focus-border, var(--__ac-button-secondary-active-focus-border, var(--a-surface-default))),
     var(--a-shadow-focus);
-}
-
-.navds-dropzone__area-input {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
-  cursor: pointer;
-}
-
-.navds-dropzone--disabled .navds-dropzone__area-input {
-  cursor: default;
-  z-index: -1;
-}
-
-.navds-dropzone__area-input::file-selector-button {
-  cursor: pointer;
 }
 
 .navds-dropzone__area-release {

--- a/@navikt/core/css/form/file-upload.css
+++ b/@navikt/core/css/form/file-upload.css
@@ -53,14 +53,6 @@
   --__ac-dropzone-background: var(--a-surface-action-subtle-hover);
 }
 
-.navds-dropzone__area:hover > .navds-dropzone__area-button {
-  color: var(--ac-button-secondary-hover-text, var(--__ac-button-secondary-hover-text, var(--a-text-action-on-action-subtle)));
-  background-color: var(
-    --ac-button-secondary-hover-bg,
-    var(--__ac-button-secondary-hover-bg, var(--a-surface-action-subtle-hover))
-  );
-}
-
 .navds-dropzone--dragging > .navds-dropzone__area::after {
   outline: 1px dashed var(--a-border-subtle);
   outline-offset: -1px;
@@ -104,33 +96,18 @@
   outline-width: 2px;
 }
 
-.navds-dropzone__area:has(:focus-visible) > .navds-dropzone__area-button {
-  outline: 2px solid transparent;
-  outline-offset: 2px;
-  box-shadow:
-    inset 0 0 0 2px var(--ac-button-secondary-focus-border, var(--__ac-button-secondary-focus-border, var(--a-border-action))),
-    var(--a-shadow-focus);
+.navds-dropzone__area:hover > .navds-dropzone__area-button {
+  color: var(--ac-button-secondary-hover-text, var(--__ac-button-secondary-hover-text, var(--a-text-action-on-action-subtle)));
+  background-color: var(
+    --ac-button-secondary-hover-bg,
+    var(--__ac-button-secondary-hover-bg, var(--a-surface-action-subtle-hover))
+  );
 }
 
-@supports (not selector(:focus-visible)) or (not selector(:has(a))) {
-  .navds-dropzone__area:focus-within > .navds-dropzone__area-button {
-    box-shadow:
-      inset 0 0 0 2px var(--ac-button-secondary-focus-border, var(--__ac-button-secondary-focus-border, var(--a-border-action))),
-      var(--a-shadow-focus);
-  }
-}
-
-.navds-dropzone__area:has(:active) .navds-dropzone__area-button {
+.navds-dropzone__area:active .navds-dropzone__area-button {
   color: var(--ac-button-secondary-active-text, var(--__ac-button-secondary-active-text, var(--a-text-on-action)));
   background-color: var(--ac-button-secondary-active-bg, var(--__ac-button-secondary-active-bg, var(--a-surface-action-active)));
   box-shadow: none;
-}
-
-.navds-dropzone__area:has(:focus-visible:active) .navds-dropzone__area-button {
-  box-shadow:
-    inset 0 0 0 1px
-      var(--ac-button-secondary-active-focus-border, var(--__ac-button-secondary-active-focus-border, var(--a-surface-default))),
-    var(--a-shadow-focus);
 }
 
 .navds-dropzone__area-release {

--- a/@navikt/core/react/src/form/file-upload/file-upload-dropzone.stories.tsx
+++ b/@navikt/core/react/src/form/file-upload/file-upload-dropzone.stories.tsx
@@ -78,10 +78,10 @@ export const States: StoryObj = {
 };
 States.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
-  const input = canvas.getByLabelText("Drag over test", {
-    selector: "input",
+  const button = canvas.getByLabelText("Drag over test", {
+    selector: "button",
   });
-  fireEvent.dragOver(input);
+  fireEvent.dragEnter(button);
 };
 
 export const Translation: StoryObj = {

--- a/@navikt/core/react/src/form/file-upload/file-upload-dropzone.stories.tsx
+++ b/@navikt/core/react/src/form/file-upload/file-upload-dropzone.stories.tsx
@@ -72,15 +72,17 @@ export const States: StoryObj = {
       />
 
       <h2>Dragging</h2>
-      <FileUpload.Dropzone label="Drag over test" onSelect={onSelect} />
+      <FileUpload.Dropzone
+        label="Drag over test"
+        multiple={false}
+        onSelect={onSelect}
+      />
     </div>
   ),
 };
 States.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
-  const button = canvas.getByLabelText("Drag over test", {
-    selector: "button",
-  });
+  const button = canvas.getByText("Velg fil");
   fireEvent.dragEnter(button);
 };
 

--- a/@navikt/core/react/src/form/file-upload/file-upload.stories.tsx
+++ b/@navikt/core/react/src/form/file-upload/file-upload.stories.tsx
@@ -71,7 +71,7 @@ export const Default: StoryFn = () => {
         <FileUpload.Dropzone
           label="Last opp filer til søknaden"
           description={`Maks størrelse ${MAX_SIZE_MB} MB`}
-          /* accept=".doc,.docx,.xls,.xlsx,.pdf" */
+          accept=".doc,.docx,.xls,.xlsx,.pdf"
           maxSizeInBytes={MAX_SIZE}
           fileLimit={{ max: MAX_FILES, current: acceptedFiles.length }}
           onSelect={addFiles}

--- a/@navikt/core/react/src/form/file-upload/file-upload.stories.tsx
+++ b/@navikt/core/react/src/form/file-upload/file-upload.stories.tsx
@@ -84,7 +84,7 @@ export const Default: StoryFn = () => {
         {acceptedFiles.length > 0 && (
           <VStack gap="2">
             <Heading level="3" size="xsmall">
-              {`Vedlegg (${acceptedFiles.length} av ${MAX_FILES})`}
+              {`Vedlegg (${acceptedFiles.length} av maks ${MAX_FILES})`}
             </Heading>
             <VStack as="ul" gap="3">
               {acceptedFiles.map((file, index) => (

--- a/@navikt/core/react/src/form/file-upload/parts/dropzone/Dropzone.tsx
+++ b/@navikt/core/react/src/form/file-upload/parts/dropzone/Dropzone.tsx
@@ -44,6 +44,7 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
 
     const { inputProps, errorId, showErrorMsg, hasError, inputDescriptionId } =
       useFormField({ ...props, disabled: _disabled }, "fileUpload");
+    const { id: labelId, ...inputPropsRest } = inputProps;
 
     const { upload, onChange, inputRef, mergedRef } = useFileUpload({
       ref,
@@ -67,7 +68,7 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
           "navds-dropzone--disabled": inputProps.disabled,
         })}
       >
-        <Label htmlFor={inputProps.id} className="navds-form-field__label">
+        <Label htmlFor={labelId} className="navds-form-field__label">
           {label}
         </Label>
         {!!description && (
@@ -119,7 +120,7 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
               </div>
               <Button
                 {...omit(rest, ["errorId"])}
-                {...inputProps}
+                {...inputPropsRest}
                 className="navds-dropzone__area-button"
                 type="button"
                 variant="secondary"
@@ -143,6 +144,7 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
           )}
 
           <input
+            id={labelId}
             type="file"
             style={{ display: "none" }}
             multiple={multiple}

--- a/@navikt/core/react/src/form/file-upload/parts/dropzone/Dropzone.tsx
+++ b/@navikt/core/react/src/form/file-upload/parts/dropzone/Dropzone.tsx
@@ -3,6 +3,7 @@ import React, { forwardRef } from "react";
 import { CircleSlashIcon, CloudUpIcon } from "@navikt/aksel-icons";
 import { Button } from "../../../../button";
 import { BodyShort, ErrorMessage, Label } from "../../../../typography";
+import { composeEventHandlers } from "../../../../util/composeEventHandlers";
 import { omit } from "../../../../util/omit";
 import { useFormField } from "../../../useFormField";
 import { useFileUploadTranslation } from "../../FileUpload.context";
@@ -27,6 +28,7 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
       icon: DropzoneIcon = CloudUpIcon,
       disabled,
       translations,
+      onClick,
       ...rest
     } = props;
 
@@ -64,7 +66,6 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
           "navds-dropzone--dragging": dropzoneCtx.isDraggingOver,
           "navds-dropzone--disabled": inputProps.disabled,
         })}
-        {...omit(rest, ["errorId", "id"])}
       >
         <Label htmlFor={inputProps.id} className="navds-form-field__label">
           {label}
@@ -85,7 +86,10 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
           onDragOver={dropzoneCtx.onDragOver}
           onDragLeave={dropzoneCtx.onDragLeave}
           onDrop={dropzoneCtx.onDrop}
-          onClick={() => inputRef.current?.click()}
+          onClick={composeEventHandlers(
+            onClick,
+            () => inputRef.current?.click(),
+          )}
         >
           {!inputProps.disabled && (
             <>
@@ -114,13 +118,11 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
                 </BodyShort>
               </div>
               <Button
+                {...omit(rest, ["errorId"])}
                 {...inputProps}
                 className="navds-dropzone__area-button"
+                type="button"
                 variant="secondary"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  inputRef.current?.click();
-                }}
               >
                 {multiple
                   ? translate("FileUpload.dropzone.buttonMultiple")

--- a/@navikt/core/react/src/form/file-upload/parts/dropzone/Dropzone.tsx
+++ b/@navikt/core/react/src/form/file-upload/parts/dropzone/Dropzone.tsx
@@ -4,6 +4,7 @@ import { CircleSlashIcon, CloudUpIcon } from "@navikt/aksel-icons";
 import { Button } from "../../../../button";
 import { BodyShort, ErrorMessage, Label } from "../../../../typography";
 import { composeEventHandlers } from "../../../../util/composeEventHandlers";
+import { useId } from "../../../../util/hooks";
 import { omit } from "../../../../util/omit";
 import { useFormField } from "../../../useFormField";
 import { useFileUploadTranslation } from "../../FileUpload.context";
@@ -44,7 +45,12 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
 
     const { inputProps, errorId, showErrorMsg, hasError, inputDescriptionId } =
       useFormField({ ...props, disabled: _disabled }, "fileUpload");
-    const { id: labelId, ...inputPropsRest } = inputProps;
+    const {
+      id: inputId,
+      "aria-describedby": ariaDescribedby,
+      ...inputPropsRest
+    } = inputProps;
+    const labelId = useId();
 
     const { upload, onChange, inputRef, mergedRef } = useFileUpload({
       ref,
@@ -68,7 +74,11 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
           "navds-dropzone--disabled": inputProps.disabled,
         })}
       >
-        <Label htmlFor={labelId} className="navds-form-field__label">
+        <Label
+          htmlFor={inputId}
+          id={labelId}
+          className="navds-form-field__label"
+        >
           {label}
         </Label>
         {!!description && (
@@ -121,6 +131,7 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
               <Button
                 {...omit(rest, ["errorId"])}
                 {...inputPropsRest}
+                aria-describedby={cl(labelId, ariaDescribedby)}
                 className="navds-dropzone__area-button"
                 type="button"
                 variant="secondary"
@@ -144,7 +155,7 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
           )}
 
           <input
-            id={labelId}
+            id={inputId}
             type="file"
             style={{ display: "none" }}
             multiple={multiple}

--- a/@navikt/core/react/src/form/file-upload/parts/dropzone/Dropzone.tsx
+++ b/@navikt/core/react/src/form/file-upload/parts/dropzone/Dropzone.tsx
@@ -43,7 +43,7 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
     const { inputProps, errorId, showErrorMsg, hasError, inputDescriptionId } =
       useFormField({ ...props, disabled: _disabled }, "fileUpload");
 
-    const { onChange, inputRef, mergedRef } = useFileUpload({
+    const { upload, onChange, inputRef, mergedRef } = useFileUpload({
       ref,
       onSelect,
       validator,
@@ -53,6 +53,7 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
     });
 
     const dropzoneCtx = useDropzone({
+      upload,
       disabled: inputProps.disabled,
     });
 
@@ -63,6 +64,7 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
           "navds-dropzone--dragging": dropzoneCtx.isDraggingOver,
           "navds-dropzone--disabled": inputProps.disabled,
         })}
+        {...omit(rest, ["errorId", "id"])}
       >
         <Label htmlFor={inputProps.id} className="navds-form-field__label">
           {label}
@@ -76,12 +78,14 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
             {description}
           </BodyShort>
         )}
+        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
         <div
+          className="navds-dropzone__area"
+          onDragEnter={dropzoneCtx.onDragEnter}
           onDragOver={dropzoneCtx.onDragOver}
           onDragLeave={dropzoneCtx.onDragLeave}
-          onDragEnd={dropzoneCtx.onDragEnd}
           onDrop={dropzoneCtx.onDrop}
-          className="navds-dropzone__area"
+          onClick={() => inputRef.current?.click()}
         >
           {!inputProps.disabled && (
             <>
@@ -110,10 +114,13 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
                 </BodyShort>
               </div>
               <Button
+                {...inputProps}
                 className="navds-dropzone__area-button"
                 variant="secondary"
-                onClick={() => inputRef.current?.click()}
-                tabIndex={-1}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  inputRef.current?.click();
+                }}
               >
                 {multiple
                   ? translate("FileUpload.dropzone.buttonMultiple")
@@ -134,10 +141,8 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
           )}
 
           <input
-            {...omit(rest, ["errorId"])}
-            {...inputProps}
             type="file"
-            className="navds-dropzone__area-input"
+            style={{ display: "none" }}
             multiple={multiple}
             accept={accept}
             onChange={onChange}

--- a/@navikt/core/react/src/form/file-upload/parts/dropzone/dropzone.types.ts
+++ b/@navikt/core/react/src/form/file-upload/parts/dropzone/dropzone.types.ts
@@ -5,7 +5,8 @@ import { ComponentTranslation } from "../../i18n/i18n.types";
 export interface FileUploadDropzoneProps
   extends FileUploadBaseProps,
     Omit<FormFieldProps, "size" | "readOnly">,
-    Omit<React.HTMLAttributes<HTMLDivElement>, "onSelect"> {
+    Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onSelect" | "onClick">,
+    Pick<React.HTMLAttributes<HTMLDivElement>, "onClick"> {
   /**
    * Text shown to the user.
    */

--- a/@navikt/core/react/src/form/file-upload/parts/dropzone/dropzone.types.ts
+++ b/@navikt/core/react/src/form/file-upload/parts/dropzone/dropzone.types.ts
@@ -5,7 +5,7 @@ import { ComponentTranslation } from "../../i18n/i18n.types";
 export interface FileUploadDropzoneProps
   extends FileUploadBaseProps,
     Omit<FormFieldProps, "size" | "readOnly">,
-    Omit<React.InputHTMLAttributes<HTMLInputElement>, "onSelect" | "size"> {
+    Omit<React.HTMLAttributes<HTMLDivElement>, "onSelect"> {
   /**
    * Text shown to the user.
    */

--- a/@navikt/core/react/src/form/file-upload/parts/dropzone/useDropzone.ts
+++ b/@navikt/core/react/src/form/file-upload/parts/dropzone/useDropzone.ts
@@ -1,31 +1,43 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { UseFileUploadProps } from "../../useFileUpload";
 
-export const useDropzone = ({
-  disabled,
-}: Pick<UseFileUploadProps, "disabled">) => {
-  const [isDraggingOver, setIsDraggingOver] = useState(false);
-  const isDraggingRef = useRef(false);
+interface Props {
+  upload: (fileList: FileList) => void;
+  disabled: UseFileUploadProps["disabled"];
+}
 
-  // onDragOver triggers 60+ times per second, so we cut it off to avoid excessive computation.
-  const onDragOver = () => {
-    if (isDraggingRef.current) {
-      return;
-    }
-    isDraggingRef.current = true;
+export const useDropzone = ({ upload, disabled }: Props) => {
+  const [isDraggingOver, setIsDraggingOver] = useState(false);
+
+  const onDragEnter = () => {
     setIsDraggingOver(true);
   };
 
+  const onDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  };
+
   const onDragLeave = () => {
-    isDraggingRef.current = false;
     setIsDraggingOver(false);
+  };
+
+  const onDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDraggingOver(false);
+
+    const fileList = event.dataTransfer.files;
+    if (!fileList) {
+      return;
+    }
+
+    upload(fileList);
   };
 
   return {
     isDraggingOver,
+    onDragEnter: disabled ? undefined : onDragEnter,
     onDragOver: disabled ? undefined : onDragOver,
     onDragLeave: disabled ? undefined : onDragLeave,
-    onDragEnd: disabled ? undefined : onDragLeave,
-    onDrop: disabled ? undefined : onDragLeave,
+    onDrop: disabled ? undefined : onDrop,
   };
 };

--- a/@navikt/core/react/src/form/file-upload/parts/dropzone/useDropzone.ts
+++ b/@navikt/core/react/src/form/file-upload/parts/dropzone/useDropzone.ts
@@ -14,7 +14,7 @@ export const useDropzone = ({ upload, disabled }: Props) => {
   };
 
   const onDragOver = (event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
+    event.preventDefault(); // Prevents the browser from opening the file in a new tab
   };
 
   const onDragLeave = () => {
@@ -22,7 +22,7 @@ export const useDropzone = ({ upload, disabled }: Props) => {
   };
 
   const onDrop = (event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
+    event.preventDefault(); // Prevents the browser from opening the file in a new tab
     setIsDraggingOver(false);
 
     const fileList = event.dataTransfer.files;

--- a/@navikt/core/react/src/form/file-upload/useFileUpload.ts
+++ b/@navikt/core/react/src/form/file-upload/useFileUpload.ts
@@ -20,9 +20,9 @@ export const useFileUpload = ({
   const inputRef = useRef<HTMLInputElement | null>(null);
   const mergedRef = useMergeRefs(inputRef, ref);
 
-  const upload = (fileList: File[]) => {
+  const upload = (fileList: FileList) => {
     const { files, partitionedFiles } = validateFiles(
-      fileList,
+      Array.from(fileList),
       accept,
       validator,
       maxSizeInBytes,
@@ -38,7 +38,7 @@ export const useFileUpload = ({
     }
 
     if (!disabled) {
-      upload(Array.from(fileList));
+      upload(fileList);
     }
 
     // Resets the value to make it is possible to upload the same file several consecutive times
@@ -46,6 +46,7 @@ export const useFileUpload = ({
   };
 
   return {
+    upload,
     onChange,
     inputRef,
     mergedRef,


### PR DESCRIPTION
Utfordring: Skjermleser får lest opp "Ingen fil valgt" fra input-elementet selv om man har lagt til filer, siden selve input-feltet blir nullstilt så fort filene er lagt til.

Forslag til løsning: Sette display:none på input-feltet.