### PR TITLE
[Linting] Fixed `useJsxKeyInIterable `,`noSelfAssign` and `noInnerDeclarations` rules from biome

### DIFF
--- a/@navikt/core/react/src/chat/chat.stories.tsx
+++ b/@navikt/core/react/src/chat/chat.stories.tsx
@@ -58,7 +58,7 @@ export const Size: Story = {
   render: () => (
     <VStack gap="4">
       {SIZES.map((size) => (
-        <>
+        <React.Fragment key={size}>
           <h3>{size}</h3>
           <Chat
             avatar="ON"
@@ -75,7 +75,7 @@ export const Size: Story = {
               laboris labore nisi ut.
             </Chat.Bubble>
           </Chat>
-        </>
+        </React.Fragment>
       ))}
     </VStack>
   ),
@@ -85,7 +85,7 @@ export const Variants: Story = {
   render: () => (
     <VStack gap="4">
       {VARIANTS.map((variant) => (
-        <>
+        <React.Fragment key={variant}>
           <h3>{variant}</h3>
           <Chat
             avatar="NAV"
@@ -97,7 +97,7 @@ export const Variants: Story = {
               Aute minim nisi sunt mollit duis sunt nulla minim non proident.
             </Chat.Bubble>
           </Chat>
-        </>
+        </React.Fragment>
       ))}
     </VStack>
   ),

--- a/@navikt/core/react/src/typography/stories/font.stories.tsx
+++ b/@navikt/core/react/src/typography/stories/font.stories.tsx
@@ -152,14 +152,14 @@ export const FontWeight: Story = {
     return (
       <>
         {fontWeights.map((weight) => (
-          <>
+          <React.Fragment key={weight}>
             <h2>{weight}</h2>
             <FontComponent
               key={weight}
               weight={weight}
               family="Source Sans 3"
             />
-          </>
+          </React.Fragment>
         ))}
       </>
     );

--- a/biome.json
+++ b/biome.json
@@ -51,9 +51,6 @@
         "useOptionalChain": "off",
         "useArrowFunction": "off",
         "noUselessTernary": "off"
-      },
-      "correctness": {
-        "noInnerDeclarations": "off"
       }
     },
     "ignore": [

--- a/biome.json
+++ b/biome.json
@@ -54,8 +54,7 @@
       },
       "correctness": {
         "noInnerDeclarations": "off",
-        "useJsxKeyInIterable": "off",
-        "noSelfAssign": "off"
+        "useJsxKeyInIterable": "off"
       }
     },
     "ignore": [

--- a/biome.json
+++ b/biome.json
@@ -53,8 +53,7 @@
         "noUselessTernary": "off"
       },
       "correctness": {
-        "noInnerDeclarations": "off",
-        "useJsxKeyInIterable": "off"
+        "noInnerDeclarations": "off"
       }
     },
     "ignore": [

--- a/biome.json
+++ b/biome.json
@@ -66,6 +66,7 @@
       "**/esm/**",
       "**/cjs/**",
       "**/dist/**",
+      "**/figma/**/plugin.js",
       "**/codemod/**/*.js",
       "**/tailwind/tailwind.config.js",
       "**/.next/**",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3861,7 +3861,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@npm:^7.1.2, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
+"@navikt/aksel-icons@npm:^7.2.0, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-icons@workspace:@navikt/aksel-icons"
   dependencies:
@@ -3890,8 +3890,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-stylelint@workspace:@navikt/aksel-stylelint"
   dependencies:
-    "@navikt/ds-css": "npm:^7.1.2"
-    "@navikt/ds-tokens": "npm:^7.1.2"
+    "@navikt/ds-css": "npm:^7.2.0"
+    "@navikt/ds-tokens": "npm:^7.2.0"
     concurrently: "npm:7.2.1"
     postcss-selector-parser: "npm:^6.0.13"
     postcss-value-parser: "npm:^4.2.0"
@@ -3906,7 +3906,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel@workspace:@navikt/aksel"
   dependencies:
-    "@navikt/ds-css": "npm:7.1.2"
+    "@navikt/ds-css": "npm:7.2.0"
     axios: "npm:1.7.4"
     chalk: "npm:4.1.0"
     clipboardy: "npm:^2.3.0"
@@ -3927,11 +3927,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@npm:*, @navikt/ds-css@npm:7.1.2, @navikt/ds-css@npm:^7.1.2, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@npm:*, @navikt/ds-css@npm:7.2.0, @navikt/ds-css@npm:^7.2.0, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": "npm:^7.1.2"
+    "@navikt/ds-tokens": "npm:^7.2.0"
     cssnano: "npm:6.0.0"
     fast-glob: "npm:3.2.11"
     lodash: "npm:4.17.21"
@@ -3944,14 +3944,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@npm:*, @navikt/ds-react@npm:^7.1.2, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@npm:*, @navikt/ds-react@npm:^7.2.0, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": "npm:0.25.4"
     "@floating-ui/react-dom": "npm:^2.0.9"
-    "@navikt/aksel-icons": "npm:^7.1.2"
-    "@navikt/ds-tokens": "npm:^7.1.2"
+    "@navikt/aksel-icons": "npm:^7.2.0"
+    "@navikt/ds-tokens": "npm:^7.2.0"
     "@testing-library/dom": "npm:9.3.4"
     "@testing-library/jest-dom": "npm:^5.16.0"
     "@testing-library/react": "npm:^15.0.7"
@@ -3981,11 +3981,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@npm:^7.1.2, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@npm:^7.2.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": "npm:^7.1.2"
+    "@navikt/ds-tokens": "npm:^7.2.0"
     color: "npm:4.2.3"
     lodash: "npm:^4.17.21"
     tailwindcss: "npm:^3.3.3"
@@ -3995,7 +3995,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@npm:^7.1.2, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@npm:^7.2.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -7867,11 +7867,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/aksel-icons": "npm:^7.1.2"
-    "@navikt/ds-css": "npm:^7.1.2"
-    "@navikt/ds-react": "npm:^7.1.2"
-    "@navikt/ds-tailwind": "npm:^7.1.2"
-    "@navikt/ds-tokens": "npm:^7.1.2"
+    "@navikt/aksel-icons": "npm:^7.2.0"
+    "@navikt/ds-css": "npm:^7.2.0"
+    "@navikt/ds-react": "npm:^7.2.0"
+    "@navikt/ds-tailwind": "npm:^7.2.0"
+    "@navikt/ds-tokens": "npm:^7.2.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

- noSelfAssign: did nothing
- noInnerDeclarations: did nothing
- useJsxKeyInIterable: Added keys to fragments

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
