### PR TITLE
:art: Spacer er nå span (tidligere div)

### DIFF
--- a/.changeset/thick-humans-smile.md
+++ b/.changeset/thick-humans-smile.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-Spacer: Er nå default `span` (tidligere `div`).
+Spacer: Er nå `span` (tidligere `div`).

--- a/.changeset/thick-humans-smile.md
+++ b/.changeset/thick-humans-smile.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Spacer: Er nå default `span` (tidligere `div`).

--- a/@navikt/core/react/src/layout/stack/Spacer.tsx
+++ b/@navikt/core/react/src/layout/stack/Spacer.tsx
@@ -12,6 +12,6 @@ import React from "react";
  *  <MyComponent />
  * </HStack>
  */
-export const Spacer = () => <div className="navds-stack__spacer" />;
+export const Spacer = () => <span className="navds-stack__spacer" />;
 
 export default Spacer;


### PR DESCRIPTION
### Description

Siden `Spacer` var default `div` før kunne dette føre til valideringsfeil for DOM da div ikke kan brukes i phrasing-content. Kan hende jeg har misset noe åpenbart, men tror ikke det skal være noe i veien med å bare sette den til default `span`.
> (Har det noe å si at span får display: inline? `navds-stack__spacer` bør kanskje settes til `display: block;`)

 Slipper da å legge til `OverridableComponent`.