### PR TITLE
[ActionMenu] Fixes overlapping elements for SubMenus

### DIFF
--- a/@navikt/core/css/action-menu.css
+++ b/@navikt/core/css/action-menu.css
@@ -19,10 +19,7 @@
   animation-duration: 160ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   padding: var(--__ac-action-menu-content-p);
-  scrollbar-gutter: stable;
-  scrollbar-width: thin;
   overflow: auto;
-  padding-right: 0;
   max-height: var(--__ac-action-menu-content-available-height);
 }
 

--- a/@navikt/core/css/action-menu.css
+++ b/@navikt/core/css/action-menu.css
@@ -1,22 +1,29 @@
-/* stylelint-disable csstools/value-no-unknown-custom-properties */
 .navds-action-menu__content {
+  overflow: hidden;
+  box-shadow: var(--a-shadow-medium);
+  border-radius: var(--a-border-radius-large);
+}
+
+/* stylelint-disable csstools/value-no-unknown-custom-properties */
+.navds-action-menu__content > .navds-action-menu__content-inner {
   --__ac-action-menu-content-p: var(--a-spacing-2);
   --__ac-action-menu-item-pr: var(--a-spacing-3);
   --__ac-action-menu-item-pl: var(--a-spacing-2);
   --__ac-action-menu-item-height: 2rem;
 
-  padding: var(--__ac-action-menu-content-p);
-  box-shadow: var(--a-shadow-medium);
   border-radius: var(--a-border-radius-large);
   background-color: var(--a-surface-default);
-  overflow: auto;
   min-width: 128px;
   max-width: min(95vw, 640px);
-  width: calc(100% + 17px);
-  max-height: var(--__ac-action-menu-content-available-height);
   transform-origin: var(--__ac-action-menu-content-transform-origin);
   animation-duration: 160ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  padding: var(--__ac-action-menu-content-p);
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  overflow: auto;
+  padding-right: 0;
+  max-height: var(--__ac-action-menu-content-available-height);
 }
 
 .navds-action-menu__content:where([data-state="open"]):where([data-side="bottom"]) {
@@ -183,7 +190,6 @@
   height: 1px;
   margin-block: var(--a-spacing-2);
   background-color: var(--a-border-divider);
-  margin-inline: calc(var(--__ac-action-menu-content-p) * -1);
 }
 
 .navds-action-menu__indicator {

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -368,7 +368,7 @@ const ActionMenuContent = forwardRef<HTMLDivElement, ActionMenuContentProps>(
             },
           }}
         >
-          {children}
+          <div className="navds-action-menu__content-inner">{children}</div>
         </Menu.Content>
       </Menu.Portal>
     );
@@ -952,7 +952,7 @@ const ActionMenuSubContent = forwardRef<
             },
           }}
         >
-          {children}
+          <div className="navds-action-menu__content-inner">{children}</div>
         </Menu.SubContent>
       </Menu.Portal>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3880,7 +3880,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@npm:^7.1.1, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
+"@navikt/aksel-icons@npm:^7.1.2, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-icons@workspace:@navikt/aksel-icons"
   dependencies:
@@ -3909,8 +3909,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-stylelint@workspace:@navikt/aksel-stylelint"
   dependencies:
-    "@navikt/ds-css": "npm:^7.1.1"
-    "@navikt/ds-tokens": "npm:^7.1.1"
+    "@navikt/ds-css": "npm:^7.1.2"
+    "@navikt/ds-tokens": "npm:^7.1.2"
     concurrently: "npm:7.2.1"
     postcss-selector-parser: "npm:^6.0.13"
     postcss-value-parser: "npm:^4.2.0"
@@ -3925,7 +3925,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel@workspace:@navikt/aksel"
   dependencies:
-    "@navikt/ds-css": "npm:7.1.1"
+    "@navikt/ds-css": "npm:7.1.2"
     axios: "npm:1.7.4"
     chalk: "npm:4.1.0"
     clipboardy: "npm:^2.3.0"
@@ -3946,11 +3946,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@npm:*, @navikt/ds-css@npm:7.1.1, @navikt/ds-css@npm:^7.1.1, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@npm:*, @navikt/ds-css@npm:7.1.2, @navikt/ds-css@npm:^7.1.2, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": "npm:^7.1.1"
+    "@navikt/ds-tokens": "npm:^7.1.2"
     cssnano: "npm:6.0.0"
     fast-glob: "npm:3.2.11"
     lodash: "npm:4.17.21"
@@ -3963,14 +3963,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@npm:*, @navikt/ds-react@npm:^7.1.1, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@npm:*, @navikt/ds-react@npm:^7.1.2, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": "npm:0.25.4"
     "@floating-ui/react-dom": "npm:^2.0.9"
-    "@navikt/aksel-icons": "npm:^7.1.1"
-    "@navikt/ds-tokens": "npm:^7.1.1"
+    "@navikt/aksel-icons": "npm:^7.1.2"
+    "@navikt/ds-tokens": "npm:^7.1.2"
     "@testing-library/dom": "npm:9.3.4"
     "@testing-library/jest-dom": "npm:^5.16.0"
     "@testing-library/react": "npm:^15.0.7"
@@ -4000,11 +4000,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@npm:^7.1.1, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@npm:^7.1.2, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": "npm:^7.1.1"
+    "@navikt/ds-tokens": "npm:^7.1.2"
     color: "npm:4.2.3"
     lodash: "npm:^4.17.21"
     tailwindcss: "npm:^3.3.3"
@@ -4014,7 +4014,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@npm:^7.1.1, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@npm:^7.1.2, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -7914,11 +7914,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/aksel-icons": "npm:^7.1.1"
-    "@navikt/ds-css": "npm:^7.1.1"
-    "@navikt/ds-react": "npm:^7.1.1"
-    "@navikt/ds-tailwind": "npm:^7.1.1"
-    "@navikt/ds-tokens": "npm:^7.1.1"
+    "@navikt/aksel-icons": "npm:^7.1.2"
+    "@navikt/ds-css": "npm:^7.1.2"
+    "@navikt/ds-react": "npm:^7.1.2"
+    "@navikt/ds-tailwind": "npm:^7.1.2"
+    "@navikt/ds-tokens": "npm:^7.1.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

Solves https://github.com/navikt/aksel/pull/3085#discussion_r1790161786 🤞 
Fixes issue currently caused by `width: calc(100% + 17px)`
- FloatingUi-element uses "max-content" for width calculation. This omits the 17px, thus leading to wrong calculations
- This causes the sub-menu to overlap 17 extra pixels over the element when place on the left side.

Fix: 
- Use scrollbar-gutter instead of magic numbers to avoid text-wrapping.

Result:
<img width="173" alt="Screenshot 2024-10-09 at 11 57 30" src="https://github.com/user-attachments/assets/ab52354a-293b-4110-9584-23cf900bd39f">

<img width="457" alt="Screenshot 2024-10-09 at 11 56 25" src="https://github.com/user-attachments/assets/3e2ed16d-3056-4622-a1ef-931ad941d1de">

@HalvorHaugan Might need to test on windows how scrollbar-gutter looks, the scrollbar "track" is not always present on Mac, but might differ on OS
