### PR TITLE
Combobox: Fix NullPointer error in single-select with allowNewValues

### DIFF
--- a/.changeset/cyan-carrots-return.md
+++ b/.changeset/cyan-carrots-return.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-Prevent NullPointer when selecting a new/custom option in Combobox single-select
+Prevent NullPointer when adding a new/custom option in Combobox single-select

--- a/.changeset/cyan-carrots-return.md
+++ b/.changeset/cyan-carrots-return.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Prevent NullPointer when selecting a new/custom option in Combobox single-select

--- a/@navikt/core/react/src/form/combobox/Input/Input.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.tsx
@@ -68,12 +68,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
               ? { label: value, value }
               : filteredOptions[0];
           toggleOption(selectedValue, event);
-          if (
-            !isMultiSelect &&
-            !isTextInSelectedOptions(
-              filteredOptions[0].label || selectedValue.label,
-            )
-          ) {
+          if (!isMultiSelect && !isTextInSelectedOptions(selectedValue.label)) {
             toggleIsListOpen(false);
           }
         }

--- a/@navikt/core/react/src/form/combobox/combobox.tests.stories.tsx
+++ b/@navikt/core/react/src/form/combobox/combobox.tests.stories.tsx
@@ -164,7 +164,9 @@ export const AllowNewValuesSingleSelect: StoryObject = {
     userEvent.click(input);
     await userEvent.type(input, "aaa", { delay: 200 });
     await sleep(250);
-    expect(canvas.getByRole("option", { name: "Legg til “aaa”" }));
+    expect(
+      canvas.getByRole("option", { name: "Legg til “aaa”" }),
+    ).toBeVisible();
 
     userEvent.keyboard("{ArrowDown}");
     await sleep(250);

--- a/@navikt/core/react/src/form/combobox/combobox.tests.stories.tsx
+++ b/@navikt/core/react/src/form/combobox/combobox.tests.stories.tsx
@@ -116,10 +116,11 @@ export const RemoveSelectedMultiSelect: StoryObject = {
   },
 };
 
-export const AllowNewValues: StoryObject = {
+export const AllowNewValuesMultiSelect: StoryObject = {
   render: () => {
     return (
       <UNSAFE_Combobox
+        isMultiSelect={true}
         options={options}
         label="Hva er dine favorittfrukter?"
         allowNewValues
@@ -137,11 +138,37 @@ export const AllowNewValues: StoryObject = {
 
     userEvent.keyboard("{ArrowDown}");
     await sleep(250);
+    userEvent.keyboard("{Enter}");
+    await sleep(250);
+
+    const invalidSelect = canvas.queryByLabelText("aaa slett");
+    expect(invalidSelect).toBeInTheDocument();
+  },
+};
+
+export const AllowNewValuesSingleSelect: StoryObject = {
+  render: () => {
+    return (
+      <UNSAFE_Combobox
+        options={options}
+        label="Hva er dine favorittfrukter?"
+        allowNewValues
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const input = canvas.getByLabelText("Hva er dine favorittfrukter?");
+
+    userEvent.click(input);
+    await userEvent.type(input, "aaa", { delay: 200 });
+    await sleep(250);
+    expect(canvas.getByRole("option", { name: "Legg til “aaa”" }));
+
     userEvent.keyboard("{ArrowDown}");
     await sleep(250);
     userEvent.keyboard("{Enter}");
-    await sleep(250);
-    userEvent.keyboard("{Escape}");
     await sleep(250);
 
     const invalidSelect = canvas.queryByLabelText("aaa slett");


### PR DESCRIPTION
### Description

Fixes #3047.

Previously selecting a new custom value in single-select Combobox using Enter from the Input (without arrowing down to the AddNewValues option in FilteredOptions caused a nullpointer. 

### Change summary

Prevent NullPointer when selecting a new/custom value in Combobox single-select with Enter (without selecting it in FilteredOptions)
