### PR TITLE
:art: Temakontakter får slack-melding gjennom tilbakemeldinger

### DIFF
--- a/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
+++ b/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
@@ -124,13 +124,13 @@ async function sendSlackbotFeedback(
   /**
    * We want to make sure we avoid sending the message to the same user multiple times
    */
-  const uniqueRecievers = new Map<Member["id"], Member>();
+  const uniqueRecievers = new Set<string>();
 
   [...slackProfileForEditors, ...slackProfileForTemaContacts].forEach(
-    (member) => uniqueRecievers.set(member.id, member),
+    (member) => uniqueRecievers.add(member.id),
   );
 
-  const recieverSlackIdList = [...uniqueRecievers.keys()];
+  const recieverSlackIdList = [...uniqueRecievers];
 
   let postMessageError = false;
 

--- a/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
+++ b/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
@@ -112,7 +112,7 @@ async function sendSlackbotFeedback(
     .filter((x) => !!x.id) as Member[];
 
   /**
-   * We use contributors found on article and find their matching slack profiles
+   * We use Tema contacts found on tema connected to article and find their matching slack profiles
    */
   const slackProfileForTemaContacts =
     (document.contacts

--- a/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
+++ b/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
@@ -124,13 +124,11 @@ async function sendSlackbotFeedback(
   /**
    * We want to make sure we avoid sending the message to the same user multiple times
    */
-  const uniqueRecievers = new Set<string>();
-
-  [...slackProfileForEditors, ...slackProfileForTemaContacts].forEach(
-    (member) => uniqueRecievers.add(member.id),
+  const ids = [...slackProfileForEditors, ...slackProfileForTemaContacts].map(
+    (member) => member.id,
   );
 
-  const recieverSlackIdList = [...uniqueRecievers];
+  const recieverSlackIdList = [...new Set(ids)];
 
   let postMessageError = false;
 

--- a/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
+++ b/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
@@ -130,7 +130,7 @@ async function sendSlackbotFeedback(
     (member) => uniqueRecievers.set(member.id, member),
   );
 
-  const uniqueIds = [...uniqueRecievers.keys()];
+  const recieverSlackIdList = [...uniqueRecievers.keys()];
 
   let postMessageError = false;
 
@@ -147,13 +147,13 @@ async function sendSlackbotFeedback(
             title: document.title,
           },
           feedback: validation.data.body.feedback,
-          recievers: uniqueIds,
+          recievers: recieverSlackIdList,
           sender: {
             email: user.email,
             slackId: senderSlackUser?.id,
           },
         }),
-        ...(uniqueIds.length === 0
+        ...(recieverSlackIdList.length === 0
           ? [
               {
                 type: "section",
@@ -173,13 +173,10 @@ async function sendSlackbotFeedback(
       );
     });
 
-  for (const editor of uniqueIds) {
-    if (!editor) {
-      continue;
-    }
+  for (const slackId of recieverSlackIdList) {
     await client.chat
       .postMessage({
-        channel: editor,
+        channel: slackId,
         text: `Tilbakemelding: ${validation.data.body.feedback}`,
         blocks: slackBlock({
           article: {
@@ -188,7 +185,7 @@ async function sendSlackbotFeedback(
             title: document.title,
           },
           feedback: validation.data.body.feedback,
-          recievers: uniqueIds,
+          recievers: recieverSlackIdList,
           sender: {
             email: user.email,
             slackId: senderSlackUser?.id,

--- a/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
+++ b/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
@@ -36,9 +36,9 @@ const client = new WebClient(process.env.SLACK_BOT_TOKEN);
 
 export default authProtectedApi(sendSlackbotFeedback);
 
-type MembersArray = Exclude<UsersListResponse["members"], undefined>;
+type MembersArray = NonNullable<UsersListResponse["members"]>;
 type Member = MembersArray[0] & {
-  id: string;
+  id: NonNullable<MembersArray[0]["id"]>;
 };
 
 async function sendSlackbotFeedback(

--- a/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
+++ b/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
@@ -302,7 +302,7 @@ function slackBlock({ feedback, article, recievers, sender }: SlackBlockT) {
             },
             {
               type: "text",
-              text: "\n\nMedvirkende og temakontakter (disse fikk tilbakemeldingen):\n",
+              text: "\n\nDisse fikk tilbakemeldingen (medvirkende og temakontakter):\n",
               style: {
                 bold: true,
               },

--- a/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
+++ b/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
@@ -112,7 +112,7 @@ async function sendSlackbotFeedback(
     .filter((x) => !!x.id) as Member[];
 
   /**
-   * We use Tema contacts found on tema connected to article and find their matching slack profiles
+   * We use contacts found on tema connected to article and find their matching slack profiles
    */
   const slackProfileForTemaContacts =
     (document.contacts

--- a/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
+++ b/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
@@ -159,7 +159,7 @@ async function sendSlackbotFeedback(
                 type: "section",
                 text: {
                   type: "mrkdwn",
-                  text: ":exclamation: Denne artikkelen har ingen redaktører. @here",
+                  text: ":exclamation: Denne artikkelen har ingen redaktører eller temakontater. @here",
                 },
               } satisfies SectionBlock,
             ]

--- a/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
+++ b/aksel.nav.no/website/pages/api/slack/feedback/v1/index.ts
@@ -125,17 +125,14 @@ async function sendSlackbotFeedback(
    * We want to make sure we avoid sending the message to the same user multiple times
    */
   const uniqueRecievers = new Map<Member["id"], Member>();
-  for (const member of slackProfileForEditors) {
-    uniqueRecievers.set(member.id, member);
-  }
 
-  for (const member of slackProfileForTemaContacts) {
-    uniqueRecievers.set(member.id, member);
-  }
-
-  let postMessageError = false;
+  [...slackProfileForEditors, ...slackProfileForTemaContacts].forEach(
+    (member) => uniqueRecievers.set(member.id, member),
+  );
 
   const uniqueIds = [...uniqueRecievers.keys()];
+
+  let postMessageError = false;
 
   await client.chat
     .postMessage({


### PR DESCRIPTION
### Description
https://github.com/orgs/navikt/projects/49/views/59?query=is%3Aopen+sort%3Aupdated-desc&pane=issue&itemId=53256037

- Henter ut temakontakter fra tema for artikkel
- Legger inn alle mottakere i en Map basert på id for å sikre at mottaker som er både redaktør og kontakt ikke får 2 meldinger 