### PR TITLE
List: Explicitly set list-style on ol to override reset-CSS

### DIFF
--- a/.changeset/thick-bugs-remember.md
+++ b/.changeset/thick-bugs-remember.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+List: Explicitly set list-style on ol to override reset-CSS

--- a/@navikt/core/css/list.css
+++ b/@navikt/core/css/list.css
@@ -14,6 +14,7 @@
 }
 
 .navds-list ol {
+  list-style: decimal; /* This is the default value, but some frameworks have `ol,ul { list-style:none }` */
   padding-left: 1.7rem;
 }
 


### PR DESCRIPTION
### Description

Fixes this: https://aksel.nav.no/komponenter/core/list#listdemo-ordered

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
