### PR TITLE
Combobox: Entering an already selected option and pressing enter no longer removes it

### DIFF
--- a/.changeset/nice-ligers-breathe.md
+++ b/.changeset/nice-ligers-breathe.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-Combobox: Entering an already selected option and pressing enter removes it even if shouldAutocomplete is true
+Combobox: Entering an already selected option and pressing enter no longer removes it

--- a/.changeset/nice-ligers-breathe.md
+++ b/.changeset/nice-ligers-breathe.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Combobox: Entering an already selected option and pressing enter removes it even if shouldAutocomplete is true

--- a/@navikt/core/react/src/form/combobox/Input/Input.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.tsx
@@ -56,10 +56,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           if (!isMultiSelect && !isTextInSelectedOptions(currentOption.label)) {
             toggleIsListOpen(false);
           }
-        } else if (shouldAutocomplete && isTextInSelectedOptions(value)) {
-          event.preventDefault();
-          // Trying to set the same value that is already set, so just clearing the input
-          clearInput(event);
         } else if ((allowNewValues || shouldAutocomplete) && value !== "") {
           event.preventDefault();
           // Autocompleting or adding a new value
@@ -80,7 +76,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       },
       [
         allowNewValues,
-        clearInput,
         currentOption,
         filteredOptions,
         isMultiSelect,

--- a/@navikt/core/react/src/form/combobox/Input/Input.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.tsx
@@ -56,6 +56,10 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           if (!isMultiSelect && !isTextInSelectedOptions(currentOption.label)) {
             toggleIsListOpen(false);
           }
+        } else if (isTextInSelectedOptions(value)) {
+          event.preventDefault();
+          // Trying to set the same value that is already set, so just clearing the input
+          clearInput(event);
         } else if ((allowNewValues || shouldAutocomplete) && value !== "") {
           event.preventDefault();
           // Autocompleting or adding a new value
@@ -76,6 +80,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       },
       [
         allowNewValues,
+        clearInput,
         currentOption,
         filteredOptions,
         isMultiSelect,


### PR DESCRIPTION
Currently, if `allowNewValues` and `shouldAutocomplete` is true, entering an already selected value and pressing enter does not remove it. However, it's removed if `shouldAutocomplete` is false. This seemed inconsistent, so this PR changes it so that only the input is cleared.