### PR TITLE
[Combobox] Only open dropdown onClick, not onFocus.

### DIFF
--- a/.changeset/forty-rules-ring.md
+++ b/.changeset/forty-rules-ring.md
@@ -1,5 +1,5 @@
 ---
-"@navikt/ds-react": minor
+"@navikt/ds-react": patch
 ---
 
 Combobox: Only open dropdown-list onClick, not onFocus.

--- a/.changeset/forty-rules-ring.md
+++ b/.changeset/forty-rules-ring.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+Combobox: Only open dropdown-list onClick, not onFocus.

--- a/@navikt/core/react/src/form/combobox/ComboboxWrapper.tsx
+++ b/@navikt/core/react/src/form/combobox/ComboboxWrapper.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 import cl from "clsx";
 import React, { useRef, useState } from "react";
 import { useInputContext } from "./Input/Input.context";
@@ -32,7 +35,6 @@ const ComboboxWrapper = ({
       !wrapperRef.current?.contains(event.relatedTarget) &&
       toggleOpenButtonRef?.current !== event.target
     ) {
-      toggleIsListOpen(true);
       setHasFocusWithin(true);
     }
   }
@@ -62,6 +64,14 @@ const ComboboxWrapper = ({
       )}
       onFocus={onFocusInsideWrapper}
       onBlur={onBlurWrapper}
+      onClick={() => {
+        if (inputProps.disabled || readOnly) {
+          return;
+        }
+
+        /* Allows for opening input on click, but not on focus */
+        toggleIsListOpen(true);
+      }}
     >
       {children}
     </div>

--- a/@navikt/core/react/src/form/combobox/ComboboxWrapper.tsx
+++ b/@navikt/core/react/src/form/combobox/ComboboxWrapper.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
-/* eslint-disable jsx-a11y/click-events-have-key-events */
 import cl from "clsx";
 import React, { useRef, useState } from "react";
 import { useInputContext } from "./Input/Input.context";
@@ -64,14 +61,6 @@ const ComboboxWrapper = ({
       )}
       onFocus={onFocusInsideWrapper}
       onBlur={onBlurWrapper}
-      onClick={() => {
-        if (inputProps.disabled || readOnly) {
-          return;
-        }
-
-        /* Allows for opening input on click, but not on focus */
-        toggleIsListOpen(true);
-      }}
     >
       {children}
     </div>

--- a/@navikt/core/react/src/form/combobox/Input/InputController.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/InputController.tsx
@@ -33,6 +33,7 @@ export const InputController = forwardRef<
     toggleListButton = true,
     inputClassName,
     shouldShowSelectedOptions = true,
+
     ...rest
   } = props;
 
@@ -45,7 +46,7 @@ export const InputController = forwardRef<
     readOnly,
   } = useInputContext();
 
-  const { activeDecendantId } = useFilteredOptionsContext();
+  const { activeDecendantId, toggleIsListOpen } = useFilteredOptionsContext();
   const { selectedOptions } = useSelectedOptionsContext();
 
   const mergedInputRef = useMergeRefs(inputRef, ref);
@@ -57,7 +58,14 @@ export const InputController = forwardRef<
         "navds-combobox__wrapper-inner--virtually-unfocused":
           activeDecendantId !== undefined,
       })}
-      onClick={focusInput}
+      onClick={() => {
+        if (inputProps.disabled || readOnly) {
+          return;
+        }
+
+        toggleIsListOpen(true);
+        focusInput();
+      }}
     >
       {!shouldShowSelectedOptions ? (
         <Input


### PR DESCRIPTION
### Description

This solves the issue where programmatic focus would open dropdown. This in turn would hide any error for the field in the cases that would be relevant.  

Resolves #3437


The fix itself almost seems too simple to just "work", so will need some help reviewing edgecases that might have been forgotten. I didn't actually need to check for readOnly or disabled-state for it to work, but exit early anyways just incase we change that in the future.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
