### PR TITLE
:bug: bump playroom version + set white bg

### DIFF
--- a/aksel.nav.no/playroom/package.json
+++ b/aksel.nav.no/playroom/package.json
@@ -11,7 +11,7 @@
     "babel-loader": "^9.1.3",
     "babel-plugin-preval": "^5.1.0",
     "css-loader": "^6.8.1",
-    "playroom": "^0.37.0",
+    "playroom": "^0.38.0",
     "style-loader": "^3.3.3"
   },
   "dependencies": {

--- a/aksel.nav.no/playroom/playroom.config.js
+++ b/aksel.nav.no/playroom/playroom.config.js
@@ -53,7 +53,10 @@ module.exports = {
         },
         {
           test: /\.css$/i,
-          include: [require.resolve("@navikt/ds-css")],
+          include: [
+            require.resolve("@navikt/ds-css"),
+            require.resolve("./src/frameComponent.css"),
+          ],
           use: ["style-loader", "css-loader"],
         },
       ],

--- a/aksel.nav.no/playroom/src/FrameComponent.tsx
+++ b/aksel.nav.no/playroom/src/FrameComponent.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import "@navikt/ds-css";
+import "./frameComponent.css";
 
 const FrameComponent = ({ children }: { children: React.ReactNode }) => {
   return <div id="sandbox-wrapper">{children}</div>;

--- a/aksel.nav.no/playroom/src/frameComponent.css
+++ b/aksel.nav.no/playroom/src/frameComponent.css
@@ -1,0 +1,3 @@
+iframe {
+  background-color: white;
+}


### PR DESCRIPTION
The bg was gray (very close to our own gray, but not quite, made zebrastripes in `<Table />` near invisible.

bump version to 0.38 as well for good measure (some new Search + Search & Replace features).