### PR TITLE
Allow RC versions of React 19 through peerDependencies

### DIFF
--- a/.changeset/cool-bears-walk.md
+++ b/.changeset/cool-bears-walk.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Allow RC versions of React 19 through peerDependencies

--- a/@navikt/core/react/package.json
+++ b/@navikt/core/react/package.json
@@ -629,7 +629,7 @@
   },
   "peerDependencies": {
     "@types/react": ">=17.0.30",
-    "react": ">=17.0.0"
+    "react": ">=17.0.0 || >19.0.0-rc"
   },
   "peerDependenciesMeta": {
     "@types/react": {


### PR DESCRIPTION
### Description

[Should fix this](https://nav-it.slack.com/archives/C7NE7A8UF/p1732177187507559?thread_ts=1730889521.162589&cid=C7NE7A8UF).

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
