### PR TITLE
:lock: Moved chromatic token to .env and github secrets

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           autoAcceptChanges: "main"
           token: ${{ secrets.GITHUB_TOKEN }}
-          projectToken: chpt_1dc4af6a1c8cc48
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitZeroOnChanges: false
           buildScriptName: "build:storybook-chromatic"
           onlyChanged: true

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "docgen": "yarn workspaces foreach -vv -pA run docgen",
     "changelog": "deno run --allow-read --allow-write --no-config scripts/changelog/createMainChangelog.ts",
     "updateArticleViews": "deno run --allow-net --allow-env --allow-read --no-config scripts/article-views/update-article-views/main.ts",
-    "chromatic": "npx chromatic --only-changed --project-token chpt_1dc4af6a1c8cc48 --build-script-name build:storybook-chromatic",
+    "chromatic": "npx chromatic --only-changed --build-script-name build:storybook-chromatic",
     "build:storybook-chromatic": "cross-env CHROMATIC=true storybook build",
     "build:storybook": "storybook build",
     "test": "yarn workspaces foreach -vv -pA run test",


### PR DESCRIPTION
### Description

[Slack](https://nav-it.slack.com/archives/C7NE7A8UF/p1725862934240899)

How to use Chromatic locally with `yarn chromatic` now:
- Create a new token in `.env` on root `CHROMATIC_PROJECT_TOKEN`
- Fetch key from console.cloud.google.com -> secret manager -> "CHROMATIC_PROJECT_TOKEN" (under designsystem-dev project)
