### PR TITLE
[Actionmenu] Updated examples for docs, removed `flipAlignment`-prop

### DIFF
--- a/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
@@ -205,7 +205,6 @@ const MenuRootContentNonModal = React.forwardRef<
       ref={ref}
       disableOutsidePointerEvents={false}
       onDismiss={() => context.onOpenChange(false)}
-      flipAlignment={false}
     />
   );
 });
@@ -232,7 +231,6 @@ const MenuRootContentModal = forwardRef<
         { checkForDefaultPrevented: false },
       )}
       onDismiss={() => context.onOpenChange(false)}
-      flipAlignment={false}
     />
   );
 });

--- a/@navikt/core/react/src/overlays/floating/Floating.tsx
+++ b/@navikt/core/react/src/overlays/floating/Floating.tsx
@@ -187,7 +187,6 @@ interface FloatingContentProps extends HTMLAttributes<HTMLDivElement> {
   collisionBoundary?: Boundary | Boundary[];
   collisionPadding?: number | Partial<Record<Side, number>>;
   hideWhenDetached?: boolean;
-  flipAlignment?: boolean;
   updatePositionStrategy?: "optimized" | "always";
   onPlaced?: () => void;
   arrow?: {
@@ -213,7 +212,6 @@ const FloatingContent = forwardRef<HTMLDivElement, FloatingContentProps>(
       updatePositionStrategy = "optimized",
       onPlaced,
       arrow: _arrow,
-      flipAlignment,
       ...contentProps
     }: FloatingContentProps,
     forwardedRef,
@@ -258,7 +256,6 @@ const FloatingContent = forwardRef<HTMLDivElement, FloatingContentProps>(
       altBoundary: hasExplicitBoundaries,
       /* https://floating-ui.com/docs/flip#fallbackaxissidedirection */
       fallbackAxisSideDirection: "end",
-      flipAlignment,
     };
 
     const { refs, floatingStyles, placement, isPositioned, middlewareData } =

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/danger.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/danger.tsx
@@ -9,7 +9,7 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <ActionMenu defaultOpen>
+    <ActionMenu>
       <ActionMenu.Trigger>
         <Button
           variant="secondary-neutral"
@@ -42,7 +42,7 @@ const Example = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/filter.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/filter.tsx
@@ -19,78 +19,80 @@ const Example = () => {
   };
 
   return (
-    <ActionMenu defaultOpen>
-      <ActionMenu.Trigger>
-        <Button
-          variant="secondary-neutral"
-          icon={<ChevronDownIcon aria-hidden />}
-          iconPosition="right"
-        >
-          Filter
-        </Button>
-      </ActionMenu.Trigger>
-      <ActionMenu.Content>
-        <ActionMenu.Group label="Kolonner">
-          <ActionMenu.CheckboxItem
-            checked={
-              Object.values(views).every(Boolean)
-                ? true
-                : Object.values(views).some(Boolean)
-                  ? "indeterminate"
-                  : false
-            }
-            onCheckedChange={() => {
-              const allChecked = Object.values(views).every(Boolean);
-              setViews((prevState) =>
-                Object.keys(prevState).reduce(
-                  (acc, key) => {
-                    acc[key] = !allChecked;
-                    return acc;
-                  },
-                  {} as typeof views,
-                ),
-              );
-            }}
+    <div style={{ minHeight: "28rem" }}>
+      <ActionMenu>
+        <ActionMenu.Trigger>
+          <Button
+            variant="secondary-neutral"
+            icon={<ChevronDownIcon aria-hidden />}
+            iconPosition="right"
           >
-            Velg alle
-          </ActionMenu.CheckboxItem>
-          <ActionMenu.CheckboxItem
-            checked={views.started}
-            onCheckedChange={() => handleCheckboxChange("started")}
+            Filter
+          </Button>
+        </ActionMenu.Trigger>
+        <ActionMenu.Content>
+          <ActionMenu.Group label="Kolonner">
+            <ActionMenu.CheckboxItem
+              checked={
+                Object.values(views).every(Boolean)
+                  ? true
+                  : Object.values(views).some(Boolean)
+                    ? "indeterminate"
+                    : false
+              }
+              onCheckedChange={() => {
+                const allChecked = Object.values(views).every(Boolean);
+                setViews((prevState) =>
+                  Object.keys(prevState).reduce(
+                    (acc, key) => {
+                      acc[key] = !allChecked;
+                      return acc;
+                    },
+                    {} as typeof views,
+                  ),
+                );
+              }}
+            >
+              Velg alle
+            </ActionMenu.CheckboxItem>
+            <ActionMenu.CheckboxItem
+              checked={views.started}
+              onCheckedChange={() => handleCheckboxChange("started")}
+            >
+              Oppfølging startet
+            </ActionMenu.CheckboxItem>
+            <ActionMenu.CheckboxItem
+              checked={views.fnr}
+              onCheckedChange={() => handleCheckboxChange("fnr")}
+            >
+              Fødselsnummer
+            </ActionMenu.CheckboxItem>
+            <ActionMenu.CheckboxItem
+              checked={views.tags}
+              onCheckedChange={() => handleCheckboxChange("tags")}
+            >
+              Tags
+            </ActionMenu.CheckboxItem>
+          </ActionMenu.Group>
+          <ActionMenu.Divider />
+          <ActionMenu.RadioGroup
+            onValueChange={setRows}
+            value={rows}
+            label="Rader per side"
           >
-            Oppfølging startet
-          </ActionMenu.CheckboxItem>
-          <ActionMenu.CheckboxItem
-            checked={views.fnr}
-            onCheckedChange={() => handleCheckboxChange("fnr")}
-          >
-            Fødselsnummer
-          </ActionMenu.CheckboxItem>
-          <ActionMenu.CheckboxItem
-            checked={views.tags}
-            onCheckedChange={() => handleCheckboxChange("tags")}
-          >
-            Tags
-          </ActionMenu.CheckboxItem>
-        </ActionMenu.Group>
-        <ActionMenu.Divider />
-        <ActionMenu.RadioGroup
-          onValueChange={setRows}
-          value={rows}
-          label="Rader per side"
-        >
-          <ActionMenu.RadioItem value="5">5</ActionMenu.RadioItem>
-          <ActionMenu.RadioItem value="10">10</ActionMenu.RadioItem>
-          <ActionMenu.RadioItem value="25">25</ActionMenu.RadioItem>
-          <ActionMenu.RadioItem value="50">50</ActionMenu.RadioItem>
-        </ActionMenu.RadioGroup>
-      </ActionMenu.Content>
-    </ActionMenu>
+            <ActionMenu.RadioItem value="5">5</ActionMenu.RadioItem>
+            <ActionMenu.RadioItem value="10">10</ActionMenu.RadioItem>
+            <ActionMenu.RadioItem value="25">25</ActionMenu.RadioItem>
+            <ActionMenu.RadioItem value="50">50</ActionMenu.RadioItem>
+          </ActionMenu.RadioGroup>
+        </ActionMenu.Content>
+      </ActionMenu>
+    </div>
   );
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/groups.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/groups.tsx
@@ -11,56 +11,58 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <ActionMenu defaultOpen>
-      <ActionMenu.Trigger>
-        <Button
-          variant="secondary-neutral"
-          icon={<ChevronDownIcon aria-hidden />}
-          iconPosition="right"
-        >
-          Meny
-        </Button>
-      </ActionMenu.Trigger>
-      <ActionMenu.Content>
-        <ActionMenu.Group label="Gosys">
-          <ActionMenu.Item onSelect={console.info} icon={<PersonIcon />}>
-            Personoversikt
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info} icon={<PersonGroupIcon />}>
-            Arbeidsgiveroversikt
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info} icon={<HandshakeIcon />}>
-            Samhandlere
-          </ActionMenu.Item>
-          <ActionMenu.Item
-            onSelect={console.info}
-            disabled
-            icon={<BarChartIcon />}
+    <div style={{ minHeight: "28rem" }}>
+      <ActionMenu>
+        <ActionMenu.Trigger>
+          <Button
+            variant="secondary-neutral"
+            icon={<ChevronDownIcon aria-hidden />}
+            iconPosition="right"
           >
