### PR TITLE
Hide sandbox-pages from robots 🤖 

### DIFF
--- a/aksel.nav.no/website/public/robots.txt
+++ b/aksel.nav.no/website/public/robots.txt
@@ -18,6 +18,7 @@ Disallow: /*.js$
 
 Disallow: /eksempler
 Disallow: /templates
+Disallow: /sandbox
 Disallow: /admin
 Disallow: /gp
 


### PR DESCRIPTION
### Description

Stops 3rd-party pages from indexing /sandbox. This is mostly relevant for stopping siteimprove from including these pages.
