### PR TITLE
Combo filteredoptions offset fix

### DIFF
--- a/.changeset/silver-dingos-mate.md
+++ b/.changeset/silver-dingos-mate.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+Combobox: only apply filteredOptions scroll offset when max options is rendered

--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -291,7 +291,6 @@
   padding-inline: var(--__ac-combobox-list-item-padding-inline);
   width: 100%;
   background-color: var(--ac-combobox-list-item-bg, var(--a-surface-default));
-  scroll-margin-top: 50px;
 }
 
 .navds-combobox__list-item--loading {
@@ -304,6 +303,10 @@
   border-start-start-radius: calc(var(--a-border-radius-medium) - 1px);
   border-start-end-radius: calc(var(--a-border-radius-medium) - 1px);
   border: 1px solid var(--ac-combobox-list-item-max-selected-border, var(--a-border-info));
+}
+
+.navds-combobox__list--max-selected .navds-combobox__list-item {
+  scroll-margin-top: 50px;
 }
 
 .navds-combobox__list_non-selectables:hover {

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptions.tsx
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptions.tsx
@@ -58,7 +58,9 @@ const FilteredOptions = () => {
         <ul
           ref={setFilteredOptionsRef}
           role="listbox"
-          className="navds-combobox__list-options"
+          className={cl("navds-combobox__list-options", {
+            "navds-combobox__list--max-selected": maxSelected?.isLimitReached,
+          })}
         >
           {isValueNew && !maxSelected?.isLimitReached && allowNewValues && (
             <AddNewOption />


### PR DESCRIPTION
### Description

Fixes the minor visual bug / inconsistency where when you scroll upwards, there seems to be a 1 row offset from the top of the list to the focused option. This offset is only needed in the particular instance where the 'max X of Y' maximum limit is rendered. It's sticky so it lands on top of the actual content. This is why there is a margin.

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
