### PR TITLE
refactor: Fixed no misleading character class biome

### DIFF
--- a/aksel.nav.no/website/sanity/schema/util.ts
+++ b/aksel.nav.no/website/sanity/schema/util.ts
@@ -31,7 +31,7 @@ export function sanitizeSlug(input: string) {
       })
       // Replace accented characters with non-accented equivalents
       .normalize("NFD")
-      // biome-ignore lint/suspicious/noMisleadingCharacterClass: Nextjs-loader (webpack/loaders/next-swc-loader.js) does not support adding `v` to regex expressions
+      // biome-ignore lint/suspicious/noMisleadingCharacterClass: Nextjs-loader (webpack/loaders/next-swc-loader.js) does not support the `v` flag in regex expressions
       .replace(/[\u0300-\u036f]/g, "")
       // Replace any non [a-zA-Z0-9_]
       .replace(/[^\w-]+/g, "")

--- a/aksel.nav.no/website/sanity/schema/util.ts
+++ b/aksel.nav.no/website/sanity/schema/util.ts
@@ -31,7 +31,7 @@ export function sanitizeSlug(input: string) {
       })
       // Replace accented characters with non-accented equivalents
       .normalize("NFD")
-      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/[\u0300-\u036f]/gv, "")
       // Replace any non [a-zA-Z0-9_]
       .replace(/[^\w-]+/g, "")
   );

--- a/aksel.nav.no/website/sanity/schema/util.ts
+++ b/aksel.nav.no/website/sanity/schema/util.ts
@@ -31,7 +31,8 @@ export function sanitizeSlug(input: string) {
       })
       // Replace accented characters with non-accented equivalents
       .normalize("NFD")
-      .replace(/[\u0300-\u036f]/gv, "")
+      // biome-ignore lint/suspicious/noMisleadingCharacterClass: Nextjs-loader (webpack/loaders/next-swc-loader.js) does not support adding `v` to regex expressions
+      .replace(/[\u0300-\u036f]/g, "")
       // Replace any non [a-zA-Z0-9_]
       .replace(/[^\w-]+/g, "")
   );

--- a/biome.json
+++ b/biome.json
@@ -39,9 +39,7 @@
       "suspicious": {
         "noExplicitAny": "off",
         "noArrayIndexKey": "off",
-
-        "noDoubleEquals": "off",
-        "noMisleadingCharacterClass": "off"
+        "noDoubleEquals": "off"
       },
       "complexity": {
         "noForEach": "off",


### PR DESCRIPTION
### Description

https://biomejs.dev/linter/rules/no-misleading-character-class/

Fixed by adding `v` in regex:
![Screenshot 2024-06-12 at 12 46 33](https://github.com/navikt/aksel/assets/26967723/fdaea2ec-20f0-4e95-8e91-1b8896d98fe3)

 but this is not supported in nextjs... So just added an ignore for now.

![Screenshot 2024-06-12 at 12 58 05](https://github.com/navikt/aksel/assets/26967723/6f8000a6-fcbb-4a96-9edb-ff446d92d928)

