### PR TITLE
[ActionMenu] Removed `defaultOpen`-prop, moved `rootElement`, added Modal-support

### DIFF
--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.stories.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { PencilIcon, StarIcon } from "@navikt/aksel-icons";
 import { Button } from "../../button";
 import { HStack, VStack } from "../../layout/stack";
@@ -435,11 +435,6 @@ export const TriggerWithTooltip: Story = {
   decorators: [DemoDecorator],
 };
 
-/**
- * TODO: Bugs
- * - When keydown "space" on open modal button, the modal is closed instantly.
- * Unsure if this is because of the keydown-event repeats or if its caused by eventbubbling
- */
 export const ModalTrigger: Story = {
   render: () => {
     const ref = useRef<HTMLDialogElement>(null);
@@ -463,6 +458,62 @@ export const ModalTrigger: Story = {
         <Modal ref={ref} header={{ heading: "Heading" }}>
           <Modal.Body>
             Culpa aliquip ut cupidatat laborum minim quis ex in aliqua.
+          </Modal.Body>
+          <Modal.Footer>
+            <Button type="button" onClick={() => ref.current?.close()}>
+              Close
+            </Button>
+          </Modal.Footer>
+        </Modal>
+      </div>
+    );
+  },
+  decorators: [DemoDecorator],
+};
+
+export const OpenInsideModal: Story = {
+  render: () => {
+    const ref = useRef<HTMLDialogElement>(null);
+
+    useEffect(() => {
+      ref.current?.showModal();
+    }, []);
+
+    return (
+      <div>
+        <button onClick={() => ref.current?.showModal()}>Open modal</button>
+        <Modal ref={ref} header={{ heading: "Heading" }}>
+          <Modal.Body>
+            Culpa aliquip ut cupidatat laborum minim quis ex in aliqua.
+            <ActionMenu>
+              <ActionMenu.Trigger>
+                <button>Open action</button>
+              </ActionMenu.Trigger>
+              <ActionMenu.Content>
+                <ActionMenu.Item onSelect={() => console.log("Item 1 clicked")}>
+                  Item 1
+                </ActionMenu.Item>
+                <ActionMenu.Item onSelect={() => console.log("Item 2 clicked")}>
+                  Item 2
+                </ActionMenu.Item>
+                <ActionMenu.Item onSelect={() => console.log("Item 3 clicked")}>
+                  Item 3
+                </ActionMenu.Item>
+                <ActionMenu.Item>Item</ActionMenu.Item>
+                <ActionMenu.Item>Item</ActionMenu.Item>
+                <ActionMenu.Item>Item</ActionMenu.Item>
+                <ActionMenu.Item>Item</ActionMenu.Item>
+                <ActionMenu.Item>Item</ActionMenu.Item>
+                <ActionMenu.Item>Item</ActionMenu.Item>
+                <ActionMenu.Item>Item</ActionMenu.Item>
+                <ActionMenu.Item>Item</ActionMenu.Item>
+                <ActionMenu.Item>Item</ActionMenu.Item>
+                <ActionMenu.Item>Item</ActionMenu.Item>
+                <ActionMenu.Item>Item</ActionMenu.Item>
+                <ActionMenu.Item>Item</ActionMenu.Item>
+                <ActionMenu.Item>Item</ActionMenu.Item>
+              </ActionMenu.Content>
+            </ActionMenu>
           </Modal.Body>
           <Modal.Footer>
             <Button type="button" onClick={() => ref.current?.close()}>

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -37,10 +37,6 @@ interface ActionMenuProps {
    */
   open?: boolean;
   /**
-   * Whether the menu should be open by default.
-   */
-  defaultOpen?: boolean;
-  /**
    * Callback for when the menu is opened or closed.
    */
   onOpenChange?: (open: boolean) => void;
@@ -247,14 +243,13 @@ interface ActionMenuComponent extends React.FC<ActionMenuProps> {
 const ActionMenuRoot = ({
   children,
   open: openProp,
-  defaultOpen = false,
   onOpenChange,
 }: ActionMenuProps) => {
   const triggerRef = useRef<HTMLButtonElement>(null);
 
   const [open = false, setOpen] = useControllableState({
     value: openProp,
-    defaultValue: defaultOpen,
+    defaultValue: false,
     onChange: onOpenChange,
   });
 
@@ -840,21 +835,17 @@ interface ActionMenuSubProps {
    */
   open?: boolean;
   /**
-   * Whether the sub-menu should be open by default.
-   */
-  defaultOpen?: boolean;
-  /**
    * Callback for when the sub-menu is opened or closed.
    */
   onOpenChange?: (open: boolean) => void;
 }
 
 export const ActionMenuSub = (props: ActionMenuSubProps) => {
-  const { children, open: openProp, onOpenChange, defaultOpen = false } = props;
+  const { children, open: openProp, onOpenChange } = props;
 
   const [open = false, setOpen] = useControllableState({
     value: openProp,
-    defaultValue: defaultOpen,
+    defaultValue: false,
     onChange: onOpenChange,
   });
 

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -1,6 +1,7 @@
 import cl from "clsx";
 import React, { forwardRef, useRef } from "react";
 import { ChevronRightIcon } from "@navikt/aksel-icons";
+import { useModalContext } from "../../modal/Modal.context";
 import { Slot } from "../../slot/Slot";
 import { OverridableComponent, useId } from "../../util";
 import { composeEventHandlers } from "../../util/composeEventHandlers";
@@ -244,9 +245,12 @@ const ActionMenuRoot = ({
   children,
   open: openProp,
   onOpenChange,
-  rootElement,
+  rootElement: rootElementProp,
 }: ActionMenuProps) => {
   const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const modalContext = useModalContext(false);
+  const rootElement = modalContext ? modalContext.ref.current : rootElementProp;
 
   const [open = false, setOpen] = useControllableState({
     value: openProp,

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -21,8 +21,7 @@ type ActionMenuContextValue = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onOpenToggle: () => void;
-  rootElement: MenuPortalProps["rootElement"];
-};
+} & Pick<MenuPortalProps, "rootElement">;
 
 const [ActionMenuProvider, useActionMenuContext] =
   createContext<ActionMenuContextValue>({
@@ -31,7 +30,7 @@ const [ActionMenuProvider, useActionMenuContext] =
       "ActionMenu sub-components cannot be rendered outside the ActionMenu component.",
   });
 
-interface ActionMenuProps {
+type ActionMenuProps = {
   children?: React.ReactNode;
   /**
    * Whether the menu is open or not.
@@ -42,11 +41,7 @@ interface ActionMenuProps {
    * Callback for when the menu is opened or closed.
    */
   onOpenChange?: (open: boolean) => void;
-  /**
-   * An optional container where the portaled content should be appended.
-   */
-  rootElement?: MenuPortalProps["rootElement"];
-}
+} & Pick<MenuPortalProps, "rootElement">;
 
 interface ActionMenuComponent extends React.FC<ActionMenuProps> {
   /**

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -21,7 +21,8 @@ type ActionMenuContextValue = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onOpenToggle: () => void;
-} & Pick<MenuPortalProps, "rootElement">;
+  rootElement: MenuPortalProps["rootElement"];
+};
 
 const [ActionMenuProvider, useActionMenuContext] =
   createContext<ActionMenuContextValue>({

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -20,7 +20,7 @@ type ActionMenuContextValue = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onOpenToggle: () => void;
-};
+} & Pick<React.ComponentPropsWithoutRef<typeof Menu.Portal>, "rootElement">;
 
 const [ActionMenuProvider, useActionMenuContext] =
   createContext<ActionMenuContextValue>({
@@ -29,7 +29,7 @@ const [ActionMenuProvider, useActionMenuContext] =
       "ActionMenu sub-components cannot be rendered outside the ActionMenu component.",
   });
 
-interface ActionMenuProps {
+type ActionMenuProps = {
   children?: React.ReactNode;
   /**
    * Whether the menu is open or not.
@@ -40,7 +40,7 @@ interface ActionMenuProps {
    * Callback for when the menu is opened or closed.
    */
   onOpenChange?: (open: boolean) => void;
-}
+} & Pick<React.ComponentPropsWithoutRef<typeof Menu.Portal>, "rootElement">;
 
 interface ActionMenuComponent extends React.FC<ActionMenuProps> {
   /**
@@ -244,6 +244,7 @@ const ActionMenuRoot = ({
   children,
   open: openProp,
   onOpenChange,
+  rootElement,
 }: ActionMenuProps) => {
   const triggerRef = useRef<HTMLButtonElement>(null);
 
@@ -261,6 +262,7 @@ const ActionMenuRoot = ({
       open={open}
       onOpenChange={setOpen}
       onOpenToggle={() => setOpen((prevOpen) => !prevOpen)}
+      rootElement={rootElement}
     >
       <Menu open={open} onOpenChange={setOpen} modal>
         {children}
@@ -323,58 +325,46 @@ export const ActionMenuTrigger = forwardRef<
 /*                             ActionMenuContent                              */
 /* -------------------------------------------------------------------------- */
 interface ActionMenuContentProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, "id">,
-    Pick<React.ComponentPropsWithoutRef<typeof Menu.Portal>, "rootElement"> {
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "id"> {
   children?: React.ReactNode;
 }
 
 export const ActionMenuContent = forwardRef<
   HTMLDivElement,
   ActionMenuContentProps
->(
-  (
-    {
-      children,
-      className,
-      style,
-      rootElement,
-      ...rest
-    }: ActionMenuContentProps,
-    ref,
-  ) => {
-    const context = useActionMenuContext();
+>(({ children, className, style, ...rest }: ActionMenuContentProps, ref) => {
+  const context = useActionMenuContext();
 
-    return (
-      <Menu.Portal rootElement={rootElement} asChild>
-        <Menu.Content
-          ref={ref}
-          id={context.contentId}
-          aria-labelledby={context.triggerId}
-          className={cl("navds-action-menu__content", className)}
-          {...rest}
-          align="start"
-          sideOffset={4}
-          collisionPadding={10}
-          onCloseAutoFocus={() => {
-            context.triggerRef.current?.focus();
-          }}
-          safeZone={{ anchor: context.triggerRef.current }}
-          style={{
-            ...style,
-            ...{
-              "--__ac-action-menu-content-transform-origin":
-                "var(--ac-floating-transform-origin)",
-              "--__ac-action-menu-content-available-height":
-                "var(--ac-floating-available-height)",
-            },
-          }}
-        >
-          <div className="navds-action-menu__content-inner">{children}</div>
-        </Menu.Content>
-      </Menu.Portal>
-    );
-  },
-);
+  return (
+    <Menu.Portal rootElement={context.rootElement} asChild>
+      <Menu.Content
+        ref={ref}
+        id={context.contentId}
+        aria-labelledby={context.triggerId}
+        className={cl("navds-action-menu__content", className)}
+        {...rest}
+        align="start"
+        sideOffset={4}
+        collisionPadding={10}
+        onCloseAutoFocus={() => {
+          context.triggerRef.current?.focus();
+        }}
+        safeZone={{ anchor: context.triggerRef.current }}
+        style={{
+          ...style,
+          ...{
+            "--__ac-action-menu-content-transform-origin":
+              "var(--ac-floating-transform-origin)",
+            "--__ac-action-menu-content-available-height":
+              "var(--ac-floating-available-height)",
+          },
+        }}
+      >
+        <div className="navds-action-menu__content-inner">{children}</div>
+      </Menu.Content>
+    </Menu.Portal>
+  );
+});
 
 /* -------------------------------------------------------------------------- */
 /*                              ActionMenuLabel                               */
@@ -902,59 +892,48 @@ export const ActionMenuSubTrigger = forwardRef<
 type ActionMenuSubContentElement = React.ElementRef<typeof Menu.Content>;
 
 interface ActionMenuSubContentProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    Pick<React.ComponentPropsWithoutRef<typeof Menu.Portal>, "rootElement"> {
+  extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
 }
 
 export const ActionMenuSubContent = forwardRef<
   ActionMenuSubContentElement,
   ActionMenuSubContentProps
->(
-  (
-    {
-      children,
-      className,
-      style,
-      rootElement,
-      ...rest
-    }: ActionMenuSubContentProps,
-    ref,
-  ) => {
-    return (
-      <Menu.Portal rootElement={rootElement}>
-        <Menu.SubContent
-          ref={ref}
-          alignOffset={-4}
-          sideOffset={1}
-          collisionPadding={10}
-          {...rest}
-          className={cl(
-            "navds-action-menu__content navds-action-menu__sub-content",
-            className,
-          )}
-          style={{
-            ...style,
-            ...{
-              "--ac-action-menu-content-transform-origin":
-                "var(--ac-floating-transform-origin)",
-              "--ac-action-menu-content-available-width":
-                "var(--ac-floating-available-width)",
-              "--ac-action-menu-content-available-height":
-                "var(--ac-floating-available-height)",
-              "--ac-action-menu-trigger-width":
-                "var(--ac-floating-anchor-width)",
-              "--ac-action-menu-trigger-height":
-                "var(--ac-floating-anchor-height)",
-            },
-          }}
-        >
-          <div className="navds-action-menu__content-inner">{children}</div>
-        </Menu.SubContent>
-      </Menu.Portal>
-    );
-  },
-);
+>(({ children, className, style, ...rest }: ActionMenuSubContentProps, ref) => {
+  const context = useActionMenuContext();
+
+  return (
+    <Menu.Portal rootElement={context.rootElement}>
+      <Menu.SubContent
+        ref={ref}
+        alignOffset={-4}
+        sideOffset={1}
+        collisionPadding={10}
+        {...rest}
+        className={cl(
+          "navds-action-menu__content navds-action-menu__sub-content",
+          className,
+        )}
+        style={{
+          ...style,
+          ...{
+            "--ac-action-menu-content-transform-origin":
+              "var(--ac-floating-transform-origin)",
+            "--ac-action-menu-content-available-width":
+              "var(--ac-floating-available-width)",
+            "--ac-action-menu-content-available-height":
+              "var(--ac-floating-available-height)",
+            "--ac-action-menu-trigger-width": "var(--ac-floating-anchor-width)",
+            "--ac-action-menu-trigger-height":
+              "var(--ac-floating-anchor-height)",
+          },
+        }}
+      >
+        <div className="navds-action-menu__content-inner">{children}</div>
+      </Menu.SubContent>
+    </Menu.Portal>
+  );
+});
 
 /* -------------------------------------------------------------------------- */
 ActionMenu.Trigger = ActionMenuTrigger;

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -9,7 +9,7 @@ import { createContext } from "../../util/create-context";
 import { useMergeRefs } from "../../util/hooks";
 import { useControllableState } from "../../util/hooks/useControllableState";
 import { requireReactElement } from "../../util/requireReactElement";
-import { Menu } from "../floating-menu/Menu";
+import { Menu, MenuPortalProps } from "../floating-menu/Menu";
 
 /* -------------------------------------------------------------------------- */
 /*                                 ActionMenu                                 */
@@ -21,7 +21,8 @@ type ActionMenuContextValue = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onOpenToggle: () => void;
-} & Pick<React.ComponentPropsWithoutRef<typeof Menu.Portal>, "rootElement">;
+  rootElement: MenuPortalProps["rootElement"];
+};
 
 const [ActionMenuProvider, useActionMenuContext] =
   createContext<ActionMenuContextValue>({
@@ -30,7 +31,7 @@ const [ActionMenuProvider, useActionMenuContext] =
       "ActionMenu sub-components cannot be rendered outside the ActionMenu component.",
   });
 
-type ActionMenuProps = {
+interface ActionMenuProps {
   children?: React.ReactNode;
   /**
    * Whether the menu is open or not.
@@ -41,7 +42,11 @@ type ActionMenuProps = {
    * Callback for when the menu is opened or closed.
    */
   onOpenChange?: (open: boolean) => void;
-} & Pick<React.ComponentPropsWithoutRef<typeof Menu.Portal>, "rootElement">;
+  /**
+   * An optional container where the portaled content should be appended.
+   */
+  rootElement?: MenuPortalProps["rootElement"];
+}
 
 interface ActionMenuComponent extends React.FC<ActionMenuProps> {
   /**

--- a/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
@@ -205,7 +205,6 @@ const MenuRootContentNonModal = React.forwardRef<
       ref={ref}
       disableOutsidePointerEvents={false}
       onDismiss={() => context.onOpenChange(false)}
-      flipAlignment={false}
     />
   );
 });
@@ -232,7 +231,6 @@ const MenuRootContentModal = forwardRef<
         { checkForDefaultPrevented: false },
       )}
       onDismiss={() => context.onOpenChange(false)}
-      flipAlignment={false}
     />
   );
 });

--- a/@navikt/core/react/src/overlays/floating/Floating.tsx
+++ b/@navikt/core/react/src/overlays/floating/Floating.tsx
@@ -187,7 +187,6 @@ interface FloatingContentProps extends HTMLAttributes<HTMLDivElement> {
   collisionBoundary?: Boundary | Boundary[];
   collisionPadding?: number | Partial<Record<Side, number>>;
   hideWhenDetached?: boolean;
-  flipAlignment?: boolean;
   updatePositionStrategy?: "optimized" | "always";
   onPlaced?: () => void;
   arrow?: {
@@ -213,7 +212,6 @@ const FloatingContent = forwardRef<HTMLDivElement, FloatingContentProps>(
       updatePositionStrategy = "optimized",
       onPlaced,
       arrow: _arrow,
-      flipAlignment,
       ...contentProps
     }: FloatingContentProps,
     forwardedRef,
@@ -258,7 +256,6 @@ const FloatingContent = forwardRef<HTMLDivElement, FloatingContentProps>(
       altBoundary: hasExplicitBoundaries,
       /* https://floating-ui.com/docs/flip#fallbackaxissidedirection */
       fallbackAxisSideDirection: "end",
-      flipAlignment,
     };
 
     const { refs, floatingStyles, placement, isPositioned, middlewareData } =

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/danger.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/danger.tsx
@@ -9,7 +9,7 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <ActionMenu defaultOpen>
+    <ActionMenu>
       <ActionMenu.Trigger>
         <Button
           variant="secondary-neutral"
@@ -42,7 +42,7 @@ const Example = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/filter.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/filter.tsx
@@ -19,78 +19,80 @@ const Example = () => {
   };
 
   return (
-    <ActionMenu defaultOpen>
-      <ActionMenu.Trigger>
-        <Button
-          variant="secondary-neutral"
-          icon={<ChevronDownIcon aria-hidden />}
-          iconPosition="right"
-        >
-          Filter
-        </Button>
-      </ActionMenu.Trigger>
-      <ActionMenu.Content>
-        <ActionMenu.Group label="Kolonner">
-          <ActionMenu.CheckboxItem
-            checked={
-              Object.values(views).every(Boolean)
-                ? true
-                : Object.values(views).some(Boolean)
-                  ? "indeterminate"
-                  : false
-            }
-            onCheckedChange={() => {
-              const allChecked = Object.values(views).every(Boolean);
-              setViews((prevState) =>
-                Object.keys(prevState).reduce(
-                  (acc, key) => {
-                    acc[key] = !allChecked;
-                    return acc;
-                  },
-                  {} as typeof views,
-                ),
-              );
-            }}
+    <div style={{ minHeight: "28rem" }}>
+      <ActionMenu>
+        <ActionMenu.Trigger>
+          <Button
+            variant="secondary-neutral"
+            icon={<ChevronDownIcon aria-hidden />}
+            iconPosition="right"
           >
-            Velg alle
-          </ActionMenu.CheckboxItem>
-          <ActionMenu.CheckboxItem
-            checked={views.started}
-            onCheckedChange={() => handleCheckboxChange("started")}
+            Filter
+          </Button>
+        </ActionMenu.Trigger>
+        <ActionMenu.Content>
+          <ActionMenu.Group label="Kolonner">
+            <ActionMenu.CheckboxItem
+              checked={
+                Object.values(views).every(Boolean)
+                  ? true
+                  : Object.values(views).some(Boolean)
+                    ? "indeterminate"
+                    : false
+              }
+              onCheckedChange={() => {
+                const allChecked = Object.values(views).every(Boolean);
+                setViews((prevState) =>
+                  Object.keys(prevState).reduce(
+                    (acc, key) => {
+                      acc[key] = !allChecked;
+                      return acc;
+                    },
+                    {} as typeof views,
+                  ),
+                );
+              }}
+            >
+              Velg alle
+            </ActionMenu.CheckboxItem>
+            <ActionMenu.CheckboxItem
+              checked={views.started}
+              onCheckedChange={() => handleCheckboxChange("started")}
+            >
+              Oppfølging startet
+            </ActionMenu.CheckboxItem>
+            <ActionMenu.CheckboxItem
+              checked={views.fnr}
+              onCheckedChange={() => handleCheckboxChange("fnr")}
+            >
+              Fødselsnummer
+            </ActionMenu.CheckboxItem>
+            <ActionMenu.CheckboxItem
+              checked={views.tags}
+              onCheckedChange={() => handleCheckboxChange("tags")}
+            >
+              Tags
+            </ActionMenu.CheckboxItem>
+          </ActionMenu.Group>
+          <ActionMenu.Divider />
+          <ActionMenu.RadioGroup
+            onValueChange={setRows}
+            value={rows}
+            label="Rader per side"
           >
-            Oppfølging startet
-          </ActionMenu.CheckboxItem>
-          <ActionMenu.CheckboxItem
-            checked={views.fnr}
-            onCheckedChange={() => handleCheckboxChange("fnr")}
-          >
-            Fødselsnummer
-          </ActionMenu.CheckboxItem>
-          <ActionMenu.CheckboxItem
-            checked={views.tags}
-            onCheckedChange={() => handleCheckboxChange("tags")}
-          >
-            Tags
-          </ActionMenu.CheckboxItem>
-        </ActionMenu.Group>
-        <ActionMenu.Divider />
-        <ActionMenu.RadioGroup
-          onValueChange={setRows}
-          value={rows}
-          label="Rader per side"
-        >
-          <ActionMenu.RadioItem value="5">5</ActionMenu.RadioItem>
-          <ActionMenu.RadioItem value="10">10</ActionMenu.RadioItem>
-          <ActionMenu.RadioItem value="25">25</ActionMenu.RadioItem>
-          <ActionMenu.RadioItem value="50">50</ActionMenu.RadioItem>
-        </ActionMenu.RadioGroup>
-      </ActionMenu.Content>
-    </ActionMenu>
+            <ActionMenu.RadioItem value="5">5</ActionMenu.RadioItem>
+            <ActionMenu.RadioItem value="10">10</ActionMenu.RadioItem>
+            <ActionMenu.RadioItem value="25">25</ActionMenu.RadioItem>
+            <ActionMenu.RadioItem value="50">50</ActionMenu.RadioItem>
+          </ActionMenu.RadioGroup>
+        </ActionMenu.Content>
+      </ActionMenu>
+    </div>
   );
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/groups.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/groups.tsx
@@ -11,56 +11,58 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <ActionMenu defaultOpen>
-      <ActionMenu.Trigger>
-        <Button
-          variant="secondary-neutral"
-          icon={<ChevronDownIcon aria-hidden />}
-          iconPosition="right"
-        >
-          Meny
-        </Button>
-      </ActionMenu.Trigger>
-      <ActionMenu.Content>
-        <ActionMenu.Group label="Gosys">
-          <ActionMenu.Item onSelect={console.info} icon={<PersonIcon />}>
-            Personoversikt
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info} icon={<PersonGroupIcon />}>
-            Arbeidsgiveroversikt
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info} icon={<HandshakeIcon />}>
-            Samhandlere
-          </ActionMenu.Item>
-          <ActionMenu.Item
-            onSelect={console.info}
-            disabled
-            icon={<BarChartIcon />}
+    <div style={{ minHeight: "28rem" }}>
+      <ActionMenu>
+        <ActionMenu.Trigger>
+          <Button
+            variant="secondary-neutral"
+            icon={<ChevronDownIcon aria-hidden />}
+            iconPosition="right"
           >
-            Oppgavestatistikk
-          </ActionMenu.Item>
-          <ActionMenu.Item
-            onSelect={console.info}
-            icon={<MagnifyingGlassIcon />}
-          >
-            Søk journalpost
-          </ActionMenu.Item>
-        </ActionMenu.Group>
-        <ActionMenu.Divider />
-        <ActionMenu.Group label="Systemer og oppslagsverk">
-          <ActionMenu.Item onSelect={console.info}>A-inntekt</ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info}>
-            Aa-registeret
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info}>Modia</ActionMenu.Item>
-        </ActionMenu.Group>
-      </ActionMenu.Content>
-    </ActionMenu>
+            Meny
+          </Button>
+        </ActionMenu.Trigger>
+        <ActionMenu.Content>
+          <ActionMenu.Group label="Gosys">
+            <ActionMenu.Item onSelect={console.info} icon={<PersonIcon />}>
+              Personoversikt
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info} icon={<PersonGroupIcon />}>
+              Arbeidsgiveroversikt
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info} icon={<HandshakeIcon />}>
+              Samhandlere
+            </ActionMenu.Item>
+            <ActionMenu.Item
+              onSelect={console.info}
+              disabled
+              icon={<BarChartIcon />}
+            >
+              Oppgavestatistikk
+            </ActionMenu.Item>
+            <ActionMenu.Item
+              onSelect={console.info}
+              icon={<MagnifyingGlassIcon />}
+            >
+              Søk journalpost
+            </ActionMenu.Item>
+          </ActionMenu.Group>
+          <ActionMenu.Divider />
+          <ActionMenu.Group label="Systemer og oppslagsverk">
+            <ActionMenu.Item onSelect={console.info}>A-inntekt</ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info}>
+              Aa-registeret
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info}>Modia</ActionMenu.Item>
+          </ActionMenu.Group>
+        </ActionMenu.Content>
+      </ActionMenu>
+    </div>
   );
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/header.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/header.tsx
@@ -11,58 +11,68 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <InternalHeader>
-      <InternalHeader.Title as="h1">Sykepenger</InternalHeader.Title>
-      <Spacer />
-      <ActionMenu defaultOpen>
-        <ActionMenu.Trigger>
-          <InternalHeader.Button>
-            <MenuGridIcon fontSize="1.5rem" title="Systemer og oppslagsverk" />
-          </InternalHeader.Button>
-        </ActionMenu.Trigger>
-        <ActionMenu.Content>
-          <ActionMenu.Group label="Gosys">
-            <ActionMenu.Item onSelect={console.info} icon={<PersonIcon />}>
-              Personoversikt
-            </ActionMenu.Item>
-            <ActionMenu.Item onSelect={console.info} icon={<PersonGroupIcon />}>
-              Arbeidsgiveroversikt
-            </ActionMenu.Item>
-            <ActionMenu.Item onSelect={console.info} icon={<HandshakeIcon />}>
-              Samhandlere
-            </ActionMenu.Item>
-            <ActionMenu.Item
-              onSelect={console.info}
-              disabled
-              icon={<BarChartIcon />}
-            >
-              Oppgavestatistikk
-            </ActionMenu.Item>
-            <ActionMenu.Item
-              onSelect={console.info}
-              icon={<MagnifyingGlassIcon />}
-            >
-              Søk journalpost
-            </ActionMenu.Item>
-          </ActionMenu.Group>
-          <ActionMenu.Divider />
-          <ActionMenu.Group label="Systemer og oppslagsverk">
-            <ActionMenu.Item onSelect={console.info}>A-inntekt</ActionMenu.Item>
-            <ActionMenu.Item onSelect={console.info}>
-              Aa-registeret
-            </ActionMenu.Item>
-            <ActionMenu.Item onSelect={console.info}>Modia</ActionMenu.Item>
-          </ActionMenu.Group>
-        </ActionMenu.Content>
-      </ActionMenu>
+    <div style={{ minHeight: "28rem" }}>
+      <InternalHeader>
+        <InternalHeader.Title as="h1">Sykepenger</InternalHeader.Title>
+        <Spacer />
+        <ActionMenu>
+          <ActionMenu.Trigger>
+            <InternalHeader.Button>
+              <MenuGridIcon
+                fontSize="1.5rem"
+                title="Systemer og oppslagsverk"
+              />
+            </InternalHeader.Button>
+          </ActionMenu.Trigger>
+          <ActionMenu.Content>
+            <ActionMenu.Group label="Gosys">
+              <ActionMenu.Item onSelect={console.info} icon={<PersonIcon />}>
+                Personoversikt
+              </ActionMenu.Item>
+              <ActionMenu.Item
+                onSelect={console.info}
+                icon={<PersonGroupIcon />}
+              >
+                Arbeidsgiveroversikt
+              </ActionMenu.Item>
+              <ActionMenu.Item onSelect={console.info} icon={<HandshakeIcon />}>
+                Samhandlere
+              </ActionMenu.Item>
+              <ActionMenu.Item
+                onSelect={console.info}
+                disabled
+                icon={<BarChartIcon />}
+              >
+                Oppgavestatistikk
+              </ActionMenu.Item>
+              <ActionMenu.Item
+                onSelect={console.info}
+                icon={<MagnifyingGlassIcon />}
+              >
+                Søk journalpost
+              </ActionMenu.Item>
+            </ActionMenu.Group>
+            <ActionMenu.Divider />
+            <ActionMenu.Group label="Systemer og oppslagsverk">
+              <ActionMenu.Item onSelect={console.info}>
+                A-inntekt
+              </ActionMenu.Item>
+              <ActionMenu.Item onSelect={console.info}>
+                Aa-registeret
+              </ActionMenu.Item>
+              <ActionMenu.Item onSelect={console.info}>Modia</ActionMenu.Item>
+            </ActionMenu.Group>
+          </ActionMenu.Content>
+        </ActionMenu>
 
