### PR TITLE
FormSummary.Heading: Fjern overridable, level oblig. og css-justeringer på <sm

### DIFF
--- a/@navikt/core/css/form/form-summary.css
+++ b/@navikt/core/css/form/form-summary.css
@@ -15,7 +15,7 @@
 @media (max-width: 479px) {
   .navds-form-summary__header {
     padding: var(--a-spacing-3) var(--a-spacing-4);
-    flex-wrap: wrap;
+    flex-direction: column;
   }
 }
 

--- a/@navikt/core/css/form/form-summary.css
+++ b/@navikt/core/css/form/form-summary.css
@@ -54,6 +54,17 @@
   padding-bottom: 0;
 }
 
+@media (max-width: 479px) {
+  .navds-form-summary__answer:not(:last-child) {
+    margin-bottom: var(--a-spacing-3);
+    padding-bottom: var(--a-spacing-3);
+  }
+
+  .navds-form-summary__answer:has(.navds-form-summary__answer) {
+    padding-bottom: var(--a-spacing-5);
+  }
+}
+
 .navds-form-summary__value:first-of-type {
   margin-top: var(--a-spacing-1);
 }

--- a/@navikt/core/react/src/form/form-summary/FormSummary.stories.tsx
+++ b/@navikt/core/react/src/form/form-summary/FormSummary.stories.tsx
@@ -341,7 +341,25 @@ export const Chromatic: StoryObj<typeof FormSummary> = {
       </div>
     </div>
   ),
