### PR TITLE
[Chromatic] Ignores darkside css updates

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -55,7 +55,7 @@ jobs:
           exitZeroOnChanges: false
           buildScriptName: "build:storybook-chromatic"
           onlyChanged: true
-          untraced: "**/package.json|yarn.lock|**/*.md"
+          untraced: "**/package.json|yarn.lock|**/*.md|**/core/css/darkside/**/*.css"
           externals: \@navikt/core/css/**/*.css
           traceChanged: true
         env:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -55,7 +55,7 @@ jobs:
           exitZeroOnChanges: false
           buildScriptName: "build:storybook-chromatic"
           onlyChanged: true
-          untraced: "**/package.json|yarn.lock|**/*.md|**/core/css/darkside/**/*.css"
+          untraced: "**/package.json|yarn.lock|**/*.md|**/core/css/**/*.darkside.css"
           externals: \@navikt/core/css/**/*.css
           traceChanged: true
         env:


### PR DESCRIPTION
### Description

We are currently on pace to fly past the snapshot limit. This is mostly caused by the frequent updates to darkside CSS since turbosnap ignores. For now we can ignore the changes to new CSS in snapshots

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
