### PR TITLE
Check code examples with axe

### DIFF
--- a/.changeset/popular-meals-lay.md
+++ b/.changeset/popular-meals-lay.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+Pagination: :lipstick: Updated font-weight to 600 and marked 'page'-prop on 'Item' as deprecated.

--- a/.changeset/thirty-snakes-doubt.md
+++ b/.changeset/thirty-snakes-doubt.md
@@ -1,0 +1,5 @@
+---
+"@navikt/aksel-stylelint": minor
+---
+
+Pagination: Added some classes to list of deprecated (removed) classes.

--- a/.changeset/thirty-snakes-doubt.md
+++ b/.changeset/thirty-snakes-doubt.md
@@ -2,4 +2,4 @@
 "@navikt/aksel-stylelint": minor
 ---
 
-Pagination: Added some classes to list of deprecated (removed) classes.
+Pagination: :boom: Added some classes to list of deprecated (removed) classes.

--- a/@navikt/aksel-stylelint/src/deprecations.ts
+++ b/@navikt/aksel-stylelint/src/deprecations.ts
@@ -66,6 +66,6 @@ export const deprecations: DeprecatedList = [
       "navds-pagination__next-text",
       "navds-pagination__prev-text",
     ],
-    message: "Removed in v7.1.0. These classes had not effect and were removed",
+    message: "These classes had no effect and were removed in v7.1.0",
   },
 ];

--- a/@navikt/aksel-stylelint/src/deprecations.ts
+++ b/@navikt/aksel-stylelint/src/deprecations.ts
@@ -60,4 +60,12 @@ export const deprecations: DeprecatedList = [
     classes: ["navds-textarea__wrapper"],
     message: "Removed in v6.0.0",
   },
+  {
+    classes: [
+      "navds-pagination__prev-next-icon",
+      "navds-pagination__next-text",
+      "navds-pagination__prev-text",
+    ],
+    message: "Removed in v7.1.0. These classes had not effect and were removed",
+  },
 ];

--- a/@navikt/core/react/src/pagination/Pagination.tsx
+++ b/@navikt/core/react/src/pagination/Pagination.tsx
@@ -189,21 +189,13 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
               size={size}
               icon={
                 <ChevronLeftIcon
-                  className="navds-pagination__prev-next-icon"
                   {...(prevNextTexts
                     ? { "aria-hidden": true }
                     : { title: "Forrige" })}
                 />
               }
             >
