### PR TITLE
Combobox: Pressing Escape in while focusing a Combobox inside a Modal will close the Modal 

### DIFF
--- a/.changeset/silly-walls-sip.md
+++ b/.changeset/silly-walls-sip.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Prevent Escape in open Combobox from closing Modals

--- a/@navikt/core/react/src/form/combobox/Input/Input.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.tsx
@@ -134,7 +134,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           }
         } else if (e.key === "Escape") {
           if (isListOpen) {
-            e.preventDefault(); // Prevents the Escape on keydown from closing en encasing Modal, as Combobox reacts on keyup.
+            e.preventDefault(); // Prevents closing an encasing Modal, as Combobox reacts on keyup.
           }
         } else if (e.key === "ArrowDown") {
           // Check that cursor position is at the end of the input field,

--- a/@navikt/core/react/src/form/combobox/Input/Input.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.tsx
@@ -96,10 +96,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
       e.preventDefault();
       switch (e.key) {
-        case "Escape":
-          clearInput(e);
-          toggleIsListOpen(false);
-          break;
         case "Enter":
         case "Accept":
           onEnter(e);
@@ -133,8 +129,10 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             e.preventDefault();
           }
         } else if (e.key === "Escape") {
-          if (isListOpen) {
+          if (isListOpen || value) {
             e.preventDefault(); // Prevents closing an encasing Modal, as Combobox reacts on keyup.
+            clearInput(e);
+            toggleIsListOpen(false);
           }
         } else if (e.key === "ArrowDown") {
           // Check that cursor position is at the end of the input field,

--- a/@navikt/core/react/src/form/combobox/Input/Input.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.tsx
@@ -132,6 +132,10 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           if (activeDecendantId || value) {
             e.preventDefault();
           }
+        } else if (e.key === "Escape") {
+          if (isListOpen) {
+            e.preventDefault(); // Prevents the Escape on keydown from closing en encasing Modal, as Combobox reacts on keyup.
+          }
         } else if (e.key === "ArrowDown") {
           // Check that cursor position is at the end of the input field,
           // so we don't interfere with text editing

--- a/@navikt/core/react/src/form/combobox/Input/Input.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.tsx
@@ -163,6 +163,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         isListOpen,
         activeDecendantId,
         setIsMouseLastUsedInputDevice,
+        clearInput,
         toggleIsListOpen,
         virtualFocus,
       ],

--- a/@navikt/core/react/src/form/combobox/combobox.stories.tsx
+++ b/@navikt/core/react/src/form/combobox/combobox.stories.tsx
@@ -1,7 +1,9 @@
 import { Meta, StoryFn } from "@storybook/react";
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "../../button";
 import { Chips } from "../../chips";
 import { VStack } from "../../layout/stack";
+import { Modal } from "../../modal";
 import { TextField } from "../textfield";
 import { UNSAFE_Combobox } from "./index";
 
@@ -399,6 +401,38 @@ export const WithError: StoryFn = () => {
       }}
       onToggleSelected={(_, isSelected) => setHasSelectedValue(isSelected)}
     />
+  );
+};
+
+export const InModal: StoryFn = () => {
+  const modalRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    modalRef.current?.showModal();
+  }, []);
+
+  return (
+    <>
+      <Button onClick={() => modalRef.current?.showModal()}>Åpne modal</Button>
+      <Modal
+        ref={modalRef}
+        header={{ heading: "Overskrift" }}
+        width="medium"
+        style={{ height: "auto" }}
+      >
+        <Modal.Body style={{ height: "100% " }}>
+          <p>
+            Modalen skal ikke lukke seg om man trykker Escape mens virtuelt
+            fokus er i Combobox sin nedtrekksliste eller om inputfeltet
+            inneholder tekst.
+          </p>
+          <UNSAFE_Combobox
+            options={options}
+            label="Hva er dine favorittfrukter?"
+          />
+        </Modal.Body>
+      </Modal>
+    </>
   );
 };
 


### PR DESCRIPTION


### Description

If pressing Escape in a Combobox inside of a Modal, the Modal would close.
Combobox should instead swallow the keydown event, so it does not close the Modal.
NB! This fix only swallows the event if FilteredOptions is open.

Fixes #3052 

### Change summary

Suppress keydown event when pressing Escape key while Combobox.FilteredOptions is open

### For discussion:

I don't have any tests yet, because I couldn't get them to fail pre-fix.

Turns out Storybook/Testing Library `userEvent.keyboard("{Escape}")` does not cause the Modal to close, while doing the same manually (even in Storybook) will cause the error. Found [references to the same here](https://github.com/testing-library/user-event/issues/969), and [a potential fix here](https://codesandbox.io/p/sandbox/v14-userevent-keyboard-escape-forked-b9sxol?file=%2Fsrc%2FApp.test.js%3A6%2C1-16%2C3), but then the fix wouldn't work in the test (but it worked in real-life).

Do we need tests for this?