### PR TITLE
:tada: Fikset search-bug der for god score fjernet resultat

### DIFF
--- a/aksel.nav.no/website/components/website-modules/search/utils/fuse-search.ts
+++ b/aksel.nav.no/website/components/website-modules/search/utils/fuse-search.ts
@@ -20,5 +20,7 @@ export function fuseSearch(results: any[], query: string) {
     includeMatches: true,
     threshold: 0.3,
   });
-  return fuse.search(query).filter((x) => x.score && x.score < 0.3);
+  return fuse
+    .search(query)
+    .filter((x) => x.score !== undefined && x.score < 0.3);
 }


### PR DESCRIPTION
### Description

Når score === 0 (topresultat) feilet `x.score`-sjekken da 0 er falsy