### PR TITLE
:lipstick: break-normal on body text, but break-all on types, as they…

### DIFF
--- a/aksel.nav.no/website/components/sanity-modules/props/parts/DtList.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/props/parts/DtList.tsx
@@ -41,7 +41,7 @@ export const DtList = ({ prop }: { prop: Prop; parent: string }) => {
   return (
     <BodyShort as="ul" className="dtlist overflow-x-auto">
       {prop.type && (
-        <li className="my-3 flex flex-col px-3 text-base md:flex-row">
+        <li className="my-3 flex flex-col break-all px-3 text-base md:flex-row">
           <div className="min-w-24 font-semibold">Type: </div>
           <code className="mt-05 text-sm">
             {Highlighter({ type: prop.type })}

--- a/aksel.nav.no/website/components/sanity-modules/props/parts/PropTabell.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/props/parts/PropTabell.tsx
@@ -19,7 +19,7 @@ const PropTable = ({ komponent }: PropTableProps) => {
         {komponent?.title ? komponent.title : "Props"}
       </Heading>
 
-      <div className="toc-ignore relative mb-8 break-all">
+      <div className="toc-ignore relative mb-8 break-normal">
         {komponent?.propref?.proplist?.length === 0 && (
           <div className="mb-8 rounded-b-lg border border-gray-300 p-2">
             <BodyShort>Fant ingen props for denne komponenten.</BodyShort>

--- a/aksel.nav.no/website/components/sanity-modules/props/parts/PropTabell.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/props/parts/PropTabell.tsx
@@ -19,7 +19,7 @@ const PropTable = ({ komponent }: PropTableProps) => {
         {komponent?.title ? komponent.title : "Props"}
       </Heading>
 
-      <div className="toc-ignore relative mb-8 break-normal">
+      <div className="toc-ignore relative mb-8">
         {komponent?.propref?.proplist?.length === 0 && (
           <div className="mb-8 rounded-b-lg border border-gray-300 p-2">
             <BodyShort>Fant ingen props for denne komponenten.</BodyShort>


### PR DESCRIPTION
stuff like this `ResponsiveProp<SpaceDelimitedAttribute<BorderRadiiToken>>` prevents breaking when set to `break-normal`, so for types we should set `break-all`, they will be ugly to look at no matter _what_ we do to them >:) 