### PR TITLE
[aksel.nav.no] Fix React warning in Snippet

### DIFF
--- a/aksel.nav.no/website/components/sanity-modules/code-snippet/Snippet.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/code-snippet/Snippet.tsx
@@ -73,7 +73,7 @@ const CodeSnippet = ({ node: { code, title } }: CodeSnippetProps) => {
               {tokens.map((line, i) => (
                 <span
                   key={i}
-                  {...getLineProps({ line, key: i })}
+                  {...getLineProps({ line })}
                   className={cl(
                     "last-of-type:pb-4",
                     terminalStyling(language) ? "flex items-center" : "block",
@@ -86,7 +86,7 @@ const CodeSnippet = ({ node: { code, title } }: CodeSnippetProps) => {
                     />
                   )}
                   {line.map((token, key) => (
-                    <span key={key} {...getTokenProps({ token, key })} />
+                    <span key={key} {...getTokenProps({ token })} />
                   ))}
                 </span>
               ))}


### PR DESCRIPTION
Fixes warning when visiting a component page: "Warning: A props object containing a "key" prop is being spread into JSX"