### PR TITLE
default align to stretch and start align link items in example

### DIFF
--- a/@navikt/core/react/src/layout/stack/Stack.tsx
+++ b/@navikt/core/react/src/layout/stack/Stack.tsx
@@ -31,6 +31,7 @@ export type StackProps = PrimitiveProps &
     >;
     /**
      * CSS `align-items` property.
+     * @default "stretch"
      *
      * @example
      * align='center'
@@ -72,7 +73,7 @@ export const Stack: OverridableComponent<StackProps, HTMLDivElement> =
         children,
         className,
         as: Component = "div",
-        align,
+        align = "stretch",
         justify,
         wrap = true,
         gap,

--- a/aksel.nav.no/website/pages/eksempler/link/variants.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link/variants.tsx
@@ -3,7 +3,7 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <VStack gap="3">
+    <VStack gap="3" align="start">
       <Link href="#" variant="action">
         Action variant
       </Link>


### PR DESCRIPTION
`align-items` defaulter til `stretch` i specen, så da synes jeg docen burde gjøre det tydelig: https://www.w3.org/TR/css-flexbox-1/#align-items-property