### PR TITLE
feat: Added version-tag to tokens

### DIFF
--- a/@navikt/core/tokens/config/version-tag.js
+++ b/@navikt/core/tokens/config/version-tag.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+const path = require("path");
+
+const cssFilePath = path.join(__dirname, "../dist/tokens.css");
+const packageJsonPath = path.join(__dirname, "../package.json");
+
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+const version = packageJson.version;
+
+let cssContent = fs.readFileSync(cssFilePath, "utf8");
+
+cssContent = cssContent.replace("{", `{\n  --aksel-version: "${version}";`);
+
+fs.writeFileSync(cssFilePath, cssContent);

--- a/@navikt/core/tokens/config/version-tag.js
+++ b/@navikt/core/tokens/config/version-tag.js
@@ -9,7 +9,7 @@ const version = packageJson.version;
 
 let cssContent = fs.readFileSync(cssFilePath, "utf8");
 
-if (!cssContent.includes("--aksel-version")) {
-  cssContent = cssContent.replace("{", `{\n  --aksel-version: "${version}";`);
+if (!cssContent.includes("--a-version")) {
+  cssContent = cssContent.replace("{", `{\n  --a-version: "${version}";`);
   fs.writeFileSync(cssFilePath, cssContent);
 }

--- a/@navikt/core/tokens/config/version-tag.js
+++ b/@navikt/core/tokens/config/version-tag.js
@@ -9,6 +9,7 @@ const version = packageJson.version;
 
 let cssContent = fs.readFileSync(cssFilePath, "utf8");
 
-cssContent = cssContent.replace("{", `{\n  --aksel-version: "${version}";`);
-
-fs.writeFileSync(cssFilePath, cssContent);
+if (!cssContent.includes("--aksel-version")) {
+  cssContent = cssContent.replace("{", `{\n  --aksel-version: "${version}";`);
+  fs.writeFileSync(cssFilePath, cssContent);
+}

--- a/@navikt/core/tokens/package.json
+++ b/@navikt/core/tokens/package.json
@@ -18,7 +18,7 @@
     "docs.json"
   ],
   "scripts": {
-    "build": "node ./config/build.js > /dev/null",
+    "build": "node ./config/build.js > /dev/null && node ./config/version-tag.js",
     "watch": "nodemon --watch src/index.js --exec \"yarn build\"",
     "token": "cd config && style-dictionary build",
     "test": "vitest run",


### PR DESCRIPTION
### Description

Often when debugging bugs in applications one lacks context for what version they are using. This feature adds a token `--aksel-version` to the token-css and will be added to the CSS by reference. Since this is added with `yarn boot`, the released code built in `release.yml` workflow will have the correct/most up-to-date version released 🎉 

Discussion: Should the token be verbose like now with `aksel-version`, or more in-line with the rest `a-version`?
![Screenshot 2024-06-11 at 14 38 32](https://github.com/navikt/aksel/assets/26967723/e5ab51b1-852a-4786-946d-db488f1bf9a4)