-            Oppgavestatistikk
-          </ActionMenu.Item>
-          <ActionMenu.Item
-            onSelect={console.info}
-            icon={<MagnifyingGlassIcon />}
-          >
-            Søk journalpost
-          </ActionMenu.Item>
-        </ActionMenu.Group>
-        <ActionMenu.Divider />
-        <ActionMenu.Group label="Systemer og oppslagsverk">
-          <ActionMenu.Item onSelect={console.info}>A-inntekt</ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info}>
-            Aa-registeret
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info}>Modia</ActionMenu.Item>
-        </ActionMenu.Group>
-      </ActionMenu.Content>
-    </ActionMenu>
+            Meny
+          </Button>
+        </ActionMenu.Trigger>
+        <ActionMenu.Content>
+          <ActionMenu.Group label="Gosys">
+            <ActionMenu.Item onSelect={console.info} icon={<PersonIcon />}>
+              Personoversikt
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info} icon={<PersonGroupIcon />}>
+              Arbeidsgiveroversikt
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info} icon={<HandshakeIcon />}>
+              Samhandlere
+            </ActionMenu.Item>
+            <ActionMenu.Item
+              onSelect={console.info}
+              disabled
+              icon={<BarChartIcon />}
+            >
+              Oppgavestatistikk
+            </ActionMenu.Item>
+            <ActionMenu.Item
+              onSelect={console.info}
+              icon={<MagnifyingGlassIcon />}
+            >
+              Søk journalpost
+            </ActionMenu.Item>
+          </ActionMenu.Group>
+          <ActionMenu.Divider />
+          <ActionMenu.Group label="Systemer og oppslagsverk">
+            <ActionMenu.Item onSelect={console.info}>A-inntekt</ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info}>
+              Aa-registeret
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info}>Modia</ActionMenu.Item>
+          </ActionMenu.Group>
+        </ActionMenu.Content>
+      </ActionMenu>
+    </div>
   );
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/header.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/header.tsx
@@ -11,58 +11,68 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <InternalHeader>
-      <InternalHeader.Title as="h1">Sykepenger</InternalHeader.Title>
-      <Spacer />
-      <ActionMenu defaultOpen>
-        <ActionMenu.Trigger>
-          <InternalHeader.Button>
-            <MenuGridIcon fontSize="1.5rem" title="Systemer og oppslagsverk" />
-          </InternalHeader.Button>
-        </ActionMenu.Trigger>
-        <ActionMenu.Content>
-          <ActionMenu.Group label="Gosys">
-            <ActionMenu.Item onSelect={console.info} icon={<PersonIcon />}>
-              Personoversikt
-            </ActionMenu.Item>
-            <ActionMenu.Item onSelect={console.info} icon={<PersonGroupIcon />}>
-              Arbeidsgiveroversikt
-            </ActionMenu.Item>
-            <ActionMenu.Item onSelect={console.info} icon={<HandshakeIcon />}>
-              Samhandlere
-            </ActionMenu.Item>
-            <ActionMenu.Item
-              onSelect={console.info}
-              disabled
-              icon={<BarChartIcon />}
-            >
-              Oppgavestatistikk
-            </ActionMenu.Item>
-            <ActionMenu.Item
-              onSelect={console.info}
-              icon={<MagnifyingGlassIcon />}
-            >
-              Søk journalpost
-            </ActionMenu.Item>
-          </ActionMenu.Group>
-          <ActionMenu.Divider />
-          <ActionMenu.Group label="Systemer og oppslagsverk">
-            <ActionMenu.Item onSelect={console.info}>A-inntekt</ActionMenu.Item>
-            <ActionMenu.Item onSelect={console.info}>
-              Aa-registeret
-            </ActionMenu.Item>
-            <ActionMenu.Item onSelect={console.info}>Modia</ActionMenu.Item>
-          </ActionMenu.Group>
-        </ActionMenu.Content>
-      </ActionMenu>
+    <div style={{ minHeight: "28rem" }}>
+      <InternalHeader>
+        <InternalHeader.Title as="h1">Sykepenger</InternalHeader.Title>
+        <Spacer />
+        <ActionMenu>
+          <ActionMenu.Trigger>
+            <InternalHeader.Button>
+              <MenuGridIcon
+                fontSize="1.5rem"
+                title="Systemer og oppslagsverk"
+              />
+            </InternalHeader.Button>
+          </ActionMenu.Trigger>
+          <ActionMenu.Content>
+            <ActionMenu.Group label="Gosys">
+              <ActionMenu.Item onSelect={console.info} icon={<PersonIcon />}>
+                Personoversikt
+              </ActionMenu.Item>
+              <ActionMenu.Item
+                onSelect={console.info}
+                icon={<PersonGroupIcon />}
+              >
+                Arbeidsgiveroversikt
+              </ActionMenu.Item>
+              <ActionMenu.Item onSelect={console.info} icon={<HandshakeIcon />}>
+                Samhandlere
+              </ActionMenu.Item>
+              <ActionMenu.Item
+                onSelect={console.info}
+                disabled
+                icon={<BarChartIcon />}
+              >
+                Oppgavestatistikk
+              </ActionMenu.Item>
+              <ActionMenu.Item
+                onSelect={console.info}
+                icon={<MagnifyingGlassIcon />}
+              >
+                Søk journalpost
+              </ActionMenu.Item>
+            </ActionMenu.Group>
+            <ActionMenu.Divider />
+            <ActionMenu.Group label="Systemer og oppslagsverk">
+              <ActionMenu.Item onSelect={console.info}>
+                A-inntekt
+              </ActionMenu.Item>
+              <ActionMenu.Item onSelect={console.info}>
+                Aa-registeret
+              </ActionMenu.Item>
+              <ActionMenu.Item onSelect={console.info}>Modia</ActionMenu.Item>
+            </ActionMenu.Group>
+          </ActionMenu.Content>
+        </ActionMenu>
 
