### PR TITLE
Fix error message when starting Storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -88,17 +88,18 @@ export default {
     const { mergeConfig } = await import("vite");
 
     // The TsconfigPathsPlugin is only used to silence errors when importing nextjs components, but the imports does not acutally work.
+    const tsConfigPathsPluginOpts = { root: "aksel.nav.no/website/" };
 
     return mergeConfig(config, {
       plugins:
         configType === "PRODUCTION"
           ? [
-              TsconfigPathsPlugin(),
+              TsconfigPathsPlugin(tsConfigPathsPluginOpts),
               turbosnap({
                 rootDir: config.root ?? process.cwd(),
               }),
             ]
-          : [TsconfigPathsPlugin()],
+          : [TsconfigPathsPlugin(tsConfigPathsPluginOpts)],
     });
   },
 } satisfies StorybookConfig;


### PR DESCRIPTION
Fixes this error message when starting Storybook: `[tsconfig-paths] An error occurred while parsing "(...)\examples\astro\tsconfig.json"`