### PR TITLE
sanity: removed scheduling

### DIFF
--- a/aksel.nav.no/website/sanity/sanity.config.tsx
+++ b/aksel.nav.no/website/sanity/sanity.config.tsx
@@ -32,11 +32,6 @@ export const workspaceConfig = defineConfig([
     basePath: "/admin/dev",
     icon: TestFlaskIcon,
     auth: authStore("development"),
-    document: {
-      newDocumentOptions: (prev) => {
-        return prev;
-      },
-    },
   },
 ]);
 

--- a/aksel.nav.no/website/sanity/sanity.config.tsx
+++ b/aksel.nav.no/website/sanity/sanity.config.tsx
@@ -3,7 +3,8 @@ import { colorInput } from "@sanity/color-input";
 import { nbNOLocale } from "@sanity/locale-nb-no";
 import { table } from "@sanity/table";
 import { visionTool } from "@sanity/vision";
-import { defineConfig } from "sanity";
+import React from "react";
+import { FieldProps, defineConfig } from "sanity";
 import { media } from "sanity-plugin-media";
 import { structureTool } from "sanity/structure";
 import { DatabaseIcon, TestFlaskIcon } from "@navikt/aksel-icons";
@@ -11,7 +12,7 @@ import { SANITY_API_VERSION, SANITY_PROJECT_ID } from "./config";
 import { defaultDocumentNode, publicationFlow, structure } from "./plugins";
 import { schema } from "./schema";
 import { InputWithCounter } from "./schema/custom-components";