-      <InternalHeader.User name="Ola Normann" />
-    </InternalHeader>
+        <InternalHeader.User name="Ola Normann" />
+      </InternalHeader>
+    </div>
   );
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/items.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/items.tsx
@@ -4,7 +4,7 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <ActionMenu defaultOpen>
+    <ActionMenu>
       <ActionMenu.Trigger>
         <Button
           variant="secondary-neutral"
@@ -34,7 +34,7 @@ const Example = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/links.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/links.tsx
@@ -5,7 +5,7 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <ActionMenu defaultOpen>
+    <ActionMenu>
       <ActionMenu.Trigger>
         <Button
           variant="secondary-neutral"
@@ -52,7 +52,7 @@ const RemixExample = () => (
 */
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/shortcuts.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/shortcuts.tsx
@@ -4,49 +4,51 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <ActionMenu defaultOpen>
-      <ActionMenu.Trigger>
-        <Button
-          variant="secondary-neutral"
-          icon={<ChevronDownIcon aria-hidden />}
-          iconPosition="right"
-        >
-          Meny
-        </Button>
-      </ActionMenu.Trigger>
-      <ActionMenu.Content>
-        <ActionMenu.Group label="Gosys">
-          <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+A">
-            Personoversikt
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+K">
-            Arbeidsgiveroversikt
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+S">
-            Samhandlere
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+E">
-            Oppgavestatistikk
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+L">
-            Søk journalpost
-          </ActionMenu.Item>
-        </ActionMenu.Group>
-        <ActionMenu.Divider />
-        <ActionMenu.Group label="Systemer og oppslagsverk">
-          <ActionMenu.Item onSelect={console.info}>A-inntekt</ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info}>
-            Aa-registeret
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info}>Modia</ActionMenu.Item>
-        </ActionMenu.Group>
-      </ActionMenu.Content>
-    </ActionMenu>
+    <div style={{ minHeight: "28rem" }}>
+      <ActionMenu>
+        <ActionMenu.Trigger>
+          <Button
+            variant="secondary-neutral"
+            icon={<ChevronDownIcon aria-hidden />}
+            iconPosition="right"
+          >
+            Meny
+          </Button>
+        </ActionMenu.Trigger>
+        <ActionMenu.Content>
+          <ActionMenu.Group label="Gosys">
+            <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+A">
+              Personoversikt
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+K">
+              Arbeidsgiveroversikt
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+S">
+              Samhandlere
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+E">
+              Oppgavestatistikk
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+L">
+              Søk journalpost
+            </ActionMenu.Item>
+          </ActionMenu.Group>
+          <ActionMenu.Divider />
+          <ActionMenu.Group label="Systemer og oppslagsverk">
+            <ActionMenu.Item onSelect={console.info}>A-inntekt</ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info}>
+              Aa-registeret
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info}>Modia</ActionMenu.Item>
+          </ActionMenu.Group>
+        </ActionMenu.Content>
+      </ActionMenu>
+    </div>
   );
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/sub-menu.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/sub-menu.tsx
@@ -4,105 +4,110 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <Table>
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell scope="col">ID</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Status</Table.HeaderCell>
-          <Table.HeaderCell />
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        {data.map(({ id, status }, i) => {
-          return (
-            <Table.Row key={i + status}>
-              <Table.HeaderCell scope="row">{id}</Table.HeaderCell>
-              <Table.DataCell>{status}</Table.DataCell>
-              <Table.DataCell align="right">
-                <ActionMenu defaultOpen={i === 1}>
-                  <ActionMenu.Trigger>
-                    <Button
-                      variant="tertiary-neutral"
-                      icon={<MenuElipsisVerticalIcon title="Saksmeny" />}
-                      size="small"
-                    />
-                  </ActionMenu.Trigger>
-                  <ActionMenu.Content>
-                    <ActionMenu.Group label={`Sak #${id}`}>
-                      <ActionMenu.Item onSelect={console.info}>
-                        Ta sak
-                      </ActionMenu.Item>
-                      <ActionMenu.Sub>
-                        <ActionMenu.SubTrigger>
-                          Endre status
-                        </ActionMenu.SubTrigger>
-                        <ActionMenu.SubContent>
-                          <ActionMenu.Item onSelect={console.info}>
-                            Avslått
-                          </ActionMenu.Item>
-                          <ActionMenu.Item onSelect={console.info}>
-                            Godkjent
-                          </ActionMenu.Item>
-                          <ActionMenu.Sub>
-                            <ActionMenu.SubTrigger>
-                              Andre valg
-                            </ActionMenu.SubTrigger>
-                            <ActionMenu.SubContent>
+    <div style={{ minHeight: "28rem" }}>
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell scope="col">ID</Table.HeaderCell>
+            <Table.HeaderCell scope="col">Status</Table.HeaderCell>
+            <Table.HeaderCell />
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {data.map(({ id, status }, i) => {
+            return (
+              <Table.Row key={i + status} shadeOnHover={false}>
+                <Table.HeaderCell scope="row">{id}</Table.HeaderCell>
+                <Table.DataCell>{status}</Table.DataCell>
+                <Table.DataCell align="right">
+                  <ActionMenu>
+                    <ActionMenu.Trigger>
+                      <Button
+                        variant="tertiary-neutral"
+                        icon={<MenuElipsisVerticalIcon title="Saksmeny" />}
+                        size="small"
+                      />
+                    </ActionMenu.Trigger>
+                    <ActionMenu.Content>
+                      <ActionMenu.Group label={`Sak #${id}`}>
+                        <ActionMenu.Item onSelect={console.info}>
+                          Ta sak
+                        </ActionMenu.Item>
+                        <ActionMenu.Sub>
+                          <ActionMenu.SubTrigger>
+                            Endre status
+                          </ActionMenu.SubTrigger>
+                          <ActionMenu.SubContent>
+                            <ActionMenu.Item onSelect={console.info}>
+                              Avslått
+                            </ActionMenu.Item>
+                            <ActionMenu.Item onSelect={console.info}>
+                              Godkjent
+                            </ActionMenu.Item>
+                            <ActionMenu.Sub>
+                              <ActionMenu.SubTrigger>
+                                Andre valg
+                              </ActionMenu.SubTrigger>
+                              <ActionMenu.SubContent>
+                                <ActionMenu.Item onSelect={console.info}>
+                                  Til godkjenning
+                                </ActionMenu.Item>
+                                <ActionMenu.Item onSelect={console.info}>
+                                  Under behandling
+                                </ActionMenu.Item>
+                                <ActionMenu.Item onSelect={console.info}>
+                                  Under kontroll
+                                </ActionMenu.Item>
+                              </ActionMenu.SubContent>
+                            </ActionMenu.Sub>
+                          </ActionMenu.SubContent>
+                        </ActionMenu.Sub>
+                        <ActionMenu.Sub>
+                          <ActionMenu.SubTrigger>
+                            Tildel saksbehandler
+                          </ActionMenu.SubTrigger>
+                          <ActionMenu.SubContent>
+                            <ActionMenu.Group label="Saksbehandlere">
                               <ActionMenu.Item onSelect={console.info}>
-                                Til godkjenning
+                                Ola Normann
                               </ActionMenu.Item>
                               <ActionMenu.Item onSelect={console.info}>
-                                Under behandling
+                                Bo Ramberg
+                              </ActionMenu.Item>
+                              <ActionMenu.Item onSelect={console.info} disabled>
+                                Ole Olsen
+                              </ActionMenu.Item>
+                              <ActionMenu.Item onSelect={console.info} disabled>
+                                Janne Nilssen
                               </ActionMenu.Item>
                               <ActionMenu.Item onSelect={console.info}>
-                                Under kontroll
+                                Karin Jakobsen
                               </ActionMenu.Item>
-                            </ActionMenu.SubContent>
-                          </ActionMenu.Sub>
-                        </ActionMenu.SubContent>
-                      </ActionMenu.Sub>
-                      <ActionMenu.Sub>
-                        <ActionMenu.SubTrigger>
-                          Tildel saksbehandler
-                        </ActionMenu.SubTrigger>
-                        <ActionMenu.SubContent>
-                          <ActionMenu.Group label="Saksbehandlere">
-                            <ActionMenu.Item onSelect={console.info}>
-                              Ola Normann
-                            </ActionMenu.Item>
-                            <ActionMenu.Item onSelect={console.info}>
-                              Bo Ramberg
-                            </ActionMenu.Item>
-                            <ActionMenu.Item onSelect={console.info} disabled>
-                              Ole Olsen
-                            </ActionMenu.Item>
-                            <ActionMenu.Item onSelect={console.info} disabled>
-                              Janne Nilssen
-                            </ActionMenu.Item>
-                            <ActionMenu.Item onSelect={console.info}>
-                              Karin Jakobsen
-                            </ActionMenu.Item>
-                            <ActionMenu.Item onSelect={console.info}>
-                              Kari Nordmann
-                            </ActionMenu.Item>
-                          </ActionMenu.Group>
-                        </ActionMenu.SubContent>
-                      </ActionMenu.Sub>
+                              <ActionMenu.Item onSelect={console.info}>
+                                Kari Nordmann
+                              </ActionMenu.Item>
+                            </ActionMenu.Group>
+                          </ActionMenu.SubContent>
+                        </ActionMenu.Sub>
 
-                      <ActionMenu.Divider />
+                        <ActionMenu.Divider />
 
-                      <ActionMenu.Item variant="danger" onSelect={console.info}>
-                        Slett sak
-                      </ActionMenu.Item>
-                    </ActionMenu.Group>
-                  </ActionMenu.Content>
-                </ActionMenu>
-              </Table.DataCell>
-            </Table.Row>
-          );
-        })}
-      </Table.Body>
-    </Table>
+                        <ActionMenu.Item
+                          variant="danger"
+                          onSelect={console.info}
+                        >
+                          Slett sak
+                        </ActionMenu.Item>
+                      </ActionMenu.Group>
+                    </ActionMenu.Content>
+                  </ActionMenu>
+                </Table.DataCell>
+              </Table.Row>
+            );
+          })}
+        </Table.Body>
+      </Table>
+    </div>
   );
 };
 
@@ -126,7 +131,7 @@ const data = [
 ];
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {


### PR DESCRIPTION
### Description

Removed this prop: https://floating-ui.com/docs/flip#flipalignment, since it lead to ActionMenu being opened on the wrong sides more aggressively.

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
