### PR TITLE
:construction_worker: make yarn install on CI fail if you forget to u…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: echo "NPM_AUTH_TOKEN=${{ secrets.READER_TOKEN }}" >> $GITHUB_ENV
 
       - name: Install dependencies
-        run: yarn
+        run: yarn --immutable
 
       - name: Boot (build packages)
         run: yarn boot


### PR DESCRIPTION
yarn's [--immutable](https://yarnpkg.com/cli/install)

~~also, maybe we could add what [this SO answer](https://stackoverflow.com/a/69944063) mentions as well:~~

~~`yarn --immutable --immutable-cache --check-cache`~~ ?

~~extra info: https://v3.yarnpkg.com/features/zero-installs~~

(don't think Zero-installs is for us)