### PR TITLE
Use the modern range notation for media queries

### DIFF
--- a/@navikt/core/css/darkside/date.darkside.css
+++ b/@navikt/core/css/darkside/date.darkside.css
@@ -323,7 +323,7 @@
   border: none;
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-date {
     padding: var(--a-spacing-5) var(--a-spacing-4);
   }

--- a/@navikt/core/css/darkside/form/combobox.darkside.css
+++ b/@navikt/core/css/darkside/form/combobox.darkside.css
@@ -384,7 +384,7 @@
 }
 
 /* Mobile */
-@media (max-width: 479px) {
+@media (width <= 479px) {
   .navds-combobox__button-toggle-list {
     right: 0.5rem;
   }

--- a/@navikt/core/css/darkside/form/form-summary.darkside.css
+++ b/@navikt/core/css/darkside/form/form-summary.darkside.css
@@ -13,7 +13,7 @@
   gap: 0 var(--ax-spacing-3);
 }
 
-@media (max-width: 479px) {
+@media (width <= 479px) {
   .navds-form-summary__header {
     padding: var(--ax-spacing-3) var(--ax-spacing-4);
     flex-direction: column;
@@ -35,7 +35,7 @@
   margin: 0;
 }
 
-@media (max-width: 479px) {
+@media (width <= 479px) {
   .navds-form-summary__answers {
     padding: var(--ax-spacing-4);
   }
@@ -55,7 +55,7 @@
   padding-bottom: 0;
 }
 
-@media (max-width: 479px) {
+@media (width <= 479px) {
   .navds-form-summary__answer:not(:last-child) {
     margin-bottom: var(--ax-spacing-3);
     padding-bottom: var(--ax-spacing-3);

--- a/@navikt/core/css/darkside/guide-panel.darkside.css
+++ b/@navikt/core/css/darkside/guide-panel.darkside.css
@@ -31,7 +31,7 @@
   padding-top: var(--a-spacing-12);
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-guide-panel {
     --__ac-guide-panel-guide-size: 6.25rem;
   }
@@ -61,7 +61,7 @@
   min-height: calc(var(--__ac-guide-panel-guide-size) + var(--a-spacing-5) + var(--a-spacing-5));
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-guide-panel--not-poster {
     --__ac-guide-panel-guide-size: 5rem;
   }
@@ -74,7 +74,7 @@
 
 /* responsive-poster (on desktop) */
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-guide-panel--responsive-poster {
     --__ac-guide-panel-guide-size: 5rem;
 

--- a/@navikt/core/css/darkside/modal.darkside.css
+++ b/@navikt/core/css/darkside/modal.darkside.css
@@ -75,7 +75,7 @@
   }
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-modal {
     max-width: calc(100% - 2em);
   }
@@ -85,7 +85,7 @@
   }
 }
 
-@media (min-height: 480px) {
+@media (height >= 480px) {
   .navds-modal {
     max-height: calc(100% - 2em);
   }

--- a/@navikt/core/css/darkside/primitives/base.darkside.css
+++ b/@navikt/core/css/darkside/primitives/base.darkside.css
@@ -298,7 +298,7 @@
   grid-column: var(--__ac-r-grid-column);
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-r-p {
     --__ac-r-padding: var(--__ac-r-p-sm);
   }
@@ -400,7 +400,7 @@
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .navds-r-p {
     --__ac-r-padding: var(--__ac-r-p-md);
   }
@@ -502,7 +502,7 @@
   }
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-r-p {
     --__ac-r-padding: var(--__ac-r-p-lg);
   }
@@ -604,7 +604,7 @@
   }
 }
 
-@media (min-width: 1280px) {
+@media (width >= 1280px) {
   .navds-r-p {
     --__ac-r-padding: var(--__ac-r-p-xl);
   }
@@ -706,7 +706,7 @@
   }
 }
 
-@media (min-width: 1440px) {
+@media (width >= 1440px) {
   .navds-r-p {
     --__ac-r-padding: var(--__ac-r-p-2xl);
   }

--- a/@navikt/core/css/darkside/primitives/bleed.darkside.css
+++ b/@navikt/core/css/darkside/primitives/bleed.darkside.css
@@ -42,7 +42,7 @@
   padding-block: var(--__ac-bleed-padding-block);
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-bleed {
     --__ac-bleed-margin-inline: var(--__ac-bleed-margin-inline-sm);
     --__ac-bleed-margin-block: var(--__ac-bleed-margin-block-sm);
@@ -54,7 +54,7 @@
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .navds-bleed {
     --__ac-bleed-margin-inline: var(--__ac-bleed-margin-inline-md);
     --__ac-bleed-margin-block: var(--__ac-bleed-margin-block-md);
@@ -66,7 +66,7 @@
   }
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-bleed {
     --__ac-bleed-margin-inline: var(--__ac-bleed-margin-inline-lg);
     --__ac-bleed-margin-block: var(--__ac-bleed-margin-block-lg);
@@ -78,7 +78,7 @@
   }
 }
 
-@media (min-width: 1280px) {
+@media (width >= 1280px) {
   .navds-bleed {
     --__ac-bleed-margin-inline: var(--__ac-bleed-margin-inline-xl);
     --__ac-bleed-margin-block: var(--__ac-bleed-margin-block-xl);
@@ -90,7 +90,7 @@
   }
 }
 
-@media (min-width: 1440px) {
+@media (width >= 1440px) {
   .navds-bleed {
     --__ac-bleed-margin-inline: var(--__ac-bleed-margin-inline-2xl);
     --__ac-bleed-margin-block: var(--__ac-bleed-margin-block-2xl);

--- a/@navikt/core/css/darkside/primitives/box.darkside.css
+++ b/@navikt/core/css/darkside/primitives/box.darkside.css
@@ -35,31 +35,31 @@
   box-shadow: var(--__ac-box-shadow);
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-box-border-radius {
     --__ac-box-border-radius: var(--__ac-box-border-radius-sm);
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .navds-box-border-radius {
     --__ac-box-border-radius: var(--__ac-box-border-radius-md);
   }
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-box-border-radius {
     --__ac-box-border-radius: var(--__ac-box-border-radius-lg);
   }
 }
 
-@media (min-width: 1280px) {
+@media (width >= 1280px) {
   .navds-box-border-radius {
     --__ac-box-border-radius: var(--__ac-box-border-radius-xl);
   }
 }
 
-@media (min-width: 1440px) {
+@media (width >= 1440px) {
   .navds-box-border-radius {
     --__ac-box-border-radius: var(--__ac-box-border-radius-2xl);
   }

--- a/@navikt/core/css/darkside/primitives/hgrid.darkside.css
+++ b/@navikt/core/css/darkside/primitives/hgrid.darkside.css
@@ -29,7 +29,7 @@
   align-items: var(--__ac-hgrid-align);
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-hgrid {
     --__ac-hgrid-columns: var(--__ac-hgrid-columns-sm);
   }
@@ -39,7 +39,7 @@
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .navds-hgrid {
     --__ac-hgrid-columns: var(--__ac-hgrid-columns-md);
   }
@@ -49,7 +49,7 @@
   }
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-hgrid {
     --__ac-hgrid-columns: var(--__ac-hgrid-columns-lg);
   }
@@ -59,7 +59,7 @@
   }
 }
 
-@media (min-width: 1280px) {
+@media (width >= 1280px) {
   .navds-hgrid {
     --__ac-hgrid-columns: var(--__ac-hgrid-columns-xl);
   }
@@ -69,7 +69,7 @@
   }
 }
 
-@media (min-width: 1440px) {
+@media (width >= 1440px) {
   .navds-hgrid {
     --__ac-hgrid-columns: var(--__ac-hgrid-columns-2xl);
   }

--- a/@navikt/core/css/darkside/primitives/page.darkside.css
+++ b/@navikt/core/css/darkside/primitives/page.darkside.css
@@ -56,7 +56,7 @@
   padding-inline: var(--__ac-page-padding-inline);
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-pageblock--gutters {
     --__ac-page-padding-inline: var(--a-spacing-12);
   }

--- a/@navikt/core/css/darkside/primitives/responsive.darkside.css
+++ b/@navikt/core/css/darkside/primitives/responsive.darkside.css
@@ -1,58 +1,58 @@
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-responsive__below--sm {
     display: none !important;
   }
 }
 
-@media (max-width: 479px) {
+@media (width <= 479px) {
   .navds-responsive__above--sm {
     display: none !important;
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .navds-responsive__below--md {
     display: none !important;
   }
 }
 
-@media (max-width: 767px) {
+@media (width <= 767px) {
   .navds-responsive__above--md {
     display: none !important;
   }
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-responsive__below--lg {
     display: none !important;
   }
 }
 
-@media (max-width: 1023px) {
+@media (width <= 1023px) {
   .navds-responsive__above--lg {
     display: none !important;
   }
 }
 
-@media (min-width: 1280px) {
+@media (width >= 1280px) {
   .navds-responsive__below--xl {
     display: none !important;
   }
 }
 
-@media (max-width: 1279px) {
+@media (width <= 1279px) {
   .navds-responsive__above--xl {
     display: none !important;
   }
 }
 
-@media (min-width: 1440px) {
+@media (width >= 1440px) {
   .navds-responsive__below--2xl {
     display: none !important;
   }
 }
 
-@media (max-width: 1439px) {
+@media (width <= 1439px) {
   .navds-responsive__above--2xl {
     display: none !important;
   }

--- a/@navikt/core/css/darkside/primitives/stack.darkside.css
+++ b/@navikt/core/css/darkside/primitives/stack.darkside.css
@@ -64,7 +64,7 @@
   margin-inline-start: calc(var(--__ac-stack-gap) * -1);
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-stack-gap {
     --__ac-stack-gap: var(--__ac-stack-gap-sm);
   }
@@ -82,7 +82,7 @@
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .navds-stack-gap {
     --__ac-stack-gap: var(--__ac-stack-gap-md);
   }
@@ -100,7 +100,7 @@
   }
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-stack-gap {
     --__ac-stack-gap: var(--__ac-stack-gap-lg);
   }
@@ -118,7 +118,7 @@
   }
 }
 
-@media (min-width: 1280px) {
+@media (width >= 1280px) {
   .navds-stack-gap {
     --__ac-stack-gap: var(--__ac-stack-gap-xl);
   }
@@ -136,7 +136,7 @@
   }
 }
 
-@media (min-width: 1440px) {
+@media (width >= 1440px) {
   .navds-stack-gap {
     --__ac-stack-gap: var(--__ac-stack-gap-2xl);
   }

--- a/@navikt/core/css/darkside/typography.darkside.css
+++ b/@navikt/core/css/darkside/typography.darkside.css
@@ -37,7 +37,7 @@ body,
 }
 
 /* Mobile scale */
-@media (max-width: 480px) {
+@media (width <= 480px) {
   .navds-heading--xlarge {
     font-size: var(--ax-font-size-heading-xlarge);
     letter-spacing: -0.008em;

--- a/@navikt/core/css/date.css
+++ b/@navikt/core/css/date.css
@@ -323,7 +323,7 @@
   border: none;
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-date {
     padding: var(--a-spacing-5) var(--a-spacing-4);
   }

--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -382,7 +382,7 @@
 
 /* Mobile */
 
-@media (max-width: 479px) {
+@media (width <= 479px) {
   .navds-combobox__button-toggle-list {
     right: 0.5rem;
   }

--- a/@navikt/core/css/form/form-summary.css
+++ b/@navikt/core/css/form/form-summary.css
@@ -13,7 +13,7 @@
   gap: 0 var(--a-spacing-2);
 }
 
-@media (max-width: 479px) {
+@media (width <= 479px) {
   .navds-form-summary__header {
     padding: var(--a-spacing-3) var(--a-spacing-4);
     flex-direction: column;
@@ -35,7 +35,7 @@
   margin: 0;
 }
 
-@media (max-width: 479px) {
+@media (width <= 479px) {
   .navds-form-summary__answers {
     padding: var(--a-spacing-4);
   }
@@ -55,7 +55,7 @@
   padding-bottom: 0;
 }
 
-@media (max-width: 479px) {
+@media (width <= 479px) {
   .navds-form-summary__answer:not(:last-child) {
     margin-bottom: var(--a-spacing-3);
     padding-bottom: var(--a-spacing-3);

--- a/@navikt/core/css/guide-panel.css
+++ b/@navikt/core/css/guide-panel.css
@@ -31,7 +31,7 @@
   padding-top: var(--a-spacing-12);
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-guide-panel {
     --__ac-guide-panel-guide-size: 6.25rem;
   }
@@ -61,7 +61,7 @@
   min-height: calc(var(--__ac-guide-panel-guide-size) + var(--a-spacing-5) + var(--a-spacing-5));
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-guide-panel--not-poster {
     --__ac-guide-panel-guide-size: 5rem;
   }
@@ -74,7 +74,7 @@
 
 /* responsive-poster (on desktop) */
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-guide-panel--responsive-poster {
     --__ac-guide-panel-guide-size: 5rem;
 

--- a/@navikt/core/css/modal.css
+++ b/@navikt/core/css/modal.css
@@ -60,7 +60,7 @@
   width: var(--ac-modal-width-medium, 700px);
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-modal {
     max-width: calc(100% - 2em);
   }
@@ -70,7 +70,7 @@
   }
 }
 
-@media (min-height: 480px) {
+@media (height >= 480px) {
   .navds-modal {
     max-height: calc(100% - 2em);
   }

--- a/@navikt/core/css/primitives/base.css
+++ b/@navikt/core/css/primitives/base.css
@@ -298,7 +298,7 @@
   grid-column: var(--__ac-r-grid-column);
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-r-p {
     --__ac-r-padding: var(--__ac-r-p-sm);
   }
@@ -400,7 +400,7 @@
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .navds-r-p {
     --__ac-r-padding: var(--__ac-r-p-md);
   }
@@ -502,7 +502,7 @@
   }
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-r-p {
     --__ac-r-padding: var(--__ac-r-p-lg);
   }
@@ -604,7 +604,7 @@
   }
 }
 
-@media (min-width: 1280px) {
+@media (width >= 1280px) {
   .navds-r-p {
     --__ac-r-padding: var(--__ac-r-p-xl);
   }
@@ -706,7 +706,7 @@
   }
 }
 
-@media (min-width: 1440px) {
+@media (width >= 1440px) {
   .navds-r-p {
     --__ac-r-padding: var(--__ac-r-p-2xl);
   }

--- a/@navikt/core/css/primitives/bleed.css
+++ b/@navikt/core/css/primitives/bleed.css
@@ -42,7 +42,7 @@
   padding-block: var(--__ac-bleed-padding-block);
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-bleed {
     --__ac-bleed-margin-inline: var(--__ac-bleed-margin-inline-sm);
     --__ac-bleed-margin-block: var(--__ac-bleed-margin-block-sm);
@@ -54,7 +54,7 @@
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .navds-bleed {
     --__ac-bleed-margin-inline: var(--__ac-bleed-margin-inline-md);
     --__ac-bleed-margin-block: var(--__ac-bleed-margin-block-md);
@@ -66,7 +66,7 @@
   }
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-bleed {
     --__ac-bleed-margin-inline: var(--__ac-bleed-margin-inline-lg);
     --__ac-bleed-margin-block: var(--__ac-bleed-margin-block-lg);
@@ -78,7 +78,7 @@
   }
 }
 
-@media (min-width: 1280px) {
+@media (width >= 1280px) {
   .navds-bleed {
     --__ac-bleed-margin-inline: var(--__ac-bleed-margin-inline-xl);
     --__ac-bleed-margin-block: var(--__ac-bleed-margin-block-xl);
@@ -90,7 +90,7 @@
   }
 }
 
-@media (min-width: 1440px) {
+@media (width >= 1440px) {
   .navds-bleed {
     --__ac-bleed-margin-inline: var(--__ac-bleed-margin-inline-2xl);
     --__ac-bleed-margin-block: var(--__ac-bleed-margin-block-2xl);

--- a/@navikt/core/css/primitives/box.css
+++ b/@navikt/core/css/primitives/box.css
@@ -35,31 +35,31 @@
   box-shadow: var(--__ac-box-shadow);
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-box-border-radius {
     --__ac-box-border-radius: var(--__ac-box-border-radius-sm);
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .navds-box-border-radius {
     --__ac-box-border-radius: var(--__ac-box-border-radius-md);
   }
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-box-border-radius {
     --__ac-box-border-radius: var(--__ac-box-border-radius-lg);
   }
 }
 
-@media (min-width: 1280px) {
+@media (width >= 1280px) {
   .navds-box-border-radius {
     --__ac-box-border-radius: var(--__ac-box-border-radius-xl);
   }
 }
 
-@media (min-width: 1440px) {
+@media (width >= 1440px) {
   .navds-box-border-radius {
     --__ac-box-border-radius: var(--__ac-box-border-radius-2xl);
   }

--- a/@navikt/core/css/primitives/hgrid.css
+++ b/@navikt/core/css/primitives/hgrid.css
@@ -29,7 +29,7 @@
   align-items: var(--__ac-hgrid-align);
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-hgrid {
     --__ac-hgrid-columns: var(--__ac-hgrid-columns-sm);
   }
@@ -39,7 +39,7 @@
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .navds-hgrid {
     --__ac-hgrid-columns: var(--__ac-hgrid-columns-md);
   }
@@ -49,7 +49,7 @@
   }
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-hgrid {
     --__ac-hgrid-columns: var(--__ac-hgrid-columns-lg);
   }
@@ -59,7 +59,7 @@
   }
 }
 
-@media (min-width: 1280px) {
+@media (width >= 1280px) {
   .navds-hgrid {
     --__ac-hgrid-columns: var(--__ac-hgrid-columns-xl);
   }
@@ -69,7 +69,7 @@
   }
 }
 
-@media (min-width: 1440px) {
+@media (width >= 1440px) {
   .navds-hgrid {
     --__ac-hgrid-columns: var(--__ac-hgrid-columns-2xl);
   }

--- a/@navikt/core/css/primitives/page.css
+++ b/@navikt/core/css/primitives/page.css
@@ -56,7 +56,7 @@
   padding-inline: var(--__ac-page-padding-inline);
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-pageblock--gutters {
     --__ac-page-padding-inline: var(--a-spacing-12);
   }

--- a/@navikt/core/css/primitives/responsive.css
+++ b/@navikt/core/css/primitives/responsive.css
@@ -1,58 +1,58 @@
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-responsive__below--sm {
     display: none !important;
   }
 }
 
-@media (max-width: 479px) {
+@media (width <= 479px) {
   .navds-responsive__above--sm {
     display: none !important;
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .navds-responsive__below--md {
     display: none !important;
   }
 }
 
-@media (max-width: 767px) {
+@media (width <= 767px) {
   .navds-responsive__above--md {
     display: none !important;
   }
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-responsive__below--lg {
     display: none !important;
   }
 }
 
-@media (max-width: 1023px) {
+@media (width <= 1023px) {
   .navds-responsive__above--lg {
     display: none !important;
   }
 }
 
-@media (min-width: 1280px) {
+@media (width >= 1280px) {
   .navds-responsive__below--xl {
     display: none !important;
   }
 }
 
-@media (max-width: 1279px) {
+@media (width <= 1279px) {
   .navds-responsive__above--xl {
     display: none !important;
   }
 }
 
-@media (min-width: 1440px) {
+@media (width >= 1440px) {
   .navds-responsive__below--2xl {
     display: none !important;
   }
 }
 
-@media (max-width: 1439px) {
+@media (width <= 1439px) {
   .navds-responsive__above--2xl {
     display: none !important;
   }

--- a/@navikt/core/css/primitives/stack.css
+++ b/@navikt/core/css/primitives/stack.css
@@ -64,7 +64,7 @@
   margin-inline-start: calc(var(--__ac-stack-gap) * -1);
 }
 
-@media (min-width: 480px) {
+@media (width >= 480px) {
   .navds-stack-gap {
     --__ac-stack-gap: var(--__ac-stack-gap-sm);
   }
@@ -82,7 +82,7 @@
   }
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .navds-stack-gap {
     --__ac-stack-gap: var(--__ac-stack-gap-md);
   }
@@ -100,7 +100,7 @@
   }
 }
 
-@media (min-width: 1024px) {
+@media (width >= 1024px) {
   .navds-stack-gap {
     --__ac-stack-gap: var(--__ac-stack-gap-lg);
   }
@@ -118,7 +118,7 @@
   }
 }
 
-@media (min-width: 1280px) {
+@media (width >= 1280px) {
   .navds-stack-gap {
     --__ac-stack-gap: var(--__ac-stack-gap-xl);
   }
@@ -136,7 +136,7 @@
   }
 }
 
-@media (min-width: 1440px) {
+@media (width >= 1440px) {
   .navds-stack-gap {
     --__ac-stack-gap: var(--__ac-stack-gap-2xl);
   }

--- a/@navikt/core/css/typography.css
+++ b/@navikt/core/css/typography.css
@@ -35,7 +35,7 @@
 }
 
 /* Mobile scale */
-@media (max-width: 480px) {
+@media (width <= 480px) {
   .navds-heading--xlarge {
     font-size: var(--a-font-size-heading-xlarge);
     letter-spacing: -0.008em;

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
       "function-url-quotes": null,
       "property-no-vendor-prefix": null,
       "alpha-value-notation": "number",
-      "media-feature-range-notation": "prefix",
+      "media-feature-range-notation": "context",
       "import-notation": "string",
       "declaration-property-value-disallowed-list": {
         "justify-content": [


### PR DESCRIPTION
# internal tooling PR

Since we use lightningCSS to [transpile](https://lightningcss.dev/playground/#%7B%22minify%22%3Afalse%2C%22customMedia%22%3Atrue%2C%22cssModules%22%3Afalse%2C%22analyzeDependencies%22%3Afalse%2C%22targets%22%3A%7B%22chrome%22%3A6225920%7D%2C%22include%22%3A0%2C%22exclude%22%3A0%2C%22source%22%3A%22%40media%20(width%20%3E%3D%201024px)%20%7B%5Cn%20%20.thing%20%7B%5Cn%20%20%20%20color%3A%20red%3B%5Cn%20%20%7D%5Cn%7D%22%2C%22visitorEnabled%22%3Afalse%2C%22visitor%22%3A%22%7B%5Cn%20%20Color(color)%20%7B%5Cn%20%20%20%20if%20(color.type%20%3D%3D%3D%20'rgb')%20%7B%5Cn%20%20%20%20%20%20color.g%20%3D%200%3B%5Cn%20%20%20%20%20%20return%20color%3B%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%22%2C%22unusedSymbols%22%3A%5B%5D%2C%22version%22%3A%22local%22%7D) anyways, I think we should use the modern syntax as it's much easier to reason about imo. (less :brain: required, I always mix up what `min-width` means in the media query == does that apply when above the threshold or below it?)

