### PR TITLE
feat: API-routes for entering draftmode in nextjs

### DIFF
--- a/aksel.nav.no/website/package.json
+++ b/aksel.nav.no/website/package.json
@@ -40,6 +40,7 @@
     "@sanity/color-input": "^3.1.1",
     "@sanity/image-url": "1.0.2",
     "@sanity/locale-nb-no": "^1.1.7",
+    "@sanity/preview-url-secret": "^1.6.12",
     "@sanity/table": "1.1.2",
     "@sanity/vision": "3.41.1",
     "@slack/web-api": "^7.0.2",

--- a/aksel.nav.no/website/pages/api/preview/disable-draft.ts
+++ b/aksel.nav.no/website/pages/api/preview/disable-draft.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handle(
+  _req: NextApiRequest,
+  res: NextApiResponse<void>,
+): void {
+  // Exit the current user from "Draft Mode".
+  res.setDraftMode({ enable: false });
+
+  // Redirect the user back to the index page.
+  res.writeHead(307, { Location: "/" });
+  res.end();
+}

--- a/aksel.nav.no/website/pages/api/preview/draft.ts
+++ b/aksel.nav.no/website/pages/api/preview/draft.ts
@@ -1,0 +1,44 @@
+import { validatePreviewUrl } from "@sanity/preview-url-secret";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createClient } from "next-sanity";
+import {
+  SANITY_API_VERSION,
+  SANITY_DATASET,
+  SANITY_PROJECT_ID,
+} from "@/sanity/config";
+
+const token = process.env.SANITY_PREVIEW_TOKEN;
+
+if (!token) {
+  throw new Error(
+    "A secret is provided but there is no `SANITY_PREVIEW_TOKEN` environment variable setup.",
+  );
+}
+
+const client = createClient({
+  projectId: SANITY_PROJECT_ID,
+  dataset: SANITY_DATASET,
+  apiVersion: SANITY_API_VERSION,
+  useCdn: false,
+  token,
+});
+
+export default async function handle(
+  req: NextApiRequest,
+  res: NextApiResponse<string | void>,
+) {
+  if (!req.url) {
+    throw new Error("Missing url");
+  }
+  const { isValid, redirectTo = "/" } = await validatePreviewUrl(
+    client,
+    req.url,
+  );
+  if (!isValid) {
+    return res.status(401).send("Invalid secret");
+  }
+  // Enable Draft Mode by setting the cookies
+  res.setDraftMode({ enable: true });
+  res.writeHead(307, { Location: redirectTo });
+  res.end();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -28219,6 +28219,7 @@ __metadata:
     "@sanity/color-input": ^3.1.1
     "@sanity/image-url": 1.0.2
     "@sanity/locale-nb-no": ^1.1.7
+    "@sanity/preview-url-secret": ^1.6.12
     "@sanity/schema": 3.41.1
     "@sanity/table": 1.1.2
     "@sanity/vision": 3.41.1


### PR DESCRIPTION
### Description

One of multiple steps for enabling proper use of Draft-mode in nextjs with Sanity. Based on the [new Sanity docs](https://www.sanity.io/guides/nextjs-live-preview). Extracted from this WIP branch https://github.com/navikt/aksel/compare/main...sanity-preview-sync

### Why replace preview with draftmode?

https://nextjs.org/docs/pages/building-your-application/configuring/draft-mode

New major versions of `next-sanity` assumes that everyone is using draft-mode, a new feature released in next 13.4 replacing preview-mode.

Makes it possible to share articles under development with people not a member of the sanity-project. This has been somewhat of an issue with the template work for forms where one had to take a PDF-screenshot of the page for sharing.
- This is done by sanity adding a secret to the preview URL that allows everyone using it to see the page preview
- Draft mode is a "per build" instance, so each time we redeploy the website the previous access is lost without a new secret

### Unsolved issues
~~Before we replace preview with draftmode completely it would be nice for members of the studio to still have the ability to write aksel.nav.no/preview/... to enter draftmode.~~ After some digging this seems to be possible if we continue to send the "withCredidentials"-config to sanity. 