### PR TITLE
Combobox: Fix issue where using arrow keys in list would make the entire page scroll

### DIFF
--- a/.changeset/kind-carpets-add.md
+++ b/.changeset/kind-carpets-add.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+Combobox: Fix issue where using arrow keys in list would make the entire page scroll

--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -293,6 +293,10 @@
   background-color: var(--ac-combobox-list-item-bg, var(--a-surface-default));
 }
 
+.navds-combobox__list:has(.navds-combobox__list_non-selectables) .navds-combobox__list-item {
+  scroll-margin-top: 48px;
+}
+
 .navds-combobox__list-item--loading {
   justify-content: center;
   background-color: var(--ac-combobox-list-item-loading-bg, var(--a-surface-default));

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/useVirtualFocus.ts
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/useVirtualFocus.ts
@@ -45,7 +45,7 @@ const useVirtualFocus = (
 
   const setActiveAndScrollToElement = (element?: HTMLElement) => {
     setActiveElement(element);
-    element?.scrollIntoView?.({ block: "center" });
+    element?.scrollIntoView?.({ block: "nearest" });
   };
 
   const moveFocusUp = () => {


### PR DESCRIPTION
### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
