### PR TITLE
[Datepicker] `DateWrapper` now uses state instead of ref

### DIFF
--- a/.changeset/few-dragons-behave.md
+++ b/.changeset/few-dragons-behave.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Datepicker: Bruk av 'open'-prop ved første render kunne føre til at dialog ikke åpnet seg.

--- a/.changeset/few-dragons-behave.md
+++ b/.changeset/few-dragons-behave.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-Datepicker: Bruk av 'open'-prop ved første render kunne føre til at dialog ikke åpnet seg.
+Datepicker: Use of 'open'-prop set to 'true' on first render could lead to the dialog not opening.

--- a/@navikt/core/react/src/date/datepicker/DatePicker.tsx
+++ b/@navikt/core/react/src/date/datepicker/DatePicker.tsx
@@ -1,6 +1,6 @@
 import cl from "clsx";
 import { isWeekend } from "date-fns";
-import React, { forwardRef, useRef, useState } from "react";
+import React, { forwardRef, useState } from "react";
 import { DateRange, DayPicker, isMatch } from "react-day-picker";
 import { omit } from "../../util";
 import { useId } from "../../util/hooks";
@@ -88,8 +88,8 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
     const ariaId = useId(id);
     const [open, setOpen] = useState(_open ?? false);
 
-    const wrapperRef = useRef<HTMLDivElement | null>(null);
-    const mergedRef = useMergeRefs(wrapperRef, ref);
+    const [wrapperRef, setWrapperRef] = useState<HTMLDivElement | null>(null);
+    const mergedRef = useMergeRefs(setWrapperRef, ref);
 
     const [selectedDates, setSelectedDates] = React.useState<
       Date | Date[] | DateRange | undefined
@@ -167,7 +167,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
           {children}
           <DateWrapper
             open={_open ?? open}
-            anchor={wrapperRef.current}
+            anchor={wrapperRef}
             onClose={() => onClose?.() ?? setOpen(false)}
             locale={locale}
             variant={mode}

--- a/@navikt/core/react/src/date/datepicker/DatePicker.tsx
+++ b/@navikt/core/react/src/date/datepicker/DatePicker.tsx
@@ -88,6 +88,7 @@ export const DatePicker = forwardRef<HTMLDivElement, DatePickerProps>(
     const ariaId = useId(id);
     const [open, setOpen] = useState(_open ?? false);
 
+    /* We use state here to insure that anchor is defined if open is true on initial render */
     const [wrapperRef, setWrapperRef] = useState<HTMLDivElement | null>(null);
     const mergedRef = useMergeRefs(setWrapperRef, ref);
 

--- a/@navikt/core/react/src/date/monthpicker/MonthPicker.tsx
+++ b/@navikt/core/react/src/date/monthpicker/MonthPicker.tsx
@@ -1,5 +1,5 @@
 import cl from "clsx";
-import React, { forwardRef, useRef, useState } from "react";
+import React, { forwardRef, useState } from "react";
 import { DayPickerProvider } from "react-day-picker";
 import { useId } from "../../util/hooks";
 import { useMergeRefs } from "../../util/hooks/useMergeRefs";
@@ -81,8 +81,8 @@ export const MonthPicker = forwardRef<HTMLDivElement, MonthPickerProps>(
     const ariaId = useId(id);
     const [open, setOpen] = useState(_open ?? false);
 
-    const wrapperRef = useRef<HTMLDivElement | null>(null);
-    const mergedRef = useMergeRefs(wrapperRef, ref);
+    const [wrapperRef, setWrapperRef] = useState<HTMLDivElement | null>(null);
+    const mergedRef = useMergeRefs(setWrapperRef, ref);
 
     const [selectedMonth, setSelectedMonth] = useState<Date | undefined>(
       defaultSelected,
@@ -118,7 +118,7 @@ export const MonthPicker = forwardRef<HTMLDivElement, MonthPickerProps>(
           {children}
           <DateWrapper
             open={_open ?? open}
-            anchor={wrapperRef.current}
+            anchor={wrapperRef}
             onClose={() => onClose?.() ?? setOpen(false)}
             locale={locale}
             variant="month"

--- a/@navikt/core/react/src/date/monthpicker/MonthPicker.tsx
+++ b/@navikt/core/react/src/date/monthpicker/MonthPicker.tsx
@@ -81,6 +81,7 @@ export const MonthPicker = forwardRef<HTMLDivElement, MonthPickerProps>(
     const ariaId = useId(id);
     const [open, setOpen] = useState(_open ?? false);
 
+    /* We use state here to insure that anchor is defined if open is true on initial render */
     const [wrapperRef, setWrapperRef] = useState<HTMLDivElement | null>(null);
     const mergedRef = useMergeRefs(setWrapperRef, ref);
 


### PR DESCRIPTION
### Description

This solves an issue where use of `open={true}` on initial render could cause the Popover-anchor to be null, thus not opening the popover. 

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
