### PR TITLE
[ActionMenu] Sub-menu now uses onClick for opening and closing instead of pointermove

### DIFF
--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -286,14 +286,7 @@ interface ActionMenuTriggerProps
 
 const ActionMenuTrigger = forwardRef<HTMLButtonElement, ActionMenuTriggerProps>(
   (
-    {
-      children,
-      onPointerDown,
-      onKeyDown,
-      style,
-      onClick,
-      ...rest
-    }: ActionMenuTriggerProps,
+    { children, onKeyDown, style, onClick, ...rest }: ActionMenuTriggerProps,
     ref,
   ) => {
     const context = useActionMenuContext();
@@ -312,45 +305,7 @@ const ActionMenuTrigger = forwardRef<HTMLButtonElement, ActionMenuTriggerProps>(
           ref={mergedRefs}
           {...rest}
           style={{ ...style, pointerEvents: context.open ? "auto" : undefined }}
-          onPointerDown={composeEventHandlers(onPointerDown, (event) => {
-            const disabled = event.currentTarget.disabled;
-            /**
-             * Only call handler with left button (onPointerDown gets triggered by all mouse buttons),
-             * but not when the control key is pressed (avoiding MacOS right click)
-             */
-            if (!disabled && event.button === 0 && event.ctrlKey === false) {
-              context.onOpenToggle();
-              /**
-               * Prevent trigger focusing when opening, allowing the content to be given focus without competition
-               */
-              if (!context.open) {
-                event.preventDefault();
-
-                /**
-                 * Close the menu if pointerUp happens outside of the menu or the trigger
-                 */
-                const pointerUpCallback = (e: PointerEvent) => {
-                  const triggerRef = context.triggerRef?.current;
-                  const closestContent = (e.target as Element)?.closest(
-                    "[data-aksel-menu-content]",
-                  );
-                  const isInsideSafezone =
-                    closestContent?.contains(e.target as Node) ||
-                    triggerRef?.contains(e.target as Node) ||
-                    e.target === triggerRef ||
-                    e.target === closestContent;
-
-                  if (!isInsideSafezone) {
-                    context.onOpenChange(false);
-                  }
-                };
-                document.addEventListener("pointerup", pointerUpCallback, {
-                  once: true,
-                });
-              }
-            }
-          })}
-          onClick={composeEventHandlers(onClick, () => context.onOpenToggle())}
+          onClick={composeEventHandlers(onClick, context.onOpenToggle)}
           onKeyDown={composeEventHandlers(onKeyDown, (event) => {
             if (event.key === "ArrowDown") {
               context.onOpenChange(true);

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -291,6 +291,7 @@ const ActionMenuTrigger = forwardRef<HTMLButtonElement, ActionMenuTriggerProps>(
       onPointerDown,
       onKeyDown,
       style,
+      onClick,
       ...rest
     }: ActionMenuTriggerProps,
     ref,
@@ -349,38 +350,14 @@ const ActionMenuTrigger = forwardRef<HTMLButtonElement, ActionMenuTriggerProps>(
               }
             }
           })}
-          /* TODO: Use onClick instead of these two */
+          onClick={composeEventHandlers(onClick, () => context.onOpenToggle())}
           onKeyDown={composeEventHandlers(onKeyDown, (event) => {
             if (event.currentTarget.disabled) {
               return;
             }
-            if (["Enter"].includes(event.key)) {
-              context.onOpenToggle();
-            }
             if (event.key === "ArrowDown") {
               context.onOpenChange(true);
-            }
-            /**
-             * Stop keydown from scrolling window
-             */
-            if (["Enter", "ArrowDown"].includes(event.key)) {
-              event.preventDefault();
-            }
-          })}
-          onKeyUp={composeEventHandlers(onKeyDown, (event) => {
-            if (event.currentTarget.disabled) {
-              return;
-            }
-            if ([" "].includes(event.key)) {
-              context.onOpenToggle();
-            }
-            if (event.key === "ArrowDown") {
-              context.onOpenChange(true);
-            }
-            /**
-             * Stop keydown from scrolling window
-             */
-            if ([" ", "ArrowDown"].includes(event.key)) {
+              /* Stop keydown from scrolling window */
               event.preventDefault();
             }
           })}

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -352,9 +352,6 @@ const ActionMenuTrigger = forwardRef<HTMLButtonElement, ActionMenuTriggerProps>(
           })}
           onClick={composeEventHandlers(onClick, () => context.onOpenToggle())}
           onKeyDown={composeEventHandlers(onKeyDown, (event) => {
-            if (event.currentTarget.disabled) {
-              return;
-            }
             if (event.key === "ArrowDown") {
               context.onOpenChange(true);
               /* Stop keydown from scrolling window */

--- a/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
@@ -28,11 +28,6 @@ const FIRST_LAST_KEYS = [...FIRST_KEYS, ...LAST_KEYS];
 type SubMenuSide = "left" | "right";
 type CheckedState = boolean | "indeterminate";
 
-/**
- * TODO:
- * - When on small screen + submenu, submenu can open below anchor. We need to handle this case correctly with mouseover and arrow keys
- */
-
 /* -------------------------------------------------------------------------- */
 /*                                    Menu                                    */
 /* -------------------------------------------------------------------------- */

--- a/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
@@ -499,17 +499,16 @@ const MenuItemInternal = forwardRef<
     }: MenuItemInternalProps,
     forwardedRef,
   ) => {
-    const menuContext = useMenuContext();
+    const context = useMenuContext();
     const { register } = useMenuDescendant({
       disabled,
       closeMenu: () => {
         rest["data-submenu-trigger"] &&
-          menuContext.open &&
-          menuContext.onOpenChange(false);
+          context.open &&
+          context.onOpenChange(false);
       },
     });
 
-    const context = useMenuContext();
     const ref = useRef<HTMLDivElement>(null);
     const composedRefs = useMergeRefs(forwardedRef, ref, register);
 

--- a/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
@@ -208,9 +208,7 @@ const MenuRootContentNonModal = React.forwardRef<
       {...props}
       ref={ref}
       disableOutsidePointerEvents={false}
-      onDismiss={() => {
-        context.onOpenChange(false);
-      }}
+      onDismiss={() => context.onOpenChange(false)}
     />
   );
 });

--- a/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
@@ -916,8 +916,7 @@ const MenuSubContent = forwardRef<
           }
           event.preventDefault();
         }}