-      <InternalHeader.User name="Ola Normann" />
-    </InternalHeader>
+        <InternalHeader.User name="Ola Normann" />
+      </InternalHeader>
+    </div>
   );
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/items.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/items.tsx
@@ -4,7 +4,7 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <ActionMenu defaultOpen>
+    <ActionMenu>
       <ActionMenu.Trigger>
         <Button
           variant="secondary-neutral"
@@ -34,7 +34,7 @@ const Example = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/links.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/links.tsx
@@ -5,7 +5,7 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <ActionMenu defaultOpen>
+    <ActionMenu>
       <ActionMenu.Trigger>
         <Button
           variant="secondary-neutral"
@@ -52,7 +52,7 @@ const RemixExample = () => (
 */
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/shortcuts.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/shortcuts.tsx
@@ -4,49 +4,51 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <ActionMenu defaultOpen>
-      <ActionMenu.Trigger>
-        <Button
-          variant="secondary-neutral"
-          icon={<ChevronDownIcon aria-hidden />}
-          iconPosition="right"
-        >
-          Meny
-        </Button>
-      </ActionMenu.Trigger>
-      <ActionMenu.Content>
-        <ActionMenu.Group label="Gosys">
-          <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+A">
-            Personoversikt
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+K">
-            Arbeidsgiveroversikt
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+S">
-            Samhandlere
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+E">
-            Oppgavestatistikk
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+L">
-            Søk journalpost
-          </ActionMenu.Item>
-        </ActionMenu.Group>
-        <ActionMenu.Divider />
-        <ActionMenu.Group label="Systemer og oppslagsverk">
-          <ActionMenu.Item onSelect={console.info}>A-inntekt</ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info}>
-            Aa-registeret
-          </ActionMenu.Item>
-          <ActionMenu.Item onSelect={console.info}>Modia</ActionMenu.Item>
-        </ActionMenu.Group>
-      </ActionMenu.Content>
-    </ActionMenu>
+    <div style={{ minHeight: "28rem" }}>
+      <ActionMenu>
+        <ActionMenu.Trigger>
+          <Button
+            variant="secondary-neutral"
+            icon={<ChevronDownIcon aria-hidden />}
+            iconPosition="right"
+          >
+            Meny
+          </Button>
+        </ActionMenu.Trigger>
+        <ActionMenu.Content>
+          <ActionMenu.Group label="Gosys">
+            <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+A">
+              Personoversikt
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+K">
+              Arbeidsgiveroversikt
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+S">
+              Samhandlere
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+E">
+              Oppgavestatistikk
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info} shortcut="Ctrl+L">
+              Søk journalpost
+            </ActionMenu.Item>
+          </ActionMenu.Group>
+          <ActionMenu.Divider />
+          <ActionMenu.Group label="Systemer og oppslagsverk">
+            <ActionMenu.Item onSelect={console.info}>A-inntekt</ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info}>
+              Aa-registeret
+            </ActionMenu.Item>
+            <ActionMenu.Item onSelect={console.info}>Modia</ActionMenu.Item>
+          </ActionMenu.Group>
+        </ActionMenu.Content>
+      </ActionMenu>
+    </div>
   );
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/sub-menu.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/sub-menu.tsx
@@ -4,105 +4,110 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <Table>
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell scope="col">ID</Table.HeaderCell>
-          <Table.HeaderCell scope="col">Status</Table.HeaderCell>
-          <Table.HeaderCell />
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        {data.map(({ id, status }, i) => {
-          return (
-            <Table.Row key={i + status}>
-              <Table.HeaderCell scope="row">{id}</Table.HeaderCell>
-              <Table.DataCell>{status}</Table.DataCell>
-              <Table.DataCell align="right">
-                <ActionMenu defaultOpen={i === 1}>
-                  <ActionMenu.Trigger>
-                    <Button
-                      variant="tertiary-neutral"
-                      icon={<MenuElipsisVerticalIcon title="Saksmeny" />}
-                      size="small"
-                    />
-                  </ActionMenu.Trigger>
-                  <ActionMenu.Content>
-                    <ActionMenu.Group label={`Sak #${id}`}>
-                      <ActionMenu.Item onSelect={console.info}>
-                        Ta sak
-                      </ActionMenu.Item>
-                      <ActionMenu.Sub>
-                        <ActionMenu.SubTrigger>
-                          Endre status
-                        </ActionMenu.SubTrigger>
-                        <ActionMenu.SubContent>
-                          <ActionMenu.Item onSelect={console.info}>
-                            Avslått
-                          </ActionMenu.Item>
-                          <ActionMenu.Item onSelect={console.info}>
-                            Godkjent
-                          </ActionMenu.Item>
-                          <ActionMenu.Sub>
-                            <ActionMenu.SubTrigger>
-                              Andre valg
-                            </ActionMenu.SubTrigger>
-                            <ActionMenu.SubContent>
+    <div style={{ minHeight: "28rem" }}>
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell scope="col">ID</Table.HeaderCell>
+            <Table.HeaderCell scope="col">Status</Table.HeaderCell>
+            <Table.HeaderCell />
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {data.map(({ id, status }, i) => {
+            return (
+              <Table.Row key={i + status} shadeOnHover={false}>
+                <Table.HeaderCell scope="row">{id}</Table.HeaderCell>
+                <Table.DataCell>{status}</Table.DataCell>
+                <Table.DataCell align="right">
+                  <ActionMenu>
+                    <ActionMenu.Trigger>
+                      <Button
+                        variant="tertiary-neutral"
+                        icon={<MenuElipsisVerticalIcon title="Saksmeny" />}
+                        size="small"
+                      />
+                    </ActionMenu.Trigger>
+                    <ActionMenu.Content>
+                      <ActionMenu.Group label={`Sak #${id}`}>
+                        <ActionMenu.Item onSelect={console.info}>
+                          Ta sak
+                        </ActionMenu.Item>
+                        <ActionMenu.Sub>
+                          <ActionMenu.SubTrigger>
+                            Endre status
+                          </ActionMenu.SubTrigger>
+                          <ActionMenu.SubContent>
+                            <ActionMenu.Item onSelect={console.info}>
+                              Avslått
+                            </ActionMenu.Item>
+                            <ActionMenu.Item onSelect={console.info}>
+                              Godkjent
+                            </ActionMenu.Item>
+                            <ActionMenu.Sub>
+                              <ActionMenu.SubTrigger>
+                                Andre valg
+                              </ActionMenu.SubTrigger>
+                              <ActionMenu.SubContent>
+                                <ActionMenu.Item onSelect={console.info}>
+                                  Til godkjenning
+                                </ActionMenu.Item>
+                                <ActionMenu.Item onSelect={console.info}>
+                                  Under behandling
+                                </ActionMenu.Item>
+                                <ActionMenu.Item onSelect={console.info}>
+                                  Under kontroll
+                                </ActionMenu.Item>
+                              </ActionMenu.SubContent>
+                            </ActionMenu.Sub>
+                          </ActionMenu.SubContent>
+                        </ActionMenu.Sub>
+                        <ActionMenu.Sub>
+                          <ActionMenu.SubTrigger>
+                            Tildel saksbehandler
+                          </ActionMenu.SubTrigger>
+                          <ActionMenu.SubContent>
+                            <ActionMenu.Group label="Saksbehandlere">
                               <ActionMenu.Item onSelect={console.info}>
-                                Til godkjenning
+                                Ola Normann
                               </ActionMenu.Item>
                               <ActionMenu.Item onSelect={console.info}>
-                                Under behandling
+                                Bo Ramberg
+                              </ActionMenu.Item>
+                              <ActionMenu.Item onSelect={console.info} disabled>
+                                Ole Olsen
+                              </ActionMenu.Item>
+                              <ActionMenu.Item onSelect={console.info} disabled>
+                                Janne Nilssen
                               </ActionMenu.Item>
                               <ActionMenu.Item onSelect={console.info}>
-                                Under kontroll
+                                Karin Jakobsen
                               </ActionMenu.Item>
-                            </ActionMenu.SubContent>
-                          </ActionMenu.Sub>
-                        </ActionMenu.SubContent>
-                      </ActionMenu.Sub>
-                      <ActionMenu.Sub>
-                        <ActionMenu.SubTrigger>
-                          Tildel saksbehandler
-                        </ActionMenu.SubTrigger>
-                        <ActionMenu.SubContent>
-                          <ActionMenu.Group label="Saksbehandlere">
-                            <ActionMenu.Item onSelect={console.info}>
-                              Ola Normann
-                            </ActionMenu.Item>
-                            <ActionMenu.Item onSelect={console.info}>
-                              Bo Ramberg
-                            </ActionMenu.Item>
-                            <ActionMenu.Item onSelect={console.info} disabled>
-                              Ole Olsen
-                            </ActionMenu.Item>
-                            <ActionMenu.Item onSelect={console.info} disabled>
-                              Janne Nilssen
-                            </ActionMenu.Item>
-                            <ActionMenu.Item onSelect={console.info}>
-                              Karin Jakobsen
-                            </ActionMenu.Item>
-                            <ActionMenu.Item onSelect={console.info}>
-                              Kari Nordmann
-                            </ActionMenu.Item>
-                          </ActionMenu.Group>
-                        </ActionMenu.SubContent>
-                      </ActionMenu.Sub>
+                              <ActionMenu.Item onSelect={console.info}>
+                                Kari Nordmann
+                              </ActionMenu.Item>
+                            </ActionMenu.Group>
+                          </ActionMenu.SubContent>
+                        </ActionMenu.Sub>
 
-                      <ActionMenu.Divider />
+                        <ActionMenu.Divider />
 
-                      <ActionMenu.Item variant="danger" onSelect={console.info}>
-                        Slett sak
-                      </ActionMenu.Item>
-                    </ActionMenu.Group>
-                  </ActionMenu.Content>
-                </ActionMenu>
-              </Table.DataCell>
-            </Table.Row>
-          );
-        })}
-      </Table.Body>
-    </Table>
+                        <ActionMenu.Item
+                          variant="danger"
+                          onSelect={console.info}
+                        >
+                          Slett sak
+                        </ActionMenu.Item>
+                      </ActionMenu.Group>
+                    </ActionMenu.Content>
+                  </ActionMenu>
+                </Table.DataCell>
+              </Table.Row>
+            );
+          })}
+        </Table.Body>
+      </Table>
+    </div>
   );
 };
 
@@ -126,7 +131,7 @@ const data = [
 ];
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { variant: "static" });
 
 /* Storybook story */
 export const Demo = {


### PR DESCRIPTION
### Description

Hide whitespace for better diff-view

- Se no current use for `defaultOpen`, so removed it
- Moved rootElement to "root" to avoid having to declare it multiple times
- Now re-uses same logic found in Tooltip where Modal-ref is used as rootElement when used inside Modal



### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation
- [x] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
