### PR TITLE
Include templates in ds storybook

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -58,7 +58,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: x3xqdfgkujg
           exitZeroOnChanges: false
-          buildScriptName: "build:storybook"
+          buildScriptName: "build:storybook-chromatic"
           onlyChanged: true
           untraced: "**/package.json|yarn.lock|**/*.md"
           externals: \@navikt/core/css/**/*.css

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,6 +10,7 @@ on:
     branches: [main, next]
     paths:
       - "@navikt/**"
+      - "aksel.nav.no/website/pages/templates/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,9 +1,54 @@
+import { loadCsf } from "@storybook/csf-tools";
+import { StorybookConfig } from "@storybook/react-vite";
+import { readFileSync } from "fs";
 import turbosnap from "vite-plugin-turbosnap";
+import TsconfigPathsPlugin from "vite-tsconfig-paths";
+
+const indexRegex = /export const args = {\s+index: (\d+),/;
 
 export default {
-  staticDirs: ["./public"],
+  experimental_indexers: (indexers) => {
+    // Changes here might need to be reflected in aksel.nav.no/website/.storybook/main.ts
+    const customIndexer = async (fileName: string, opts) => {
+      let code = readFileSync(fileName, "utf-8").toString();
 
-  stories: () => ["../@navikt/**/*.stories.@(js|jsx|ts|tsx|mdx)", "./*.mdx"],
+      const matches = indexRegex.exec(code);
+      const prefix = matches ? `${matches[1]} | ` : "";
+
+      code = code.split(
+        /\/\/ EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE/,
+      )[0];
+
+      const [templateName, name] = fileName
+        .split(`pages/templates/`)[1]
+        .replace(".tsx", "")
+        .split("/");
+      const storyName = process.env.CHROMATIC
+        ? `${templateName} | ${prefix}${name}` // Chromatic does not support folders
+        : `${prefix}${name}`;
+
+      code += `
+        export default { title: "Templates/${templateName}/${storyName}" };
+        export const Demo = { render: Example };
+        Demo.storyName = "${storyName}";`;
+
+      return loadCsf(code, { ...opts, fileName }).parse().indexInputs;
+    };
+
+    return [
+      ...(indexers || []),
+      {
+        test: /pages\/templates\/.+?.tsx$/,
+        createIndex: customIndexer,
+      },
+    ];
+  },
+  staticDirs: ["./public"],
+  stories: () => [
+    "../@navikt/**/*.stories.@(js|jsx|ts|tsx|mdx)",
+    "./*.mdx",
+    "../aksel.nav.no/website/pages/templates/**/*.tsx",
+  ],
   addons: [
     "@storybook/addon-a11y",
     "@whitespace/storybook-addon-html",
@@ -36,21 +81,24 @@ export default {
   },
   typescript: {
     check: false,
-    checkOptions: {},
     reactDocgen: false,
   },
 
   async viteFinal(config, { configType }) {
     const { mergeConfig } = await import("vite");
+
+    // The TsconfigPathsPlugin is only used to silence errors when importing nextjs components, but the imports does not acutally work.
+
     return mergeConfig(config, {
       plugins:
         configType === "PRODUCTION"
           ? [
+              TsconfigPathsPlugin(),
               turbosnap({
                 rootDir: config.root ?? process.cwd(),
               }),
             ]
-          : [],
+          : [TsconfigPathsPlugin()],
     });
   },
-};
+} satisfies StorybookConfig;

--- a/aksel.nav.no/website/package.json
+++ b/aksel.nav.no/website/package.json
@@ -99,6 +99,7 @@
     "showdown": "^2.1.0",
     "start-server-and-test": "^2.0.3",
     "ts-node": "^10.9.1",
+    "tsconfig-paths-webpack-plugin": "^4.1.0",
     "typescript": "^5.1.6",
     "vitest": "^1.2.2"
   }