-import { getTemplates } from "./util";
+import { newDocumentsCreator } from "./util";
 
 export const workspaceConfig = defineConfig([
   {
@@ -31,6 +32,11 @@ export const workspaceConfig = defineConfig([
     basePath: "/admin/dev",
     icon: TestFlaskIcon,
     auth: authStore("development"),
+    document: {
+      newDocumentOptions: (prev) => {
+        return prev;
+      },
+    },
   },
 ]);
 
@@ -39,9 +45,10 @@ function defaultConfig() {
     projectId: SANITY_PROJECT_ID,
     apiVersion: SANITY_API_VERSION,
     schema,
+    scheduledPublishing: { enabled: false },
     form: {
       components: {
-        field: (props) => {
+        field: (props: FieldProps) => {
           const name = props.schemaType?.name;
 
           if (name === "string" && props.schemaType?.options?.maxLength) {
@@ -56,12 +63,7 @@ function defaultConfig() {
       },
     },
     document: {
-      newDocumentOptions: (prev, { creationContext }) => {
-        if (creationContext.type === "global") {
-          return getTemplates();
-        }
-        return prev;
-      },
+      newDocumentOptions: newDocumentsCreator,
     },
     plugins: [
       structureTool({

--- a/aksel.nav.no/website/sanity/schema/custom-components/InputWithCounter.tsx
+++ b/aksel.nav.no/website/sanity/schema/custom-components/InputWithCounter.tsx
@@ -1,9 +1,10 @@
 import cl from "clsx";
-import { StringInputProps, TextInputProps } from "sanity";
+import React from "react";
+import { FieldProps } from "sanity";
 import { Box, Detail, VStack } from "@navikt/ds-react";
 
 export function InputWithCounter(
-  props: (StringInputProps | TextInputProps) & {
+  props: FieldProps & {
     size?: "medium" | "large";
   },
 ) {
@@ -13,9 +14,8 @@ export function InputWithCounter(
     <VStack gap="1">
       {props.renderDefault(props)}
       <Counter
-        // @ts-expect-error - maxLength is a custom prop not officially supported
         maxLength={schemaType?.options?.maxLength}
-        currentLength={value?.length ?? 0}
+        currentLength={typeof value === "string" ? value?.length ?? 0 : 0}
       />
     </VStack>
   );

--- a/aksel.nav.no/website/sanity/schema/custom-components/InputWithCounter.tsx
+++ b/aksel.nav.no/website/sanity/schema/custom-components/InputWithCounter.tsx
@@ -15,7 +15,7 @@ export function InputWithCounter(
       {props.renderDefault(props)}
       <Counter
         maxLength={schemaType?.options?.maxLength}
-        currentLength={typeof value === "string" ? value?.length ?? 0 : 0}
+        currentLength={typeof value === "string" ? value.length : 0}
       />
     </VStack>
   );

--- a/aksel.nav.no/website/sanity/util.tsx
+++ b/aksel.nav.no/website/sanity/util.tsx
@@ -1,6 +1,9 @@
-import { ConfigContext, NewDocumentOptionsResolver } from "sanity";
+import {
+  ConditionalPropertyCallbackContext,
+  NewDocumentOptionsResolver,
+} from "sanity";
 
-export const devsOnly = ({ currentUser }: ConfigContext) =>
+export const devsOnly = ({ currentUser }: ConditionalPropertyCallbackContext) =>
   !currentUser?.roles.find(({ name }) =>
     ["developer", "administrator"].includes(name),
   );

--- a/aksel.nav.no/website/sanity/util.tsx
+++ b/aksel.nav.no/website/sanity/util.tsx
@@ -1,56 +1,64 @@
-export const devsOnly = ({ currentUser }) =>
-  !currentUser.roles.find(({ name }) =>
+import { ConfigContext, NewDocumentOptionsResolver } from "sanity";
+
+export const devsOnly = ({ currentUser }: ConfigContext) =>
+  !currentUser?.roles.find(({ name }) =>
     ["developer", "administrator"].includes(name),
   );
 
-export const getTemplates = () => {
-  const templates = {
-    profil: [
-      {
-        title: "Profilside",
-        id: "profilRole",
-        templateId: "editor",
-      },
-    ],
-    god_praksis_forfatter: [
-      {
-        title: "God praksis artikkel",
-        id: "godPraksisForfatterRole",
-        templateId: "aksel_artikkel",
-        subtitle: "Fagartikkel",
-      },
-    ],
-    blogger: [
-      {
-        title: "Bloggpost",
-        id: "bloggerRole",
-        templateId: "aksel_blogg",
-      },
-    ],
-    grunnleggende: [
-      {
-        title: "Grunnleggende artikkel",
-        id: "grunnleggendeRole",
-        templateId: "ds_artikkel",
-        subtitle: "Guider og dokumentasjon for designsystemet",
-      },
-    ],
-    komponenter: [
-      {
-        title: "Komponent artikkel",
-        id: "komponenterRole",
-        templateId: "komponent_artikkel",
-        subtitle: "Dokumentasjon for designsystemet",
-      },
-    ],
-    prinsipper: [
-      {
-        title: "Prinsipp artikkel",
-        id: "prinsippereRole",
-        templateId: "aksel_prinsipp",
-      },
-    ],
-  };
+export const newDocumentsCreator: NewDocumentOptionsResolver = (
+  prev,
+  { creationContext },
+) => {
+  if (creationContext.type === "global") {
+    const templates = {
+      profil: [
+        {
+          title: "Profilside",
+          id: "profilRole",
+          templateId: "editor",
+        },
+      ],
+      god_praksis_forfatter: [
+        {
+          title: "God praksis artikkel",
+          id: "godPraksisForfatterRole",
+          templateId: "aksel_artikkel",
+          subtitle: "Fagartikkel",
+        },
+      ],
+      blogger: [
+        {
+          title: "Bloggpost",
+          id: "bloggerRole",
+          templateId: "aksel_blogg",
+        },
+      ],
+      grunnleggende: [
+        {
+          title: "Grunnleggende artikkel",
+          id: "grunnleggendeRole",
+          templateId: "ds_artikkel",
+          subtitle: "Guider og dokumentasjon for designsystemet",
+        },
+      ],
+      komponenter: [
+        {
+          title: "Komponent artikkel",
+          id: "komponenterRole",
+          templateId: "komponent_artikkel",
+          subtitle: "Dokumentasjon for designsystemet",
+        },
+      ],
+      prinsipper: [
+        {
+          title: "Prinsipp artikkel",
+          id: "prinsippereRole",
+          templateId: "aksel_prinsipp",
+        },
+      ],
+    };
+    return Object.values(templates).flat();
+  }
 
-  return Object.values(templates).flat();
+  return prev;
 };


### PR DESCRIPTION
### Description

Our project has no real use for scheduling publishing, so it can be turned off with 
```jsx
scheduledPublishing: { enabled: false },
```
https://www.sanity.io/docs/scheduled-publishing

As a side-effect some ts-types failed now, so had to fix them before comitting