### PR TITLE
:bug: Removed psuedo-state plugin

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -71,7 +71,11 @@ export default {
         },
       },
     },
-    "storybook-addon-pseudo-states",
+    /**
+     * https://github.com/chromaui/storybook-addon-pseudo-states/issues/101
+     * Currently disabled to avoid interference with darkmode update
+     */
+    /* "storybook-addon-pseudo-states", */
   ],
   framework: {
     name: "@storybook/react-vite",

--- a/@navikt/core/react/src/link/stories/link.stories.tsx
+++ b/@navikt/core/react/src/link/stories/link.stories.tsx
@@ -219,7 +219,8 @@ export const Chromatic = () => (
 );
 Chromatic.parameters = { chromatic: { disable: false } };
 
-export const ChromaticHover = () => (
+/* See .storybook/main.ts comment for explanation */
+/* export const ChromaticHover = () => (
   <>
     <h2>With icon</h2>
     <LinkWithIcon />
@@ -245,9 +246,10 @@ export const ChromaticHover = () => (
 ChromaticHover.parameters = {
   chromatic: { disable: false },
   pseudo: { hover: true },
-};
+}; */
 
-export const ChromaticFocusVisible = () => (
+/* See .storybook/main.ts comment for explanation */
+/* export const ChromaticFocusVisible = () => (
   <>
     <h2>With icon</h2>
     <LinkWithIcon />
@@ -273,9 +275,10 @@ export const ChromaticFocusVisible = () => (
 ChromaticFocusVisible.parameters = {
   chromatic: { disable: false },
   pseudo: { focusVisible: true },
-};
+}; */
 
-export const ChromaticActive = () => (
+/* See .storybook/main.ts comment for explanation */
+/* export const ChromaticActive = () => (
   <>
     <h2>With icon</h2>
     <LinkWithIcon />
@@ -301,4 +304,4 @@ export const ChromaticActive = () => (
 ChromaticActive.parameters = {
   chromatic: { disable: false },
   pseudo: { active: true },
-};
+}; */


### PR DESCRIPTION
### Description

The plugin `storybook-addon-pseudo-states` is currently interfering in some cases where we use the `not` selector. This causes some components like Select, Checkbox, Radio ++ to now use correct CSS. Until this is resolved in the future hopefully, i disabled the plugin for now to avoid more bugs when updating to darkmode.

https://github.com/chromaui/storybook-addon-pseudo-states/issues/101

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [x] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