-        // The menu might close because of focusing another menu item in the parent menu. We
-        // don't want it to refocus the trigger in that case so we handle trigger focus ourselves.
+        /* Since we manually focus Subtrigger, we prevent use of auto-focus */
         onCloseAutoFocus={(event) => event.preventDefault()}
         onEscapeKeyDown={composeEventHandlers(
           props.onEscapeKeyDown,

--- a/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
@@ -25,7 +25,6 @@ const FIRST_KEYS = ["ArrowDown", "PageUp", "Home"];
 const LAST_KEYS = ["ArrowUp", "PageDown", "End"];
 const FIRST_LAST_KEYS = [...FIRST_KEYS, ...LAST_KEYS];
 
-type SubMenuSide = "left" | "right";
 type CheckedState = boolean | "indeterminate";
 
 /* -------------------------------------------------------------------------- */
@@ -302,8 +301,6 @@ const MenuContentInternal = forwardRef<
       contentRef,
       context.onContentChange,
     );
-    const pointerDirRef = React.useRef<SubMenuSide>("right");
-    const lastPointerXRef = React.useRef(0);
 
     return (
       <FocusScope
@@ -366,28 +363,6 @@ const MenuContentInternal = forwardRef<
                 }
                 descendants.firstEnabled()?.node?.focus();
               })}
