### PR TITLE
[aksel.nav.no] Adjust list of outdated articles

### DIFF
--- a/aksel.nav.no/website/sanity/plugins/structure/structure.util.ts
+++ b/aksel.nav.no/website/sanity/plugins/structure/structure.util.ts
@@ -82,7 +82,7 @@ export function listOutdatedArticles(
       S.documentTypeList(type)
         .title("Artikler")
         .filter(
-          `_type == $type && (dateTime(updateInfo.lastVerified + "T00:00:00Z") < dateTime(now()) - 60*60*24*${threshold})`,
+          `_type == $type && (dateTime(updateInfo.lastVerified + "T00:00:00Z") < dateTime(now()) - 60*60*24*$threshold) && !(_id in path("drafts.**"))`,
         )
         .apiVersion(SANITY_API_VERSION)
         .params({ type, threshold })

--- a/aksel.nav.no/website/sanity/schema/documents/komponenter/artikkel.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/komponenter/artikkel.tsx
@@ -132,4 +132,11 @@ export const KomponentArtikkel = defineType({
     }),
     BaseSEOPreset,
   ],
+  orderings: [
+    {
+      title: "Sist godkjent",
+      name: "lastVerified",
+      by: [{ field: "updateInfo.lastVerified", direction: "asc" }],
+    },
+  ],
 });


### PR DESCRIPTION
- Exclude unpublished articles
- Add possibility to manually sort by lastVerified (since `defaultOrdering()` for some reason isn't working anymore)