### PR TITLE
:bug: Modal: Fix issue where polyfill-classname was not applied when using SSR (Next.js)

### DIFF
--- a/.changeset/flat-donkeys-draw.md
+++ b/.changeset/flat-donkeys-draw.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+:bug: Modal: Fix issue where polyfill-classname was not applied when using SSR (Next.js)

--- a/@navikt/core/react/src/modal/Modal.tsx
+++ b/@navikt/core/react/src/modal/Modal.tsx
@@ -115,6 +115,9 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
       // We check both to avoid activating polyfill twice when not using portal.
       if (needPolyfill && modalRef.current && portalNode) {
         dialogPolyfill.registerDialog(modalRef.current);
+
+        // Force-add the "polyfilled" class in case of SSR (needPolyfill will always be false on the server)
+        modalRef.current.classList.add("navds-modal--polyfilled");
       }
       // We set autofocus on the dialog element to prevent the default behavior where first focusable element gets focus when modal is opened.
       // This is mainly to fix an edge case where having a Tooltip as the first focusable element would make it activate when you open the modal.

--- a/@navikt/core/react/src/modal/Modal.tsx
+++ b/@navikt/core/react/src/modal/Modal.tsx
@@ -21,6 +21,8 @@ import {
 import dialogPolyfill, { needPolyfill } from "./dialog-polyfill";
 import { ModalProps } from "./types";
 
+const polyfillClassName = "navds-modal--polyfilled";
+
 interface ModalComponent
   extends React.ForwardRefExoticComponent<
     ModalProps & React.RefAttributes<HTMLDialogElement>
@@ -117,7 +119,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
         dialogPolyfill.registerDialog(modalRef.current);
 
         // Force-add the "polyfilled" class in case of SSR (needPolyfill will always be false on the server)
-        modalRef.current.classList.add("navds-modal--polyfilled");
+        modalRef.current.classList.add(polyfillClassName);
       }
       // We set autofocus on the dialog element to prevent the default behavior where first focusable element gets focus when modal is opened.
       // This is mainly to fix an edge case where having a Tooltip as the first focusable element would make it activate when you open the modal.
@@ -145,7 +147,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
       typeof width === "string" && ["small", "medium"].includes(width);
 
     const mergedClassName = cl("navds-modal", className, {
-      "navds-modal--polyfilled": needPolyfill,
+      polyfillClassName: needPolyfill,
       "navds-modal--autowidth": !width,
       [`navds-modal--${width}`]: isWidthPreset,
     });


### PR DESCRIPTION
Feels a bit hacky, but at the same time somewhat elegant since we don't need another `useState` or something like that. But let me know if you can think of a better way to fix it.

The problem is that `needPolyfill` is `false` when the component is rendered on the server. It is correctly set to `true` when running in the browser, but the className is not actually updated. (You get a warning that the className did not match server etc.)