### PR TITLE
:lipstick: Fjernet Illustrasjon fra bloggsider

### DIFF
--- a/aksel.nav.no/website/components/sanity-modules/cards/BloggCard.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/cards/BloggCard.tsx
@@ -15,7 +15,7 @@ const BloggCard = ({ blog }: BloggCardProps) => {
   return (
     <li
       key={blog._id}
-      className="flex h-full flex-col place-content-start border-b border-b-border-subtle pb-8"
+      className="flex h-full flex-col place-content-start border-b border-b-border-subtle pb-10"
     >
       <Heading size="medium" as="div">
         <NextLink href={`/${blog.slug}`} passHref legacyBehavior>
@@ -32,7 +32,7 @@ const BloggCard = ({ blog }: BloggCardProps) => {
           </Link>
         </NextLink>
       </Heading>
-      <BodyLong className="my-2">{blog?.ingress}</BodyLong>
+      <BodyLong className="my-2 line-clamp-2">{blog?.ingress}</BodyLong>
       {getAuthors(blog).length > 0 && (
         <BodyShort
           size="small"

--- a/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
+++ b/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
@@ -17,7 +17,6 @@ import {
 } from "@/types";
 import { abbrName, dateStr, getImage } from "@/utils";
 import { BloggAd } from "@/web/BloggAd";
-import { AkselCubeStatic } from "@/web/aksel-cube/AkselCube";
 import { SEO } from "@/web/seo/SEO";
 import NotFotfund from "../404";
 
@@ -165,7 +164,6 @@ const Page = ({ blogg, morePosts, publishDate }: PageProps["props"]) => {
           </div>
         </div>
         <div className="relative mt-16">
-          <AkselCubeStatic className="z-0 text-amber-300 opacity-20" />
           <div className="relative z-10 mt-8 px-4">
             <SanityBlockContent
               className="dynamic-wrapper-prose"

--- a/aksel.nav.no/website/pages/produktbloggen/index.tsx
+++ b/aksel.nav.no/website/pages/produktbloggen/index.tsx
@@ -14,7 +14,6 @@ import {
   ResolveSlugT,
 } from "@/types";
 import { BloggAd } from "@/web/BloggAd";
-import { AkselCubeStatic } from "@/web/aksel-cube/AkselCube";
 import { LatestBloggposts } from "@/web/blogg-page/BloggPage";
 import { SEO } from "@/web/seo/SEO";
 import NotFotfund from "../404";
@@ -80,7 +79,6 @@ const Page = (props: PageProps["props"]) => {
           id="hovedinnhold"
           className="relative overflow-hidden focus:outline-none"
         >
-          <AkselCubeStatic className="text-[#FFE78A] opacity-10" />
           <div className="mx-auto mb-40 grid w-full max-w-screen-2xl px-4 sm:px-6">
             <LatestBloggposts
               bloggs={props?.bloggposts}


### PR DESCRIPTION
### Description

Resolves #2823

- Fjernet Aksel-illustrasjon fra blogg forside og artikkelside
- Justerte padding for riktig sentrering av cards
- bruker line-clamp for å hindre lengre tekster i cards