### PR TITLE
feat: Added stale-issue handling

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+# https://github.com/actions/stale
+name: Mark stale issues
+
+on:
+  schedule:
+    - cron: "31 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 120
+          days-before-pr-stale: -1
+          days-before-close: 30
+          any-of-labels: "Besvart"
+          stale-issue-message: |-
+            Hei! Det ser ut som det ikke har vært aktivitet her på en stund. Etter 30 dager vil den bli automatisk lukket.
+
+            Om det fortsatt er relevant eller du har oppdateringer, vil en kommentar hindre at det lukkes. Du kan alltids åpne issue igjen hvis det skulle være nødvendig!
+          stale-issue-label: "no-issue-activity"
+          ascending: true
+          operations-per-run: 200

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,9 +21,9 @@ jobs:
           days-before-close: 30
           any-of-labels: "Besvart"
           stale-issue-message: |-
-            Hei! Det ser ut som det ikke har vært aktivitet her på en stund. Etter 30 dager vil den bli automatisk lukket.
+            Hei! Det ser ut som det ikke har vært aktivitet her på en stund. Etter 30 dager vil saken bli lukket automatisk.
 
-            Om det fortsatt er relevant eller du har oppdateringer, vil en kommentar hindre at det lukkes. Du kan alltids åpne issue igjen hvis det skulle være nødvendig!
+            Om saken fortsatt er relevant eller du har oppdateringer, vil en kommentar hindre at den lukkes. Du kan alltids åpne den igjen hvis det skulle være nødvendig!
           stale-issue-label: "no-issue-activity"
           ascending: true
           operations-per-run: 200


### PR DESCRIPTION
### Description

Runs a stale-issue check every night. Only cares about issue that has label `Besvart`, every other issue is ignored. This lets us incrementally add the label when we discuss them at issue meetings, and/or write a response asking for further follow-up.

- Gets "stale" after 120 days
- Closed 30 days after stale (so 120 + 30 days)