### PR TITLE
Fileupload: Remove list-styling when used in `ul`

### DIFF
--- a/.changeset/warm-adults-allow.md
+++ b/.changeset/warm-adults-allow.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Fileupload: Remove browser styling from FileUpload.Item when used as in list.

--- a/.changeset/warm-adults-allow.md
+++ b/.changeset/warm-adults-allow.md
@@ -2,4 +2,4 @@
 "@navikt/ds-css": patch
 ---
 
-Fileupload: Remove browser styling from FileUpload.Item when used as in list.
+FileUpload: Remove browser styling from FileUpload.Item when used in list.

--- a/@navikt/core/css/darkside/form/file-upload.darkside.css
+++ b/@navikt/core/css/darkside/form/file-upload.darkside.css
@@ -1,12 +1,3 @@
-/* Makes it easier for user to use FileItem in semantic lists */
-.navds-file-upload {
-  & :is(ul, li) {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-}
-
 /* --------------------------- FileUpload Dropzone -------------------------- */
 .navds-dropzone__area {
   --__axc-dropzone-background: var(--ax-bg-input);
@@ -154,6 +145,14 @@
 }
 
 /* ----------------------------- FileUpload Item ---------------------------- */
+.navds-file-upload :is(ul, li),
+ul:has(> li.navds-file-item),
+li.navds-file-item {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .navds-file-item__inner {
   background-color: var(--ax-bg-raised);
   border: 1px solid var(--ax-border-subtleA);

--- a/@navikt/core/css/form/file-upload.css
+++ b/@navikt/core/css/form/file-upload.css
@@ -1,13 +1,4 @@
 /**
-* Makes it easier for user to use FileItem in semantic lists
-*/
-.navds-file-upload :is(ul, li) {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-/**
  * FileUpload.Dropzone
  */
 
@@ -163,6 +154,13 @@
 /**
  * FileUpload.Item
  */
+.navds-file-upload :is(ul, li),
+ul:has(> li.navds-file-item),
+li.navds-file-item {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
 
 .navds-file-item__inner {
   outline: 1px solid var(--a-border-subtle);


### PR DESCRIPTION
### Description

Our current implementation assumed that you wrapped it inside the `FileUpload`-component

Resolves #3412

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
