### PR TITLE
:bug: Complete CSS-build was included in `components.css` bundle

### DIFF
--- a/.changeset/thick-tools-behave.md
+++ b/.changeset/thick-tools-behave.md
@@ -2,4 +2,4 @@
 "@navikt/ds-css": patch
 ---
 
-CSS: Resolved regressions where them complete stylesheet was included in scoped 'components.css' file.
+CSS: Resolved regression where the complete stylesheet was included in scoped 'components.css' file.

--- a/.changeset/thick-tools-behave.md
+++ b/.changeset/thick-tools-behave.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+CSS: Resolved regressions where them complete stylesheet was included in scoped 'components.css' file.

--- a/@navikt/core/css/config/bundle.js
+++ b/@navikt/core/css/config/bundle.js
@@ -66,7 +66,13 @@ async function bundleComponents() {
   const css = fs.readFileSync(indexSrc);
 
   /* Remove @charset, baseline */
-  const cssString = css.toString().split("\n").slice(2).join("\n");
+  const cssString = css
+    .toString()
+    .split("\n")
+    .filter((line) => {
+      return line.startsWith("@import") && !line.includes("baseline");
+    })
+    .join("\n");
 
   const result = await postcss([cssImports, combineSelectors]).process(
     cssString,


### PR DESCRIPTION
### Description

This regressions was a result of an update ~2 months ago where an extra line was added to the index.css file, breaking the parsing logic used in bundler.

<img width="815" alt="Screenshot 2024-12-05 at 10 34 39" src="https://github.com/user-attachments/assets/47a898d0-da5a-4762-b40b-f918082e733a">

Fixed by now filter out unwanted lines when bundling and not relying on `.slice`


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
