### PR TITLE
Fikset CDN deploy av Aksel og designsystem assets

### DIFF
--- a/.github/workflows/push-to-cdn.yaml
+++ b/.github/workflows/push-to-cdn.yaml
@@ -20,11 +20,13 @@ jobs:
       - uses: "actions/checkout@v3"
 
       - id: upload
-        uses: navikt/frontend/actions/cdn-upload/v1@main
+        uses: nais/deploy/actions/cdn-upload/v2@master
         with:
-          cdn-team-name: aksel
+          team: aksel
           source: ./fonts
           destination: "" # uploads folder to team root
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
 
       - run: echo uploaded file ${{ steps.upload.outputs.uploaded }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,13 @@ jobs:
 
       - name: Upload updated icon.zip to NAV CDN
         if: steps.changesets.outputs.published == 'true'
-        uses: navikt/frontend/actions/cdn-upload/v1@main
+        uses: nais/deploy/actions/cdn-upload/v2@master
         with:
-          cdn-team-name: aksel
+          team: aksel
           source: ./@navikt/aksel-icons/aksel-icons.zip
           destination: "/icons/zip"
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Get @navikt/ds-css version
         run: |
@@ -94,8 +96,10 @@ jobs:
 
       - name: Upload CSS to NAV CDN
         if: steps.changesets.outputs.published == 'true'
-        uses: navikt/frontend/actions/cdn-upload/v1@main
+        uses: nais/deploy/actions/cdn-upload/v2@master
         with:
-          cdn-team-name: aksel
+          team: aksel
           source: ./@navikt/core/css/dist/version/${{env.version}}
           destination: "@navikt/ds-css"
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}

--- a/aksel.nav.no/website/next.config.js
+++ b/aksel.nav.no/website/next.config.js
@@ -57,7 +57,7 @@ const nextConfig = {
   publicRuntimeConfig: {
     NEXT_PUBLIC_TEST: process.env.NEXT_PUBLIC_TEST,
   },
-  assetPrefix: useCdn ? "https://cdn.nav.no/aksel/website" : undefined,
+  assetPrefix: useCdn ? "https://cdn.nav.no/designsystem/website" : undefined,
   async headers() {
     return [
       {


### PR DESCRIPTION
Siden CDN-deploy nå er koblet til nais-team er nytt team "aksel" laget der designsystem assets kan lastes opp til. Opplasting av font, css og ikoner er koblet til "aksel"-namespace, mens website (nettsiden) er koblet til "designsystem" namespace