### PR TITLE
[React] Scoped context

### DIFF
--- a/@navikt/core/react/src/util/create-scoped-context.tsx
+++ b/@navikt/core/react/src/util/create-scoped-context.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+
+function createContext<ContextValueType extends object | null>(
+  rootComponentName: string,
+  defaultContext?: ContextValueType,
+) {
+  const Context = React.createContext<ContextValueType | undefined>(
+    defaultContext,
+  );
+
+  function Provider(props: ContextValueType & { children: React.ReactNode }) {
+    const { children, ...context } = props;
+    // Only re-memoize when prop values change
+
+    const value = React.useMemo(
+      () => context,
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      Object.values(context),
+    ) as ContextValueType;
+    return <Context.Provider value={value}>{children}</Context.Provider>;
+  }
+
+  function useContext(consumerName: string) {
+    const context = React.useContext(Context);
+    if (context) return context;
+    if (defaultContext !== undefined) return defaultContext;
+    // if a defaultContext wasn't specified, it's a required context.
+    throw new Error(
+      `\`${consumerName}\` must be used within \`${rootComponentName}\``,
+    );
+  }
+
+  Provider.displayName = rootComponentName + "Provider";
+  return [Provider, useContext] as const;
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * createContextScope
+ * -----------------------------------------------------------------------------------------------*/
+
+type Scope<C = any> = { [scopeName: string]: React.Context<C>[] } | undefined;
+type ScopeHook = (scope: Scope) => { [__scopeProp: string]: Scope };
+interface CreateScope {
+  scopeName: string;
+  (): ScopeHook;
+}
+
+function createContextScope(
+  scopeName: string,
+  createContextScopeDeps: CreateScope[] = [],
+) {
+  let defaultContexts: any[] = [];
+
+  /* -----------------------------------------------------------------------------------------------
+   * createContext
+   * ---------------------------------------------------------------------------------------------*/
+
+  function createScopedContext<ContextValueType extends object | null>(
+    rootComponentName: string,
+    defaultContext?: ContextValueType,
+  ) {
+    const BaseContext = React.createContext<ContextValueType | undefined>(
+      defaultContext,
+    );
+    const index = defaultContexts.length;
+    defaultContexts = [...defaultContexts, defaultContext];
+
+    function Provider(
+      props: ContextValueType & {
+        scope: Scope<ContextValueType>;
+        children: React.ReactNode;
+      },
+    ) {
+      const { scope, children, ...context } = props;
+      const Context = scope?.[scopeName][index] || BaseContext;
+      // Only re-memoize when prop values change
+      const value = React.useMemo(
+        () => context,
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        Object.values(context),
+      ) as ContextValueType;
+      return <Context.Provider value={value}>{children}</Context.Provider>;
+    }
+
+    function useContext(
+      consumerName: string,
+      scope: Scope<ContextValueType | undefined>,
+    ) {
+      const Context = scope?.[scopeName][index] || BaseContext;
+      const context = React.useContext(Context);
+      if (context) return context;
+      if (defaultContext !== undefined) return defaultContext;
+      // if a defaultContext wasn't specified, it's a required context.
+      throw new Error(
+        `\`${consumerName}\` must be used within \`${rootComponentName}\``,
+      );
+    }
+
+    Provider.displayName = rootComponentName + "Provider";
+    return [Provider, useContext] as const;
+  }
+
+  /* -----------------------------------------------------------------------------------------------
+   * createScope
+   * ---------------------------------------------------------------------------------------------*/
+
+  const createScope: CreateScope = () => {
+    const scopeContexts = defaultContexts.map((defaultContext) => {
+      return React.createContext(defaultContext);
+    });
+    return function useScope(scope: Scope) {
+      const contexts = scope?.[scopeName] || scopeContexts;
+      return React.useMemo(
+        () => ({
+          [`__scope${scopeName}`]: { ...scope, [scopeName]: contexts },
+        }),
+        [scope, contexts],
+      );
+    };
+  };
+
+  createScope.scopeName = scopeName;
+  return [
+    createScopedContext,
+    composeContextScopes(createScope, ...createContextScopeDeps),
+  ] as const;
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * composeContextScopes
+ * -----------------------------------------------------------------------------------------------*/
+
+function composeContextScopes(...scopes: CreateScope[]) {
+  const baseScope = scopes[0];
+  if (scopes.length === 1) return baseScope;
+
+  const createScope: CreateScope = () => {
+    const scopeHooks = scopes.map((_createScope) => ({
+      useScope: _createScope(),
+      scopeName: _createScope.scopeName,
+    }));
+
+    return function useComposedScopes(overrideScopes) {
+      const nextScopes = scopeHooks.reduce(
+        (_nextScopes, { useScope, scopeName }) => {
+          // We are calling a hook inside a callback which React warns against to avoid inconsistent
+          // renders, however, scoping doesn't have render side effects so we ignore the rule.
+          // eslint-disable-next-line react-hooks/rules-of-hooks
+          const scopeProps = useScope(overrideScopes);
+          const currentScope = scopeProps[`__scope${scopeName}`];
+          return { ..._nextScopes, ...currentScope };
+        },
+        {},
+      );
+
+      return React.useMemo(
+        () => ({ [`__scope${baseScope.scopeName}`]: nextScopes }),
+        [nextScopes],
+      );
+    };
+  };
+
+  createScope.scopeName = baseScope.scopeName;
+  return createScope;
+}
+
+/* -----------------------------------------------------------------------------------------------*/
+
+export { createContext, createContextScope };
+export type { CreateScope, Scope };


### PR DESCRIPTION
### Description

Scoped context lar man scope en context til et spesifikt "component-tree"

Er ikke 100% på at dette løser problemet i praksis, så må nesten merges inn for så bli testet litt videre på. Er derfor ikke tatt i bruk i noen komponenter i denne PR-en

## Bruk

```jsx
const [createDescendantContext, createDescendantScope] = createContextScope("DescendantProvider");
```
`createDescendantContext` er her den samme funksjonen som `createContext` [som blir brukt i dag](https://github.com/navikt/aksel/blob/3f65eee9e947c6e6423d581c5c0da7adf0cea486/%40navikt/core/react/src/tabs/Tabs.context.ts#L20C47-L20C60)

Sammen med descendant-API et blir `createDescendantScope` eksportert sammen med det.

For å lage et nytt context-scope blir da f.eks Tabs å gjøre dette: 

```jsx
const [createTabsContext, createTabsScope] = createContextScope("TabsComponent", [
  createDescendantScope,
]);
```

Alle nye contexter for Tabs blir da opprettet med `createTabsContext`

## Eksempel på dagens utfordring

Tabs bruker descendant-context for å registrere hver tab. I dette eksemplet bruker også DismissableLayer det samme descendant-API et og da context. DismissableLayer vil da registrere seg selv på samme liste av descendants som listen over tabs, noe som brekker begge komponentenen. 

Et mer realistisk scenario: 
- Helptext blir brukt inne i Tabs.Panel
- Popover blir brukt inne i Tabs.Panel

```jsx
<Tabs >
  <Tabs.List>
      <Tabs.Tab />
  </Tabs.List>
  <Tabs.Panel>
      <DismissableLayer>
          <div />
      </DismissableLayer>
  </Tabs.Panel>
</Tabs>
```