### PR TITLE
:bug: Combobox: trailing spaces are no longer accepted autocomplete-letters

### DIFF
--- a/.changeset/nasty-jeans-invent.md
+++ b/.changeset/nasty-jeans-invent.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+:bug: Combobox: trailing spaces no longer work like wildcards for autocomplete suggestions

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/filtered-options-util.ts
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/filtered-options-util.ts
@@ -10,9 +10,10 @@ const getMatchingValuesFromList = (value: string, list: ComboboxOption[]) =>
   list.filter((listItem) => isPartOfText(value, listItem.label));
 
 const getFirstValueStartingWith = (text: string, list: ComboboxOption[]) => {
-  const normalizedText = normalizeText(text);
+  const lowercasedText =
+    typeof text === "string" ? text.toLocaleLowerCase() : "";
   return list.find((listItem) =>
-    normalizeText(listItem.label).startsWith(normalizedText),
+    normalizeText(listItem.label).startsWith(lowercasedText),
   );
 };
 

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/filtered-options-util.ts
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/filtered-options-util.ts
@@ -10,10 +10,8 @@ const getMatchingValuesFromList = (value: string, list: ComboboxOption[]) =>
   list.filter((listItem) => isPartOfText(value, listItem.label));
 
 const getFirstValueStartingWith = (text: string, list: ComboboxOption[]) => {
-  const lowercasedText =
-    typeof text === "string" ? text.toLocaleLowerCase() : "";
   return list.find((listItem) =>
-    normalizeText(listItem.label).startsWith(lowercasedText),
+    normalizeText(listItem.label).startsWith(text.toLocaleLowerCase()),
   );
 };
 

--- a/@navikt/core/react/src/form/combobox/combobox.stories.tsx
+++ b/@navikt/core/react/src/form/combobox/combobox.stories.tsx
@@ -27,11 +27,13 @@ const options = [
   "grape",
   "kiwi",
   "mango",
+  "mangosteen",
+  "mango pie",
   "passion fruit",
   "pineapple",
   "strawberry",
   "watermelon",
-  "grape fruit",
+  "grapefruit",
 ];
 
 export const Default: StoryFunction = (props) => (


### PR DESCRIPTION
### Description

Found this bug a while ago. The bug: After triggering autocomplete, adding a trailing space will continue the suggestion. For example, writing "ap  " (with two trailing spaces) will be interpreted as having written "appl", given that the first autocomplete suggestion is "apple". Spaces almost function as a wildcard. A letter after the space(s) stops the behaviour. 

This fix: trailing spaces no longer work as wildcards in autocomplete. They still work as spaces for multiple words. 

---

Discussion:
With this fix, writing spaces still don't filter out items in the dropdown (like writing a letter will). So adding a space after a word won't remove all results that don't include that space. This might be convenient in some cases, but it also allows for confusing edge cases like this:

![Screenshot 2024-08-15 at 11 35 59](https://github.com/user-attachments/assets/e4812235-0646-4e25-a452-1a61a73de180)

Here, the third (instead of the first) option in the dropdown is the autocomplete suggestion. Is the fact that the autocomplete result is not always on top more confusing than it is convenient? If so, I will make space like letters
