### PR TITLE
Combobox: Don't scroll when moving virtual focus with mouse

### DIFF
--- a/.changeset/green-suits-wave.md
+++ b/.changeset/green-suits-wave.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Combobox: Don't scroll when browsing list with mouse

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/useVirtualFocus.ts
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/useVirtualFocus.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export type VirtualFocusType = {
   activeElement: HTMLElement | undefined;
@@ -43,6 +43,11 @@ const useVirtualFocus = (
       : false;
   };
 
+  const setActiveAndScrollToElement = (element?: HTMLElement) => {
+    setActiveElement(element);
+    element?.scrollIntoView({ block: "nearest" });
+  };
+
   const moveFocusUp = () => {
     if (!activeElement) {
       return;
@@ -53,14 +58,14 @@ const useVirtualFocus = (
     if (_currentIndex === 0) {
       setActiveElement(undefined);
     } else {
-      setActiveElement(elementAbove);
+      setActiveAndScrollToElement(elementAbove);
     }
   };
 
   const moveFocusDown = () => {
     const elementsAbleToReceiveFocus = getElementsAbleToReceiveFocus();
     if (!activeElement) {
-      setActiveElement(elementsAbleToReceiveFocus[0]);
+      setActiveAndScrollToElement(elementsAbleToReceiveFocus[0]);
       return;
     }
     const _currentIndex = elementsAbleToReceiveFocus.indexOf(activeElement);
@@ -68,17 +73,17 @@ const useVirtualFocus = (
       return;
     }
 
-    setActiveElement(elementsAbleToReceiveFocus[_currentIndex + 1]);
+    setActiveAndScrollToElement(elementsAbleToReceiveFocus[_currentIndex + 1]);
   };
 
   const resetFocus = () => setActiveElement(undefined);
   const moveFocusToTop = () => {
     const elementsAbleToReceiveFocus = getElementsAbleToReceiveFocus();
-    setActiveElement(elementsAbleToReceiveFocus[0]);
+    setActiveAndScrollToElement(elementsAbleToReceiveFocus[0]);
   };
   const moveFocusToBottom = () => {
     const elementsAbleToReceiveFocus = getElementsAbleToReceiveFocus();
-    setActiveElement(
+    setActiveAndScrollToElement(
       elementsAbleToReceiveFocus[elementsAbleToReceiveFocus.length - 1],
     );
   };
@@ -98,7 +103,7 @@ const useVirtualFocus = (
     const elementsAbleToReceiveFocus = getElementsAbleToReceiveFocus();
     const currentIndex = elementsAbleToReceiveFocus.indexOf(activeElement);
     const newIndex = Math.max(currentIndex - numberOfElements, 0);
-    setActiveElement(elementsAbleToReceiveFocus[newIndex]);
+    setActiveAndScrollToElement(elementsAbleToReceiveFocus[newIndex]);
   };
 
   const moveFocusDownBy = (numberOfElements: number) => {
@@ -110,12 +115,8 @@ const useVirtualFocus = (
       currentIndex + numberOfElements,
       elementsAbleToReceiveFocus.length - 1,
     );
-    setActiveElement(elementsAbleToReceiveFocus[newIndex]);
+    setActiveAndScrollToElement(elementsAbleToReceiveFocus[newIndex]);
   };
-
-  useEffect(() => {
-    activeElement?.scrollIntoView?.({ block: "nearest" });
-  }, [activeElement]);
 
   return {
     activeElement,

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/useVirtualFocus.ts
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/useVirtualFocus.ts
@@ -45,7 +45,7 @@ const useVirtualFocus = (
 
   const setActiveAndScrollToElement = (element?: HTMLElement) => {
     setActiveElement(element);
-    element?.scrollIntoView({ block: "nearest" });
+    element?.scrollIntoView?.({ block: "nearest" });
   };
 
   const moveFocusUp = () => {

--- a/@navikt/core/react/src/form/combobox/Input/Input.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.tsx
@@ -177,10 +177,12 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           if (value !== searchTerm) {
             setValue(searchTerm);
           }
-          if (virtualFocus.activeElement === null || !isListOpen) {
+          if (!isListOpen) {
             toggleIsListOpen(true);
+            setTimeout(virtualFocus.moveFocusDown, 0); // Wait until list is visible so that scrollIntoView works
+          } else {
+            virtualFocus.moveFocusDown();
           }
-          virtualFocus.moveFocusDown();
         } else if (e.key === "ArrowUp") {
           if (value !== "" && value !== searchTerm) {
             onChange(value);
@@ -199,19 +201,23 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           virtualFocus.moveFocusToTop();
         } else if (e.key === "End") {
           e.preventDefault();
-          if (virtualFocus.activeElement === null || !isListOpen) {
+          if (!isListOpen) {
             toggleIsListOpen(true);
+            setTimeout(virtualFocus.moveFocusToBottom, 0); // Wait until list is visible so that scrollIntoView works
+          } else {
+            virtualFocus.moveFocusToBottom();
           }
-          virtualFocus.moveFocusToBottom();
         } else if (e.key === "PageUp") {
           e.preventDefault();
           virtualFocus.moveFocusUpBy(6);
         } else if (e.key === "PageDown") {
           e.preventDefault();
-          if (virtualFocus.activeElement === null || !isListOpen) {
+          if (!isListOpen) {
             toggleIsListOpen(true);
+            setTimeout(() => virtualFocus.moveFocusDownBy(6), 0); // Wait until list is visible so that scrollIntoView works
+          } else {
+            virtualFocus.moveFocusDownBy(6);
           }
-          virtualFocus.moveFocusDownBy(6);
         }
       },
       [


### PR DESCRIPTION
### Description

If you move the mouse to the top of the list, it will sometimes scroll up. Especially in Firefox.
Problem was introduced [here](https://github.com/navikt/aksel/pull/3158/files#diff-5e3747081862474416d8ab12c14bfc7d5f25976a1468fdd3a001bb8ac6937af2R117). Here I have tried to solve the original problem a different way. (The original problem was that scrollIntoView didn't work when calling it right after toggleIsListOpen(true) since the list wasn't visible yet.)

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
