### PR TITLE
Bumped allowed react-versions

### DIFF
--- a/.changeset/serious-moons-fly.md
+++ b/.changeset/serious-moons-fly.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+React: Allow all react versions above 17.0.0 trough peerDependencies.

--- a/@navikt/core/react/package.json
+++ b/@navikt/core/react/package.json
@@ -628,8 +628,8 @@
     "vitest": "^1.2.2"
   },
   "peerDependencies": {
-    "@types/react": "^17.0.30 || ^18.0.0",
-    "react": "^17.0.0 || ^18.0.0"
+    "@types/react": ">=17.0.30",
+    "react": ">=17.0.0"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
### Description

By changing peerDependencies to `>=17.0.0`, users of react v19 will no longer get any warnings. AFAIK there is nothing stopping use of React 19 with our system today

### Component Checklist 📝

- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
