### PR TITLE
[Darkside] :sparkles: Added logo-token

### DIFF
--- a/@navikt/core/tokens/darkside/tokens/semantic.ts
+++ b/@navikt/core/tokens/darkside/tokens/semantic.ts
@@ -20,6 +20,11 @@ export function semanticTokenConfig(
         type: "color",
         group: "text",
       },
+      logo: {
+        value: theme === "light" ? "#C30000" : "{ax.neutral.1000.value}",
+        type: "color",
+        group: "text",
+      },
     },
     bg: {
       default: {


### PR DESCRIPTION
### Description

Added a `--ax-text-logo`-token that is red in lightmode and white in darkmode

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
