### PR TITLE
Datepicker/MonthPicker required bugs

### DIFF
--- a/.changeset/fifty-hairs-fix.md
+++ b/.changeset/fifty-hairs-fix.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+DatePicker/MonthPicker: Valgt datoer får nå `aria-pressed` for å bedre indikere valg for skjermleser.

--- a/.changeset/fifty-hairs-fix.md
+++ b/.changeset/fifty-hairs-fix.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-DatePicker/MonthPicker: Valgt datoer får nå `aria-pressed` for å bedre indikere valg for skjermleser.
+DatePicker/MonthPicker: Valgte datoer får nå `aria-pressed` for å bedre indikere valg for skjermleser.

--- a/.changeset/five-cherries-boil.md
+++ b/.changeset/five-cherries-boil.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+DatePicker/MonthPicker: `required`-prop stoppet ikke de-select av allerede valgt dato.

--- a/@navikt/core/react/src/date/datepicker/datepicker.stories.tsx
+++ b/@navikt/core/react/src/date/datepicker/datepicker.stories.tsx
@@ -445,8 +445,7 @@ export const WeekDayClick = () => {
 export const Required = {
   render: () => {
     const { datepickerProps } = useDatepicker({
-      locale: "nb",
-      defaultSelected: new Date(),
+      defaultSelected: new Date("Apr 10 2024"),
       required: true,
     });
 

--- a/@navikt/core/react/src/date/datepicker/datepicker.stories.tsx
+++ b/@navikt/core/react/src/date/datepicker/datepicker.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, within } from "@storybook/test";
 import { isSameDay } from "date-fns";
 import React, { useId, useState } from "react";
+import { act } from "react-dom/test-utils";
 import { Button } from "../../button";
 import { HGrid } from "../../layout/grid";
 import { VStack } from "../../layout/stack";
@@ -438,6 +440,45 @@ export const WeekDayClick = () => {
       />
     </VStack>
   );
+};
+
+export const Required = {
+  render: () => {
+    const { datepickerProps } = useDatepicker({
+      locale: "nb",
+      defaultSelected: new Date(),
+      disabled: [new Date("Apr 1 2022")],
+      required: true,
+    });
+
+    return (
+      <div style={{ height: "20rem" }}>
+        <DatePicker.Standalone {...datepickerProps} />
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const button10 = canvas.getByRole("button", { pressed: true });
+
+    await act(async () => {
+      await userEvent.click(button10);
+    });
+
+    expect(button10.ariaPressed).toBe("true");
+
+    const button17 = canvas.getByText("17").closest("button");
+
+    expect(button17?.ariaPressed).toBe("false");
+
+    await act(async () => {
+      button17 && (await userEvent.click(button17));
+    });
+
+    expect(button17?.ariaPressed).toBe("true");
+    expect(button10.ariaPressed).toBe("false");
+  },
 };
 
 export const ModalDemo = () => {

--- a/@navikt/core/react/src/date/datepicker/datepicker.stories.tsx
+++ b/@navikt/core/react/src/date/datepicker/datepicker.stories.tsx
@@ -447,7 +447,6 @@ export const Required = {
     const { datepickerProps } = useDatepicker({
       locale: "nb",
       defaultSelected: new Date(),
-      disabled: [new Date("Apr 1 2022")],
       required: true,
     });
 

--- a/@navikt/core/react/src/date/datepicker/parts/DayButton.tsx
+++ b/@navikt/core/react/src/date/datepicker/parts/DayButton.tsx
@@ -23,6 +23,8 @@ const DayButton = (props: DayProps) => {
       role={undefined}
       aria-label={dateTime}
       aria-hidden={dayRender.activeModifiers.outside}
+      aria-selected={undefined}
+      aria-pressed={!!dayRender.activeModifiers.selected}
     />
   );
 };

--- a/@navikt/core/react/src/date/hooks/useDatepicker.tsx
+++ b/@navikt/core/react/src/date/hooks/useDatepicker.tsx
@@ -238,7 +238,7 @@ export const useDatepicker = (
       anchorRef?.focus();
     }
 
-    if (!required && selected) {
+    if (selected) {
       updateDate(undefined);
       setInputValue("");
       updateValidation({ isValidDate: false, isEmpty: true });

--- a/@navikt/core/react/src/date/hooks/useDatepicker.tsx
+++ b/@navikt/core/react/src/date/hooks/useDatepicker.tsx
@@ -232,7 +232,7 @@ export const useDatepicker = (
     if (selected && required) {
       return;
     }
-    console.log(day, selected);
+
     if (day && !selected) {
       handleOpen(false);
       anchorRef?.focus();

--- a/@navikt/core/react/src/date/hooks/useDatepicker.tsx
+++ b/@navikt/core/react/src/date/hooks/useDatepicker.tsx
@@ -229,6 +229,10 @@ export const useDatepicker = (
 
   /* Only allow de-selecting if not required */
   const handleDayClick: DayClickEventHandler = (day, { selected }) => {
+    if (selected && required) {
+      return;
+    }
+    console.log(day, selected);
     if (day && !selected) {
       handleOpen(false);
       anchorRef?.focus();

--- a/@navikt/core/react/src/date/hooks/useMonthPicker.tsx
+++ b/@navikt/core/react/src/date/hooks/useMonthPicker.tsx
@@ -225,13 +225,17 @@ export const useMonthpicker = (
 
   /* Only allow de-selecting if not required */
   const handleMonthClick = (month?: Date) => {
+    if (!month && required) {
+      return;
+    }
+
     if (month) {
       handleOpen(false);
       setYear(month);
       anchorRef?.focus();
     }
 
-    if (!required && !month) {
+    if (!month) {
       updateMonth(undefined);
       updateValidation({ isValidMonth: false, isEmpty: true });
       setInputValue("");

--- a/@navikt/core/react/src/date/monthpicker/MonthButton.tsx
+++ b/@navikt/core/react/src/date/monthpicker/MonthButton.tsx
@@ -66,6 +66,7 @@ export const MonthButton = ({
       type="button"
       onClick={() => onSelect(isSelected ? undefined : month)}
       disabled={isDisabled}
+      aria-pressed={!!isSelected}
       className={cl("navds-date__month-button", {
         "rdp-day_today": dateIsInCurrentMonth(month, year),
         "rdp-day_selected": isSelected,

--- a/@navikt/core/react/src/date/monthpicker/monthpicker.stories.tsx
+++ b/@navikt/core/react/src/date/monthpicker/monthpicker.stories.tsx
@@ -126,8 +126,7 @@ export const UseMonthpickerFormat = () => {
 export const Required = {
   render: () => {
     const { monthpickerProps } = useMonthpicker({
-      locale: "nb",
-      defaultSelected: new Date(),
+      defaultSelected: new Date("Apr 10 2024"),
       required: true,
     });
 

--- a/@navikt/core/react/src/date/monthpicker/monthpicker.stories.tsx
+++ b/@navikt/core/react/src/date/monthpicker/monthpicker.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryFn, StoryObj } from "@storybook/react";
+import { expect, userEvent, within } from "@storybook/test";
 import { setYear } from "date-fns";
 import React, { useId, useState } from "react";
+import { act } from "react-dom/test-utils";
 import { Button } from "../../button";
 import { useMonthpicker } from "../hooks";
 import { DateInputProps } from "../parts/DateInput";
@@ -121,25 +123,43 @@ export const UseMonthpickerFormat = () => {
   );
 };
 
-export const Required = () => {
-  const { inputProps, monthpickerProps } = useMonthpicker({
-    locale: "nb",
-    defaultSelected: new Date(),
-    disabled: [new Date("Apr 1 2022")],
-    required: true,
-  });
+export const Required = {
+  render: () => {
+    const { monthpickerProps } = useMonthpicker({
+      locale: "nb",
+      defaultSelected: new Date(),
+      disabled: [new Date("Apr 1 2022")],
+      required: true,
+    });
 
-  return (
-    <div style={{ height: "20rem" }}>
-      <MonthPicker {...monthpickerProps}>
-        <MonthPicker.Input
-          {...inputProps}
-          label="Velg måned"
-          variant="monthpicker"
-        />
-      </MonthPicker>
-    </div>
-  );
+    return (
+      <div style={{ height: "20rem" }}>
+        <MonthPicker.Standalone {...monthpickerProps} />
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const buttonApr = canvas.getByRole("button", { pressed: true });
+
+    await act(async () => {
+      await userEvent.click(buttonApr);
+    });
+
+    expect(buttonApr.ariaPressed).toBe("true");
+
+    const buttonSep = canvas.getByText("september").closest("button");
+
+    expect(buttonSep?.ariaPressed).toBe("false");
+
+    await act(async () => {
+      buttonSep && (await userEvent.click(buttonSep));
+    });
+
+    expect(buttonSep?.ariaPressed).toBe("true");
+    expect(buttonApr.ariaPressed).toBe("false");
+  },
 };
 
 export const UserControlled = () => {
@@ -193,7 +213,6 @@ export const Chromatic: Story = {
       <DisabledMonths />
       <UseMonthpicker />
       <UseMonthpickerFormat />
-      <Required />
       <UserControlled />
       <FollowYear />
     </div>

--- a/@navikt/core/react/src/date/monthpicker/monthpicker.stories.tsx
+++ b/@navikt/core/react/src/date/monthpicker/monthpicker.stories.tsx
@@ -128,7 +128,6 @@ export const Required = {
     const { monthpickerProps } = useMonthpicker({
       locale: "nb",
       defaultSelected: new Date(),
-      disabled: [new Date("Apr 1 2022")],
       required: true,
     });
 


### PR DESCRIPTION
### Description

Resolves #2829

MonthPicker sin "required"-prop gjorde ingenting. Fikset nå med at det returneres tidlig hvis knapp allerede er valgt og man klikker på den. 

For Datepicker var problemet at onChange-event ++ ble kjørt når den ikke burde.

- Satte opp tester i storybook for begge eksemplene

## A11y

Oppdaget at react-day-picker bruker `aria-selected` på knappene, noe som ikke er lov. Riktig syntax for knapper er `aria-pressed` som Date og Month-pickers er oppdatert til å bruke nå. For MonthPicker vil dette være en stor forbedring da den ikke hadde noe selected/pressed fra før.