### PR TITLE
combobox :children_crossing: tweaks for single select

### DIFF
--- a/.changeset/fast-beans-repeat.md
+++ b/.changeset/fast-beans-repeat.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Combobox :children_crossing: single select now hides selected value when typing, onBlur clears input

--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -99,6 +99,7 @@
   border: none;
   padding: 0;
   margin: 0;
+  margin-left: var(--a-spacing-1);
   min-width: 10ch;
   width: 100%;
   height: var(--__ac-combobox-input-height);

--- a/@navikt/core/react/src/form/combobox/ComboboxWrapper.tsx
+++ b/@navikt/core/react/src/form/combobox/ComboboxWrapper.tsx
@@ -21,7 +21,7 @@ const ComboboxWrapper = ({
   inputSize,
   toggleIsListOpen,
 }: ComboboxWrapperProps) => {
-  const { toggleOpenButtonRef } = useInputContext();
+  const { toggleOpenButtonRef, setValue } = useInputContext();
 
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const [hasFocusWithin, setHasFocusWithin] = useState(false);
@@ -40,6 +40,7 @@ const ComboboxWrapper = ({
     if (!wrapperRef.current?.contains(e.relatedTarget)) {
       toggleIsListOpen(false);
       setHasFocusWithin(false);
+      setValue("");
     }
   }
 

--- a/@navikt/core/react/src/form/combobox/ComboboxWrapper.tsx
+++ b/@navikt/core/react/src/form/combobox/ComboboxWrapper.tsx
@@ -21,7 +21,7 @@ const ComboboxWrapper = ({
   inputSize,
   toggleIsListOpen,
 }: ComboboxWrapperProps) => {
-  const { toggleOpenButtonRef, setValue } = useInputContext();
+  const { toggleOpenButtonRef, clearInput } = useInputContext();
 
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const [hasFocusWithin, setHasFocusWithin] = useState(false);
@@ -40,7 +40,7 @@ const ComboboxWrapper = ({
     if (!wrapperRef.current?.contains(e.relatedTarget)) {
       toggleIsListOpen(false);
       setHasFocusWithin(false);
-      setValue("");
+      clearInput(e);
     }
   }
 

--- a/@navikt/core/react/src/form/combobox/SelectedOptions/SelectedOptions.tsx
+++ b/@navikt/core/react/src/form/combobox/SelectedOptions/SelectedOptions.tsx
@@ -36,9 +36,11 @@ const SelectedOptions: React.FC<SelectedOptionsProps> = ({
   size,
   children,
 }) => {
+  const { value } = useInputContext();
+  const { isMultiSelect } = useSelectedOptionsContext();
   return (
     <Chips className="navds-combobox__selected-options" size={size}>
-      {selectedOptions.length
+      {value.length === 0 || (isMultiSelect && selectedOptions.length)
         ? selectedOptions.map((option, i) => (
             <Option key={option.label + i} option={option} />
           ))


### PR DESCRIPTION
### Description

Closes https://github.com/navikt/team-aksel/issues/577
This + https://github.com/navikt/aksel/pull/3071 Closes https://github.com/navikt/aksel/issues/2891

### Change summary

- hide the selected value when inputing text
- delete input value on blur (you must actually select something with intent to select it, this prevents the field from "looking like it's filled in when it's actually not")

#### Versioning 🏷️

- Run `yarn changeset` to generate a version-entry for change.
- - Bug/hotfix: Patch
