### PR TITLE
Tailwind: Fixed 'screen' -> 'screens' bug to properly adopt breakpoints.

### DIFF
--- a/.changeset/stupid-pianos-end.md
+++ b/.changeset/stupid-pianos-end.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-tailwind": major
+---
+
+Tailwind: Extended 'screens'-config in theme to match Aksel breakpoints. Tailwind and Primitives can now be used side by side with matching dynamic breakpoints. See migration for potential issues when adopting. TODO: Add link

--- a/@navikt/core/tailwind/src/index.ts
+++ b/@navikt/core/tailwind/src/index.ts
@@ -18,7 +18,7 @@ const tokens = Object.entries(TokensBuild).reduce((old, [key, val]) => {
 const config = {
   theme: {
     colors: getColors(tokens),
-    screen: getBreakpoints(tokens),
+    screens: getBreakpoints(tokens),
     extend: {
       spacing: Reducer(tokens, ["spacing"]),
       zIndex: Reducer(tokens, ["z-index"]),

--- a/aksel.nav.no/website/components/layout/templates/WithSidebar.tsx
+++ b/aksel.nav.no/website/components/layout/templates/WithSidebar.tsx
@@ -109,7 +109,7 @@ export const WithSidebar = ({
               </div>
             )}
             {variant === "landingPage" && (
-              <div className="pointer-events-none absolute right-0 top-0 hidden sm:block">
+              <div className="pointer-events-none absolute right-0 top-0 hidden md:block">
                 <HeaderCube />
               </div>
             )}

--- a/aksel.nav.no/website/pages/komponenter/index.tsx
+++ b/aksel.nav.no/website/pages/komponenter/index.tsx
@@ -109,7 +109,7 @@ const Page = ({ page, sidebar, links }: PageProps["props"]) => {
               href: `https://github.com/navikt/aksel/issues/new?labels=forespørsel+🥰%2Ckomponenter+🧩&template=update-component.yml&title=%5BInnspill+til+komponent%5D%3A+`,
             },
           ]}
-          className="grid-cols-1 pb-8 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
+          className="grid-cols-1 pb-8 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3"
           variant="komponentside"
         />
         {komponentKategorier

--- a/aksel.nav.no/website/tailwind.config.js
+++ b/aksel.nav.no/website/tailwind.config.js
@@ -12,9 +12,6 @@ module.exports = {
       active: 'active~="true"',
     },
     extend: {
-      screens: {
-        "2xl": "1440px",
-      },
       colors: {
         "aksel-heading": "var(--a-deepblue-800)",
         pink: {


### PR DESCRIPTION
### Description

Someone (me) can't type properly and as a consequence our tailwind-config did not properly adopt the 'screens' config for breakpoints added 1+ year ago.  

- https://tailwindcss.com/docs/screens


## Why is this a breaking change?

```
// Native Tailwind config
'sm': '640px',
'md': '768px',
'lg': '1024px',
'xl': '1280px',
'2xl': '1536px',
```

Every project using tailwind will have used these values for their breakpoints before. By changing to our breakpoints with this change, `sm` will now be `480px` and `2xl` will be `1440px`. 
- Few if any will be affected by the `2xl` change since one seldom use that breakpoint
- Quite a few will most likely be affected by the `sm`-change. In most cases this will not actually require a code update on their side, but will need each project to check that everything still looks as it should. Worst case scenario might be elements not wrapping properly 🤔 The change itself is only a 160px difference, so the possibility for **actual** breaking changes are few.

Nice thing about the update is that each project can override this themselves by just adding two lines of code in their config. This allows them to update to next major without actually using this update. Since each project using tailwind already have a config, this will be quite easy to adopt.
```
extend: {
      screens: {
        'sm': '640px',
        '2xl': '1536px',
      },
    }
```
