### PR TITLE
[Liniting] Updated to biome v1.9

### DIFF
--- a/@navikt/core/css/copybutton.css
+++ b/@navikt/core/css/copybutton.css
@@ -31,7 +31,6 @@
 @media (forced-colors: active) {
   .navds-copybutton {
     background-color: ButtonFace;
-    border-color: ButtonText;
     border: solid 1px ButtonText;
     color: ButtonText;
   }

--- a/@navikt/core/css/internalheader.css
+++ b/@navikt/core/css/internalheader.css
@@ -10,7 +10,6 @@
 @media (forced-colors: active) {
   .navds-internalheader {
     background-color: ButtonFace;
-    border-color: ButtonText;
     border: solid 1px ButtonText;
     color: ButtonText;
   }

--- a/@navikt/core/css/read-more.css
+++ b/@navikt/core/css/read-more.css
@@ -19,7 +19,6 @@
 @media (forced-colors: active) {
   .navds-read-more__button {
     background-color: ButtonFace;
-    border-color: ButtonText;
     border: solid 1px ButtonText;
     color: ButtonText;
   }

--- a/@navikt/core/react/src/date/datepicker/datepicker.stories.tsx
+++ b/@navikt/core/react/src/date/datepicker/datepicker.stories.tsx
@@ -73,40 +73,37 @@ export const Default: StoryObj<DefaultStoryProps> = {
           locale={props.locale}
           disableWeekends={props.disableWeekends}
         >
-          {!props.standalone && (
-            <>
-              {props.inputfield && props.mode !== "multiple" ? (
-                <>
-                  {props.mode === "range" ? (
-                    <div style={{ display: "flex", gap: "1rem" }}>
-                      <DatePicker.Input
-                        label="Fra"
-                        size={props?.size}
-                        {...rangeCtx.fromInputProps}
-                      />
-                      <DatePicker.Input
-                        label="Til"
-                        size={props?.size}
-                        {...rangeCtx.toInputProps}
-                      />
-                    </div>
-                  ) : (
-                    <>
-                      <DatePicker.Input
-                        label="Velg dato"
-                        size={props?.size}
-                        {...singleCtx.inputProps}
-                      />
-                    </>
-                  )}
-                </>
-              ) : (
-                <Button onClick={() => setOpen((x) => !x)}>
-                  Åpne datovelger
-                </Button>
-              )}
-            </>
-          )}
+          {!props.standalone &&
+            (props.inputfield && props.mode !== "multiple" ? (
+              <>
+                {props.mode === "range" ? (
+                  <div style={{ display: "flex", gap: "1rem" }}>
+                    <DatePicker.Input
+                      label="Fra"
+                      size={props?.size}
+                      {...rangeCtx.fromInputProps}
+                    />
+                    <DatePicker.Input
+                      label="Til"
+                      size={props?.size}
+                      {...rangeCtx.toInputProps}
+                    />
+                  </div>
+                ) : (
+                  <>
+                    <DatePicker.Input
+                      label="Velg dato"
+                      size={props?.size}
+                      {...singleCtx.inputProps}
+                    />
+                  </>
+                )}
+              </>
+            ) : (
+              <Button onClick={() => setOpen((x) => !x)}>
+                Åpne datovelger
+              </Button>
+            ))}
         </Comp>
       </div>
     );

--- a/@navikt/core/react/src/date/datepicker/datepicker.stories.tsx
+++ b/@navikt/core/react/src/date/datepicker/datepicker.stories.tsx
@@ -90,13 +90,11 @@ export const Default: StoryObj<DefaultStoryProps> = {
                     />
                   </div>
                 ) : (
-                  <>
-                    <DatePicker.Input
-                      label="Velg dato"
-                      size={props?.size}
-                      {...singleCtx.inputProps}
-                    />
-                  </>
+                  <DatePicker.Input
+                    label="Velg dato"
+                    size={props?.size}
+                    {...singleCtx.inputProps}
+                  />
                 )}
               </>
             ) : (

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptions.tsx
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptions.tsx
@@ -54,6 +54,7 @@ const FilteredOptions = () => {
       )}
 
       {shouldRenderFilteredOptionsList && (
+        /* biome-ignore lint/a11y/useFocusableInteractive: Interaction is not handeled by listbox itself. */
         <ul
           ref={setFilteredOptionsRef}
           role="listbox"

--- a/@navikt/core/react/src/progress-bar/ProgressBar.tsx
+++ b/@navikt/core/react/src/progress-bar/ProgressBar.tsx
@@ -107,6 +107,7 @@ export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(
     }, [simulated?.seconds]);
 
     return (
+      /* biome-ignore lint/a11y/useFocusableInteractive: Progressbar is not interactive. */
       <div
         ref={ref}
         className={cl(

--- a/@navikt/core/react/src/progress-bar/ProgressBar.tsx
+++ b/@navikt/core/react/src/progress-bar/ProgressBar.tsx
@@ -122,6 +122,7 @@ export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(
             ? `Fremdrift kan ikke beregnes, antatt tid er: ${simulated?.seconds} sekunder`
             : `${Math.round(value)} av ${Math.round(valueMax)}`
         }
+        // biome-ignore lint/a11y/useAriaPropsForRole: We found that adding valueMin was not needed
         role="progressbar"
         aria-labelledby={ariaLabelledBy}
         aria-label={ariaLabel}

--- a/@navikt/core/react/src/table/stories/table-1.stories.tsx
+++ b/@navikt/core/react/src/table/stories/table-1.stories.tsx
@@ -98,61 +98,6 @@ export const SizeSmall = () => <TableComponent size="small" />;
 
 export const Buttons = () => <TableComponent size="small" button />;
 
-export const WithDivs = () => {
-  return (
-    <div className="navds-table" role="table">
-      <div className="navds-table__header" role="rowgroup">
-        <div className="navds-table__row" role="row">
-          <div className="navds-table__header-cell" role="columnheader">
-            Fornavn
-          </div>
-          <div className="navds-table__header-cell" role="columnheader">
-            Etternavn
-          </div>
-          <div className="navds-table__header-cell" role="columnheader">
-            Rolle
-          </div>
-        </div>
-      </div>
-      <div className="navds-table__body" role="rowgroup">
-        <div className="navds-table__row" role="row">
-          <div className="navds-table__data-cell" role="cell">
-            Jean-Luc
-          </div>
-          <div className="navds-table__data-cell" role="cell">
-            Picard
-          </div>
-          <div className="navds-table__data-cell" role="cell">
-            Kaptein
-          </div>
-        </div>
-        <div className="navds-table__row" role="row">
-          <div className="navds-table__data-cell" role="cell">
-            William
-          </div>
-          <div className="navds-table__data-cell" role="cell">
-            Riker
-          </div>
-          <div className="navds-table__data-cell" role="cell">
-            Kommandør
-          </div>
-        </div>
-        <div className="navds-table__row" role="row">
-          <div className="navds-table__data-cell" role="cell">
-            Geordi
-          </div>
-          <div className="navds-table__data-cell" role="cell">
-            La Forge
-          </div>
-          <div className="navds-table__data-cell" role="cell">
-            Sjefsingeniør
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
 const SelectionTable = ({ size = "medium" }: { size?: "small" | "medium" }) => {
   const useToggleList = (initialState) => {
     const [list, setList] = useState(initialState);
@@ -258,10 +203,6 @@ export const Chromatic = {
       <div>
         <h3>With Buttons</h3>
         <Buttons />
-      </div>
-      <div>
-        <h3>Custom with divs</h3>
-        <WithDivs />
       </div>
       <div>
         <h3>Selection</h3>

--- a/@navikt/core/react/src/util/hooks/descendants/descendant.stories.tsx
+++ b/@navikt/core/react/src/util/hooks/descendants/descendant.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { Box } from "../../../layout/box";
 import { HStack } from "../../../layout/stack";
 import { createDescendantContext } from "./useDescendant";
 
@@ -16,7 +15,10 @@ const [
   _useDescendantsContext,
   useDescendants,
   useDescendant,
-] = createDescendantContext<HTMLDivElement, { value?: string }>();
+] = createDescendantContext<
+  HTMLButtonElement | HTMLInputElement,
+  { value?: string }
+>();
 
 function Select({ children }: { children?: React.ReactNode }) {
   const descendants = useDescendants();
@@ -37,9 +39,8 @@ function Option({ value, disabled }: { value?: string; disabled?: boolean }) {
   });
 
   return (
-    <Box
+    <button
       ref={register}
-      role="button"
       tabIndex={0}
       data-value={value}
       onKeyDown={(event) => {
@@ -51,7 +52,7 @@ function Option({ value, disabled }: { value?: string; disabled?: boolean }) {
       }}
     >
       Option {index + 1}
-    </Box>
+    </button>
   );
 }
 

--- a/aksel.nav.no/website/components/sanity-modules/props/PropsSeksjon.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/props/PropsSeksjon.tsx
@@ -16,16 +16,13 @@ const PropsSeksjon = ({ node }: PropsSeksjonProps) => {
 
   return (
     <div className="mb-16">
-      {node?.komponenter?.length > 0 && (
-        <>
-          {node.komponenter.map((prop) => (
-            <PropTableV2
-              komponent={prop as unknown as PropTableT}
-              key={prop?._key}
-            />
-          ))}
-        </>
-      )}
+      {node?.komponenter?.length > 0 &&
+        node.komponenter.map((prop) => (
+          <PropTableV2
+            komponent={prop as unknown as PropTableT}
+            key={prop?._key}
+          />
+        ))}
     </div>
   );
 };

--- a/aksel.nav.no/website/components/styles/global.css
+++ b/aksel.nav.no/website/components/styles/global.css
@@ -38,16 +38,6 @@ html:has(.globalstyles) {
   scroll-margin-block: 5rem;
 }
 
-/* Improves rendering of images for chrome on Windows */
-/* stylelint-disable-next-line media-feature-name-no-vendor-prefix */
-@media screen and (-webkit-min-device-pixel-ratio: 0) and (min-resolution: 0.001dpcm) {
-  .globalstyles img {
-    transform: translateZ(0);
-    /* stylelint-disable-next-line value-no-vendor-prefix */
-    image-rendering: -webkit-optimize-contrast !important;
-  }
-}
-
 /* Unset for Safari 11+ */
 @media not all and (min-resolution: 0.001dpcm) {
   @supports (-webkit-appearance: none) and (stroke-color: transparent) {

--- a/aksel.nav.no/website/components/styles/global.css
+++ b/aksel.nav.no/website/components/styles/global.css
@@ -38,15 +38,6 @@ html:has(.globalstyles) {
   scroll-margin-block: 5rem;
 }
 
-/* Unset for Safari 11+ */
-@media not all and (min-resolution: 0.001dpcm) {
-  @supports (-webkit-appearance: none) and (stroke-color: transparent) {
-    .globalstyles img {
-      image-rendering: unset !important;
-    }
-  }
-}
-
 .skiplink {
   @apply absolute left-0 -translate-y-full bg-border-focus p-4 text-text-on-inverted no-underline focus-within:translate-y-0 focus-within:shadow-[inset_0_0_0_2px_white] focus-within:outline-none;
 }

--- a/aksel.nav.no/website/components/website-modules/Feedback/Feedback.tsx
+++ b/aksel.nav.no/website/components/website-modules/Feedback/Feedback.tsx
@@ -155,23 +155,22 @@ export const FeedbackForm = ({ user }: { user: AuthUser }) => {
       >
         Send inn
       </Button>
-      <>
-        {state === "error" && (
-          <Alert variant="error" className="mt-4" role="alert">
-            Noe gikk galt. Hvis feilen oppstår flere ganger eller du har lyst
-            til å sende tilbakemeldingen direkte finner du oss under{" "}
-            <Link inlineText href="https://nav-it.slack.com/archives/C7NE7A8UF">
-              #aksel-designsystemet
-            </Link>{" "}
-            på slack.
-            <BodyShort
-              textColor="subtle"
-              size="small"
-              className="mt-3"
-            >{`Feil-id: ${APIError}`}</BodyShort>
-          </Alert>
-        )}
-      </>
+
+      {state === "error" && (
+        <Alert variant="error" className="mt-4" role="alert">
+          Noe gikk galt. Hvis feilen oppstår flere ganger eller du har lyst til
+          å sende tilbakemeldingen direkte finner du oss under{" "}
+          <Link inlineText href="https://nav-it.slack.com/archives/C7NE7A8UF">
+            #aksel-designsystemet
+          </Link>{" "}
+          på slack.
+          <BodyShort
+            textColor="subtle"
+            size="small"
+            className="mt-3"
+          >{`Feil-id: ${APIError}`}</BodyShort>
+        </Alert>
+      )}
     </form>
   );
 };

--- a/aksel.nav.no/website/components/website-modules/menu/Menu.tsx
+++ b/aksel.nav.no/website/components/website-modules/menu/Menu.tsx
@@ -42,7 +42,8 @@ export function MenuUl({ children, id, className }: MenuListProps) {
     <ul
       className={cl(styles.menuList, className)}
       id={id}
-      role="list" // WebKit browsers remove list semantics when list-style-type is none
+      // biome-ignore lint/a11y/noRedundantRoles: WebKit browsers remove list semantics when list-style-type is none
+      role="list"
     >
       {children}
     </ul>

--- a/aksel.nav.no/website/pages/komponenter/[...slug].tsx
+++ b/aksel.nav.no/website/pages/komponenter/[...slug].tsx
@@ -235,23 +235,21 @@ const Page = ({
         </a>
       )}
       {pack && (
-        <>
-          <a
-            target="_blank"
-            rel="noreferrer noopener"
-            href={pack.changelog}
-            className="flex items-center gap-1 underline hover:text-text-default hover:no-underline focus:bg-blue-800 focus:text-text-on-inverted focus:no-underline focus:shadow-focus focus:outline-none"
-            onClick={() =>
-              amplitude.track(AmplitudeEvents.link, {
-                kilde: "intro-lenker komponenter",
-                til: "endringslogg",
-              })
-            }
-          >
-            <ChangelogIcon />
-            Endringslogg
-          </a>
-        </>
+        <a
+          target="_blank"
+          rel="noreferrer noopener"
+          href={pack.changelog}
+          className="flex items-center gap-1 underline hover:text-text-default hover:no-underline focus:bg-blue-800 focus:text-text-on-inverted focus:no-underline focus:shadow-focus focus:outline-none"
+          onClick={() =>
+            amplitude.track(AmplitudeEvents.link, {
+              kilde: "intro-lenker komponenter",
+              til: "endringslogg",
+            })
+          }
+        >
+          <ChangelogIcon />
+          Endringslogg
+        </a>
       )}
     </BodyShort>
   );

--- a/biome.json
+++ b/biome.json
@@ -58,8 +58,7 @@
         "useExhaustiveDependencies": "off",
         "noInnerDeclarations": "off",
         "useJsxKeyInIterable": "off",
-        "noSelfAssign": "off",
-        "noUnknownMediaFeatureName": "info"
+        "noSelfAssign": "off"
       }
     },
     "ignore": [

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,6 @@
         "useMediaCaption": "off",
         "useKeyWithClickEvents": "off",
         "noNoninteractiveTabindex": "off",
-        "useAriaPropsForRole": "off",
         "useSemanticElements": "off"
       },
       "style": {

--- a/biome.json
+++ b/biome.json
@@ -26,8 +26,7 @@
         "useKeyWithClickEvents": "off",
         "noNoninteractiveTabindex": "off",
         "useAriaPropsForRole": "off",
-        "useSemanticElements": "off",
-        "useFocusableInteractive": "off"
+        "useSemanticElements": "off"
       },
       "style": {
         "useImportType": "off",

--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,8 @@
         "useKeyWithClickEvents": "off",
         "noNoninteractiveTabindex": "off",
         "useAriaPropsForRole": "off",
-        "useSemanticElements": "off"
+        "useSemanticElements": "off",
+        "useFocusableInteractive": "off"
       },
       "style": {
         "useImportType": "off",
@@ -57,7 +58,8 @@
         "useExhaustiveDependencies": "off",
         "noInnerDeclarations": "off",
         "useJsxKeyInIterable": "off",
-        "noSelfAssign": "off"
+        "noSelfAssign": "off",
+        "noUnknownMediaFeatureName": "info"
       }
     },
     "ignore": [

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,8 @@
         "useMediaCaption": "off",
         "useKeyWithClickEvents": "off",
         "noNoninteractiveTabindex": "off",
-        "useAriaPropsForRole": "off"
+        "useAriaPropsForRole": "off",
+        "useSemanticElements": "off"
       },
       "style": {
         "useImportType": "off",

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.7.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.3/schema.json",
   "organizeImports": {
     "enabled": true
   },

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "url": "https://github.com/navikt/aksel.git"
   },
   "devDependencies": {
-    "@biomejs/biome": "1.8.0",
+    "@biomejs/biome": "1.9.3",
     "@changesets/cli": "2.26.2",
     "@storybook/addon-a11y": "^8.3.4",
     "@storybook/addon-essentials": "^8.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1728,18 +1728,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@biomejs/biome@npm:1.8.0":
-  version: 1.8.0
-  resolution: "@biomejs/biome@npm:1.8.0"
+"@biomejs/biome@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@biomejs/biome@npm:1.9.3"
   dependencies:
-    "@biomejs/cli-darwin-arm64": "npm:1.8.0"
-    "@biomejs/cli-darwin-x64": "npm:1.8.0"
-    "@biomejs/cli-linux-arm64": "npm:1.8.0"
-    "@biomejs/cli-linux-arm64-musl": "npm:1.8.0"
-    "@biomejs/cli-linux-x64": "npm:1.8.0"
-    "@biomejs/cli-linux-x64-musl": "npm:1.8.0"
-    "@biomejs/cli-win32-arm64": "npm:1.8.0"
-    "@biomejs/cli-win32-x64": "npm:1.8.0"
+    "@biomejs/cli-darwin-arm64": "npm:1.9.3"
+    "@biomejs/cli-darwin-x64": "npm:1.9.3"
+    "@biomejs/cli-linux-arm64": "npm:1.9.3"
+    "@biomejs/cli-linux-arm64-musl": "npm:1.9.3"
+    "@biomejs/cli-linux-x64": "npm:1.9.3"
+    "@biomejs/cli-linux-x64-musl": "npm:1.9.3"
+    "@biomejs/cli-win32-arm64": "npm:1.9.3"
+    "@biomejs/cli-win32-x64": "npm:1.9.3"
   dependenciesMeta:
     "@biomejs/cli-darwin-arm64":
       optional: true
@@ -1759,62 +1759,62 @@ __metadata:
       optional: true
   bin:
     biome: bin/biome
-  checksum: 10/a83d41d3559de0c30aa91ddb603851440578cf76ebf5bb540c6b81679ccabfe5d92ba108d7321b84b87acac124fa581c6302ba8a7919f391b444ca6048a5e86f
+  checksum: 10/22278454245f3ca178762df09721389abb884fbce87f834f6979a6a9d8db397df160a6d5019a3c7f6bd7d54d136bfaf1b6d3e6852fd9cf45bebc2be0337cb7dd
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-arm64@npm:1.8.0":
-  version: 1.8.0
-  resolution: "@biomejs/cli-darwin-arm64@npm:1.8.0"
+"@biomejs/cli-darwin-arm64@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@biomejs/cli-darwin-arm64@npm:1.9.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-x64@npm:1.8.0":
-  version: 1.8.0
-  resolution: "@biomejs/cli-darwin-x64@npm:1.8.0"
+"@biomejs/cli-darwin-x64@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@biomejs/cli-darwin-x64@npm:1.9.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64-musl@npm:1.8.0":
-  version: 1.8.0
-  resolution: "@biomejs/cli-linux-arm64-musl@npm:1.8.0"
+"@biomejs/cli-linux-arm64-musl@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@biomejs/cli-linux-arm64-musl@npm:1.9.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64@npm:1.8.0":
-  version: 1.8.0
-  resolution: "@biomejs/cli-linux-arm64@npm:1.8.0"
+"@biomejs/cli-linux-arm64@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@biomejs/cli-linux-arm64@npm:1.9.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64-musl@npm:1.8.0":
-  version: 1.8.0
-  resolution: "@biomejs/cli-linux-x64-musl@npm:1.8.0"
+"@biomejs/cli-linux-x64-musl@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@biomejs/cli-linux-x64-musl@npm:1.9.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64@npm:1.8.0":
-  version: 1.8.0
-  resolution: "@biomejs/cli-linux-x64@npm:1.8.0"
+"@biomejs/cli-linux-x64@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@biomejs/cli-linux-x64@npm:1.9.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-arm64@npm:1.8.0":
-  version: 1.8.0
-  resolution: "@biomejs/cli-win32-arm64@npm:1.8.0"
+"@biomejs/cli-win32-arm64@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@biomejs/cli-win32-arm64@npm:1.9.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-x64@npm:1.8.0":
-  version: 1.8.0
-  resolution: "@biomejs/cli-win32-x64@npm:1.8.0"
+"@biomejs/cli-win32-x64@npm:1.9.3":
+  version: 1.9.3
+  resolution: "@biomejs/cli-win32-x64@npm:1.9.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7750,7 +7750,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel@workspace:."
   dependencies:
-    "@biomejs/biome": "npm:1.8.0"
+    "@biomejs/biome": "npm:1.9.3"
     "@changesets/cli": "npm:2.26.2"
     "@storybook/addon-a11y": "npm:^8.3.4"
     "@storybook/addon-essentials": "npm:^8.3.4"


### PR DESCRIPTION
### Description

Ignored rules: 
- useSemanticElements: We have lots of cases where the native elements don't stack up to custom implementations. Some examples for changes they want: role combobox -> `<select>`, role status -> `<output>`. Best to ignore for now, but wold be a good idea in the future to do a collective walgrough and check if we can change some things.

Remaining changes are updates recommended by Biome, like not needed React.Fragments, duplicate border and border-color and unknown media queries

@HalvorHaugan Could you test the page https://aksel.nav.no/god-praksis/artikler/slik-gjor-du-en-lavterskel-brukertest-av-tekst with some different image sizes while toggling translateZ and image-rendering CSS on the `<img>` element? I notice not difference in image quality on Mac, but might be a chrome on windows only thing. 

<img width="1512" alt="Screenshot 2024-10-03 at 09 42 21" src="https://github.com/user-attachments/assets/d0f5fc36-5abb-45d5-b29e-8c447d50da0b">


### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
