### PR TITLE
Website: :bug: code example chip to same on first page

### DIFF
--- a/aksel.nav.no/website/components/sanity-modules/code-examples/CodeExamples.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/code-examples/CodeExamples.tsx
@@ -101,15 +101,16 @@ const ComponentExamples = ({ node }: CodeExamplesProps) => {
           <Chips>
             {node.dir.filer.map((fil) => {
               const id = `${node.dir.title.toLowerCase()}demo-${fil.navn}`;
+              const isSelected = active === fil.navn;
               return (
                 <Chips.Toggle
                   checkmark={false}
                   key={fil._key}
                   value={fil.navn}
-                  selected={active === fil.navn}
+                  selected={isSelected}
                   id={id}
                   onClick={() => {
-                    if (active === fil.navn) return;
+                    if (isSelected) return;
                     setUnloaded(true);
                     const newPath = `${router.asPath.split("#")[0]}#${id}`;
                     router.replace(newPath);

--- a/aksel.nav.no/website/components/sanity-modules/code-examples/CodeExamples.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/code-examples/CodeExamples.tsx
@@ -109,9 +109,9 @@ const ComponentExamples = ({ node }: CodeExamplesProps) => {
                   selected={active === fil.navn}
                   id={id}
                   onClick={() => {
-                    const newPath = `${router.asPath.split("#")[0]}#${id}`;
-                    if (newPath === router.asPath) return;
+                    if (active === fil.navn) return;
                     setUnloaded(true);
+                    const newPath = `${router.asPath.split("#")[0]}#${id}`;
                     router.replace(newPath);
                   }}
                 >


### PR DESCRIPTION
### Description

The bug with the code examples still happens, but only on the first page load, when there is no fragment selected (and the current path doesn't match any of the chip paths)

Re-using the existing conditional check for selected seems to fix it for the first page as well.

