### PR TITLE
[Aksel.nav.no] Hide private props better

### DIFF
--- a/aksel.nav.no/website/components/sanity-modules/props/parts/DtList.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/props/parts/DtList.tsx
@@ -34,10 +34,6 @@ type Prop = Partial<{
 }>;
 
 export const DtList = ({ prop }: { prop: Prop; parent: string }) => {
-  if (prop?.description?.includes("@private")) {
-    return null;
-  }
-
   return (
     <BodyShort as="ul" className="dtlist overflow-x-auto">
       {prop.type && (

--- a/aksel.nav.no/website/components/sanity-modules/props/parts/PropTabell.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/props/parts/PropTabell.tsx
@@ -1,4 +1,4 @@
-import { BodyShort, Heading } from "@navikt/ds-react";
+import { Heading } from "@navikt/ds-react";
 import ErrorBoundary from "@/error-boundary";
 import { PropTableT } from "@/types";
 import { DtList } from "./DtList";
@@ -8,6 +8,15 @@ type PropTableProps = {
 };
 
 const PropTable = ({ komponent }: PropTableProps) => {
+  const propList =
+    komponent?.propref?.proplist?.filter(
+      (prop) => !prop.description?.includes("@private"),
+    ) ?? [];
+
+  if (propList.length === 0) {
+    return null;
+  }
+
   return (
     <div lang="en">
       <Heading
@@ -20,12 +29,6 @@ const PropTable = ({ komponent }: PropTableProps) => {
       </Heading>
 
       <div className="toc-ignore relative mb-8">
-        {komponent?.propref?.proplist?.length === 0 && (
-          <div className="mb-8 rounded-b-lg border border-gray-300 p-2">
-            <BodyShort>Fant ingen props for denne komponenten.</BodyShort>
-          </div>
-        )}
-
         <dl>
           {komponent?.overridable && (
             <div className="border border-t-0 border-gray-300 p-2">
@@ -51,7 +54,7 @@ const PropTable = ({ komponent }: PropTableProps) => {
               </dd>
             </div>
           )}
-          {komponent?.propref?.proplist?.map((prop) => (
+          {propList.map((prop) => (
             <div
               className="border border-t-0 border-gray-300 p-2 last-of-type:rounded-b-lg"
               key={prop.name}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3711,7 +3711,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@npm:^7.2.1, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
+"@navikt/aksel-icons@npm:^7.3.0, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-icons@workspace:@navikt/aksel-icons"
   dependencies:
@@ -3742,8 +3742,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-stylelint@workspace:@navikt/aksel-stylelint"
   dependencies:
-    "@navikt/ds-css": "npm:^7.2.1"
-    "@navikt/ds-tokens": "npm:^7.2.1"
+    "@navikt/ds-css": "npm:^7.3.0"
+    "@navikt/ds-tokens": "npm:^7.3.0"
     concurrently: "npm:9.0.1"
     postcss-selector-parser: "npm:^6.0.13"
     postcss-value-parser: "npm:^4.2.0"
@@ -3758,7 +3758,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel@workspace:@navikt/aksel"
   dependencies:
-    "@navikt/ds-css": "npm:7.2.1"
+    "@navikt/ds-css": "npm:7.3.0"
     axios: "npm:1.7.4"
     chalk: "npm:4.1.0"
     clipboardy: "npm:^2.3.0"
@@ -3779,11 +3779,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@npm:*, @navikt/ds-css@npm:7.2.1, @navikt/ds-css@npm:^7.2.1, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@npm:*, @navikt/ds-css@npm:7.3.0, @navikt/ds-css@npm:^7.3.0, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": "npm:^7.2.1"
+    "@navikt/ds-tokens": "npm:^7.3.0"
     autoprefixer: "npm:^10.4.20"
     cssnano: "npm:6.0.0"
     fast-glob: "npm:3.2.11"
@@ -3797,14 +3797,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@npm:*, @navikt/ds-react@npm:^7.2.1, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@npm:*, @navikt/ds-react@npm:^7.3.0, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": "npm:0.25.4"
     "@floating-ui/react-dom": "npm:^2.0.9"
-    "@navikt/aksel-icons": "npm:^7.2.1"
-    "@navikt/ds-tokens": "npm:^7.2.1"
+    "@navikt/aksel-icons": "npm:^7.3.0"
+    "@navikt/ds-tokens": "npm:^7.3.0"
     "@testing-library/dom": "npm:9.3.4"
     "@testing-library/jest-dom": "npm:^5.16.0"
     "@testing-library/react": "npm:^15.0.7"
@@ -3832,11 +3832,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@npm:^7.2.1, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@npm:^7.3.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": "npm:^7.2.1"
+    "@navikt/ds-tokens": "npm:^7.3.0"
     color: "npm:4.2.3"
     lodash: "npm:^4.17.21"
     tailwindcss: "npm:^3.3.3"
@@ -3846,7 +3846,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@npm:^7.2.1, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@npm:^7.3.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -7729,11 +7729,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/aksel-icons": "npm:^7.2.1"
-    "@navikt/ds-css": "npm:^7.2.1"
-    "@navikt/ds-react": "npm:^7.2.1"
-    "@navikt/ds-tailwind": "npm:^7.2.1"
-    "@navikt/ds-tokens": "npm:^7.2.1"
+    "@navikt/aksel-icons": "npm:^7.3.0"
+    "@navikt/ds-css": "npm:^7.3.0"
+    "@navikt/ds-react": "npm:^7.3.0"
+    "@navikt/ds-tailwind": "npm:^7.3.0"
+    "@navikt/ds-tokens": "npm:^7.3.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

Actually filter out private props, not only the description

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
