### PR TITLE
:bug: Modal now handles cases where it was opened with `show()`

### DIFF
--- a/.changeset/sweet-birds-care.md
+++ b/.changeset/sweet-birds-care.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Modal: Modal now shows up while screensharing with Vergic"

--- a/.changeset/sweet-birds-care.md
+++ b/.changeset/sweet-birds-care.md
@@ -2,4 +2,4 @@
 "@navikt/ds-css": patch
 ---
 
-Modal: Now shows up while screensharing with Vergic"
+Modal: Now shows up while screensharing with Vergic

--- a/.changeset/sweet-birds-care.md
+++ b/.changeset/sweet-birds-care.md
@@ -2,4 +2,4 @@
 "@navikt/ds-css": patch
 ---
 
-Modal: Modal now shows up while screensharing with Vergic"
+Modal: Now shows up while screensharing with Vergic"

--- a/@navikt/core/css/modal.css
+++ b/@navikt/core/css/modal.css
@@ -14,6 +14,10 @@
   max-height: 100%;
   max-width: 100%;
   color: var(--a-text-default);
+
+  /* In case Modal is opened with `show()` */
+  inset: 0;
+  z-index: 9999;
 }
 
 .navds-modal[open] {

--- a/@navikt/core/css/modal.css
+++ b/@navikt/core/css/modal.css
@@ -28,6 +28,7 @@
 
 .navds-modal--polyfilled {
   top: 50%;
+  bottom: unset; /* Overrides inset: 0 from .navds-modal */
   transform: translate(0, -50%);
 
   /* From polyfill (dialog-polyfill/dist/dialog-polyfill.css): */

--- a/@navikt/core/css/modal.css
+++ b/@navikt/core/css/modal.css
@@ -15,7 +15,7 @@
   max-width: 100%;
   color: var(--a-text-default);
 
-  /* In case Modal is opened with `show()` */
+  /* In case Modal is opened with `show()`, in eg. Vergic screensharing */
   inset: 0;
   z-index: 9999;
 }


### PR DESCRIPTION
### Description

In Vergic (Screenshare solution), Modal was opened with `open`-prop. This currently breaks since body is set to `overflow: hidden`. In the case of the Modal not being visible on the screen, you then had no visual way to close it.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
