### PR TITLE
:adhesive_bandage: Combobox: placeholder fix

### DIFF
--- a/.changeset/friendly-pens-sin.md
+++ b/.changeset/friendly-pens-sin.md
@@ -3,4 +3,4 @@
 "@navikt/aksel": patch
 ---
 
-:adhesive_bandage: Placeholder goes away when value added
+:adhesive_bandage: Combobox: Placeholder goes away when an option is selected

--- a/.changeset/friendly-pens-sin.md
+++ b/.changeset/friendly-pens-sin.md
@@ -1,6 +1,5 @@
 ---
 "@navikt/ds-react": patch
-"@navikt/aksel": patch
 ---
 
 :adhesive_bandage: Combobox: Placeholder goes away when an option is selected

--- a/.changeset/friendly-pens-sin.md
+++ b/.changeset/friendly-pens-sin.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/aksel": patch
+---
+
+:adhesive_bandage: Placeholder goes away when value added

--- a/@navikt/core/react/src/form/combobox/Input/Input.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.tsx
@@ -230,6 +230,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         aria-activedescendant={activeDecendantId}
         aria-describedby={ariaDescribedBy}
         aria-invalid={inputProps["aria-invalid"]}
+        placeholder={selectedOptions.length ? undefined : rest.placeholder}
         className={cl(
           inputClassName,
           "navds-combobox__input",

--- a/@navikt/core/react/src/form/combobox/Input/InputController.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/InputController.tsx
@@ -34,6 +34,7 @@ export const InputController = forwardRef<
     toggleListButtonLabel,
     inputClassName,
     shouldShowSelectedOptions = true,
+    placeholder,
     ...rest
   } = props;
 
@@ -65,6 +66,7 @@ export const InputController = forwardRef<
           id={inputProps.id}
           ref={mergedInputRef}
           inputClassName={inputClassName}
+          placeholder={selectedOptions.length ? "" : placeholder}
           {...rest}
         />
       ) : (
@@ -74,6 +76,7 @@ export const InputController = forwardRef<
             ref={mergedInputRef}
             inputClassName={inputClassName}
             shouldShowSelectedOptions={shouldShowSelectedOptions}
+            placeholder={selectedOptions.length ? "" : placeholder}
             {...rest}
           />
         </SelectedOptions>

--- a/@navikt/core/react/src/form/combobox/Input/InputController.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/InputController.tsx
@@ -34,7 +34,6 @@ export const InputController = forwardRef<
     toggleListButtonLabel,
     inputClassName,
     shouldShowSelectedOptions = true,
-    placeholder,
     ...rest
   } = props;
 
@@ -66,7 +65,6 @@ export const InputController = forwardRef<
           id={inputProps.id}
           ref={mergedInputRef}
           inputClassName={inputClassName}
-          placeholder={selectedOptions.length ? "" : placeholder}
           {...rest}
         />
       ) : (
@@ -76,7 +74,6 @@ export const InputController = forwardRef<
             ref={mergedInputRef}
             inputClassName={inputClassName}
             shouldShowSelectedOptions={shouldShowSelectedOptions}
-            placeholder={selectedOptions.length ? "" : placeholder}
             {...rest}
           />
         </SelectedOptions>

--- a/@navikt/core/react/src/form/combobox/combobox.stories.tsx
+++ b/@navikt/core/react/src/form/combobox/combobox.stories.tsx
@@ -35,7 +35,11 @@ const options = [
 ];
 
 export const Default: StoryFunction = (props) => (
-  <UNSAFE_Combobox {...props} id="combobox" />
+  <UNSAFE_Combobox
+    {...props}
+    maxSelected={{ limit: Number(props.maxSelected) }}
+    id="combobox"
+  />
 );
 
 Default.args = {

--- a/@navikt/core/react/src/form/combobox/combobox.stories.tsx
+++ b/@navikt/core/react/src/form/combobox/combobox.stories.tsx
@@ -51,6 +51,9 @@ Default.argTypes = {
   description: {
     control: { type: "text" },
   },
+  placeholder: {
+    control: { type: "text" },
+  },
   disabled: {
     control: { type: "boolean" },
   },


### PR DESCRIPTION
### Description

Original issue afaik: https://nav-it.slack.com/archives/C7NE7A8UF/p1714377788972099

With this fix, the placeholder of the Combobox input-element is no longer visible if the user has added a value to selectedOptions (i.e. picked a value from the dropdown or added a custom value). This took a while because of internal discussions of the placeholder prop in Combobox. 
