### PR TITLE
Checkbox: Remove redundant attribute aria-checked

### DIFF
--- a/.changeset/tiny-jobs-arrive.md
+++ b/.changeset/tiny-jobs-arrive.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Checkbox: Remove redundant attribute aria-checked

--- a/@navikt/core/react/src/form/checkbox/Checkbox.tsx
+++ b/@navikt/core/react/src/form/checkbox/Checkbox.tsx
@@ -41,7 +41,6 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           {...omit(inputProps, ["aria-invalid"])}
           type="checkbox"
           className="navds-checkbox__input"
-          aria-checked={props.indeterminate ? "mixed" : inputProps.checked}
           ref={(el) => {
             if (el) {
               el.indeterminate = props.indeterminate ?? false;


### PR DESCRIPTION
### Description

https://nav-it.slack.com/archives/C7NE7A8UF/p1729665701404419
The HTML validator doesn't like using `aria-checked` on `<input type="checkbox">`. Afaics it works fine without.

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
