### PR TITLE
refactor: DescendantContext er nå scopet

### DIFF
--- a/@navikt/core/react/src/util/hooks/descendants/useDescendant.tsx
+++ b/@navikt/core/react/src/util/hooks/descendants/useDescendant.tsx
@@ -31,16 +31,6 @@ export function createDescendantContext<
     ),
   );
 
-  type Context<S> = S extends true
-    ? ReturnType<typeof _useDescendants>
-    : ReturnType<typeof _useDescendants> | undefined;
-
-  function _useDescendantsContext<S extends boolean = true>(
-    strict: S = true as S,
-  ): Context<S> {
-    return useDescendantsContext(strict);
-  }
-
   /**
    * @internal
    * This hook provides information to descendant component:
@@ -94,7 +84,7 @@ export function createDescendantContext<
     // context provider
     ContextProvider,
     // call this when you need to read from context
-    _useDescendantsContext,
+    useDescendantsContext,
     // descendants state information, to be called and passed to `ContextProvider`
     _useDescendants,
     // descendant index information


### PR DESCRIPTION
### Description

Forrige iterasjon før denne omskrivingen la `createContext` på "globalt" nivå. I tilfellene der man hadde 2 komponenter som begge bruker `createDescendantContext`, så ville begge bruke samme context-instans.
Dette skaper problemer når disse 2 komponentene er separate og antar at sine "descendants" bare er relatert til seg selv.

Problemet har ikke oppstått tidligere for Tabs og ToggleGroup siden man alltid lager en ny context når de blir nøstet og da ikke arver "parent" sin descendant-klasse.


```jsx
// Tabs.tsx
// Lager en ny descendant context hver gang man lager en ny tabs instans, slik at man aldri får et problem med inheritance
    const descendants = useTabsDescendants();
    <TabsDescendantsProvider value={descendants}>
    ...
```

Kode som brakk før
- Prøver først å hente allerede laget `context`
- Hvis `context` finnes bruker man bare den, og resetter ikke context
- I dette tilfellet så ville `context` allerede vært opprettet hvis denne koden var brukt inne i `<Tabs />` og `DismissableLayer` ville håndtert kode basert på registrerte `Tabs.Tab`.

```jsx
    const context = useDismissableDescendantsContext();

    return context ? (
      <DismissableLayerNode ref={ref} {...props} />
    ) : (
      <DismissableRoot>
        <DismissableLayerNode ref={ref} {...props} />
      </DismissableRoot>
    );
  },
);
```

Etter denne oppdateringen vil da DismissableLayer descendants og Tabs descendants være 2 separate lister.



`_useDescendantsContext` tar også inn `strict`-boolean slik at consumer selv kan si om context er påkrevd initialisert før den blir brukt.