-              onPointerMove={composeEventHandlers(
-                rest.onPointerMove,
-                whenMouse((event) => {
-                  const target = event.target as HTMLElement;
-                  const pointerXHasChanged =
-                    lastPointerXRef.current !== event.clientX;
-
-                  // We don't use `event.movementX` for this check because Safari will
-                  // always return `0` on a pointer event.
-                  if (
-                    event.currentTarget.contains(target) &&
-                    pointerXHasChanged
-                  ) {
-                    const newDir =
-                      event.clientX > lastPointerXRef.current
-                        ? "right"
-                        : "left";
-                    pointerDirRef.current = newDir;
-                    lastPointerXRef.current = event.clientX;
-                  }
-                }),
-              )}
             />
           </RovingFocus>
         </DismissableLayer>

--- a/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
@@ -783,9 +783,9 @@ const MenuSub: React.FC<MenuSubProps> = ({
     <Floating>
       <MenuProvider
         open={open}
-        onOpenChange={(e) => {
-          handleOpenChange(e);
-          if (e) {
+        onOpenChange={(open) => {
+          handleOpenChange(open);
+          if (open) {
             /* Makes sure to close all adjacent submenus if they are open */
             values().forEach((descendant) => {
               if (descendant.node !== trigger) {

--- a/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
@@ -783,9 +783,9 @@ const MenuSub: React.FC<MenuSubProps> = ({
     <Floating>
       <MenuProvider
         open={open}
-        onOpenChange={(open) => {
-          handleOpenChange(open);
-          if (open) {
+        onOpenChange={(_open) => {
+          handleOpenChange(_open);
+          if (_open) {
             /* Makes sure to close all adjacent submenus if they are open */
             values().forEach((descendant) => {
               if (descendant.node !== trigger) {

--- a/@navikt/core/react/src/overlays/floating-menu/parts/RovingFocus.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/parts/RovingFocus.tsx
@@ -7,12 +7,7 @@ import { DescendantsManager } from "../../../util/hooks/descendants/descendant";
 interface RovingFocusProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "tabIndex"> {
   asChild?: boolean;
-  descendants: DescendantsManager<
-    HTMLDivElement,
-    {
-      closeMenu: () => void;
-    }
-  >;
+  descendants: DescendantsManager<HTMLDivElement, any>;
   onEntryFocus?: (event: Event) => void;
 }
 
@@ -30,8 +25,8 @@ const RovingFocus = forwardRef<HTMLDivElement, RovingFocusProps>(
       onMouseDown,
       onFocus,
       ...rest
-    }: RovingFocusProps,
-    ref,
+    },
+    ref: React.Ref<HTMLDivElement>,
   ) => {
     const _ref = React.useRef<HTMLDivElement>(null);
     const composedRefs = useMergeRefs(ref, _ref);

--- a/@navikt/core/react/src/overlays/floating-menu/parts/RovingFocus.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/parts/RovingFocus.tsx
@@ -7,7 +7,12 @@ import { DescendantsManager } from "../../../util/hooks/descendants/descendant";
 interface RovingFocusProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "tabIndex"> {
   asChild?: boolean;
-  descendants: DescendantsManager<HTMLDivElement, object>;
+  descendants: DescendantsManager<
+    HTMLDivElement,
+    {
+      closeMenu: () => void;
+    }
+  >;
   onEntryFocus?: (event: Event) => void;
 }
 


### PR DESCRIPTION
Use this view for better diff: https://github.com/navikt/aksel/pull/3193/files?diff=unified&w=1

As a sideffect we got the problem where if you have multiple sub-menues in the same content, they could both be open at the same time. To avoid this we use the descendant context to manually close every other submenu when opening itself. 
```tsx
  onOpenChange={(e) => {
  handleOpenChange(e);
  if (e) {
    /* Makes sure to close all adjacent submenus if they are open */
    values().forEach((descendant) => {
      if (descendant.node !== trigger) {
        descendant.closeMenu();
      }
    });
  }
}}
```

Not a fan of the implementation for this, but can't think of any other relatively easy method for this without adding new complexity making it even worse to understand.
