### PR TITLE
[Aksel.nav.no] :bug: Accordion now deconstructs sanity-references

### DIFF
--- a/aksel.nav.no/website/sanity/interface/queries.js
+++ b/aksel.nav.no/website/sanity/interface/queries.js
@@ -126,6 +126,7 @@ const accordionBlock = `_type == "accordion"=>{
     ...,
     content[]{
       ...,
+      ${markDef},
       ${defaultBlock}
     }
   }


### PR DESCRIPTION
### Description

Looks like we (i) had forgot to handle internal references to documents inside the Accordion-block. This is now fixed by calling markDef

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
