### PR TITLE
Tabs.List: Remove redundant icon titles

### DIFF
--- a/.changeset/cool-peaches-look.md
+++ b/.changeset/cool-peaches-look.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Tabs.List: Remove redundant icon titles

--- a/@navikt/core/react/src/tabs/parts/tablist/ScrollButtons.tsx
+++ b/@navikt/core/react/src/tabs/parts/tablist/ScrollButtons.tsx
@@ -17,11 +17,7 @@ function ScrollButton({ hidden, onClick, dir }: ScrollButtonProps) {
       onClick={onClick}
       aria-hidden
     >
-      {dir === "left" ? (
-        <ChevronLeftIcon title="scroll tilbake" />
-      ) : (
-        <ChevronRightIcon title="scroll neste" />
-      )}
+      {dir === "left" ? <ChevronLeftIcon /> : <ChevronRightIcon />}
     </div>
   );
 }


### PR DESCRIPTION
### Description

I suggest removing these titles instead of translating them. The container has aria-hidden, so it doesn't do anything for screen readers (keyboard users are supposed to use arrow keys on keyboard instead). For seeing people, I think the icon would be sufficient? In most cases, overflow will only happen on mobile anyways. Let me know what you think.

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
