### PR TITLE
JSDoc for translations

### DIFF
--- a/@navikt/core/react/src/util/i18n/locales/nb.ts
+++ b/@navikt/core/react/src/util/i18n/locales/nb.ts
@@ -9,25 +9,40 @@ interface TranslationMap {
 export default {
   FileUpload: {
     dropzone: {
+      /** @default "Velg fil", */
       button: "Velg fil",
+      /** @default "Velg filer", */
       buttonMultiple: "Velg filer",
+      /** @default "Dra og slipp filen her", */
       dragAndDrop: "Dra og slipp filen her",
+      /** @default "Dra og slipp filer her", */
       dragAndDropMultiple: "Dra og slipp filer her",
+      /** @default "Slipp", */
       drop: "Slipp",
+      /** @default "eller", */
       or: "eller",
+      /** @default "Filopplasting er deaktivert", */
       disabled: "Filopplasting er deaktivert",
+      /** @default "Du kan ikke laste opp flere filer", */
       disabledFilelimit: "Du kan ikke laste opp flere filer",
     },
     item: {
+      /** @default "Prøv å laste opp filen på nytt", */
       retryButtonTitle: "Prøv å laste opp filen på nytt",
+      /** @default "Slett filen", */
       deleteButtonTitle: "Slett filen",
+      /** @default "Laster opp…", */
       uploading: "Laster opp…",
+      /** @default "Laster ned…", */
       downloading: "Laster ned…",
     },
   },
   FormProgress: {
+    /** @default "Steg {activeStep} av {totalSteps}" */
     step: "Steg {activeStep} av {totalSteps}",
+    /** @default "Vis alle steg" */
     showAllSteps: "Vis alle steg",
+    /** @default "Skjul alle steg" */
     hideAllSteps: "Skjul alle steg",
   },
 } satisfies TranslationMap;


### PR DESCRIPTION
What do you think about this? Will make it easier when developers write their own translations, since they can easily see the original text. (Based on an [idea from Ken](https://github.com/navikt/aksel/pull/3209#pullrequestreview-2354305519))

![image](https://github.com/user-attachments/assets/ff18bba8-b527-490e-b068-732a305c10c3)

nb.ts becomes a bit messy, though. Any ideas to mitigate this?