### PR TITLE
[Aksel.nav.no] Add support for markdown-links in intro-texts

### DIFF
--- a/aksel.nav.no/website/pages/grunnleggende/index.tsx
+++ b/aksel.nav.no/website/pages/grunnleggende/index.tsx
@@ -15,6 +15,7 @@ import {
   SidebarT,
 } from "@/types";
 import { generateSidebar } from "@/utils";
+import { TextWithMarkdownLink } from "@/web/TextWithMarkdownLink";
 import { PagePreview } from "@/web/preview/PagePreview";
 import { SEO } from "@/web/seo/SEO";
 import { grunnleggendeKategorier } from "../../sanity/config";
@@ -97,7 +98,9 @@ const Page = ({ page, sidebar, links }: PageProps["props"]) => {
               <div>
                 {page?.[`ingress_${kat.value}`] && (
                   <BodyLong size="large" className="mb-4 only:mb-7">
-                    {page[`ingress_${kat.value}`]}
+                    <TextWithMarkdownLink>
+                      {page[`ingress_${kat.value}`]}
+                    </TextWithMarkdownLink>
                   </BodyLong>
                 )}
                 {page?.[`intro_${kat.value}`] && (

--- a/aksel.nav.no/website/pages/komponenter/index.tsx
+++ b/aksel.nav.no/website/pages/komponenter/index.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/types";
 import { generateSidebar } from "@/utils";
 import { IntroCards } from "@/web/IntroCards";
+import { TextWithMarkdownLink } from "@/web/TextWithMarkdownLink";
 import { PagePreview } from "@/web/preview/PagePreview";
 import { SEO } from "@/web/seo/SEO";
 import { komponentKategorier } from "../../sanity/config";
@@ -133,7 +134,9 @@ const Page = ({ page, sidebar, links }: PageProps["props"]) => {
               <div>
                 {page?.[`ingress_${kat.value}`] && (
                   <BodyLong size="large" className="mb-4 only:mb-7">
-                    {page[`ingress_${kat.value}`]}
+                    <TextWithMarkdownLink>
+                      {page[`ingress_${kat.value}`]}
+                    </TextWithMarkdownLink>
                   </BodyLong>
                 )}
                 {page?.[`intro_${kat.value}`] && (

--- a/aksel.nav.no/website/pages/monster-maler/index.tsx
+++ b/aksel.nav.no/website/pages/monster-maler/index.tsx
@@ -15,6 +15,7 @@ import {
   SidebarT,
 } from "@/types";
 import { generateSidebar } from "@/utils";
+import { TextWithMarkdownLink } from "@/web/TextWithMarkdownLink";
 import { PagePreview } from "@/web/preview/PagePreview";
 import { SEO } from "@/web/seo/SEO";
 import { templatesKategorier } from "../../sanity/config";
@@ -97,7 +98,9 @@ const Page = ({ page, sidebar, links }: PageProps["props"]) => {
               <div>
                 {page?.[`ingress_${kat.value}`] && (
                   <BodyLong size="large" className="mb-4 only:mb-7">
-                    {page[`ingress_${kat.value}`]}
+                    <TextWithMarkdownLink>
+                      {page[`ingress_${kat.value}`]}
+                    </TextWithMarkdownLink>
                   </BodyLong>
                 )}
                 {page?.[`intro_${kat.value}`] && (

--- a/aksel.nav.no/website/sanity/schema/documents/grunnleggende/landingsside.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/grunnleggende/landingsside.tsx
@@ -10,6 +10,7 @@ const views = () => {
     list.push(
       defineField({
         title: `Ingress ${kat.title}`,
+        description: "Støtter markdown-lenker",
         name: `ingress_${kat.value}`,
         type: "text",
         rows: 2,

--- a/aksel.nav.no/website/sanity/schema/documents/komponenter/landingsside.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/komponenter/landingsside.tsx
@@ -10,6 +10,7 @@ const views = () => {
     list.push(
       defineField({
         title: `Ingress ${kat.title}`,
+        description: "Støtter markdown-lenker",
         name: `ingress_${kat.value}`,
         type: "text",
         rows: 2,

--- a/aksel.nav.no/website/sanity/schema/documents/templates/landingsside.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/templates/landingsside.tsx
@@ -10,6 +10,7 @@ const views = () => {
     list.push(
       defineField({
         title: `Ingress ${kat.title}`,
+        description: "Støtter markdown-lenker",
         name: `ingress_${kat.value}`,
         type: "text",
         rows: 2,


### PR DESCRIPTION
### Description

Added markdown-support for /grunnleggende, /komponenter and /monster-maler

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
