### PR TITLE
Combobox: :lipstick: tweak the visibility of chevron

### DIFF
--- a/.changeset/ninety-gifts-thank.md
+++ b/.changeset/ninety-gifts-thank.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Datepicker/Select: :lipstick: dim non-interactable icons when readonly is set.

--- a/@navikt/core/css/date.css
+++ b/@navikt/core/css/date.css
@@ -281,7 +281,7 @@
 /* Readonly */
 .navds-date__field--readonly .navds-date__field-button {
   cursor: default;
-  color: var(--a-grayalpha-500);
+  color: var(--a-gray-500);
 }
 
 .navds-date__caption-button {

--- a/@navikt/core/css/date.css
+++ b/@navikt/core/css/date.css
@@ -281,6 +281,7 @@
 /* Readonly */
 .navds-date__field--readonly .navds-date__field-button {
   cursor: default;
+  color: var(--a-grayalpha-500);
 }
 
 .navds-date__caption-button {

--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -41,7 +41,7 @@
 }
 
 .navds-combobox--readonly .navds-combobox__button-toggle-list {
-  color: var(--a-grayalpha-500);
+  color: var(--a-gray-500);
 }
 
 .navds-combobox--readonly .navds-text-field__input,

--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -41,7 +41,7 @@
 }
 
 .navds-combobox--readonly .navds-combobox__button-toggle-list {
-  color: var(--a-gray-300);
+  color: var(--a-grayalpha-500);
 }
 
 .navds-combobox--readonly .navds-text-field__input,

--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -40,6 +40,10 @@
   pointer-events: none;
 }
 
+.navds-combobox--readonly .navds-combobox__button-toggle-list {
+  color: var(--a-gray-300);
+}
+
 .navds-combobox--readonly .navds-text-field__input,
 .navds-combobox--readonly .navds-combobox__input {
   background-color: var(--a-surface-subtle);

--- a/@navikt/core/css/form/select.css
+++ b/@navikt/core/css/form/select.css
@@ -111,5 +111,5 @@
 }
 
 .navds-select--readonly .navds-select__chevron {
-  color: var(--a-grayalpha-500);
+  color: var(--a-gray-500);
 }

--- a/@navikt/core/css/form/select.css
+++ b/@navikt/core/css/form/select.css
@@ -109,3 +109,7 @@
   border-color: var(--a-border-subtle);
   cursor: default;
 }
+
+.navds-select--readonly .navds-select__chevron {
+  color: var(--a-grayalpha-500);
+}


### PR DESCRIPTION
Minor tweak, discussed with designer, and this is a compromise on keeping the chevron for recognizeability, but also not drawing too much attention too it as an interactive element while it's `readonly`.
