### PR TITLE
[Aksel.nav.no] Open all Accordions when searched

### DIFF
--- a/aksel.nav.no/website/components/sanity-modules/accordion/Accordion.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/accordion/Accordion.tsx
@@ -5,7 +5,7 @@ import { SanityBlockContent } from "@/sanity-block";
 import { AccordionT } from "@/types";
 
 type AccordionProps = {
-  node: AccordionT;
+  node?: AccordionT;
 };
 
 const Accordion = ({ node }: AccordionProps) => {

--- a/aksel.nav.no/website/components/sanity-modules/accordion/Accordion.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/accordion/Accordion.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Accordion as DsAccordion } from "@navikt/ds-react";
 import ErrorBoundary from "@/error-boundary";
 import { SanityBlockContent } from "@/sanity-block";
@@ -8,6 +9,27 @@ type AccordionProps = {
 };
 
 const Accordion = ({ node }: AccordionProps) => {
+  const [openAccordions, setOpenAccordions] = useState<number[]>([]);
+
+  useEffect(() => {
+    const listener = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "f") {
+        setOpenAccordions((node?.list ?? []).map((_, i) => i));
+      }
+    };
+
+    document.addEventListener("keydown", listener);
+    return () => document.removeEventListener("keydown", listener);
+  }, [node?.list]);
+
+  const handleOpenChange = (index: number) => {
+    if (openAccordions.includes(index)) {
+      setOpenAccordions(openAccordions.filter((i) => i !== index));
+    } else {
+      setOpenAccordions([...openAccordions, index]);
+    }
+  };
+
   if (!node || node.list.length === 0) {
     return null;
   }
@@ -15,8 +37,12 @@ const Accordion = ({ node }: AccordionProps) => {
   return (
     <div className="mb-8">
       <DsAccordion>
-        {node.list.map((el) => (
-          <DsAccordion.Item key={el._key}>
+        {node.list.map((el, index) => (
+          <DsAccordion.Item
+            key={el._key}
+            open={openAccordions.includes(index)}
+            onOpenChange={() => handleOpenChange(index)}
+          >
             <DsAccordion.Header>{el.title}</DsAccordion.Header>
             <DsAccordion.Content>
               <SanityBlockContent blocks={el.content} className="toc-ignore" />


### PR DESCRIPTION
### Description

When the user presses ctrl/cmd + f for searching the page, each accordion opens. Solution replicates nav.no

Resolves #3176

For testing
https://aksel.nav.no/god-praksis/artikler/skriveregler-i-nav

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
