### PR TITLE
[Darkside] Actionmenu CSS update

### DIFF
--- a/@navikt/core/css/darkside/action-menu.darkside.css
+++ b/@navikt/core/css/darkside/action-menu.darkside.css
@@ -39,10 +39,10 @@
 }
 
 .navds-action-menu__content > .navds-action-menu__content-inner {
-  --__acx-action-menu-content-p: var(--ax-spacing-2);
-  --__acx-action-menu-item-pr: var(--ax-spacing-2);
-  --__acx-action-menu-item-pl: var(--ax-spacing-2);
-  --__acx-action-menu-item-height: 2rem;
+  --__axc-action-menu-content-p: var(--ax-spacing-2);
+  --__axc-action-menu-item-pr: var(--ax-spacing-2);
+  --__axc-action-menu-item-pl: var(--ax-spacing-2);
+  --__axc-action-menu-item-height: 2rem;
 
   border-radius: var(--ax-border-radius-large);
   background-color: var(--ax-bg-raised);
@@ -52,7 +52,7 @@
   transform-origin: var(--__ac-action-menu-content-transform-origin);
   animation-duration: 160ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-  padding: var(--__acx-action-menu-content-p);
+  padding: var(--__axc-action-menu-content-p);
   overflow: auto;
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   max-height: var(--__ac-action-menu-content-available-height);
@@ -63,14 +63,14 @@
   display: flex;
   align-items: center;
   gap: var(--ax-spacing-2);
-  min-height: var(--__acx-action-menu-item-height);
+  min-height: var(--__axc-action-menu-item-height);
   cursor: default;
   border-radius: var(--ax-border-radius-medium);
   position: relative;
-  padding-left: var(--__acx-action-menu-item-pl);
-  padding-right: var(--__acx-action-menu-item-pr);
+  padding-left: var(--__axc-action-menu-item-pl);
+  padding-right: var(--__axc-action-menu-item-pr);
   font-size: var(--ax-font-size-medium);
-  scroll-margin-block: var(--__acx-action-menu-content-p);
+  scroll-margin-block: var(--__axc-action-menu-content-p);
   line-height: 1.5;
   color: var(--ax-text-default);
   text-decoration: none;
@@ -93,11 +93,11 @@
 }
 
 .navds-action-menu__item--has-icon {
-  --__acx-action-menu-item-pl: var(--ax-spacing-6);
+  --__axc-action-menu-item-pl: var(--ax-spacing-6);
 }
 
 .navds-action-menu__sub-trigger {
-  --__acx-action-menu-item-pr: var(--ax-spacing-05);
+  --__axc-action-menu-item-pr: var(--ax-spacing-05);
 
   &[data-state="open"] {
     background-color: var(--ax-bg-neutral-moderate-pressed);
@@ -132,7 +132,7 @@
 .navds-action-menu__marker--left {
   position: absolute;
   left: 0;
-  width: var(--__acx-action-menu-item-pl);
+  width: var(--__axc-action-menu-item-pl);
   display: inline-flex;
   justify-content: center;
 }
@@ -161,9 +161,9 @@
 .navds-action-menu__label {
   display: flex;
   align-items: center;
-  min-height: calc(var(--__acx-action-menu-item-height) - 6px);
-  padding-right: var(--__acx-action-menu-item-pr);
-  padding-left: var(--__acx-action-menu-item-pl);
+  min-height: calc(var(--__axc-action-menu-item-height) - 6px);
+  padding-right: var(--__axc-action-menu-item-pr);
+  padding-left: var(--__axc-action-menu-item-pl);
   color: var(--ax-text-subtle);
   border-radius: var(--ax-border-radius-medium);
   user-select: none;

--- a/@navikt/core/css/darkside/action-menu.darkside.css
+++ b/@navikt/core/css/darkside/action-menu.darkside.css
@@ -144,6 +144,10 @@
   &[data-state="open"] {
     background-color: var(--ax-bg-neutral-moderate-pressed);
   }
+
+  &:focus {
+    background-color: var(--ax-bg-accent-moderate-hoverA);
+  }
 }
 
 .navds-action-menu__item--danger {

--- a/@navikt/core/css/darkside/action-menu.darkside.css
+++ b/@navikt/core/css/darkside/action-menu.darkside.css
@@ -1,42 +1,33 @@
+/* --------------------------- ActionMenu content --------------------------- */
 .navds-action-menu__content {
   overflow: hidden;
-  box-shadow: var(--a-shadow-medium);
-  border-radius: var(--a-border-radius-large);
-}
+  border-radius: var(--ax-border-radius-large);
+  border: 1px solid var(--ax-border-subtleA);
 
-/* stylelint-disable csstools/value-no-unknown-custom-properties */
-.navds-action-menu__content > .navds-action-menu__content-inner {
-  --__ac-action-menu-content-p: var(--a-spacing-2);
-  --__ac-action-menu-item-pr: var(--a-spacing-3);
-  --__ac-action-menu-item-pl: var(--a-spacing-2);
-  --__ac-action-menu-item-height: 2rem;
+  /* TODO: Use token here when added */
+  box-shadow:
+    0 0 1px 0 rgb(7 9 13/ 0.02),
+    0 2px 5px 0 rgb(7 9 13/ 0.1),
+    0 10px 16px 0 rgb(7 9 13/ 0.12);
 
-  border-radius: var(--a-border-radius-large);
-  background-color: var(--a-surface-default);
-  min-width: 128px;
-  max-width: min(95vw, 640px);
-  transform-origin: var(--__ac-action-menu-content-transform-origin);
-  animation-duration: 160ms;
-  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-  padding: var(--__ac-action-menu-content-p);
-  overflow: auto;
-  max-height: var(--__ac-action-menu-content-available-height);
-}
+  &[data-state="open"] {
+    /* TODO: rewrite to starting-style transition */
+    &[data-side="bottom"] {
+      animation-name: aksel-action-from-bottom, aksel-action-fade-in;
+    }
 
-.navds-action-menu__content:where([data-state="open"]):where([data-side="bottom"]) {
-  animation-name: aksel-action-from-bottom, aksel-action-fade-in;
-}
+    &[data-side="top"] {
+      animation-name: aksel-action-from-top, aksel-action-fade-in;
+    }
 
-.navds-action-menu__content:where([data-state="open"]):where([data-side="top"]) {
-  animation-name: aksel-action-from-top, aksel-action-fade-in;
-}
+    &[data-side="right"] {
+      animation-name: aksel-action-from-left, aksel-action-fade-in;
+    }
 
-.navds-action-menu__content:where([data-state="open"]):where([data-side="left"]) {
-  animation-name: aksel-action-from-left, aksel-action-fade-in;
-}
-
-.navds-action-menu__content:where([data-state="open"]):where([data-side="right"]) {
-  animation-name: aksel-action-from-right, aksel-action-fade-in;
+    &[data-side="left"] {
+      animation-name: aksel-action-from-right, aksel-action-fade-in;
+    }
+  }
 }
 
 @keyframes aksel-action-from-bottom {
@@ -89,64 +80,97 @@
   }
 }
 
+.navds-action-menu__content > .navds-action-menu__content-inner {
+  --__acx-action-menu-content-p: var(--ax-spacing-2);
+  --__acx-action-menu-item-pr: var(--ax-spacing-3);
+  --__acx-action-menu-item-pl: var(--ax-spacing-2);
+  --__acx-action-menu-item-height: 2rem;
+
+  border-radius: var(--ax-border-radius-large);
+  background-color: var(--ax-bg-raised);
+  min-width: 128px;
+  max-width: min(95vw, 640px);
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+  transform-origin: var(--__ac-action-menu-content-transform-origin);
+  animation-duration: 160ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  padding: var(--__acx-action-menu-content-p);
+  overflow: auto;
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+  max-height: var(--__ac-action-menu-content-available-height);
+}
+
+/* ----------------------------- ActionMenu Item ---------------------------- */
 .navds-action-menu__item {
   display: flex;
   align-items: center;
-  gap: var(--a-spacing-2);
-  min-height: var(--__ac-action-menu-item-height);
+  gap: var(--ax-spacing-2);
+  min-height: var(--__acx-action-menu-item-height);
   cursor: default;
-  border-radius: var(--a-border-radius-medium);
+  border-radius: var(--ax-border-radius-medium);
   position: relative;
-  padding-left: var(--__ac-action-menu-item-pl);
-  padding-right: var(--__ac-action-menu-item-pr);
-  font-size: var(--a-font-size-medium);
-  scroll-margin-block: var(--__ac-action-menu-content-p);
+  padding-left: var(--__acx-action-menu-item-pl);
+  padding-right: var(--__acx-action-menu-item-pr);
+  font-size: var(--ax-font-size-medium);
+  scroll-margin-block: var(--__acx-action-menu-content-p);
   line-height: 1.5;
-  color: var(--a-text-default);
+  color: var(--ax-text-default);
   text-decoration: none;
-}
 
-.navds-action-menu__item svg {
-  flex-shrink: 0;
+  & svg {
+    flex-shrink: 0;
+  }
+
+  &:focus {
+    outline: none;
+    background-color: var(--ax-bg-accent-moderate-hoverA);
+    color: var(--ax-text-default);
+  }
+
+  &[aria-disabled="true"] {
+    color: var(--ax-text-subtle);
+    opacity: 0.5;
+    pointer-events: none;
+  }
 }
 
 .navds-action-menu__item--has-icon {
-  --__ac-action-menu-item-pl: var(--a-spacing-6);
+  --__ac-action-menu-item-pl: var(--ax-spacing-6);
 }
 
 .navds-action-menu__sub-trigger {
-  --__ac-action-menu-item-pr: var(--a-spacing-05);
-}
+  --__ac-action-menu-item-pr: var(--ax-spacing-05);
 
-.navds-action-menu__item:focus {
-  outline: none;
-  background-color: var(--a-surface-action-subtle-hover);
-  color: var(--a-text-default);
+  &[data-state="open"] {
+    background-color: var(--ax-bg-neutral-moderate-pressed);
+  }
 }
 
 .navds-action-menu__item--danger {
-  color: var(--a-text-danger);
+  color: var(--ax-text-danger);
+
+  &:focus {
+    background-color: var(--ax-bg-danger-moderate-hoverA);
+    color: var(--ax-text-danger-strong);
+  }
 }
 
-.navds-action-menu__item--danger:focus {
-  background-color: var(--a-surface-danger-subtle);
-}
-
+/* ---------------------------- ActionMenu marker --------------------------- */
 .navds-action-menu__marker {
   display: flex;
   align-items: center;
-  gap: var(--a-spacing-1);
+  gap: var(--ax-spacing-1);
 }
 
 .navds-action-menu__marker--right {
   margin-left: auto;
-  padding-left: var(--a-spacing-4);
+  padding-left: var(--ax-spacing-4);
 }
 
-.navds-action-menu__marker--left {
+.---navds-action-menu__marker--left {
   position: absolute;
   left: 0;
-  width: var(--__ac-action-menu-item-pl);
+  width: var(--__acx-action-menu-item-pl);
   display: inline-flex;
   justify-content: center;
 }
@@ -156,46 +180,57 @@
   flex-shrink: 0;
 }
 
+/* --------------------------- ActionMenu shortcut -------------------------- */
 .navds-action-menu__shortcut {
-  background-color: var(--a-surface-neutral-subtle);
-  color: var(--a-text-default);
-  border-radius: var(--a-border-radius-small);
-  padding: 0 var(--a-spacing-1);
+  background-color: var(--ax-bg-neutral-moderateA);
+  color: var(--ax-text-default);
+  border-radius: var(--ax-border-radius-small);
+  padding: 0 var(--ax-spacing-1);
   min-width: 1.125rem;
   height: 1.125rem;
   line-height: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: var(--a-font-size-small);
+  font-size: var(--ax-font-size-small);
 }
 
+/* ---------------------------- ActionMenu Grouping ---------------------------- */
 .navds-action-menu__label {
   display: flex;
   align-items: center;
-  min-height: calc(var(--__ac-action-menu-item-height) - 6px);
-  padding-right: var(--__ac-action-menu-item-pr);
-  padding-left: var(--__ac-action-menu-item-pl);
-  color: var(--a-text-subtle);
-  border-radius: var(--a-border-radius-medium);
+  min-height: calc(var(--__acx-action-menu-item-height) - 6px);
+  padding-right: var(--__acx-action-menu-item-pr);
+  padding-left: var(--__acx-action-menu-item-pl);
+  color: var(--ax-text-subtle);
+  border-radius: var(--ax-border-radius-medium);
   user-select: none;
   cursor: default;
-  font-size: var(--a-font-size-small);
+  font-size: var(--ax-font-size-small);
 }
 
 .navds-action-menu__divider {
   height: 1px;
-  margin-block: var(--a-spacing-2);
-  background-color: var(--a-border-divider);
+  margin-block: var(--ax-spacing-2);
+  background-color: var(--ax-border-subtleA);
 }
 
+/* -------------------------- ActionMenu indicator -------------------------- */
 .navds-action-menu__indicator {
   display: grid;
   place-content: center;
-}
 
-.navds-action-menu__indicator-icon {
-  font-size: 14px;
+  &[data-state="unchecked"] .navds-action-menu__indicator-icon--unchecked {
+    display: block;
+  }
+
+  &[data-state="checked"] .navds-action-menu__indicator-icon--checked {
+    display: block;
+  }
+
+  &[data-state="indeterminate"] .navds-action-menu__indicator-icon--indeterminate {
+    display: block;
+  }
 }
 
 .navds-action-menu__indicator-icon--unchecked,
@@ -204,24 +239,6 @@
   display: none;
 }
 
-.navds-action-menu__indicator[data-state="unchecked"] .navds-action-menu__indicator-icon--unchecked {
-  display: block;
-}
-
-.navds-action-menu__indicator:where([data-state="checked"]) .navds-action-menu__indicator-icon--checked {
-  display: block;
-}
-
-.navds-action-menu__indicator:where([data-state="indeterminate"]) .navds-action-menu__indicator-icon--indeterminate {
-  display: block;
-}
-
-.navds-action-menu__item:where([aria-disabled="true"]) {
-  color: var(--a-text-subtle);
-  opacity: 0.5;
-  pointer-events: none;
-}
-
-.navds-action-menu__sub-trigger:where([data-state="open"]) {
-  background-color: var(--a-surface-neutral-subtle);
+.navds-action-menu__indicator-icon {
+  font-size: 14px;
 }

--- a/@navikt/core/css/darkside/action-menu.darkside.css
+++ b/@navikt/core/css/darkside/action-menu.darkside.css
@@ -82,7 +82,7 @@
 
 .navds-action-menu__content > .navds-action-menu__content-inner {
   --__acx-action-menu-content-p: var(--ax-spacing-2);
-  --__acx-action-menu-item-pr: var(--ax-spacing-3);
+  --__acx-action-menu-item-pr: var(--ax-spacing-2);
   --__acx-action-menu-item-pl: var(--ax-spacing-2);
   --__acx-action-menu-item-height: 2rem;
 
@@ -135,11 +135,11 @@
 }
 
 .navds-action-menu__item--has-icon {
-  --__ac-action-menu-item-pl: var(--ax-spacing-6);
+  --__acx-action-menu-item-pl: var(--ax-spacing-6);
 }
 
 .navds-action-menu__sub-trigger {
-  --__ac-action-menu-item-pr: var(--ax-spacing-05);
+  --__acx-action-menu-item-pr: var(--ax-spacing-05);
 
   &[data-state="open"] {
     background-color: var(--ax-bg-neutral-moderate-pressed);
@@ -167,7 +167,7 @@
   padding-left: var(--ax-spacing-4);
 }
 
-.---navds-action-menu__marker--left {
+.navds-action-menu__marker--left {
   position: absolute;
   left: 0;
   width: var(--__acx-action-menu-item-pl);
@@ -216,6 +216,13 @@
 }
 
 /* -------------------------- ActionMenu indicator -------------------------- */
+
+.navds-action-menu__indicator-icon--unchecked,
+.navds-action-menu__indicator-icon--checked,
+.navds-action-menu__indicator-icon--indeterminate {
+  display: none;
+}
+
 .navds-action-menu__indicator {
   display: grid;
   place-content: center;
@@ -231,12 +238,6 @@
   &[data-state="indeterminate"] .navds-action-menu__indicator-icon--indeterminate {
     display: block;
   }
-}
-
-.navds-action-menu__indicator-icon--unchecked,
-.navds-action-menu__indicator-icon--checked,
-.navds-action-menu__indicator-icon--indeterminate {
-  display: none;
 }
 
 .navds-action-menu__indicator-icon {

--- a/@navikt/core/css/darkside/action-menu.darkside.css
+++ b/@navikt/core/css/darkside/action-menu.darkside.css
@@ -9,74 +9,32 @@
     0 0 1px 0 rgb(7 9 13/ 0.02),
     0 2px 5px 0 rgb(7 9 13/ 0.1),
     0 10px 16px 0 rgb(7 9 13/ 0.12);
+  transition: transform 250ms cubic-bezier(0, 0, 0, 1) allow-discrete;
 
   &[data-state="open"] {
-    /* TODO: rewrite to starting-style transition */
     &[data-side="bottom"] {
-      animation-name: aksel-action-from-bottom, aksel-action-fade-in;
+      @starting-style {
+        transform: translateY(-4px);
+      }
     }
 
     &[data-side="top"] {
-      animation-name: aksel-action-from-top, aksel-action-fade-in;
+      @starting-style {
+        transform: translateY(4px);
+      }
     }
 
     &[data-side="right"] {
-      animation-name: aksel-action-from-left, aksel-action-fade-in;
+      @starting-style {
+        transform: translateX(-4px);
+      }
     }
 
     &[data-side="left"] {
-      animation-name: aksel-action-from-right, aksel-action-fade-in;
+      @starting-style {
+        transform: translateX(4px);
+      }
     }
-  }
-}
-
-@keyframes aksel-action-from-bottom {
-  from {
-    transform: translateY(-4px);
-  }
-
-  to {
-    transform: translateY(0);
-  }
-}
-
-@keyframes aksel-action-from-top {
-  from {
-    transform: translateY(4px);
-  }
-
-  to {
-    transform: translateY(0);
-  }
-}
-
-@keyframes aksel-action-from-left {
-  from {
-    transform: translateX(4px);
-  }
-
-  to {
-    transform: translateY(0);
-  }
-}
-
-@keyframes aksel-action-from-right {
-  from {
-    transform: translateX(-4px);
-  }
-
-  to {
-    transform: translateY(0);
-  }
-}
-
-@keyframes aksel-action-fade-in {
-  from {
-    opacity: 0.01;
-  }
-
-  to {
-    opacity: 1;
   }
 }
 

--- a/@navikt/core/css/darkside/action-menu.darkside.css
+++ b/@navikt/core/css/darkside/action-menu.darkside.css
@@ -86,7 +86,6 @@
   }
 
   &[aria-disabled="true"] {
-    color: var(--ax-text-subtle);
     opacity: 0.5;
     pointer-events: none;
   }

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.stories.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.stories.tsx
@@ -49,7 +49,7 @@ export const OnlyItems: Story = {
             Item 3
           </ActionMenu.Item>
           <ActionMenu.Item
-            onSelect={() => console.log("Item 3 clicked")}
+            onSelect={() => console.log("Item 4 clicked")}
             variant="danger"
           >
             Item 4

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.stories.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.stories.tsx
@@ -387,6 +387,9 @@ export const Disabled: Story = {
           <ActionMenu.Item disabled shortcut="T+W">
             Item 1
           </ActionMenu.Item>
+          <ActionMenu.Item disabled variant="danger">
+            Delete
+          </ActionMenu.Item>
           <ActionMenu.Sub>
             <ActionMenu.SubTrigger disabled>Submenu 1</ActionMenu.SubTrigger>
             <ActionMenu.SubContent>

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.stories.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.stories.tsx
@@ -48,6 +48,12 @@ export const OnlyItems: Story = {
           <ActionMenu.Item onSelect={() => console.log("Item 3 clicked")}>
             Item 3
           </ActionMenu.Item>
+          <ActionMenu.Item
+            onSelect={() => console.log("Item 3 clicked")}
+            variant="danger"
+          >
+            Item 4
+          </ActionMenu.Item>
         </ActionMenu.Content>
       </ActionMenu>
     );

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -621,7 +621,7 @@ export const ActionMenuCheckboxItem = forwardRef<
                   width="24"
                   height="24"
                   rx="4"
-                  fill="var(--a-border-default)"
+                  fill="var(--ax-border-default, var(--a-border-default))"
                 />
                 <rect
                   x="1"
@@ -629,7 +629,7 @@ export const ActionMenuCheckboxItem = forwardRef<
                   width="22"
                   height="22"
                   rx="3"
-                  fill="var(--a-surface-default)"
+                  fill="var(--ax-bg-default, var(--a-surface-default))"
                   strokeWidth="2"
                 />
               </g>
@@ -638,7 +638,7 @@ export const ActionMenuCheckboxItem = forwardRef<
                   width="24"
                   height="24"
                   rx="4"
-                  fill="var(--a-surface-action-selected)"
+                  fill="var(--ax-bg-accent-strong-pressed, var(--a-surface-action-selected))"
                 />
                 <rect
                   x="6"
@@ -646,7 +646,7 @@ export const ActionMenuCheckboxItem = forwardRef<
                   width="12"
                   height="4"
                   rx="1"
-                  fill="var(--a-surface-default)"
+                  fill="var(--ax-bg-default, var(--a-surface-default))"
                 />
               </g>
               <g className="navds-action-menu__indicator-icon--checked">
@@ -654,11 +654,11 @@ export const ActionMenuCheckboxItem = forwardRef<
                   width="24"
                   height="24"
                   rx="4"
-                  fill="var(--a-surface-action-selected)"
+                  fill="var(--ax-bg-accent-strong-pressed, var(--a-surface-action-selected))"
                 />
                 <path
                   d="M10.0352 13.4148L16.4752 7.40467C17.0792 6.83965 18.029 6.86933 18.5955 7.47478C19.162 8.08027 19.1296 9.03007 18.5245 9.59621L11.0211 16.5993C10.741 16.859 10.3756 17 10.0002 17C9.60651 17 9.22717 16.8462 8.93914 16.5611L6.43914 14.0611C5.85362 13.4756 5.85362 12.5254 6.43914 11.9399C7.02467 11.3544 7.97483 11.3544 8.56036 11.9399L10.0352 13.4148Z"
-                  fill="var(--a-surface-default)"
+                  fill="var(--ax-bg-default, var(--a-surface-default))"
                 />
               </g>
             </svg>
@@ -756,7 +756,7 @@ export const ActionMenuRadioItem = forwardRef<
                   width="24"
                   height="24"
                   rx="12"
-                  fill="var(--a-border-default)"
+                  fill="var(--ax-border-default, var(--a-border-default))"
                 />
                 <rect
                   x="1"
@@ -765,7 +765,7 @@ export const ActionMenuRadioItem = forwardRef<
                   height="22"
                   rx="11"
                   strokeWidth="2"
-                  fill="var(--a-surface-default)"
+                  fill="var(--ax-bg-default, var(--a-surface-default))"
                 />
               </g>
               <g className="navds-action-menu__indicator-icon--checked">
@@ -775,7 +775,7 @@ export const ActionMenuRadioItem = forwardRef<
                   width="22"
                   height="22"
                   rx="11"
-                  fill="var(--a-surface-default)"
+                  fill="var(--ax-bg-default, var(--a-surface-default))"
                 />
                 <rect
                   x="1"
@@ -783,12 +783,12 @@ export const ActionMenuRadioItem = forwardRef<
                   width="22"
                   height="22"
                   rx="11"
-                  stroke="var(--a-surface-action-selected)"
+                  stroke="var(--ax-bg-accent-strong-pressed, var(--a-surface-action-selected))"
                   strokeWidth="2"
                 />
                 <path
                   d="M20 12C20 16.4178 16.4178 20 12 20C7.58222 20 4 16.4178 4 12C4 7.58222 7.58222 4 12 4C16.4178 4 20 7.58222 20 12Z"
-                  fill="var(--a-surface-action-selected)"
+                  fill="var(--ax-bg-accent-strong-pressed, var(--a-surface-action-selected))"
                 />
               </g>
             </svg>


### PR DESCRIPTION
### Description

Had to update "hardcoded" values used inside checkbox and radio for ActionMenu. Could not use `--ax-bg-input` there because of some default colors for SVG that ruined the color with opacity

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
