### PR TITLE
[sanity] More heading-options for ExpansionCard in sanity

### DIFF
--- a/aksel.nav.no/website/components/sanity-modules/expansioncard/ExpansionCard.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/expansioncard/ExpansionCard.tsx
@@ -5,7 +5,7 @@ import { SanityBlockContent } from "@/sanity-block";
 type ExpansionCardProps = {
   node: {
     heading: string;
-    heading_level: "h3" | "h4";
+    heading_level: "h2" | "h3" | "h4";
     description?: string;
     body: any[];
   };
@@ -16,6 +16,12 @@ const ExpansionCard = ({ node }: ExpansionCardProps) => {
     return null;
   }
 
+  const cardSize = {
+    h2: "large",
+    h3: "medium",
+    h4: "small",
+  } as const;
+
   return (
     <DsExpansionCard
       id="aksel-expansioncard"
@@ -25,7 +31,8 @@ const ExpansionCard = ({ node }: ExpansionCardProps) => {
       <DsExpansionCard.Header>
         <DsExpansionCard.Title
           as={node.heading_level}
-          size={node.heading_level === "h3" ? "medium" : "small"}
+          size={cardSize[node.heading_level]}
+          className="text-aksel-heading"
         >
           {node.heading}
         </DsExpansionCard.Title>

--- a/aksel.nav.no/website/sanity/schema/objects/shared/expansion-card.tsx
+++ b/aksel.nav.no/website/sanity/schema/objects/shared/expansion-card.tsx
@@ -5,7 +5,7 @@ export type ExpansionCardT = {
   _key: string;
   _type: "expansioncard";
   heading: string;
-  heading_level: "h3" | "h4";
+  heading_level: "h2" | "h3" | "h4";
   description?: string;
   body: any[];
 };
@@ -33,6 +33,7 @@ export const ExpansionCard = defineType({
       validation: (Rule) => Rule.required(),
       options: {
         list: [
+          { value: "h2", title: "H2" },
           { value: "h3", title: "H3" },
           { value: "h4", title: "H4" },
         ],


### PR DESCRIPTION
### Description

Headings can now be H2 
- Update heading text-color to match rest of page
- Added size large for heading to match other `h2` on page
