### PR TITLE
bug: Error-handling for oppretting av nye brukerprofiler i sanity

### DIFF
--- a/aksel.nav.no/website/sanity/schema/documents/presets/editors.ts
+++ b/aksel.nav.no/website/sanity/schema/documents/presets/editors.ts
@@ -27,12 +27,21 @@ export const editorField = defineField({
       ) {
         return [];
       }
-      profile = await client.createIfNotExists({
-        _type: "editor",
-        _id: `auto-editor.${currentUser.id}`,
-        email: currentUser.email,
-        title: currentUser.name,
-      });
+      try {
+        profile = await client.createIfNotExists({
+          _type: "editor",
+          _id: `auto-editor.${currentUser.id}`,
+          email: currentUser.email,
+          title: currentUser.name,
+        });
+      } catch (error) {
+        const { logger } = await import("@navikt/next-logger");
+        logger.error({
+          message: "Failed to create sanity profile for user.",
+          roles: JSON.stringify(currentUser.roles),
+        });
+        return [];
+      }
     }
 
     return [{ _ref: profile._id, _type: "reference" }];


### PR DESCRIPTION
### Description

I tilfellet der noen logget inn i sanity med bare "viewer"-tilgang (bare read-access) brakk applikasjonen da man automatisk prøver å opprette nye profil for den brukeren.

Fix:
- Try/catch rundt write `createIfNotExists`-kall.
- logger feilen, inkludert rollene til bruker (logger bare roller og ikke navn/email da det vil være unødvendig og potensielt personvernsbrudd etc)

Prøvde å se om sanity hadde en innebygd metode for å sjekke hvilken access en bruker har mot en dokumenttype, men fant ingenting, så letteste ble en try/catch 😞 