--- a/aksel.nav.no/website/pages/templates/404/enkel.tsx
+++ b/aksel.nav.no/website/pages/templates/404/enkel.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { BodyShort, Box, Heading, Link, List, Page } from "@navikt/ds-react";
 
 const Example = () => {
@@ -80,6 +80,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/404/komplett.tsx
+++ b/aksel.nav.no/website/pages/templates/404/komplett.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { BugIcon } from "@navikt/aksel-icons";
 import {
   BodyShort,
@@ -114,6 +114,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/404/med-cta.tsx
+++ b/aksel.nav.no/website/pages/templates/404/med-cta.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import {
   BodyShort,
   Box,
@@ -94,6 +94,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/404/med-feedback.tsx
+++ b/aksel.nav.no/website/pages/templates/404/med-feedback.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { BugIcon } from "@navikt/aksel-icons";
 import {
   BodyShort,
@@ -95,6 +95,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/404/med-lang-en.tsx
+++ b/aksel.nav.no/website/pages/templates/404/med-lang-en.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import {
   BodyShort,
   Box,
@@ -103,6 +103,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/404/uten-dekorator.tsx
+++ b/aksel.nav.no/website/pages/templates/404/uten-dekorator.tsx
@@ -35,6 +35,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen", chromatic: { disable: true } },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/500/enkel.tsx
+++ b/aksel.nav.no/website/pages/templates/500/enkel.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import {
   BodyShort,
   Box,
@@ -111,6 +111,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/500/komplett.tsx
+++ b/aksel.nav.no/website/pages/templates/500/komplett.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import {
   BodyShort,
   Box,
@@ -142,6 +142,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/500/med-cta.tsx
+++ b/aksel.nav.no/website/pages/templates/500/med-cta.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import {
   BodyShort,
   Box,
@@ -118,6 +118,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/500/med-feil-id.tsx
+++ b/aksel.nav.no/website/pages/templates/500/med-feil-id.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import {
   BodyShort,
   Box,
@@ -120,6 +120,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/500/med-lang-en.tsx
+++ b/aksel.nav.no/website/pages/templates/500/med-lang-en.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import {
   BodyShort,
   Box,
@@ -133,6 +133,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/500/uten-dekorator.tsx
+++ b/aksel.nav.no/website/pages/templates/500/uten-dekorator.tsx
@@ -96,6 +96,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen", chromatic: { disable: true } },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/soknad-introside-aap/soknad-introside-aap.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside-aap/soknad-introside-aap.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { ArrowRightIcon } from "@navikt/aksel-icons";
 import {
   Accordion,
@@ -306,6 +306,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/soknad-introside-alderspensjon/soknad-introside-alderspensjon.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside-alderspensjon/soknad-introside-alderspensjon.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { ArrowRightIcon } from "@navikt/aksel-icons";
 import {
   Accordion,
@@ -355,6 +355,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/soknad-introside-foreldrepenger/soknad-introside-foreldrepenger.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside-foreldrepenger/soknad-introside-foreldrepenger.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { ArrowRightIcon } from "@navikt/aksel-icons";
 import {
   Accordion,
@@ -310,6 +310,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/soknad-introside-pass-av-barn/soknad-introside-pass-av-barn.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside-pass-av-barn/soknad-introside-pass-av-barn.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { ArrowRightIcon } from "@navikt/aksel-icons";
 import {
   Accordion,
@@ -323,6 +323,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/soknad-introside/intro-med-alert.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside/intro-med-alert.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { ArrowRightIcon } from "@navikt/aksel-icons";
 import {
   Accordion,
@@ -356,6 +356,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/soknad-introside/intro-med-alternativ-soknad.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside/intro-med-alternativ-soknad.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { ArrowRightIcon } from "@navikt/aksel-icons";
 import {
   Accordion,
@@ -369,6 +369,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/soknad-introside/intro.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside/intro.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { ArrowRightIcon } from "@navikt/aksel-icons";
 import {
   Accordion,
@@ -350,6 +350,7 @@ export default Example;
 /* Storybook story */
 export const Demo = {
   render: Example,
+  parameters: { layout: "fullscreen" },
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/templates/soknad-introside/intro.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside/intro.tsx
@@ -42,7 +42,7 @@ function Example() {
               <VStack gap="1">
                 <BodyShort size="small">NAV 10-07.03 (om relevant)</BodyShort>
                 <Heading level="1" size="large">
-                  Søknad om [ytelse] TEST
+                  Søknad om [ytelse]
                 </Heading>
               </VStack>
             </Stack>

--- a/aksel.nav.no/website/pages/templates/soknad-introside/intro.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside/intro.tsx
@@ -42,7 +42,7 @@ function Example() {
               <VStack gap="1">
                 <BodyShort size="small">NAV 10-07.03 (om relevant)</BodyShort>
                 <Heading level="1" size="large">
-                  Søknad om [ytelse]
+                  Søknad om [ytelse] TEST
                 </Heading>
               </VStack>
             </Stack>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "docgen": "yarn workspaces foreach -v -p run docgen",
     "changelog": "deno run --allow-read --allow-write --no-config scripts/changelog/createMainChangelog.ts",
     "updateArticleViews": "deno run --allow-net --allow-env --allow-read --no-config scripts/article-views/update-article-views/main.ts",
-    "chromatic": "npx chromatic --only-changed --project-token x3xqdfgkujg --build-script-name build:storybook",
+    "chromatic": "npx chromatic --only-changed --project-token x3xqdfgkujg --build-script-name build:storybook-chromatic",
+    "build:storybook-chromatic": "cross-env CHROMATIC=true storybook build",
     "build:storybook": "storybook build",
     "test": "yarn workspaces foreach -p -v run test",
     "lint": "yarn eslint --rule \"import/no-cycle:error\" . && yarn stylelint '@navikt/**/*.css'",
@@ -192,6 +193,7 @@
     "typescript": "^5.1.6",
     "vite": "^5.1.7",
     "vite-plugin-turbosnap": "^1.0.3",
+    "vite-tsconfig-paths": "^4.3.2",
     "yarn": "^1.22.10"
   },
   "_notes": "react-syntax-highlighter is a dependency of @whitespace/storybook-addon-html",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8483,6 +8483,7 @@ __metadata:
     typescript: ^5.1.6
     vite: ^5.1.7
     vite-plugin-turbosnap: ^1.0.3
+    vite-tsconfig-paths: ^4.3.2
     yarn: ^1.22.10
   languageName: unknown
   linkType: soft
@@ -15104,6 +15105,13 @@ __metadata:
   version: 0.1.4
   resolution: "globjoin@npm:0.1.4"
   checksum: 0a47d88d566122d9e42da946453ee38b398e0021515ac6a95d13f980ba8c1e42954e05ee26cfcbffce1ac1ee094d0524b16ce1dd874ca52408d6db5c6d39985b
+  languageName: node
+  linkType: hard
+
+"globrex@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "globrex@npm:0.1.2"
+  checksum: adca162494a176ce9ecf4dd232f7b802956bb1966b37f60c15e49d2e7d961b66c60826366dc2649093cad5a0d69970cfa8875bd1695b5a1a2f33dcd2aa88da3c
   languageName: node
   linkType: hard
 
@@ -26660,7 +26668,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfig-paths-webpack-plugin@npm:^4.0.1":
+"tsconfck@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "tsconfck@npm:3.0.3"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tsconfck: bin/tsconfck.js
+  checksum: 8ee0d73f730c0747d4bfe569b1931e1b3848f2adfb86ee8f3dc9aedd123f155b363dec7f51dc165fc7938ce592af753aa513adf7753ffcbee1baf97017d919dd
+  languageName: node
+  linkType: hard
+
+"tsconfig-paths-webpack-plugin@npm:^4.0.1, tsconfig-paths-webpack-plugin@npm:^4.1.0":
   version: 4.1.0
   resolution: "tsconfig-paths-webpack-plugin@npm:4.1.0"
   dependencies:
@@ -27716,6 +27738,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-tsconfig-paths@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "vite-tsconfig-paths@npm:4.3.2"
+  dependencies:
+    debug: ^4.1.1
+    globrex: ^0.1.2
+    tsconfck: ^3.0.3
+  peerDependencies:
+    vite: "*"
+  peerDependenciesMeta:
+    vite:
+      optional: true
+  checksum: 7105ff641379f9f7055110f33067b236c8ee71b1390c0e6482412cdcc7a98c2e139c1c2a483d14fe9045d1977c14dc931e1ff302d6257ec919c70379db9d2419
+  languageName: node
+  linkType: hard
+
 "vite@npm:^4.5.1":
   version: 4.5.3
   resolution: "vite@npm:4.5.3"
@@ -28205,6 +28243,7 @@ __metadata:
     tailwindcss: ^3.3.3
     tinycolor2: ^1.6.0
     ts-node: ^10.9.1
+    tsconfig-paths-webpack-plugin: ^4.1.0
     typescript: ^5.1.6
     vitest: ^1.2.2
     zod: ^3.22.4


### PR DESCRIPTION
Tried to add the templates to the "main" storybook, so that they are included in chromatic. It seems to be working, except for the "uten-dekorator" stories that import nextjs components (Header and Footer). But at least I managed to fix so that storybook builds without errors, and you only get errors when trying to open those stories.

We could consider creating a simple header and footer for use in the template, to avoid this issue.

I also tidied up a bit in the "Aksel storybook" main.ts file:
- Removed getAbsolutePath as everything seems to work without it.
- Removed csfIndexer as everything seems to work without it.
- Added types and modified the `framework` object because TS complained about it.
- Replaced manual path alias mapping with a plugin I found.