### PR TITLE
[aksel.nav.no] Show breakpoints in GuidePanel examples

### DIFF
--- a/aksel.nav.no/website/components/website-modules/examples/withDsExample.tsx
+++ b/aksel.nav.no/website/components/website-modules/examples/withDsExample.tsx
@@ -70,7 +70,7 @@ export const withDsExample = (
           style={{ background: getBg(background) }}
         >
           <Icon aria-hidden fontSize="1.5rem" /> {`${breakpoint}`}
-          <Box marginInline="2 0" style={{ color: "var(--a-text-subtle)" }}>
+          <Box marginInline="2 0" className="text-text-subtle">
             {width}px
           </Box>
         </HStack>

--- a/aksel.nav.no/website/components/website-modules/examples/withDsExample.tsx
+++ b/aksel.nav.no/website/components/website-modules/examples/withDsExample.tsx
@@ -7,7 +7,7 @@ import {
   MonitorIcon,
   TabletIcon,
 } from "@navikt/aksel-icons";
-import { HStack } from "@navikt/ds-react";
+import { Box, HStack } from "@navikt/ds-react";
 import styles from "./examples.module.css";
 
 type withDsT = {
@@ -70,6 +70,9 @@ export const withDsExample = (
           style={{ background: getBg(background) }}
         >
           <Icon aria-hidden fontSize="1.5rem" /> {`${breakpoint}`}
+          <Box marginInline="2 0" style={{ color: "var(--a-text-subtle)" }}>
+            {width}px
+          </Box>
         </HStack>
       );
     };

--- a/aksel.nav.no/website/pages/eksempler/guidepanel/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/guidepanel/demo.tsx
@@ -12,7 +12,7 @@ const Example = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { showBreakpoints: true });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/guidepanel/poster.tsx
+++ b/aksel.nav.no/website/pages/eksempler/guidepanel/poster.tsx
@@ -12,7 +12,7 @@ const Example = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { showBreakpoints: true });
 
 /* Storybook story */
 export const Demo = {


### PR DESCRIPTION
Got an idea to add the width next to the breakpoint, what do you think?