### PR TITLE
feat: Added description-prop for fileupload item

### DIFF
--- a/.changeset/sharp-walls-sip.md
+++ b/.changeset/sharp-walls-sip.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+FileUpload: Added description-prop for Item.

--- a/@navikt/core/react/src/form/file-upload/file-upload-item.stories.tsx
+++ b/@navikt/core/react/src/form/file-upload/file-upload-item.stories.tsx
@@ -146,3 +146,15 @@ export const Download: StoryObj = {
     </VStack>
   ),
 };
+
+export const Description: StoryObj = {
+  render: () => (
+    <VStack gap="5">
+      <FileUpload.Item file={fileTxt} description="Mottat 11.11.11" />
+      <FileUpload.Item
+        file={fileTxt}
+        description="Lorem ipsum dolor, sit amet consectetur adipisicing elit. Enim officiis nisi beatae quia non iste nihil accusantium nobis amet, officia eius, repellendus a cupiditate, commodi eos! Quis illum repudiandae exercitationem."
+      />
+    </VStack>
+  ),
+};

--- a/@navikt/core/react/src/form/file-upload/parts/item/Item.tsx
+++ b/@navikt/core/react/src/form/file-upload/parts/item/Item.tsx
@@ -45,7 +45,7 @@ export interface FileUploadItemProps
    */
   status?: "downloading" | "uploading" | "idle";
   /**
-   * File-description. Replaces filesize when status is "idle".
+   * File description. Replaces file size when status is "idle".
    * This is useful for displaying upload date. Should not act as a replacement for error messages.
    */
   description?: string;

--- a/@navikt/core/react/src/form/file-upload/parts/item/Item.tsx
+++ b/@navikt/core/react/src/form/file-upload/parts/item/Item.tsx
@@ -45,6 +45,11 @@ export interface FileUploadItemProps
    */
   status?: "downloading" | "uploading" | "idle";
   /**
+   * File-description. Replaces filesize when status is "idle".
+   * This is useful for displaying upload date. Should not act as a replacement for error messages.
+   */
+  description?: string;
+  /**
    * Props for the action button.
    */
   button?: {
@@ -71,6 +76,7 @@ export const Item: OverridableComponent<FileUploadItemProps, HTMLDivElement> =
         onFileClick,
         button,
         translations,
+        description,
         ...rest
       }: FileUploadItemProps,
       ref,
@@ -91,7 +97,7 @@ export const Item: OverridableComponent<FileUploadItemProps, HTMLDivElement> =
         if (status === "downloading") {
           return translate("item.downloading");
         }
-        return formatFileSize(file);
+        return description ?? formatFileSize(file);
       }
 
       return (


### PR DESCRIPTION
### Description

#2816

`description`-prop replaces filesize when status is `idle`. If user still wants to display the filesize they can either edit the filename, or add it to the description