### PR TITLE
FileUpload.Dropzone: Fiks feil med duplisert id

### DIFF
--- a/.changeset/famous-panthers-appear.md
+++ b/.changeset/famous-panthers-appear.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+FileUpload.Dropzone: Fiks feil med duplisert id

--- a/@navikt/core/react/src/form/file-upload/parts/dropzone/Dropzone.tsx
+++ b/@navikt/core/react/src/form/file-upload/parts/dropzone/Dropzone.tsx
@@ -129,7 +129,7 @@ const Dropzone = forwardRef<HTMLInputElement, FileUploadDropzoneProps>(
                 <BodyShort as="div">{translate("dropzone.or")}</BodyShort>
               </div>
               <Button
-                {...omit(rest, ["errorId"])}
+                {...omit(rest, ["errorId", "id"])}
                 {...inputPropsRest}
                 aria-describedby={cl(labelId, ariaDescribedby)}
                 className="navds-dropzone__area-button"


### PR DESCRIPTION
Når man satt `id` eksplisitt på Dropzone, ble den satt på både button og input.