### PR TITLE
[Combobox] Handles autocomplete correctly when `allowNewValues` is on

### DIFF
--- a/.changeset/fifty-ghosts-poke.md
+++ b/.changeset/fifty-ghosts-poke.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Combobox: onToggleSelected is now called with correct value when autocomplete and new values are allowed.

--- a/@navikt/core/react/src/form/combobox/Input/Input.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.tsx
@@ -11,6 +11,7 @@ import { useMergeRefs } from "../../../util/hooks";
 import filteredOptionsUtil from "../FilteredOptions/filtered-options-util";
 import { useFilteredOptionsContext } from "../FilteredOptions/filteredOptionsContext";
 import { useSelectedOptionsContext } from "../SelectedOptions/selectedOptionsContext";
+import { ComboboxOption } from "../types";
 import { useInputContext } from "./Input.context";
 
 interface InputProps
@@ -93,19 +94,23 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           clearInput(event);
         } else if ((allowNewValues || shouldAutocomplete) && value !== "") {
           event.preventDefault();
-          // Autocompleting or adding a new value
-          const selectedValue =
-            allowNewValues && isValueNew
-              ? { label: value, value }
-              : filteredOptionsUtil.getFirstValueStartingWith(
-                  value,
-                  filteredOptions,
-                ) || filteredOptions[0];
+
+          const autoCompletedOption =
+            filteredOptionsUtil.getFirstValueStartingWith(
+              value,
+              filteredOptions,
+            );
+          let selectedValue: ComboboxOption | undefined;
+
+          if (shouldAutocomplete && autoCompletedOption) {
+            selectedValue = autoCompletedOption;
+          } else if (allowNewValues && isValueNew) {
+            selectedValue = { label: value, value };
+          }
 
           if (!selectedValue) {
             return;
           }
-
           toggleOption(selectedValue, event);
           if (!isMultiSelect && !isTextInSelectedOptions(selectedValue.label)) {
             toggleIsListOpen(false);

--- a/@navikt/core/react/src/form/combobox/__tests__/combobox.test.tsx
+++ b/@navikt/core/react/src/form/combobox/__tests__/combobox.test.tsx
@@ -290,6 +290,45 @@ describe("Render combobox", () => {
         false,
       );
     });
+
+    test("and pressing enter to select autocompleted word will select existing word when addNewOptions is true", async () => {
+      const onToggleSelected = vi.fn();
+      render(
+        <App
+          onToggleSelected={onToggleSelected}
+          options={options.map((opt) => ({
+            label: `${opt} (${opt})`,
+            value: opt,
+          }))}
+          shouldAutocomplete
+          allowNewValues
+        />,
+      );
+
+      const combobox = screen.getByRole("combobox", {
+        name: "Hva er dine favorittfrukter?",
+      });
+
+      await act(async () => {
+        await userEvent.click(combobox);
+
+        await userEvent.type(combobox, "p");
+      });
+
+      expect(combobox.getAttribute("value")).toBe(
+        "passion fruit (passion fruit)",
+      );
+
+      await act(async () => {
+        await userEvent.keyboard("{Enter}");
+      });
+
+      expect(onToggleSelected).toHaveBeenCalledWith(
+        "passion fruit",
+        true,
+        false,
+      );
+    });
   });
 
   describe("has keyboard navigation", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3711,7 +3711,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@npm:^7.3.1, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
+"@navikt/aksel-icons@npm:^7.4.0, @navikt/aksel-icons@workspace:@navikt/aksel-icons":
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-icons@workspace:@navikt/aksel-icons"
   dependencies:
@@ -3742,8 +3742,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel-stylelint@workspace:@navikt/aksel-stylelint"
   dependencies:
-    "@navikt/ds-css": "npm:^7.3.1"
-    "@navikt/ds-tokens": "npm:^7.3.1"
+    "@navikt/ds-css": "npm:^7.4.0"
+    "@navikt/ds-tokens": "npm:^7.4.0"
     concurrently: "npm:9.0.1"
     postcss-selector-parser: "npm:^6.0.13"
     postcss-value-parser: "npm:^4.2.0"
@@ -3758,7 +3758,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/aksel@workspace:@navikt/aksel"
   dependencies:
-    "@navikt/ds-css": "npm:7.3.1"
+    "@navikt/ds-css": "npm:7.4.0"
     axios: "npm:1.7.4"
     chalk: "npm:4.1.0"
     clipboardy: "npm:^2.3.0"
@@ -3779,11 +3779,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-css@npm:*, @navikt/ds-css@npm:7.3.1, @navikt/ds-css@npm:^7.3.1, @navikt/ds-css@workspace:@navikt/core/css":
+"@navikt/ds-css@npm:*, @navikt/ds-css@npm:7.4.0, @navikt/ds-css@npm:^7.4.0, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@navikt/ds-tokens": "npm:^7.3.1"
+    "@navikt/ds-tokens": "npm:^7.4.0"
     autoprefixer: "npm:^10.4.20"
     cssnano: "npm:6.0.0"
     fast-glob: "npm:3.2.11"
@@ -3797,14 +3797,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-react@npm:*, @navikt/ds-react@npm:^7.3.1, @navikt/ds-react@workspace:@navikt/core/react":
+"@navikt/ds-react@npm:*, @navikt/ds-react@npm:^7.4.0, @navikt/ds-react@workspace:@navikt/core/react":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-react@workspace:@navikt/core/react"
   dependencies:
     "@floating-ui/react": "npm:0.25.4"
     "@floating-ui/react-dom": "npm:^2.0.9"
-    "@navikt/aksel-icons": "npm:^7.3.1"
-    "@navikt/ds-tokens": "npm:^7.3.1"
+    "@navikt/aksel-icons": "npm:^7.4.0"
+    "@navikt/ds-tokens": "npm:^7.4.0"
     "@testing-library/dom": "npm:9.3.4"
     "@testing-library/jest-dom": "npm:^5.16.0"
     "@testing-library/react": "npm:^15.0.7"
@@ -3832,11 +3832,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tailwind@npm:^7.3.1, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
+"@navikt/ds-tailwind@npm:^7.4.0, @navikt/ds-tailwind@workspace:@navikt/core/tailwind":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tailwind@workspace:@navikt/core/tailwind"
   dependencies:
-    "@navikt/ds-tokens": "npm:^7.3.1"
+    "@navikt/ds-tokens": "npm:^7.4.0"
     color: "npm:4.2.3"
     lodash: "npm:^4.17.21"
     tailwindcss: "npm:^3.3.3"
@@ -3846,7 +3846,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@navikt/ds-tokens@npm:^7.3.1, @navikt/ds-tokens@workspace:@navikt/core/tokens":
+"@navikt/ds-tokens@npm:^7.4.0, @navikt/ds-tokens@workspace:@navikt/core/tokens":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-tokens@workspace:@navikt/core/tokens"
   dependencies:
@@ -7729,11 +7729,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel.nav.no@workspace:aksel.nav.no"
   dependencies:
-    "@navikt/aksel-icons": "npm:^7.3.1"
-    "@navikt/ds-css": "npm:^7.3.1"
-    "@navikt/ds-react": "npm:^7.3.1"
-    "@navikt/ds-tailwind": "npm:^7.3.1"
-    "@navikt/ds-tokens": "npm:^7.3.1"
+    "@navikt/aksel-icons": "npm:^7.4.0"
+    "@navikt/ds-css": "npm:^7.4.0"
+    "@navikt/ds-react": "npm:^7.4.0"
+    "@navikt/ds-tailwind": "npm:^7.4.0"
+    "@navikt/ds-tokens": "npm:^7.4.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

Resolves #3286

Before, when both `shouldAutoComplete` and `allowNewValues` were enabled:
- When having an autocompleted value, hitting enter treated it like a "new" value
- This lead to seemingly existing values being added by their label

[Sandbox for old bug](https://aksel.nav.no/sandbox/index.html?code=N4Igxg9gJgpiBcJgApkEoAEBeAfB4AOgHYYaREDOALhgKIAeAhgLYAOANjNhutnoSVJkIlGgG0KMTmCowoAeVZUAliIoAaDJKoBlKTBlzFKtQF1uAJRiMZAOgCuknVUazkY4kKEQlqymIAGU1sAN0Z2exh1Ty8MHxN-AEZgsIiomNJTNABuDIwAJxgqe3ySZDzSAB4oZRCcCqFKgFUAOR0AQQAxWgB9AGEIZgAjCBH6Bq9w9ggAdxaYGYA1cMiKLGAqfMiAXwmhdkYhqSwCEEWpAHMMWWZGAGtoGHyeH192DABmNFO90goACwg9nYUHa9ioEEgbE4snWmx2vzivjU63ifgotlurFQEEwuB4AliRIwByO7HgGAABgASYAQWykqTbDBiWn01I7UyU6KCYlCDkwCnslbpXnE7ZoNC7MVE5QUACywJUemkVERt3oKoMsig62AJOUzGUVApHww22lfL%2B%2BkMCmRlHWklVRntFEtVpEABUIBcLpwtbb1sg0SJNHKAzq8fUZcTwzadYivAB%2BLRFCMuhIUdy2HNO7UZ9GaENELKJoQU7Tpu2Z8oxq1CPO24zo2wAM2U7Fk%2BRxUbiGAAhFgsEiEt861ax-X3USAPTRomVGc1Op5HIxba5QTkagj9HcDxi-WM8kYU4ACQAVlJWDAjVBOPlTpoBRTzwApWinc08rxHw5SV8QEUVhWwAD-YC5lCIC4nwwF9TyAgAFRCv22H8hD-MlAJ0ABPO4YBvaCnlg%2BDTh0ABNABpVD0NITCAIQ3D8OYKQamgkiRWw8j5RovJ6JPU5OggQoQUKABaOIrgoMIiPyCg7kYVgKEIi5iJAZ9OIQzp5AsXjDxJf8BJAdp8iOZQoAoRgQjuA58igi5lJgWSOLSQD2naFCQG-PiDKwhCmjAwpNhwi4oBcyJAKabS9N-XyGNORCnIoC8RHCwUEMQ2gWhijC4qMgAhRhSiKfIQrC9S4M0058vaXSvLQnzj0AyiRBcIgqGoUCqFkNLmvkbL6to-A8sA-KIE67qYF6hD8vkHQcrokaZqKogYCGcz8kYGCKtIkB8vygBJBbhqamaNq2ihW2E%2BT7CgcqNNcmaDs6Y7%2BMAgBxLYiCICSfQwf4r3YG9OqIRh7sqx7Tneiwmhy0xNxiIKShISoGBYDguDnTcJXQaV1JAGZzKof4KAQMQPgAJgCdREgpgAOIJtiAA)

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
