### PR TITLE
:fire: Fjernet content-container.css og grid.css fra _mappings

### DIFF
--- a/.changeset/wet-books-end.md
+++ b/.changeset/wet-books-end.md
@@ -1,0 +1,5 @@
+---
+"@navikt/aksel": patch
+---
+
+Fjernet deprecated komponenter fra css

--- a/.changeset/wet-books-end.md
+++ b/.changeset/wet-books-end.md
@@ -2,4 +2,4 @@
 "@navikt/aksel": patch
 ---
 
-Fjernet deprecated komponenter fra css
+Aksel CLI: Fjernet deprecated komponenter fra css oversikt.

--- a/@navikt/core/css/config/_mappings.js
+++ b/@navikt/core/css/config/_mappings.js
@@ -98,10 +98,6 @@ const StyleMappings = {
       dependencies: [typoCss],
     },
     {
-      component: "ContentContainer",
-      main: "content-container.css",
-    },
-    {
       component: "CopyButton",
       main: "copybutton.css",
       dependencies: [typoCss],
@@ -125,7 +121,6 @@ const StyleMappings = {
       main: formCss,
       dependencies: [typoCss, "button.css", "loader.css", "link.css"],
     },
-    { component: "Grid", main: "grid.css", dependencies: [typoCss] },
     {
       component: "GuidePanel",
       main: "guide-panel.css",


### PR DESCRIPTION
### Description

Var glemt fjernet fra _mappings under forrige major. Vil ikke påvirke noens kode, så er trygt som patch