### PR TITLE
[Datepicker|MonthPicker] Flippet visning av år.

### DIFF
--- a/.changeset/thick-poems-design.md
+++ b/.changeset/thick-poems-design.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Datepicker, MonthPicker: Valg av år i Select er reversert slik at øverste år er først. Dette er endret for å være bedre tilpassett ekspertsystemer der de mest relevante årene ble vist lengst unna museperker ved klikk.

--- a/.changeset/thick-poems-design.md
+++ b/.changeset/thick-poems-design.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-Datepicker, MonthPicker: Valg av år i Select er reversert slik at øverste år er først. Dette er endret for å være bedre tilpassett ekspertsystemer der de mest relevante årene ble vist lengst unna museperker ved klikk.
+Datepicker, MonthPicker: Rekkefølgen på årstall i Select er reversert slik at siste år er øverst. Dette er endret for å være bedre tilpasset ekspertsystemer der de mest relevante årene ble vist lengst unna musepeker ved klikk.

--- a/@navikt/core/react/src/date/datepicker/parts/DropdownCaption.tsx
+++ b/@navikt/core/react/src/date/datepicker/parts/DropdownCaption.tsx
@@ -37,7 +37,11 @@ export const DropdownCaption = ({ displayMonth, id }: CaptionProps) => {
   const handleMonthChange: React.ChangeEventHandler<HTMLSelectElement> = (e) =>
     goToMonth(setMonth(startOfMonth(displayMonth), Number(e.target.value)));
 
-  const years = getYears(fromDate, toDate, displayMonth.getFullYear());
+  const years = getYears(
+    fromDate,
+    toDate,
+    displayMonth.getFullYear(),
+  ).reverse();
   const months = getMonths(fromDate, toDate, displayMonth);
 
   const previousLabel = labelPrevious(previousMonth, { locale });

--- a/@navikt/core/react/src/date/monthpicker/MonthCaption.tsx
+++ b/@navikt/core/react/src/date/monthpicker/MonthCaption.tsx
@@ -35,7 +35,7 @@ export const MonthCaption = () => {
     if (!years.map((x) => x.getFullYear()).includes(year.getFullYear())) {
       years.push(setYear(startOfYear(new Date()), year.getFullYear()));
     }
-    years.sort((a, b) => a.getFullYear() - b.getFullYear());
+    years.sort((a, b) => b.getFullYear() - a.getFullYear());
   }
 
   const handleYearChange = (e) =>


### PR DESCRIPTION
### Description

Flipper visning av år i Select brukt i DatePicker og MonthPicker. 

Resolves #2397

Etter diskusjon rundt bruk av dette i ulike OS-er, vil det for nå være best for ekspertsystemer at år vises top -> bottom: nyeste -> siste. Vi ønsker ikke å tilby en prop for dette for å unngå ulikheter mellom systemer, så dette vil være en ny standard frem til vi eventuelt lager vår egen select eller ny årsvisning.