-              {prevNextTexts && (
-                <BodyShort
-                  size={size === "xsmall" ? "small" : size}
-                  className="navds-pagination__prev-text"
-                >
-                  Forrige
-                </BodyShort>
-              )}
+              {prevNextTexts && `Forrige`}
             </Item>
           </li>
           {getSteps({ page, count, siblingCount, boundaryCount }).map(
@@ -211,7 +203,10 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
               const n = Number(step);
               return Number.isNaN(n) ? (
                 <li className="navds-pagination__ellipsis" key={`${step}${i}`}>
-                  <BodyShort size={size === "xsmall" ? "small" : size}>
+                  <BodyShort
+                    size={size === "xsmall" ? "small" : size}
+                    as="span"
+                  >
                     ...
                   </BodyShort>
                 </li>
@@ -223,9 +218,7 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
                     page={n}
                     size={size}
                   >
-                    <BodyShort size={size === "xsmall" ? "small" : size}>
-                      {n}
-                    </BodyShort>
+                    {n}
                   </Item>
                 </li>
               );
@@ -243,7 +236,6 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
               size={size}
               icon={
                 <ChevronRightIcon
-                  className="navds-pagination__prev-next-icon"
                   {...(prevNextTexts
                     ? { "aria-hidden": true }
                     : { title: "Neste" })}
@@ -251,14 +243,7 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
               }
               iconPosition="right"
             >
-              {prevNextTexts && (
-                <BodyShort
-                  size={size === "xsmall" ? "small" : size}
-                  className="navds-pagination__next-text"
-                >
-                  Neste
-                </BodyShort>
-              )}
+              {prevNextTexts && `Neste`}
             </Item>
           </li>
         </ul>

--- a/@navikt/core/react/src/pagination/PaginationItem.tsx
+++ b/@navikt/core/react/src/pagination/PaginationItem.tsx
@@ -11,9 +11,9 @@ export interface PaginationItemProps extends ButtonProps {
    */
   selected?: boolean;
   /**
-   * The page the item represents
+   * @deprecated Use `data-page` instead if you need to access the items page number
    */
-  page: number;
+  page?: number;
   /**
    * Changes padding, height and font-size
    * @default "medium"
@@ -48,7 +48,7 @@ export const Item: PaginationItemType = forwardRef(
           "navds-pagination__item--selected": selected,
         })}
         data-page={page}
-        /* TODO: Breaking change to remove. Add to future major version. */
+        /* TODO: Breaking change to remove since it's in use by some applications. Add to future major version. */
         page={page}
         {...(Component === "button" && { type: "button" })}
         {...rest}

--- a/@navikt/core/react/src/pagination/PaginationItem.tsx
+++ b/@navikt/core/react/src/pagination/PaginationItem.tsx
@@ -11,7 +11,8 @@ export interface PaginationItemProps extends ButtonProps {
    */
   selected?: boolean;
   /**
-   * @deprecated Use `data-page` instead if you need to access the items page number
+   * Currently only sets `data-page` attribute.
+   * @deprecated Use `data-page` instead if you need to access the items page number in the future.
    */
   page?: number;
   /**

--- a/aksel.nav.no/website/components/website-modules/examples/withDsExample.tsx
+++ b/aksel.nav.no/website/components/website-modules/examples/withDsExample.tsx
@@ -8,6 +8,7 @@ import {
   TabletIcon,
 } from "@navikt/aksel-icons";
 import { HStack } from "@navikt/ds-react";
+import { SEO } from "../seo/SEO";
 import styles from "./examples.module.css";
 
 type withDsT = {
@@ -75,23 +76,26 @@ export const withDsExample = (
     };
 
     return (
-      <div
-        className={cl(styles.container, {
-          [styles.containerDefault]: !variant,
-          [styles.containerStatic]: variant === "static",
-          [styles.containerFull]: variant === "full",
-          [styles.containerStaticFull]: variant === "static-full",
-        })}
-        style={{ background: getBg(background) }}
-      >
-        {showBreakpoints && <BreakpointText />}
-        <div
-          id="ds-example"
-          className={variant === "static" ? styles.exampleStatic : undefined}
+      <>
+        <SEO title="Kodeeksempel" />
+        <main
+          className={cl(styles.container, {
+            [styles.containerDefault]: !variant,
+            [styles.containerStatic]: variant === "static",
+            [styles.containerFull]: variant === "full",
+            [styles.containerStaticFull]: variant === "static-full",
+          })}
+          style={{ background: getBg(background) }}
         >
-          <Component {...props} />
-        </div>
-      </div>
+          {showBreakpoints && <BreakpointText />}
+          <div
+            id="ds-example"
+            className={variant === "static" ? styles.exampleStatic : undefined}
+          >
+            <Component {...props} />
+          </div>
+        </main>
+      </>
     );
   };
 

--- a/aksel.nav.no/website/e2e/axe.e2e.ts
+++ b/aksel.nav.no/website/e2e/axe.e2e.ts
@@ -1,13 +1,40 @@
 import AxeBuilder from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
-import urls from "./sitemap-urls.json";
+import { getDirectories } from "../scripts/update-examples/parts/get-directories";
+import { getFiles } from "../scripts/update-examples/parts/get-files";
+
+//import urls from "./sitemap-urls.json";
+
+const examples = getDirectories("eksempler");
 
 test.describe("Axe a11y", () => {
-  for (const url of urls) {
+  for (const example of examples) {
+    const testFiles = getFiles(example.path, "eksempler");
+
+    for (const testFile of testFiles.files) {
+      const url = `/eksempler/${example.path}/${testFile.replace(".tsx", "")}`;
+
+      test(`Check page ${url}`, async ({ page }) => {
+        await page.goto(`http://localhost:3000${url}`);
+        //await page.waitForLoadState("domcontentloaded");
+        const a11yScanResults = await new AxeBuilder({
+          page,
+        })
+          .disableRules(["page-has-heading-one"])
+          .analyze();
+        expect(a11yScanResults.violations).toEqual([]);
+      });
+    }
+  }
+
+  // TODO: Ser ikke ut som axe plukker opp page-attributtet på button i Pagination...
+  // TODO: Templates
+
+  /* for (const url of urls) {
     test(`Check page ${url}`, async ({ page }) => {
       await page.goto(`http://localhost:3000${url}`);
       await page.waitForLoadState("domcontentloaded");
-      const accessibilityScanResults = await new AxeBuilder({ page })
+      const a11yScanResults = await new AxeBuilder({ page })
         .disableRules(["definition-list", "scrollable-region-focusable"])
         .exclude("iframe")
         .exclude("#aksel-expansioncard")
@@ -15,9 +42,9 @@ test.describe("Axe a11y", () => {
         .exclude("#toc-scroll")
         .exclude(".aksel-codesnippet")
         .analyze();
-      expect(accessibilityScanResults.violations).toEqual([]);
+      expect(a11yScanResults.violations).toEqual([]);
     });
-  }
+  } */
 });
 
 /*

--- a/aksel.nav.no/website/pages/eksempler/pagination/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/pagination/sizes.tsx
@@ -12,24 +12,27 @@ const Example = () => {
         count={9}
         boundaryCount={1}
         siblingCount={1}
+        aria-label="Paginering medium"
       />
 
       <Pagination
-        page={pageState}
-        onPageChange={setPageState}
-        count={9}
-        boundaryCount={1}
-        siblingCount={1}
         size="small"
-      />
-
-      <Pagination
         page={pageState}
         onPageChange={setPageState}
         count={9}
         boundaryCount={1}
         siblingCount={1}
+        aria-label="Paginering small"
+      />
+
+      <Pagination
         size="xsmall"
+        page={pageState}
+        onPageChange={setPageState}
+        count={9}
+        boundaryCount={1}
+        siblingCount={1}
+        aria-label="Paginering xsmall"
       />
     </VStack>
   );

--- a/aksel.nav.no/website/playwright.config.ts
+++ b/aksel.nav.no/website/playwright.config.ts
@@ -2,7 +2,7 @@ import type { PlaywrightTestConfig } from "@playwright/test";
 import { devices } from "@playwright/test";
 import path from "path";
 
-const smoketestMatcher = /smoketest(-\w+)?\.test\.ts/;
+//const smoketestMatcher = /smoketest(-\w+)?\.test\.ts/;
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -46,10 +46,11 @@ const config: PlaywrightTestConfig = {
         ...devices["Desktop Chrome"],
       },
       ...(process.env.FULL_TEST
-        ? { testMatch: [/.*\.e2e\.(ts|tsx)/] }
-        : { testMatch: [smoketestMatcher, /search.e2e.ts/] }),
+        ? { testMatch: [/axe\.e2e\.(ts|tsx)/] }
+        : { testMatch: [/axe.e2e.ts/] }),
     },
-    {
+    // TODO: Revert all changes to this file
+    /* {
       name: "Safari",
       use: {
         ...devices["Desktop Safari"],
@@ -62,7 +63,7 @@ const config: PlaywrightTestConfig = {
         ...devices["iPhone 12"],
       },
       testMatch: [smoketestMatcher],
-    },
+    }, */
 
     /* {
       name: "firefox",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,7 +3753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@npm:^7.0.0, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
+"@navikt/aksel-icons@npm:^7.0.1, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-icons@workspace:@navikt/aksel-icons"
   dependencies:
@@ -3782,8 +3782,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-stylelint@workspace:@navikt/aksel-stylelint"
   dependencies:
-    "@navikt/ds-css": "npm:^7.0.0"
-    "@navikt/ds-tokens": "npm:^7.0.0"
+    "@navikt/ds-css": "npm:^7.0.1"
+    "@navikt/ds-tokens": "npm:^7.0.1"
     concurrently: "npm:7.2.1"
     postcss-selector-parser: "npm:^6.0.13"
     postcss-value-parser: "npm:^4.2.0"
@@ -3798,7 +3798,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel@workspace:@navikt/aksel"
   dependencies:
-    "@navikt/ds-css": "npm:7.0.0"
+    "@navikt/ds-css": "npm:7.0.1"
     axios: "npm:1.7.4"
     chalk: "npm:4.1.0"
     clipboardy: "npm:^2.3.0"
@@ -3819,11 +3819,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@npm:*, @navikt/ds-css@npm:7.0.0, @navikt/ds-css@npm:^7.0.0, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@npm:*, @navikt/ds-css@npm:7.0.1, @navikt/ds-css@npm:^7.0.1, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": "npm:^7.0.0"
+    "@navikt/ds-tokens": "npm:^7.0.1"
     cssnano: "npm:6.0.0"
     fast-glob: "npm:3.2.11"
     lodash: "npm:4.17.21"
@@ -3836,14 +3836,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@npm:*, @navikt/ds-react@npm:^7.0.0, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@npm:*, @navikt/ds-react@npm:^7.0.1, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": "npm:0.25.4"
     "@floating-ui/react-dom": "npm:^2.0.9"
-    "@navikt/aksel-icons": "npm:^7.0.0"
-    "@navikt/ds-tokens": "npm:^7.0.0"
+    "@navikt/aksel-icons": "npm:^7.0.1"
+    "@navikt/ds-tokens": "npm:^7.0.1"
     "@testing-library/dom": "npm:9.3.4"
     "@testing-library/jest-dom": "npm:^5.16.0"
     "@testing-library/react": "npm:^15.0.7"
@@ -3873,11 +3873,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@npm:^7.0.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@npm:^7.0.1, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": "npm:^7.0.0"
+    "@navikt/ds-tokens": "npm:^7.0.1"
     color: "npm:4.2.3"
     lodash: "npm:^4.17.21"
     tailwindcss: "npm:^3.3.3"
@@ -3887,7 +3887,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@npm:^7.0.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@npm:^7.0.1, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -8043,11 +8043,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/aksel-icons": "npm:^7.0.0"
-    "@navikt/ds-css": "npm:^7.0.0"
-    "@navikt/ds-react": "npm:^7.0.0"
-    "@navikt/ds-tailwind": "npm:^7.0.0"
-    "@navikt/ds-tokens": "npm:^7.0.0"
+    "@navikt/aksel-icons": "npm:^7.0.1"
+    "@navikt/ds-css": "npm:^7.0.1"
+    "@navikt/ds-react": "npm:^7.0.1"
+    "@navikt/ds-tailwind": "npm:^7.0.1"
+    "@navikt/ds-tokens": "npm:^7.0.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
I thought we should check our components for a11y issues and HTML validity. I think the easiest way is to check the examples? It might be good to check the examples anyways. Should probably also check the templates.

It seems that axe doesn't properly check that the HTML is valid, so maybe we need a separate check for that?