### PR TITLE
Collapse empty table cells and headers

### DIFF
--- a/.changeset/fifty-plums-promise.md
+++ b/.changeset/fifty-plums-promise.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Collapses empty table cells and headers by removing all padding. Makes completely empty columns invisible.

--- a/.changeset/fifty-plums-promise.md
+++ b/.changeset/fifty-plums-promise.md
@@ -2,4 +2,4 @@
 "@navikt/ds-css": patch
 ---
 
-Collapses empty table cells and headers by removing all padding. Makes completely empty columns invisible.
+Table: Collapses empty table cells and headers by removing padding. Makes completely empty columns invisible.

--- a/@navikt/core/css/table.css
+++ b/@navikt/core/css/table.css
@@ -96,7 +96,9 @@
   padding: 0;
 }
 
-.navds-table__header-cell[aria-sort] {
+.navds-table__header-cell[aria-sort],
+.navds-table__header-cell:empty,
+.navds-table__data-cell:empty {
   padding: 0;
 }
 


### PR DESCRIPTION
### Description
In some cases, at least ours, there are situations where columns in tables may be completely empty.
In our case because of asynchronous conditional components.

_In most cases the column should be removed._

#### Before and after
In the example below, the 3rd column, "Etternavn", has been emptied. The header and cells are still there, but have no content.
In the first image, between the "Fornavn" and "Rolle" columns, the gap is visually doubled due to the empty column.
<img width="268" alt="table-empty-before" src="https://github.com/user-attachments/assets/405fe313-07ab-4229-8917-6c3950a9e7d2">\
<img width="268" alt="table-empty-after" src="https://github.com/user-attachments/assets/2361eb2e-403c-4fc5-a350-5956aa070bb2">
In the second image, the gap is even between all columns with content. The empty "Etternavn" column does not add visually misaligning spacing.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
