### PR TITLE
Combobox: :bug: Fix scroll issue when using arrow keys in list

### DIFF
--- a/.changeset/blue-hotels-exist.md
+++ b/.changeset/blue-hotels-exist.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+Combobox: :bug: Fix scroll issue when using arrow keys to navigate list

--- a/.changeset/blue-hotels-exist.md
+++ b/.changeset/blue-hotels-exist.md
@@ -1,6 +1,0 @@
----
-"@navikt/ds-react": patch
-"@navikt/ds-css": patch
----
-
-Combobox: :bug: Fix scroll issue when using arrow keys to navigate list

--- a/.changeset/silver-dingos-mate.md
+++ b/.changeset/silver-dingos-mate.md
@@ -3,4 +3,4 @@
 "@navikt/ds-css": patch
 ---
 
-Combobox: only apply filteredOptions scroll offset when max options is rendered
+Combobox: :bug: Fix scroll issue when using arrow keys to navigate list

--- a/@navikt/core/css/darkside/form/combobox.darkside.css
+++ b/@navikt/core/css/darkside/form/combobox.darkside.css
@@ -305,10 +305,6 @@
   border: 1px solid var(--ac-combobox-list-item-max-selected-border, var(--a-border-info));
 }
 
-.navds-combobox__list--max-selected .navds-combobox__list-item {
-  scroll-margin-top: 50px;
-}
-
 .navds-combobox__list_non-selectables:hover {
   cursor: default;
 }

--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -305,10 +305,6 @@
   border: 1px solid var(--ac-combobox-list-item-max-selected-border, var(--a-border-info));
 }
 
-.navds-combobox__list--max-selected .navds-combobox__list-item {
-  scroll-margin-top: 50px;
-}
-
 .navds-combobox__list_non-selectables:hover {
   cursor: default;
 }

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptions.tsx
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptions.tsx
@@ -58,9 +58,7 @@ const FilteredOptions = () => {
         <ul
           ref={setFilteredOptionsRef}
           role="listbox"
-          className={cl("navds-combobox__list-options", {
-            "navds-combobox__list--max-selected": maxSelected?.isLimitReached,
-          })}
+          className="navds-combobox__list-options"
         >
           {isValueNew && !maxSelected?.isLimitReached && allowNewValues && (
             <AddNewOption />

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/useVirtualFocus.ts
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/useVirtualFocus.ts
@@ -45,7 +45,7 @@ const useVirtualFocus = (
 
   const setActiveAndScrollToElement = (element?: HTMLElement) => {
     setActiveElement(element);
-    element?.scrollIntoView?.({ block: "nearest" });
+    element?.scrollIntoView?.({ block: "center" });
   };
 
   const moveFocusUp = () => {


### PR DESCRIPTION
### Description

Fixes the bug mentioned here: https://github.com/navikt/aksel/pull/3269#issuecomment-2437822321
This partly reverts that PR.
Let me know if changing `scrollIntoView` to `center` is not an acceptable solution.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
