### PR TITLE
Combobox: :bug: Remove virtual focus on input blur instead of moving it

### DIFF
--- a/.changeset/stale-pigs-doubt.md
+++ b/.changeset/stale-pigs-doubt.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Combobox: :bug: Remove virtual focus on input blur instead of moving it

--- a/@navikt/core/react/src/form/combobox/Input/Input.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.tsx
@@ -253,7 +253,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         type="text"
         role="combobox"
         value={value}
-        onBlur={composeEventHandlers(onBlur, virtualFocus.moveFocusToTop)}
+        onBlur={composeEventHandlers(onBlur, virtualFocus.resetFocus)}
         onClick={() => {
           setHideCaret(!!maxSelected?.isLimitReached);
           value !== searchTerm && onChange(value);


### PR DESCRIPTION
### Description

Fixes an issue where selecting something after scrolling down in the list, selects something else instead: https://nav-it.slack.com/archives/C7NE7A8UF/p1729503857154699

Also fixes an issue where tabbing from input to chip and pressing enter would both remove the chip and add whatever option had virtual focus (if any).

(For reference; bug was introduced [here](https://github.com/navikt/aksel/pull/2861/commits/94014920d06083efac9407ed3cea7d7559f6f300).)

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
