### PR TITLE
:sparkles: noen enkle komponenter (render-only)

### DIFF
--- a/.changeset/rare-cheetahs-sin.md
+++ b/.changeset/rare-cheetahs-sin.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": minor
+"@navikt/ds-css": minor
+---
+
+New components: <Time /> and <Phone />

--- a/@navikt/core/css/config/_mappings.js
+++ b/@navikt/core/css/config/_mappings.js
@@ -211,6 +211,16 @@ const StyleMappings = {
       main: "date.css",
       dependencies: [typoCss, "button.css", "popover.css"],
     },
+    {
+      component: "Time",
+      main: "",
+      dependenies: [typoCss],
+    },
+    {
+      component: "Phone",
+      main: "phone.css",
+      dependenies: [typoCss],
+    },
   ],
 };
 

--- a/@navikt/core/css/index.css
+++ b/@navikt/core/css/index.css
@@ -33,3 +33,4 @@
 @import "tabs.css";
 @import "list.css";
 @import "primitives/index.css";
+@import "phone.css";

--- a/@navikt/core/css/phone.css
+++ b/@navikt/core/css/phone.css
@@ -1,0 +1,3 @@
+.navds-phone > span:not(:last-child) {
+  margin-inline-end: var(--a-spacing-1);
+}

--- a/@navikt/core/react/package.json
+++ b/@navikt/core/react/package.json
@@ -580,6 +580,26 @@
         "default": "./cjs/form/form-progress/index.js"
       }
     },
+    "./Phone": {
+      "import": {
+        "types": "./esm/phone/index.d.ts",
+        "default": "./esm/phone/index.js"
+      },
+      "require": {
+        "types": "./cjs/phone/index.d.ts",
+        "default": "./cjs/phone/index.js"
+      }
+    },
+    "./Time": {
+      "import": {
+        "types": "./esm/time/index.d.ts",
+        "default": "./esm/time/index.js"
+      },
+      "require": {
+        "types": "./cjs/time/index.d.ts",
+        "default": "./cjs/time/index.js"
+      }
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/@navikt/core/react/src/date/Time/Time.tsx
+++ b/@navikt/core/react/src/date/Time/Time.tsx
@@ -1,0 +1,48 @@
+import { format } from "date-fns";
+import { nb } from "date-fns/locale";
+import React from "react";
+
+type Props = {
+  /**
+   * The date you want to format in accordance
+   * with our guidelines for writing dates and times.
+   *
+   * https://aksel.nav.no/god-praksis/artikler/skriveregler-i-nav
+   */
+  date: Date;
+} & MutexProps;
+
+type MutexProps =
+  | {
+      day?: boolean;
+      month?: never;
+      onlyTime?: never;
+    }
+  | {
+      day?: never;
+      month?: boolean;
+      onlyTime?: never;
+    }
+  | {
+      day?: never;
+      month?: never;
+      onlyTime?: boolean;
+    };
+
+export const Time = ({
+  date,
+  day = false,
+  month = false,
+  onlyTime = false,
+}: Props) => {
+  let formatString = "d. MMMM yyyy 'kl'. hh.mm";
+  if (day) {
+    formatString = "d. MMMM yyyy";
+  } else if (month) {
+    formatString = "MMMM yyyy";
+  } else if (onlyTime) {
+    formatString = "'kl'. hh.mm";
+  }
+  const humanTime = format(date, formatString, { locale: nb });
+  return <span className="navds-time">{humanTime}</span>;
+};

--- a/@navikt/core/react/src/date/Time/Time.tsx
+++ b/@navikt/core/react/src/date/Time/Time.tsx
@@ -29,6 +29,23 @@ type MutexProps =
       onlyTime?: boolean;
     };
 
