### PR TITLE
Bump jscodeshift-add-imports

### DIFF
--- a/.changeset/nasty-rockets-pump.md
+++ b/.changeset/nasty-rockets-pump.md
@@ -1,0 +1,5 @@
+---
+"@navikt/aksel": patch
+---
+
+bump jscodeshift-add-imports to 1.0.11

--- a/.changeset/nasty-rockets-pump.md
+++ b/.changeset/nasty-rockets-pump.md
@@ -2,4 +2,4 @@
 "@navikt/aksel": patch
 ---
 
-bump jscodeshift-add-imports to 1.0.11
+Aksel-CLI: Bump jscodeshift-add-imports to 1.0.11.

--- a/@navikt/aksel/package.json
+++ b/@navikt/aksel/package.json
@@ -39,7 +39,7 @@
     "figlet": "1.6.0",
     "is-git-clean": "1.1.0",
     "jscodeshift": "^0.15.1",
-    "jscodeshift-add-imports": "1.0.10",
+    "jscodeshift-add-imports": "1.0.11",
     "lodash": "4.17.21",
     "react-scanner": "^1.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,7 +3543,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@npm:^6.15.0, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
+"@navikt/aksel-icons@npm:^6.16.0, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-icons@workspace:@navikt/aksel-icons"
   dependencies:
@@ -3572,8 +3572,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-stylelint@workspace:@navikt/aksel-stylelint"
   dependencies:
-    "@navikt/ds-css": "npm:^6.15.0"
-    "@navikt/ds-tokens": "npm:^6.15.0"
+    "@navikt/ds-css": "npm:^6.16.0"
+    "@navikt/ds-tokens": "npm:^6.16.0"
     concurrently: "npm:7.2.1"
     postcss-selector-parser: "npm:^6.0.13"
     postcss-value-parser: "npm:^4.2.0"
@@ -3588,7 +3588,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel@workspace:@navikt/aksel"
   dependencies:
-    "@navikt/ds-css": "npm:6.15.0"
+    "@navikt/ds-css": "npm:6.16.0"
     axios: "npm:1.6.0"
     chalk: "npm:4.1.0"
     clipboardy: "npm:^2.3.0"
@@ -3598,7 +3598,7 @@ __metadata:
     figlet: "npm:1.6.0"
     is-git-clean: "npm:1.1.0"
     jscodeshift: "npm:^0.15.1"
-    jscodeshift-add-imports: "npm:1.0.10"
+    jscodeshift-add-imports: "npm:1.0.11"
     lodash: "npm:4.17.21"
     react-scanner: "npm:^1.1.0"
     rimraf: "npm:6.0.1"
@@ -3609,11 +3609,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@npm:*, @navikt/ds-css@npm:6.15.0, @navikt/ds-css@npm:^6.15.0, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@npm:*, @navikt/ds-css@npm:6.16.0, @navikt/ds-css@npm:^6.16.0, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": "npm:^6.15.0"
+    "@navikt/ds-tokens": "npm:^6.16.0"
     cssnano: "npm:6.0.0"
     fast-glob: "npm:3.2.11"
     lodash: "npm:4.17.21"
@@ -3626,14 +3626,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@npm:*, @navikt/ds-react@npm:^6.15.0, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@npm:*, @navikt/ds-react@npm:^6.16.0, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": "npm:0.25.4"
     "@floating-ui/react-dom": "npm:^2.0.9"
-    "@navikt/aksel-icons": "npm:^6.15.0"
-    "@navikt/ds-tokens": "npm:^6.15.0"
+    "@navikt/aksel-icons": "npm:^6.16.0"
+    "@navikt/ds-tokens": "npm:^6.16.0"
     "@testing-library/dom": "npm:9.3.4"
     "@testing-library/jest-dom": "npm:^5.16.0"
     "@testing-library/react": "npm:^15.0.7"
@@ -3663,11 +3663,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@npm:^6.15.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@npm:^6.16.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": "npm:^6.15.0"
+    "@navikt/ds-tokens": "npm:^6.16.0"
     color: "npm:4.2.3"
     lodash: "npm:^4.17.21"
     tailwindcss: "npm:^3.3.3"
@@ -3677,7 +3677,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@npm:^6.15.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@npm:^6.16.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -7654,11 +7654,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/aksel-icons": "npm:^6.15.0"
-    "@navikt/ds-css": "npm:^6.15.0"
-    "@navikt/ds-react": "npm:^6.15.0"
-    "@navikt/ds-tailwind": "npm:^6.15.0"
-    "@navikt/ds-tokens": "npm:^6.15.0"
+    "@navikt/aksel-icons": "npm:^6.16.0"
+    "@navikt/ds-css": "npm:^6.16.0"
+    "@navikt/ds-react": "npm:^6.16.0"
+    "@navikt/ds-tailwind": "npm:^6.16.0"
+    "@navikt/ds-tokens": "npm:^6.16.0"
   languageName: unknown
   linkType: soft
 
@@ -16111,15 +16111,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jscodeshift-add-imports@npm:1.0.10":
-  version: 1.0.10
-  resolution: "jscodeshift-add-imports@npm:1.0.10"
+"jscodeshift-add-imports@npm:1.0.11":
+  version: 1.0.11
+  resolution: "jscodeshift-add-imports@npm:1.0.11"
   dependencies:
     "@babel/traverse": "npm:^7.4.5"
     jscodeshift-find-imports: "npm:^2.0.2"
   peerDependencies:
-    jscodeshift: ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0
-  checksum: 10/da502e351e8b541f62e6cc6a8b953b153fe8ad2055bbf875ff238b204f6b48a1701bdf6e8e9536bbfc7e699f52f1af539cdb0dbdd899e0608a7fdf8e3c66bbee
+    jscodeshift: ">=0.7 <1"
+  checksum: 10/c50ce72c722b24fa4535ed7bca6f2b17b5ecaa4fa579f1411bdf6cf05b6d2f2c1f1de3d7e35bc1d4d03ae09228afc3dac64fac87b39044c814c6438513d00123
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Bump jscodeshift-add-imports to 1.0.11 to mitigate vulnerabilities (e.g. https://github.com/navikt/aksel/security/dependabot/159) 

### Change summary

Bump jscodeshift-add-imports to 1.0.11