### PR TITLE
useControllableState i Expansioncard og Switch state-bug

### DIFF
--- a/.changeset/curvy-ducks-battle.md
+++ b/.changeset/curvy-ducks-battle.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Switch: Fikset edgecase der checked Switch var visuelt unchecked

--- a/@navikt/core/react/src/expansion-card/ExpansionCard.tsx
+++ b/@navikt/core/react/src/expansion-card/ExpansionCard.tsx
@@ -1,5 +1,6 @@
 import cl from "clsx";
-import React, { forwardRef, useRef, useState } from "react";
+import React, { forwardRef, useRef } from "react";
+import { useControllableState } from "../util/hooks";
 import { OverridableComponent } from "../util/types";
 import ExpansionCardContent, {
   ExpansionCardContentProps,
@@ -116,24 +117,24 @@ export const ExpansionCard = forwardRef<HTMLDivElement, ExpansionCardProps>(
     },
     ref,
   ) => {
-    const [_open, _setOpen] = useState(defaultOpen);
-
     const shouldFade = useRef<boolean>(!(Boolean(open) || defaultOpen));
 
-    const handleOpen = () => {
-      if (open === undefined) {
-        const newOpen = !_open;
-        _setOpen(newOpen);
-        onToggle?.(newOpen);
-      } else {
-        onToggle?.(!open);
-      }
-      shouldFade.current = true;
-    };
+    const [_open, _setOpen] = useControllableState({
+      value: open,
+      onChange: (newValue) => {
+        onToggle?.(newValue);
+        shouldFade.current = true;
+      },
+      defaultValue: defaultOpen,
+    });
 
     return (
       <ExpansionCardContext.Provider
-        value={{ open: open ?? _open, toggleOpen: handleOpen, size }}
+        value={{
+          open: open ?? _open,
+          toggleOpen: () => _setOpen((x) => !x),
+          size,
+        }}
       >
         <section
           {...rest}

--- a/@navikt/core/react/src/form/switch/Switch.tsx
+++ b/@navikt/core/react/src/form/switch/Switch.tsx
@@ -85,13 +85,15 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
       ...rest
     } = props;
 
-    const [checked, setChecked] = useState(
+    const [_checked, setChecked] = useState(
       defaultChecked ?? checkedProp ?? false,
     );
 
     useEffect(() => {
       checkedProp !== undefined && setChecked(checkedProp);
     }, [checkedProp]);
+
+    const checked = checkedProp ?? _checked;
 
     return (
       <div
@@ -119,6 +121,7 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
             if (readOnly) {
               return;
             }
+            /* if (checkedProp && !props.onChange) return; */
             setChecked(e.target.checked);
             props.onChange && props.onChange(e);
           }}

--- a/@navikt/core/react/src/form/switch/Switch.tsx
+++ b/@navikt/core/react/src/form/switch/Switch.tsx
@@ -121,7 +121,6 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
             if (readOnly) {
               return;
             }
-            /* if (checkedProp && !props.onChange) return; */
             setChecked(e.target.checked);
             props.onChange && props.onChange(e);
           }}


### PR DESCRIPTION
### Description

Resolves https://github.com/orgs/navikt/projects/49/views/42?query=is%3Aopen+sort%3Aupdated-desc&pane=issue&itemId=49709604

### Change summary

- ExpansionCard bruker `useControllableState`
- Switch vil nå alltid være visuelt checked når bruker sender "checked"-prop