+/**
+ * A component that displays a point in time in accordance with
+ * our best practice guidelines for displaying dates and times.
+ *
+ * https://aksel.nav.no/god-praksis/artikler/skriveregler-i-nav
+ *
+ * @see [📝 Documentation](https://aksel.nav.no/komponenter/core/time)
+ * @see 🏷 {@link Props}
+ *
+ * @example
+ * ```jsx
+ * <Time date={new Date()} />
+ * <Time date={new Date()} day />
+ * <Time date={new Date()} month />
+ * <Time date={new Date()} onlyTime />
+ * ```
+ */
 export const Time = ({
   date,
   day = false,

--- a/@navikt/core/react/src/date/Time/index.ts
+++ b/@navikt/core/react/src/date/Time/index.ts
@@ -1,0 +1,2 @@
+"use client";
+export { Time } from "./Time";

--- a/@navikt/core/react/src/date/Time/time.stories.tsx
+++ b/@navikt/core/react/src/date/Time/time.stories.tsx
@@ -5,7 +5,7 @@ import { Time } from "./Time";
 export default {
   title: "ds-react/Time",
   component: Time,
-} as Meta;
+} satisfies Meta<typeof Time>;
 
 export const Default = () => {
   return <Time date={new Date()} />;

--- a/@navikt/core/react/src/date/Time/time.stories.tsx
+++ b/@navikt/core/react/src/date/Time/time.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta } from "@storybook/react";
+import React from "react";
+import { Time } from "./Time";
+
+export default {
+  title: "ds-react/Time",
+  component: Time,
+} as Meta;
+
+export const Default = () => {
+  return <Time date={new Date()} />;
+};
+
+export const Day = () => {
+  return <Time date={new Date()} day />;
+};
+
+export const Month = () => {
+  return <Time date={new Date()} month />;
+};
+
+export const OnlyTime = () => {
+  return <Time date={new Date()} onlyTime />;
+};

--- a/@navikt/core/react/src/index.ts
+++ b/@navikt/core/react/src/index.ts
@@ -153,6 +153,8 @@ export { Select, type SelectProps } from "./form/select";
 export { Switch, type SwitchProps } from "./form/switch";
 export { Textarea, type TextareaProps } from "./form/textarea";
 export { TextField, type TextFieldProps } from "./form/textfield";
+export { Phone } from "./phone";
+export { Time } from "./date/Time";
 
 /**
  * @deprecated

--- a/@navikt/core/react/src/phone/Phone.tsx
+++ b/@navikt/core/react/src/phone/Phone.tsx
@@ -20,6 +20,23 @@ type Props = {
   prefixCode?: string;
 };
 
+/**
+ * A component that displays a phone number in accordance with
+ * our best practice guidelines for displaying phone numbers.
+ *
+ * https://aksel.nav.no/god-praksis/artikler/skriveregler-i-nav
+ *
+ * @see [📝 Documentation](https://aksel.nav.no/komponenter/core/phone)
+ * @see 🏷 {@link Props}
+ *
+ * @example
+ * ```jsx
+ * <Phone number=“04045” />
+ * <Phone number=“22222222” />
+ * <Phone number=“80030300” />
+ * <Phone number=“116117” prefixCode=“47” />
+ * ```
+ */
 export const Phone = ({ number, prefixCode }: Props) => {
   let _number = number.trim();
   if (_number.startsWith("00")) {

--- a/@navikt/core/react/src/phone/Phone.tsx
+++ b/@navikt/core/react/src/phone/Phone.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+
+type Props = {
+  /**
+   * The phonenumber itself as a raw string, it will
+   * be split up and represented in accordance with the guidelines
+   * we have for formatting phone numbers.
+   *
+   * https://aksel.nav.no/god-praksis/artikler/skriveregler-i-nav
+   *
+   * If you want to escape a country code, it's recommended to use
+   * a '+' and not a leading '00', this is why we have it as a separate
+   * prop `prefixCode`.
+   */
+  number: string;
+  /**
+   * Setting this will add `+prefixCode` to the
+   * beginning of the phone number.
+   */
+  prefixCode?: string;
+};
+
+export const Phone = ({ number, prefixCode }: Props) => {
+  let _number = number.trim();
+  if (_number.startsWith("00")) {
+    // this is to discourage 00, and instead use '+'
+    _number = _number.substring(2);
+  }
+  _number = _number.replace(/[^0-9]/g, "");
+  let numberGroups: string[] = [];
+  if (_number.length === 8 && _number.startsWith("8")) {
+    numberGroups.push(_number.substring(0, 3));
+    numberGroups.push(_number.substring(3, 5));
+    numberGroups.push(_number.substring(5, 8));
+  } else if (_number.length >= 7) {
+    for (let i = 0; i < _number.length; i += 2) {
+      numberGroups.push(_number.substring(i, i + 2));
+    }
+  } else if (_number.length === 6) {
+    numberGroups.push(_number.substring(0, 3));
+    numberGroups.push(_number.substring(3, 6));
+  } else if (_number.length <= 5) {
+    numberGroups = [_number];
+  }
+  return (
+    <span className="navds-phone">
+      {prefixCode && <span>+{prefixCode}</span>}
+      {numberGroups.map((n, idx) => (
+        <span key={idx}>{n}</span>
+      ))}
+    </span>
+  );
+};

--- a/@navikt/core/react/src/phone/index.ts
+++ b/@navikt/core/react/src/phone/index.ts
@@ -1,0 +1,2 @@
+"use client";
+export { Phone } from "./Phone";

--- a/@navikt/core/react/src/phone/phone.stories.tsx
+++ b/@navikt/core/react/src/phone/phone.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta } from "@storybook/react";
+import React from "react";
+import { VStack } from "../layout/stack";
+import { Phone } from "./Phone";
+
+export default {
+  title: "ds-react/Phone",
+  component: Phone,
+} as Meta;
+
+export const Default = () => {
+  return (
+    <VStack gap="2">
+      <Phone number="+01234567" />
+      <Phone number="  +abc34+=[03]0({})567  " />
+      <Phone number="004701234567" />
+      <Phone number="04045" />
+      <Phone number="116117" />
+      <Phone number="0123456" />
+      <Phone number="8123456" />
+      <Phone number="22222222" />
+      <Phone number="80030300" />
+      <Phone prefixCode="47" number="22222222" />
+    </VStack>
+  );
+};


### PR DESCRIPTION
We have nice guidelines to strictly render a few things: https://aksel.nav.no/god-praksis/artikler/skriveregler-i-nav

They leave little room for creative interpretation, so they should make for some simple, nice & handy components.

(can split this up into several PR's too, they felt small & simple while making them, but maybe they no longer are 🤔 )

## Phone
Render a phone number according to our guidelines

## Time
Render a point in time according to our guidelines

### Description

Closes https://github.com/navikt/team-aksel/issues/520.

it's tangentially related to https://github.com/navikt/team-aksel/issues/519 (this one is _actually_ about an `<input />`, so it's going to be a bit more complex... this rendering does take care of the "render masking", so potential re-use of code there.)

### Change summary

Added some components:
- `<Phone />`
- `<Time />`

#### Documentation 📝

- Add/update component-demos for component `aksel.nav.no/website/pages/eksempler`
- Create/Update documentation in sanity if needed
  Note: Props, tokens and examples only updates to sanity on merge to main
