### PR TITLE
Combobox: :lipstick: remove hover border color when disabled

### DIFF
--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -28,6 +28,10 @@
   cursor: not-allowed;
 }
 
+.navds-combobox--disabled .navds-text-field__input {
+  border: 1px solid var(--a-border-default);
+}
+
 .navds-combobox--readonly {
   pointer-events: none;
 }


### PR DESCRIPTION
### Description

Quick CSS fix to overrule the hover style when the combobox is disabled (it already gets ignored by readonly via pointer-events: none, but on disabled we want to have the cursor show that it's disabled as well, so we can't set pointer-events the same way.)
