### PR TITLE
Respect meta-keys when navigating in Tabs, ToggleGroup

### DIFF
--- a/.changeset/bright-pots-melt.md
+++ b/.changeset/bright-pots-melt.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Tabs, ToggleGroup: Rovingfocus now respects shift, alt, ctrl and meta-keys when navigating.

--- a/@navikt/core/react/src/tabs/parts/tablist/useTabList.ts
+++ b/@navikt/core/react/src/tabs/parts/tablist/useTabList.ts
@@ -48,9 +48,16 @@ export function useTabList() {
         End: lastTab,
       };
 
+      const shouldDoAction = !(
+        event.shiftKey ||
+        event.ctrlKey ||
+        event.altKey ||
+        event.metaKey
+      );
+
       const action = keyMap[event.key];
 
-      if (action) {
+      if (shouldDoAction && action) {
         event.preventDefault();
         action(event);
       } else if (event.key === "Tab") {

--- a/@navikt/core/react/src/toggle-group/parts/useToggleItem.ts
+++ b/@navikt/core/react/src/toggle-group/parts/useToggleItem.ts
@@ -77,9 +77,16 @@ export function useToggleItem<P extends UseToggleItemProps>(
         End: lastTab,
       };
 
+      const shouldDoAction = !(
+        event.shiftKey ||
+        event.ctrlKey ||
+        event.altKey ||
+        event.metaKey
+      );
+
       const action = keyMap[event.key];
 
-      if (action) {
+      if (shouldDoAction && action) {
         event.preventDefault();
         action(event);
       } else if (event.key === "Tab") {


### PR DESCRIPTION
### Description

We did not check for shift, ctrl, alt and meta-keys when navigating and using preventDefault() in tabs and Toggegroup. This lead to OS and Browser-spesific actions to be prevented, like changing windows, changing tabs etc.
