### PR TITLE
[Translations] Alert: i18n support

### DIFF
--- a/.changeset/real-rockets-hide.md
+++ b/.changeset/real-rockets-hide.md
@@ -1,5 +1,0 @@
----
-"@navikt/ds-react": patch
----
-
-Alert: Prepare for i18n support

--- a/.changeset/real-rockets-hide.md
+++ b/.changeset/real-rockets-hide.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Alert: Prepare for i18n support

--- a/@navikt/core/react/src/alert/Alert.tsx
+++ b/@navikt/core/react/src/alert/Alert.tsx
@@ -9,6 +9,7 @@ import {
 } from "@navikt/aksel-icons";
 import { Button } from "../button";
 import { BodyLong } from "../typography";
+import { useI18n } from "../util/i18n/i18n.context";
 
 export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -54,24 +55,12 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   onClose?: () => void;
 }
 
-const Icon = ({ variant, ...props }) => {
-  switch (variant) {
-    case "error":
-      return <XMarkOctagonFillIcon title="Feil" {...props} />;
-    case "warning":
-      return <ExclamationmarkTriangleFillIcon title="Advarsel" {...props} />;
-    case "info":
-      return <InformationSquareFillIcon title="Informasjon" {...props} />;
-    case "success":
-      return <CheckmarkCircleFillIcon title="Suksess" {...props} />;
-    default:
-      return null;
-  }
+const IconMap = {
+  error: XMarkOctagonFillIcon,
+  warning: ExclamationmarkTriangleFillIcon,
+  info: InformationSquareFillIcon,
+  success: CheckmarkCircleFillIcon,
 };
-
-export interface AlertContextProps {
-  size: "medium" | "small";
-}
 
 /**
  * A component for displaying alerts
@@ -98,6 +87,8 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
     },
     ref,
   ) => {
+    const translate = useI18n("Alert");
+    const Icon = IconMap[variant];
     return (
       <div
         {...rest}
@@ -114,7 +105,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
           },
         )}
       >
-        <Icon variant={variant} className="navds-alert__icon" />
+        <Icon title={translate(variant)} className="navds-alert__icon" />
         <BodyLong
           as="div"
           size={size}
@@ -137,8 +128,8 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
                 <XMarkIcon
                   title={
                     ["error", "warning"].includes(variant)
-                      ? "Lukk varsel"
-                      : "Lukk melding"
+                      ? translate("closeAlert")
+                      : translate("closeMessage")
                   }
                 />
               }

--- a/@navikt/core/react/src/util/i18n/locales/en.ts
+++ b/@navikt/core/react/src/util/i18n/locales/en.ts
@@ -24,4 +24,12 @@ export default {
     showAllSteps: "Show all steps",
     hideAllSteps: "Hide all steps",
   },
+  Alert: {
+    closeAlert: "Close alert",
+    closeMessage: "Close message",
+    error: "Error",
+    info: "Information",
+    success: "Success",
+    warning: "Warning",
+  },
 } satisfies Translations;

--- a/@navikt/core/react/src/util/i18n/locales/nb.ts
+++ b/@navikt/core/react/src/util/i18n/locales/nb.ts
@@ -30,4 +30,12 @@ export default {
     showAllSteps: "Vis alle steg",
     hideAllSteps: "Skjul alle steg",
   },
+  Alert: {
+    closeAlert: "Lukk varsel",
+    closeMessage: "Lukk melding",
+    error: "Feil",
+    info: "Informasjon",
+    success: "Suksess",
+    warning: "Advarsel",
+  },
 } satisfies TranslationMap;

--- a/@navikt/core/react/src/util/i18n/locales/nn.ts
+++ b/@navikt/core/react/src/util/i18n/locales/nn.ts
@@ -24,4 +24,12 @@ export default {
     showAllSteps: "Vis alle steg",
     hideAllSteps: "Skjul alle steg",
   },
+  Alert: {
+    closeAlert: "Lukk varsel",
+    closeMessage: "Lukk melding",
+    error: "Feil",
+    info: "Informasjon",
+    success: "Suksess",
+    warning: "Åtvaring",
+  },
 } satisfies Translations;


### PR DESCRIPTION
### Description

Only title-texts, so I don't think we need translation prop here.

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
