### PR TITLE
[aksel.nav.no] Support relative markdown links

### DIFF
--- a/aksel.nav.no/website/components/sanity-modules/intro-seksjon/markdown-link.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/intro-seksjon/markdown-link.tsx
@@ -1,31 +1,31 @@
 import React from "react";
-import { Link } from "@navikt/ds-react";
+import AkselLink from "@/web/AkselLink";
 
 /**
  * Splits a string into text and links,
  * and returns an array of React elements.
  */
-function markdownLink(x: string) {
-  const regex = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+function markdownLink(input: string) {
+  const regex = /\[([^\]]+)\]\(([^\s)]+)\)/g;
   let lastIndex = 0;
   const elements: React.ReactNode[] = [];
 
-  x.replace(regex, (match, text, url, index) => {
+  input.replace(regex, (match, text, url, index) => {
     if (index > lastIndex) {
-      elements.push(x.slice(lastIndex, index));
+      elements.push(input.slice(lastIndex, index));
     }
     elements.push(
-      <Link href={url} key={index}>
+      <AkselLink href={url} key={index}>
         {text}
-      </Link>,
+      </AkselLink>,
     );
 
     lastIndex = index + match.length;
     return match;
   });
 
-  if (lastIndex < x.length) {
-    elements.push(x.slice(lastIndex));
+  if (lastIndex < input.length) {
+    elements.push(input.slice(lastIndex));
   }
 
   return elements;

--- a/aksel.nav.no/website/components/website-modules/AkselLink.tsx
+++ b/aksel.nav.no/website/components/website-modules/AkselLink.tsx
@@ -1,66 +1,27 @@
-import cl from "clsx";
-import Link from "next/link";
+import NextLink from "next/link";
 import React from "react";
-import ErrorBoundary from "@/error-boundary";
+import { Link } from "@navikt/ds-react";
 import { amplitudeLogNavigation } from "@/logging";
 
-type AkselLinkProps = {
+type Props = {
   href: string;
   children: React.ReactNode;
-  inverted?: boolean;
-  className?: string;
 };
 
-const AkselLink = ({
-  href,
-  children,
-  inverted = false,
-  className,
-}: AkselLinkProps) => {
-  return (
-    <Link
-      href={href}
-      passHref
-      className={cl("group relative w-fit pr-5 focus:outline-none", className, {
-        "white focus-visible:bg-blue-200 focus-visible:text-text-default focus-visible:shadow-[0_0_0_3px_var(--a-blue-200)]":
-          inverted,
-        "text-deepblue-500 focus-visible:bg-blue-800 focus-visible:text-text-on-action focus-visible:shadow-[0_0_0_3px_var(--a-blue-800)] group-hover:text-deepblue-800":
-          !inverted,
-      })}
-      onClick={(e) =>
-        amplitudeLogNavigation("link", e.currentTarget.getAttribute("href"))
-      }
-    >
-      {children}
-      <svg
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-        className={cl(
-          "ml-2 h-[20px] w-[10px] scale-[0.85] transition-[width,right] group-hover:w-[16px]",
-          "absolute right-[5px] top-1/2 -translate-y-1/2 rotate-180 group-hover:right-0",
-        )}
-        aria-hidden
-      >
-        <path
-          d="M8 17.5L2.12132 11.6213C0.949744 10.4497 0.949746 8.55025 2.12132 7.37868L8 1.5"
-          stroke="currentColor"
-          strokeWidth="1.5"
-        />
-        <path
-          d="M16 9.72266L8 9.72266"
-          strokeWidth="1.5"
-          stroke="currentColor"
-          className="hidden group-hover:block"
-        />
-      </svg>
-    </Link>
-  );
-};
+const AkselLink = ({ href, children }: Props) => (
+  <Link
+    as={NextLink}
+    href={href}
+    inlineText
+    onClick={(e) =>
+      amplitudeLogNavigation("link", e.currentTarget.getAttribute("href"))
+    }
+    {...(href.startsWith("http") && !href.startsWith("https://aksel.nav.no/")
+      ? { target: "_blank", rel: "noreferrer noopener" }
+      : {})}
+  >
+    {children}
+  </Link>
+);
 
-export default function Component(props: AkselLinkProps) {
-  return (
-    <ErrorBoundary boundaryName="AkselLink">
-      <AkselLink {...props} />
-    </ErrorBoundary>
-  );
-}
+export default AkselLink;

--- a/aksel.nav.no/website/components/website-modules/SanityBlockContent.tsx
+++ b/aksel.nav.no/website/components/website-modules/SanityBlockContent.tsx
@@ -4,9 +4,8 @@ import {
   PortableTextReactComponents,
 } from "@portabletext/react";
 import cl from "clsx";
-import NextLink from "next/link";
 import { Children } from "react";
-import { BodyLong, Detail, Heading, Link } from "@navikt/ds-react";
+import { BodyLong, Detail, Heading } from "@navikt/ds-react";
 import Accordion from "@/cms/accordion/Accordion";
 import Alert from "@/cms/alert/Alert";
 import Bilde from "@/cms/bilde/Bilde";
@@ -24,10 +23,10 @@ import TastaturModul from "@/cms/tastatur-tabell/TastaturTabell";
 import Tips from "@/cms/tips/Tips";
 import TokenTable from "@/cms/token-tabell/TokenTable";
 import Video from "@/cms/video/Video";
-import { amplitudeLogNavigation } from "@/logging";
 import InlineCode from "@/web/InlineCode";
 import KBD from "@/web/KBD";
 import { List, ListItem } from "@/web/List";
+import AkselLink from "./AkselLink";
 
 const serializers: Partial<PortableTextReactComponents> = {
   types: {
@@ -102,42 +101,13 @@ const serializers: Partial<PortableTextReactComponents> = {
       if (!href) {
         return <span>{text}</span>;
       }
-
-      return (
-        <Link
-          as={NextLink}
-          href={href}
-          inlineText
-          onClick={(e) =>
-            amplitudeLogNavigation("link", e.currentTarget.getAttribute("href"))
-          }
-          {...(href.startsWith("http") &&
-          !href.startsWith("https://aksel.nav.no/")
-            ? { target: "_blank", rel: "noreferrer noopener" }
-            : {})}
-        >
-          {text}
-        </Link>
-      );
+      return <AkselLink href={href}>{text}</AkselLink>;
     },
     internalLink: ({ text, value: { slug } }) => {
       if (!slug || !slug.current) {
         return <span>{text}</span>;
       }
-
-      const href = `/${slug?.current}`;
-      return (
-        <Link
-          as={NextLink}
-          href={href}
-          inlineText
-          onClick={(e) =>
-            amplitudeLogNavigation("link", e.currentTarget.getAttribute("href"))
-          }
-        >
-          {text}
-        </Link>
-      );
+      return <AkselLink href={`/${slug.current}`}>{text}</AkselLink>;
     },
   },
   unknownMark: () => null,


### PR DESCRIPTION
Refactored `markdownLink` so that it uses `next/link` and calls `amplitudeLogNavigation()`. Also made the regex less strict so that it accepts relative URLs. Created a separate component for the link itself, and reused it in `SanityBlockContent`.