### PR TITLE
[Icons] Some icons that should be ignored were fetched and caused exceptions

### DIFF
--- a/@navikt/aksel-icons/config/figma/index.ts
+++ b/@navikt/aksel-icons/config/figma/index.ts
@@ -4,7 +4,10 @@ import { fetchDownloadUrls, fetchIcons } from "./fetch-icons";
 import { resolveName } from "./icon-name";
 import { makeConfig } from "./make-configs";
 
-/* https://www.figma.com/file/wEdyFjCQSBR3U7FvrMbPXa/Core-Icons-Next?node-id=277%3A1221&t=mUJzFvnsceYYXNL5-0 */
+/**
+ * https://www.figma.com/file/wEdyFjCQSBR3U7FvrMbPXa/Core-Icons-Next?node-id=277%3A1221&t=mUJzFvnsceYYXNL5-0
+ * This is the current source for all icons we are working with.
+ */
 
 const iconFolder = "./icons";
 
@@ -16,16 +19,18 @@ main();
 
 async function main() {
   console.info("Started icon-update from Figma");
+  /* Icons are published as 'components' in Figma */
   const publishedIconComponents = await fetchIcons();
 
+  /* When we have all the published icons, we can ask figma for URL's for downling them as assets */
   const imagesUrls = await fetchDownloadUrls(
     publishedIconComponents.map((x) => x.node_id),
   );
 
+  /* Lets do a clean install */
   if (existsSync(iconFolder)) {
     rmSync(iconFolder, { recursive: true, force: true });
   }
-
   mkdirSync(iconFolder);
 
   console.group(`Processing ${Object.keys(imagesUrls).length} icons...`);
@@ -34,6 +39,7 @@ async function main() {
 
   await Promise.all(
     Object.entries(imagesUrls).map(async ([nodeId, iconUrl]) => {
+      /* Each icon is now a raw string for a complete SVG */
       const iconSvg = await fetch(iconUrl)
         .then((x) => x.text())
         .catch((e) => {
@@ -52,6 +58,10 @@ async function main() {
 
       const fileName = resolveName(matchingIcon);
 
+      /*
+       * In some cases if multiple icons are published in Figma with the same name,
+       * the we will end up overwriting the icon with the same name.
+       */
       if (fileNames.has(fileName)) {
         console.warn(`Duplicate name detected: ${fileName}.`);
       }

--- a/@navikt/aksel-icons/config/figma/index.ts
+++ b/@navikt/aksel-icons/config/figma/index.ts
@@ -94,7 +94,7 @@ async function main() {
     ymlFiles.length !== publishedIconComponents.length
   ) {
     throw new Error(
-      `Icons written to directory (${filesInDir.length}) does not match the amount of icons located in Figma (${publishedIconComponents.length}).\nThis is most likely caused by duplicate icon names from figma.`,
+      `Icons (${svgFiles.length}) and configs (${ymlFiles.length}) written to directory does not match the expected amount of icons located in Figma (${publishedIconComponents.length}).\nThis is most likely caused by duplicate icon names from figma.`,
     );
   }
 

--- a/@navikt/aksel-icons/config/figma/index.ts
+++ b/@navikt/aksel-icons/config/figma/index.ts
@@ -60,7 +60,7 @@ async function main() {
 
       /*
        * In some cases if multiple icons are published in Figma with the same name,
-       * the we will end up overwriting the icon with the same name.
+       * we will end up overwriting the icon with the same name.
        */
       if (fileNames.has(fileName)) {
         console.warn(`Duplicate name detected: ${fileName}.`);

--- a/@navikt/aksel-icons/config/figma/index.ts
+++ b/@navikt/aksel-icons/config/figma/index.ts
@@ -22,7 +22,7 @@ async function main() {
   /* Icons are published as 'components' in Figma */
   const publishedIconComponents = await fetchIcons();
 
-  /* When we have all the published icons, we can ask figma for URL's for downling them as assets */
+  /* When we have all the published icons, we can ask figma for URL's for downloading them as assets */
   const imagesUrls = await fetchDownloadUrls(
     publishedIconComponents.map((x) => x.node_id),
   );
@@ -86,8 +86,13 @@ async function main() {
   makeConfig(publishedIconComponents, iconFolder);
 
   const filesInDir = readdirSync(iconFolder);
+  const svgFiles = filesInDir.filter((x) => x.endsWith(".svg"));
+  const ymlFiles = filesInDir.filter((x) => x.endsWith(".yml"));
 
-  if (filesInDir.length * 2 !== publishedIconComponents.length) {
+  if (
+    svgFiles.length !== publishedIconComponents.length ||
+    ymlFiles.length !== publishedIconComponents.length
+  ) {
     throw new Error(
       `Icons written to directory (${filesInDir.length}) does not match the amount of icons located in Figma (${publishedIconComponents.length}).\nThis is most likely caused by duplicate icon names from figma.`,
     );

--- a/@navikt/aksel-icons/config/figma/make-configs.ts
+++ b/@navikt/aksel-icons/config/figma/make-configs.ts
@@ -18,6 +18,9 @@ export const makeConfig = (
   icons: PublishedComponent[],
   dirLocation: string,
 ) => {
+  console.group("Creating icon yml...");
+
+  let counter = 0;
   for (const icon of icons) {
     const name = resolveName(icon).replace(".svg", "");
     const keywords = icon.description
@@ -62,5 +65,9 @@ export const makeConfig = (
     writeFileSync(resolve(dirLocation, `${config.name}.yml`), yml, {
       encoding: "utf8",
     });
+    counter++;
   }
+
+  console.info(`Created ${counter} icon yml files`);
+  console.groupEnd();
 };


### PR DESCRIPTION
### Description

- Added better console logging for tracking what's happening
- Filters out invalid icons (missing sections for correct labeling)
- Tracks duplicate icon-names. 

## Tracks duplicate icon-names

Right now the code throws with error since we found a duplicate icon-name "Thermometer" from Figma. This has not been detected previously so we have the version in the last screenshot in the icon-package 😅 When this is updated in Figma next week the code should hopefully run without errors

<img width="188" alt="Screenshot 2024-10-11 at 20 19 22" src="https://github.com/user-attachments/assets/f61a888c-95b8-4f97-aa88-b20539ef451c">
<img width="244" alt="Screenshot 2024-10-11 at 20 19 26" src="https://github.com/user-attachments/assets/4da11503-21e7-4076-afe5-0f9f4435a034">


## Optimizations

Previously, each icon was fetched 1 by 1 on a for-loop, most likely to avoid rate-limiting. Just for fun i tested throwing it into a `Promise.all` and running them all at the same time. This looks to be working just fine and in only ~10 seconds, not minutes like before ⚡ ⚡ ⚡ ⚡ 


### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
