### PR TITLE
[Page] Removed surface-subtle from background-prop

### DIFF
--- a/.changeset/tasty-books-give.md
+++ b/.changeset/tasty-books-give.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Page: Removed surface-subtle from background-prop

--- a/@navikt/core/react/src/layout/page/Page.tsx
+++ b/@navikt/core/react/src/layout/page/Page.tsx
@@ -14,7 +14,7 @@ export interface PageProps extends React.HTMLAttributes<HTMLElement> {
    * Background color. Accepts a color token.
    * @default "bg-default"
    */
-  background?: keyof typeof bgColors.a | "surface-subtle";
+  background?: keyof typeof bgColors.a;
   /**
    * Allows better positioning of footer
    */


### PR DESCRIPTION
### Description

Token seems to be unused after 6 months in prod, and therefore not needed.

[Search](https://github.com/search?type=code&q=org%3Anavikt+%3CPage+background%3D%22surface-subtle%22)