-  parameters: { chromatic: { disable: false } },
+  parameters: {
+    chromatic: {
+      disable: false,
+      modes: {
+        desktop: {
+          viewport: {
+            width: 620,
+            //height: 850,
+          },
+        },
+        sm: {
+          viewport: {
+            width: 479,
+            //height: 400,
+          },
+        },
+      },
+    },
+  },
 };
 
 export const CommaSeparated: StoryFn<typeof FormSummary> = () => (

--- a/@navikt/core/react/src/form/form-summary/FormSummary.stories.tsx
+++ b/@navikt/core/react/src/form/form-summary/FormSummary.stories.tsx
@@ -22,7 +22,7 @@ export default meta;
 export const Default: StoryFn<typeof FormSummary> = () => (
   <FormSummary>
     <FormSummary.Header>
-      <FormSummary.Heading>Personalia</FormSummary.Heading>
+      <FormSummary.Heading level="2">Personalia</FormSummary.Heading>
       <FormSummary.EditLink href="#" />
     </FormSummary.Header>
 
@@ -105,7 +105,7 @@ export const Default: StoryFn<typeof FormSummary> = () => (
 export const LongTexts: StoryFn<typeof FormSummary> = () => (
   <FormSummary>
     <FormSummary.Header>
-      <FormSummary.Heading>
+      <FormSummary.Heading level="2">
         Arbeidsforhold som du har i eller utenfor EØS-området
       </FormSummary.Heading>
       <FormSummary.EditLink href="#">
@@ -158,7 +158,7 @@ export const LongTexts: StoryFn<typeof FormSummary> = () => (
 export const NoLink: StoryFn<typeof FormSummary> = () => (
   <FormSummary>
     <FormSummary.Header>
-      <FormSummary.Heading>
+      <FormSummary.Heading level="2">
         Arbeidsforhold som du har i eller utenfor EØS-området
       </FormSummary.Heading>
     </FormSummary.Header>
@@ -227,7 +227,7 @@ const answers = [
 export const RealisticUsage: StoryFn<typeof FormSummary> = () => (
   <FormSummary>
     <FormSummary.Header>
-      <FormSummary.Heading>
+      <FormSummary.Heading level="2">
         Diverse informasjon om forskjellige ting og tang. Kjekt å vite.
       </FormSummary.Heading>
       <FormSummary.EditLink href="#" />
@@ -261,14 +261,14 @@ export const Empty: StoryFn<typeof FormSummary> = () => (
   <VStack gap="8">
     <FormSummary>
       <FormSummary.Header>
-        <FormSummary.Heading>Just Header</FormSummary.Heading>
+        <FormSummary.Heading level="2">Just Header</FormSummary.Heading>
         <FormSummary.EditLink href="#" />
       </FormSummary.Header>
     </FormSummary>
 
     <FormSummary>
       <FormSummary.Header>
-        <FormSummary.Heading>Empty Answers</FormSummary.Heading>
+        <FormSummary.Heading level="2">Empty Answers</FormSummary.Heading>
         <FormSummary.EditLink href="#" />
       </FormSummary.Header>
 
@@ -277,7 +277,7 @@ export const Empty: StoryFn<typeof FormSummary> = () => (
 
     <FormSummary>
       <FormSummary.Header>
-        <FormSummary.Heading>Empty Answer</FormSummary.Heading>
+        <FormSummary.Heading level="2">Empty Answer</FormSummary.Heading>
         <FormSummary.EditLink href="#" />
       </FormSummary.Header>
 
@@ -288,7 +288,7 @@ export const Empty: StoryFn<typeof FormSummary> = () => (
 
     <FormSummary>
       <FormSummary.Header>
-        <FormSummary.Heading>Empty Label & Value</FormSummary.Heading>
+        <FormSummary.Heading level="2">Empty Label & Value</FormSummary.Heading>
         <FormSummary.EditLink href="#" />
       </FormSummary.Header>
 
@@ -302,7 +302,7 @@ export const Empty: StoryFn<typeof FormSummary> = () => (
 
     <FormSummary>
       <FormSummary.Header>
-        <FormSummary.Heading>Empty Value</FormSummary.Heading>
+        <FormSummary.Heading level="2">Empty Value</FormSummary.Heading>
         <FormSummary.EditLink href="#" />
       </FormSummary.Header>
 
@@ -347,7 +347,7 @@ export const Chromatic: StoryObj<typeof FormSummary> = {
 export const CommaSeparated: StoryFn<typeof FormSummary> = () => (
   <FormSummary>
     <FormSummary.Header>
-      <FormSummary.Heading>Personalia</FormSummary.Heading>
+      <FormSummary.Heading level="2">Personalia</FormSummary.Heading>
       <FormSummary.EditLink href="#" />
     </FormSummary.Header>
 

--- a/@navikt/core/react/src/form/form-summary/FormSummary.stories.tsx
+++ b/@navikt/core/react/src/form/form-summary/FormSummary.stories.tsx
@@ -345,16 +345,14 @@ export const Chromatic: StoryObj<typeof FormSummary> = {
     chromatic: {
       disable: false,
       modes: {
-        desktop: {
+        default: {
           viewport: {
             width: 620,
-            //height: 850,
           },
         },
         sm: {
           viewport: {
             width: 479,
-            //height: 400,
           },
         },
       },

--- a/@navikt/core/react/src/form/form-summary/FormSummary.tsx
+++ b/@navikt/core/react/src/form/form-summary/FormSummary.tsx
@@ -52,7 +52,7 @@ export interface FormSummaryProps extends HTMLAttributes<HTMLDivElement> {
    * @example
    * <FormSummary>
    *   <FormSummary.Header>
-   *     <FormSummary.Heading>HeadingTekst</FormSummary.Heading>
+   *     <FormSummary.Heading level="2">HeadingTekst</FormSummary.Heading>
    *     <FormSummary.EditLink href="#" />
    *   </FormSummary.Header>
    *   <FormSummary.Answers>
@@ -72,7 +72,7 @@ export interface FormSummaryProps extends HTMLAttributes<HTMLDivElement> {
  * @example
  * <FormSummary>
  *   <FormSummary.Header>
- *     <FormSummary.Heading>HeadingTekst</FormSummary.Heading>
+ *     <FormSummary.Heading level="2">HeadingTekst</FormSummary.Heading>
  *     <FormSummary.EditLink href="#" />
  *   </FormSummary.Header>
  *   <FormSummary.Answers>

--- a/@navikt/core/react/src/form/form-summary/FormSummaryHeading.tsx
+++ b/@navikt/core/react/src/form/form-summary/FormSummaryHeading.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef } from "react";
 import { Heading, HeadingProps } from "../../typography";
-import { OverridableComponent } from "../../util/types";
 
 export interface FormSummaryHeadingProps
   extends React.HTMLAttributes<HTMLHeadingElement> {
@@ -10,16 +9,15 @@ export interface FormSummaryHeadingProps
   children: React.ReactNode;
   /**
    * The heading level.
-   * @default "3"
    */
-  level?: Exclude<HeadingProps["level"], "1">;
+  level: Exclude<HeadingProps["level"], "1">;
 }
 
-export const FormSummaryHeading: OverridableComponent<
-  FormSummaryHeadingProps,
-  HTMLHeadingElement
-> = forwardRef(({ level = "3", ...rest }, ref) => (
-  <Heading ref={ref} {...rest} size="medium" level={level} />
+export const FormSummaryHeading = forwardRef<
+  HTMLHeadingElement,
+  FormSummaryHeadingProps
+>((props: FormSummaryHeadingProps, ref) => (
+  <Heading ref={ref} {...props} size="medium" />
 ));
 
 export default FormSummaryHeading;

--- a/aksel.nav.no/website/pages/eksempler/formsummary/custom-editlink.tsx
+++ b/aksel.nav.no/website/pages/eksempler/formsummary/custom-editlink.tsx
@@ -5,7 +5,9 @@ const Example = () => {
   return (
     <FormSummary>
       <FormSummary.Header>
-        <FormSummary.Heading>Personal information</FormSummary.Heading>
+        <FormSummary.Heading level="2">
+          Personal information
+        </FormSummary.Heading>
         <FormSummary.EditLink href="#">Edit</FormSummary.EditLink>
       </FormSummary.Header>
       <FormSummary.Answers>

--- a/aksel.nav.no/website/pages/eksempler/formsummary/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/formsummary/demo.tsx
@@ -5,7 +5,7 @@ const Example = () => {
   return (
     <FormSummary>
       <FormSummary.Header>
-        <FormSummary.Heading>Personalia</FormSummary.Heading>
+        <FormSummary.Heading level="2">Personalia</FormSummary.Heading>
         <FormSummary.EditLink href="#" />
       </FormSummary.Header>
 

--- a/aksel.nav.no/website/pages/eksempler/formsummary/grouped-answers.tsx
+++ b/aksel.nav.no/website/pages/eksempler/formsummary/grouped-answers.tsx
@@ -5,7 +5,7 @@ const Example = () => {
   return (
     <FormSummary>
       <FormSummary.Header>
-        <FormSummary.Heading>Personalia</FormSummary.Heading>
+        <FormSummary.Heading level="2">Personalia</FormSummary.Heading>
         <FormSummary.EditLink href="#" />
       </FormSummary.Header>
 


### PR DESCRIPTION
1. Fjernet OverridableComponent da vi ikke ser noen grunn til å ha det.
2. CSS-justeringer for mindre skjermer.
3. `level` obligatorisk slik at man må ta et aktivt valg.

Laget ikke changeset, da jeg satser på å snike den inn i v6.6.0 før den går ut https://github.com/navikt/aksel/pull/2850