### PR TITLE
[Sanity] Oppdatert utdatertvarsel

### DIFF
--- a/aksel.nav.no/website/sanity/schema/custom-components/EditorPage.tsx
+++ b/aksel.nav.no/website/sanity/schema/custom-components/EditorPage.tsx
@@ -1,28 +1,13 @@
 import React from "react";
-import { useClient, useCurrentUser } from "sanity";
-import useSWR from "swr";
-import { Heading, Label, Link, Loader } from "@navikt/ds-react";
-import { SANITY_API_VERSION } from "@/sanity/config";
+import { useCurrentUser } from "sanity";
+import { Heading, Label, Link } from "@navikt/ds-react";
 
-export const EditorPage = () => {
+export const EditorPage = (...rest) => {
+  console.log(rest);
   const user = useCurrentUser();
 
-  const client = useClient({ apiVersion: SANITY_API_VERSION });
-  const { data, error } = useSWR(
-    `*[count((contributors[]->{email, alt_email})[@.email == "${user?.email}" || @.alt_email == "${user?.email}"]) > 0]`,
-    (query) => client.fetch(query),
-  );
-
-  if (error || !user) {
-    return <div>Feilet lasting av bruker...</div>;
-  }
-
-  if (!data) {
-    return (
-      <div className="mx-auto mt-24">
-        <Loader size="xlarge" variant="neutral" />
-      </div>
-    );
+  if (!user) {
+    return null;
   }
 
   return (

--- a/aksel.nav.no/website/sanity/schema/custom-components/EditorPage.tsx
+++ b/aksel.nav.no/website/sanity/schema/custom-components/EditorPage.tsx
@@ -3,7 +3,6 @@ import { useCurrentUser } from "sanity";
 import { Heading, Label, Link } from "@navikt/ds-react";
 
 export const EditorPage = (...rest) => {
-  console.log(rest);
   const user = useCurrentUser();
 
   if (!user) {

--- a/aksel.nav.no/website/sanity/schema/custom-components/EditorPage.tsx
+++ b/aksel.nav.no/website/sanity/schema/custom-components/EditorPage.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useCurrentUser } from "sanity";
 import { Heading, Label, Link } from "@navikt/ds-react";
 
-export const EditorPage = (...rest) => {
+export const EditorPage = () => {
   const user = useCurrentUser();
 
   if (!user) {

--- a/aksel.nav.no/website/sanity/schema/custom-components/updateInfo.tsx
+++ b/aksel.nav.no/website/sanity/schema/custom-components/updateInfo.tsx
@@ -1,24 +1,40 @@
-import { differenceInMonths } from "date-fns";
+import { differenceInDays, differenceInMonths } from "date-fns";
 import { useFormValue } from "sanity";
-import { Alert } from "@navikt/ds-react";
+import { HourglassBottomFilledIcon } from "@navikt/aksel-icons";
+import { BodyLong, Heading, Link } from "@navikt/ds-react";
 
 export function UpdateInfo() {
+  const articleType = useFormValue(["_type"]);
+
   const verified: any = useFormValue(["updateInfo", "lastVerified"]);
   if (!verified) {
     return null;
   }
   const diff = differenceInMonths(new Date(), new Date(verified));
-  const outDated = diff >= 6;
+  const diffInDays = differenceInDays(new Date(), new Date(verified));
+  const outDated = diff >= (articleType === "aksel_artikkel" ? 12 : 6);
   if (!outDated) {
     return null;
   }
 
   return (
-    <Alert variant="warning" data-theme="light">
-      Artikkelen er over 6 mnd gammel og trenger ny godkjenning!
-      <div className="mt-4">
-        Sist oppdatert: {verified.split("-").reverse().join(".")}
+    <div className="mt-4 rounded-md bg-surface-subtle p-4 dark:bg-gray-900">
+      <div className="inline-flex items-center gap-1 text-amber-700 dark:text-amber-300">
+        <HourglassBottomFilledIcon
+          aria-hidden
+          fontSize="1rem"
+          className="shrink-0"
+        />
+        <Heading level="3" size="small">
+          Artikkelen er utdatert {`(${diffInDays} dager)`}
+        </Heading>
       </div>
-    </Alert>
+      <BodyLong>
+        {`Artikkelen er utdatert og trenger ny godkjenning. Les gjennom og oppdater innholdet, for så å klikke på "Godkjenn innhold"-knapp. `}
+        <Link href="https://aksel.nav.no/side/skriv-for-aksel#a5b79ddd59da">
+          Les mer om hvorfor en artikkel regnes som utdatert.
+        </Link>
+      </BodyLong>
+    </div>
   );
 }

--- a/aksel.nav.no/website/sanity/schema/documents/god-praksis/artikkel.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/god-praksis/artikkel.tsx
@@ -38,17 +38,14 @@ export const godPraksisArtikkel = () =>
           disableNew: true,
         },
         group: "innhold",
-        /* Add required after update */
-        /* validation: (Rule) => Rule.required(), */
+        validation: (Rule) => Rule.required(),
       }),
       defineField({
         name: "undertema",
         title: "Undertema",
         type: "array",
         group: "innhold",
-        /* Add required after update */
-        /* validation: (Rule) => Rule.required(), */
-        /*  */
+        validation: (Rule) => Rule.required(),
         components: {
           field: UndertemaHighlight,
         },


### PR DESCRIPTION
### Description

Oppdatert varsel til å matche "innholdstype" og "undertema" panel. Fungerer også nå med darkmode i Sanity. Viser også nå dager siden sist, og ikke dato da det kanskje kan hjelpe med å fremheve hvor gammel en artikkel er.
- Innholdstype og Undertema er satt som required. Slipper da at artikler som opprettes fra nå -> frem til ny gp publisering ikke har riktig struktur.
- ⚡ Bruker ikke SWR for å laste editor-data for profilside
