### PR TITLE
[ActionMenu] Remove extra CSS-classes, fixed centering bug in safari

### DIFF
--- a/@navikt/core/css/action-menu.css
+++ b/@navikt/core/css/action-menu.css
@@ -106,7 +106,7 @@
   flex-shrink: 0;
 }
 
-.navds-action-menu__item:where(.navds-action-menu__checkbox, .navds-action-menu__radio, .navds-action-menu__item--has-icon) {
+.navds-action-menu__item:where(.navds-action-menu__item--has-icon) {
   --__ac-action-menu-item-pl: var(--a-spacing-6);
 }
 
@@ -184,6 +184,11 @@
   margin-block: var(--a-spacing-2);
   background-color: var(--a-border-divider);
   margin-inline: calc(var(--__ac-action-menu-content-p) * -1);
+}
+
+.navds-action-menu__indicator {
+  display: grid;
+  place-content: center;
 }
 
 .navds-action-menu__indicator-icon {

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -761,7 +761,7 @@ type ActionMenuRadioGroupProps = ActionMenuGroupLabelingProps &
 const ActionMenuRadioGroup = forwardRef<
   ActionMenuRadioGroupElement,
   ActionMenuRadioGroupProps
->(({ children, className, label, ...rest }: ActionMenuRadioGroupProps, ref) => {
+>(({ children, label, ...rest }: ActionMenuRadioGroupProps, ref) => {
   const labelId = useId();
 
   return (
@@ -769,7 +769,6 @@ const ActionMenuRadioGroup = forwardRef<
       ref={ref}
       {...rest}
       asChild={false}
-      className={cl("navds-action-menu__radio-group", className)}
       aria-labelledby={label ? labelId : undefined}
     >
       {label && (

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -533,7 +533,7 @@ type MarkerProps = {
 
 const Marker = ({ children, className, placement }: MarkerProps) => {
   return (
-    <span
+    <div
       aria-hidden
       className={cl(
         className,
@@ -542,7 +542,7 @@ const Marker = ({ children, className, placement }: MarkerProps) => {
       )}
     >
       {children}
-    </span>
+    </div>
   );
 };
 
@@ -674,7 +674,7 @@ const ActionMenuCheckboxItem = forwardRef<
         })}
         asChild={false}
         className={cl(
-          "navds-action-menu__item navds-action-menu__checkbox",
+          "navds-action-menu__item navds-action-menu__item--has-icon",
           className,
         )}
         aria-keyshortcuts={shortcut}
@@ -811,7 +811,7 @@ const ActionMenuRadioItem = forwardRef<
         })}
         asChild={false}
         className={cl(
-          "navds-action-menu__item navds-action-menu__radio",
+          "navds-action-menu__item navds-action-menu__item--has-icon",
           className,
         )}
       >


### PR DESCRIPTION
### Description

- Fixed div inside span markup
- removed checkbox and radio css since they can both use "has-icon" class
- Fixed icon centering bug in safari

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
