### PR TITLE
Modal: Don't add scroll shadow when polyfilled

### DIFF
--- a/.changeset/seven-bottles-sell.md
+++ b/.changeset/seven-bottles-sell.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Modal: Don't add scroll shadow when polyfilled

--- a/@navikt/core/css/modal.css
+++ b/@navikt/core/css/modal.css
@@ -132,6 +132,9 @@
   overflow: auto;
   overscroll-behavior: contain;
   position: relative; /* Needed to make sr-only elements position correctly - see Storybook */
+}
+
+.navds-modal:not(.navds-modal--polyfilled) .navds-modal__body {
   background:
     linear-gradient(var(--__ac-modal-bg) 30%, transparent) top,
     linear-gradient(transparent, var(--__ac-modal-bg) 60%) bottom,


### PR DESCRIPTION
### Description

Scroll shadow looked like this in Safari 14.1:
![image](https://github.com/user-attachments/assets/4b28cef1-5a64-40ed-a330-e0c396c6fe0a)

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
