### PR TITLE
[Translations] Chips.Removable: Remove translations-prop (partly reverts #3232)

### DIFF
--- a/.changeset/great-mugs-promise.md
+++ b/.changeset/great-mugs-promise.md
@@ -1,5 +1,0 @@
----
-"@navikt/ds-react": minor
----
-
-Chips.Removable: Added new i18n API

--- a/@navikt/core/react/src/chips/Removable.tsx
+++ b/@navikt/core/react/src/chips/Removable.tsx
@@ -33,7 +33,6 @@ export const RemovableChips = forwardRef<
       variant = "action",
       onDelete,
       removeLabel,
-      translations,
       className,
       onClick,
       type = "button",
@@ -41,7 +40,7 @@ export const RemovableChips = forwardRef<
     },
     ref,
   ) => {
-    const translate = useI18n("Chips", { Removable: translations });
+    const translate = useI18n("Chips");
     return (
       <button
         {...rest}

--- a/@navikt/core/react/src/chips/Removable.tsx
+++ b/@navikt/core/react/src/chips/Removable.tsx
@@ -3,7 +3,6 @@ import React, { forwardRef } from "react";
 import { XMarkIcon } from "@navikt/aksel-icons";
 import { composeEventHandlers } from "../util/composeEventHandlers";
 import { useI18n } from "../util/i18n/i18n.context";
-import { ComponentTranslation } from "../util/i18n/i18n.types";
 
 export interface ChipsRemovableProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -20,13 +19,8 @@ export interface ChipsRemovableProps
   /**
    * Replaces label read for screen-readers
    * @default "slett"
-   * @deprecated Use `translations` instead
    */
   removeLabel?: string;
-  /**
-   * i18n API for customizing texts and labels.
-   */
-  translations?: ComponentTranslation<"Chips">["Removable"];
 }
 
 export const RemovableChips = forwardRef<


### PR DESCRIPTION
### Description

We decided not having a translation-prop after all. No one was using `removeLabel`, so we will deprecate/remove it when i18n-provider is made available.

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
