### PR TITLE
[aksel.nav.no] Validate unique title in exampletext_block

### DIFF
--- a/aksel.nav.no/website/components/sanity-modules/exampletext-block/ExampletextBlock.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/exampletext-block/ExampletextBlock.tsx
@@ -5,8 +5,8 @@ import ShowMore from "@/web/ShowMore";
 
 type ExampletextBlockProps = {
   node: {
-    title: string;
-    text: string;
+    title?: string;
+    text?: string;
     readMore?: boolean;
   };
 };

--- a/aksel.nav.no/website/sanity/schema/objects/shared/expansion-card.tsx
+++ b/aksel.nav.no/website/sanity/schema/objects/shared/expansion-card.tsx
@@ -1,6 +1,15 @@
 import { defineField, defineType } from "sanity";
 import { ChevronDownIcon } from "@navikt/aksel-icons";
 
+export type ExpansionCardT = {
+  _key: string;
+  _type: "expansioncard";
+  heading: string;
+  heading_level: "h3" | "h4";
+  description?: string;
+  body: any[];
+};
+
 export const ExpansionCard = defineType({
   name: "expansioncard",
   title: "ExpansionCard",

--- a/aksel.nav.no/website/sanity/schema/objects/templates/ExampletextBlock.tsx
+++ b/aksel.nav.no/website/sanity/schema/objects/templates/ExampletextBlock.tsx
@@ -1,6 +1,17 @@
 import { defineField, defineType } from "sanity";
 import { Chat2Icon } from "@navikt/aksel-icons";
 import AkselExampletextBlock from "@/cms/exampletext-block/ExampletextBlock";
+import { ExpansionCardT } from "../shared/expansion-card";
+
+type ExampletextBlockT = {
+  _key: string;
+  _type: "exampletext_block";
+  title?: string;
+  text?: string;
+  readMore?: boolean;
+};
+
+type ContentTypesWeCareAbout = ExampletextBlockT | ExpansionCardT;
 
 export const ExampletextBlock = defineType({
   name: "exampletext_block",
@@ -16,11 +27,20 @@ export const ExampletextBlock = defineType({
       validation: (Rule) =>
         Rule.required().custom((value, context) => {
           if (!context.document) return true;
-          const content = context.document.content as any[];
-          const blocksWithThisTitle = content
-            .filter((block) => block._type === "exampletext_block")
-            .filter((block) => block.title === value);
-          if (blocksWithThisTitle.length > 1) {
+          const content = context.document.content as ContentTypesWeCareAbout[];
+          let blocksWithThisTitle = 0;
+
+          content.forEach((block) => {
+            if (block._type === "exampletext_block" && block.title === value) {
+              blocksWithThisTitle++;
+            } else if (block._type === "expansioncard") {
+              blocksWithThisTitle += block.body
+                .filter((subBlock) => subBlock._type === "exampletext_block")
+                .filter((subBlock) => subBlock.title === value).length;
+            }
+          });
+
+          if (blocksWithThisTitle > 1) {
             return "Tittelen må være unik på tvers av alle eksempeltekst-blokkene.";
           }
           return true;
@@ -45,6 +65,8 @@ export const ExampletextBlock = defineType({
     },
   },
   components: {
-    preview: (values) => <AkselExampletextBlock node={values as any} />,
+    preview: (values: Omit<ExampletextBlockT, "_key">) => (
+      <AkselExampletextBlock node={values} />
+    ),
   },
 });

--- a/aksel.nav.no/website/sanity/schema/objects/templates/ExampletextBlock.tsx
+++ b/aksel.nav.no/website/sanity/schema/objects/templates/ExampletextBlock.tsx
@@ -13,7 +13,18 @@ export const ExampletextBlock = defineType({
       name: "title",
       type: "string",
       initialValue: "Eksempeltekst",
-      validation: (Rule) => Rule.required(),
+      validation: (Rule) =>
+        Rule.required().custom((value, context) => {
+          if (!context.document) return true;
+          const content = context.document.content as any[];
+          const blocksWithThisTitle = content
+            .filter((block) => block._type === "exampletext_block")
+            .filter((block) => block.title === value);
+          if (blocksWithThisTitle.length > 1) {
+            return "Tittelen må være unik på tvers av alle eksempeltekst-blokkene.";
+          }
+          return true;
+        }),
     }),
     defineField({
       title: "Tekst",


### PR DESCRIPTION
The title on an example text block has to be unique since it's used as accessible name (aria-labelledby) on the `<section>` that wraps the block. This PR adds validation that should prevent people from making that mistake in Sanity.