### PR TITLE
LanguageProvider: Remove spreading of empty object

### DIFF
--- a/@navikt/core/react/src/provider/i18n/LanguageProvider.tsx
+++ b/@navikt/core/react/src/provider/i18n/LanguageProvider.tsx
@@ -34,13 +34,11 @@ export const useProvider = () => useContext(LanguageProviderContext);
 export const UNSAFE_AkselLanguageProvider = ({
   children,
   translations,
-  ...rest
 }: LanguageProviderProps) => {
   return (
     <LanguageProviderContext.Provider
       value={{
         translations: translations ?? nb,
-        ...rest,
       }}
     >
       {children}


### PR DESCRIPTION
### Description

Component only accepts `children` and `translations`, so `...rest` will always be empty.

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
