### PR TITLE
Link to GH-discussions from template-pages

### DIFF
--- a/aksel.nav.no/website/components/types/sanity-schema.ts
+++ b/aksel.nav.no/website/components/types/sanity-schema.ts
@@ -132,6 +132,7 @@ export interface AkselTemplatesDocT extends DocumentT<"ds_artikkel">, ArticleT {
     unsafe?: boolean;
     bilde?: any;
   };
+  gh_discussions?: string;
   intro: {
     body?: any[];
     brukes_til: string[];

--- a/aksel.nav.no/website/components/website-modules/suggestionblock/SuggestionBlock.GhPages.tsx
+++ b/aksel.nav.no/website/components/website-modules/suggestionblock/SuggestionBlock.GhPages.tsx
@@ -11,7 +11,7 @@ export const SuggestionBlockGhPages = ({
       <span className="-mt-[1px] grid h-7 shrink-0 place-content-center text-2xl">
         <HandShakeHeartIcon aria-hidden />
       </span>
-      <div className="grid">
+      <div>
         <Heading size="small" level="2">
           Samarbeid
         </Heading>

--- a/aksel.nav.no/website/components/website-modules/suggestionblock/SuggestionBlock.GhPages.tsx
+++ b/aksel.nav.no/website/components/website-modules/suggestionblock/SuggestionBlock.GhPages.tsx
@@ -1,0 +1,37 @@
+import { HandShakeHeartIcon } from "@navikt/aksel-icons";
+import { BodyLong, Button, Heading } from "@navikt/ds-react";
+
+export const SuggestionBlockGhPages = ({
+  reference,
+}: {
+  reference: string;
+}) => {
+  return (
+    <div className="mb-12 flex gap-2 rounded-lg bg-pink-100 px-6 py-4 ring-1 ring-inset ring-pink-300">
+      <span className="-mt-[1px] grid h-7 shrink-0 place-content-center text-2xl">
+        <HandShakeHeartIcon aria-hidden />
+      </span>
+      <div className="grid">
+        <Heading size="small" level="2">
+          Samarbeid
+        </Heading>
+        <BodyLong className="mt-2">
+          Malen er klar til bruk. Når du har fått prøvd den og høstet erfaringer
+          ønsker vi å lære av din innsikt. Delta i diskusjonen og bli med på å
+          forbedre malen.
+        </BodyLong>
+        <Button
+          variant="secondary-neutral"
+          as="a"
+          href={reference}
+          className="mt-4 w-fit"
+          target="_blank"
+          rel="noreferrer noopener"
+          size="small"
+        >
+          Delta i diskusjonen
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/aksel.nav.no/website/components/website-modules/suggestionblock/SuggestionBlock.stories.tsx
+++ b/aksel.nav.no/website/components/website-modules/suggestionblock/SuggestionBlock.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { SuggestionBlock } from "@/web/suggestionblock/SuggestionBlock";
+import { SuggestionBlockGhPages } from "./SuggestionBlock.GhPages";
 
 const meta = {
   title: "Website-modules/SuggestionBlock",
@@ -44,4 +45,8 @@ export const Ikoner: Story = {
   args: {
     variant: "ikoner",
   },
+};
+
+export const GhPages = {
+  render: () => <SuggestionBlockGhPages reference="http://localhost:6007" />,
 };

--- a/aksel.nav.no/website/components/website-modules/suggestionblock/SuggestionBlock.tsx
+++ b/aksel.nav.no/website/components/website-modules/suggestionblock/SuggestionBlock.tsx
@@ -190,7 +190,7 @@ const options: {
     text: "Denne komponenten er ny eller oppdatert. Tar du den i bruk ønsker vi gjerne innspill til hvordan den fungerer i tjenesten din!",
     link: `${issueUrl}?labels=forespørsel+🥰%2Ckomponenter+🧩%2Cnytt+✨&template=update-component.yml&title=%5BInnspill+til+komponent%5D%3A+`,
     heading: "Ny",
-    icon: <ChangeLogIconOutline />,
+    icon: <ChangeLogIconOutline aria-hidden />,
   },
   "komponent-beta": {
     text: "Komponenten er under utvikling, men klar for adopsjon. Vi ønsker gjerne innspill på hvordan den fungerer og hvilke forbedringer vi kan gjøre.",

--- a/aksel.nav.no/website/pages/monster-maler/[...slug].tsx
+++ b/aksel.nav.no/website/pages/monster-maler/[...slug].tsx
@@ -23,6 +23,7 @@ import { dateStr, generateSidebar, generateTableOfContents } from "@/utils";
 import { StatusTag } from "@/web/StatusTag";
 import { AkselTable, AkselTableRow } from "@/web/Table";
 import { SEO } from "@/web/seo/SEO";
+import { SuggestionBlockGhPages } from "@/web/suggestionblock/SuggestionBlock.GhPages";
 import NotFotfund from "../404";
 
 type PageProps = NextPageT<{
@@ -136,6 +137,9 @@ const Page = ({ page, sidebar, seo, publishDate, toc }: PageProps["props"]) => {
         pageProps={page}
         variant="page"
       >
+        {page.gh_discussions && (
+          <SuggestionBlockGhPages reference={page.gh_discussions} />
+        )}
         <IntroSeksjon node={page?.intro} />
         <SanityBlockContent blocks={page["content"]} />
 

--- a/aksel.nav.no/website/sanity/schema/documents/templates/artikkel.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/templates/artikkel.tsx
@@ -69,6 +69,12 @@ export const TemplatesArtikkel = defineType({
       },
     }),
     defineField({
+      title: "Github discussions link",
+      name: "gh_discussions",
+      type: "url",
+      group: "settings",
+    }),
+    defineField({
       title: "Sidebar index",
       description:
         "Overstyrer sortering av artikler i sidebar. Hvis feltet er tomt, sorteres den alfabetisk.",


### PR DESCRIPTION
### Description

Adds a new field on template-pages for gh-pages links

<img width="713" alt="Screenshot 2024-05-10 at 13 17 28" src="https://github.com/navikt/aksel/assets/26967723/668ced22-8bcc-4019-9462-e971dc607a87">
