### PR TITLE
Bugfix/combobox list items with multiple spaces get invalid

### DIFF
--- a/.changeset/shiny-news-eat.md
+++ b/.changeset/shiny-news-eat.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Combobox: Fix issue with whitespace in the ID of options with multiple spaces

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/filtered-options-util.test.ts
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/filtered-options-util.test.ts
@@ -1,0 +1,18 @@
+import { describe } from "vitest";
+import filteredOptionsUtil from "./filtered-options-util";
+
+describe("filtered options util", () => {
+  describe("getOptionId", () => {
+    it("should return the correct id", () => {
+      expect(filteredOptionsUtil.getOptionId("combobox", "option")).toBe(
+        "combobox-option-option",
+      );
+    });
+
+    it("should return the correct id with spaces", () => {
+      expect(
+        filteredOptionsUtil.getOptionId("combobox", "option with spaces"),
+      ).toBe("combobox-option-option-with-spaces");
+    });
+  });
+});

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/filtered-options-util.ts
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/filtered-options-util.ts
@@ -19,9 +19,7 @@ const getFilteredOptionsId = (comboboxId: string) =>
   `${comboboxId}-filtered-options`;
 
 const getOptionId = (comboboxId: string, option: string) =>
-  `${comboboxId.toLocaleLowerCase()}-option-${option
-    .replace(" ", "-")
-    .toLocaleLowerCase()}`;
+  `${comboboxId}-option-${option}`.replace(/\s/g, "-").toLocaleLowerCase();
 
 const getAddNewOptionId = (comboboxId: string) =>
   `${comboboxId}-combobox-new-option`;


### PR DESCRIPTION
### Description

Combobox: Fix issue where list items for options with multiple spaces get invalid IDs (including whitespace)