### PR TITLE
[Darkside] Updated input-bg in darkmode, added token for opacity

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,9 +2,9 @@ import { withThemeByClassName } from "@storybook/addon-themes";
 import { Preview } from "@storybook/react";
 import React, { useLayoutEffect } from "react";
 // @ts-expect-error - Temporary
-import darksideCss from "@navikt/ds-css/darkside/index.css?inline";
+import darksideCss from "../@navikt/core/css/darkside/index.css?inline";
 // @ts-expect-error - Temporary
-import defaultCss from "@navikt/ds-css/index.css?inline";
+import defaultCss from "../@navikt/core/css/index.css?inline";
 import { UNSAFE_AkselTheme } from "../@navikt/core/react/src/provider";
 import UNSAFE_AkselLanguageProvider from "../@navikt/core/react/src/provider/i18n/LanguageProvider";
 import en from "../@navikt/core/react/src/util/i18n/locales/en";

--- a/@navikt/core/css/darkside/button.darkside.css
+++ b/@navikt/core/css/darkside/button.darkside.css
@@ -257,10 +257,11 @@
 
 .navds-button:where(:disabled, .navds-button--disabled) {
   cursor: not-allowed;
+  user-select: none;
 }
 
 .navds-button:not(.navds-button--loading):where(:disabled, .navds-button--disabled) {
-  opacity: 0.3;
+  opacity: var(--ax-opacity-disabled);
 }
 
 /* Loader overrides */

--- a/@navikt/core/css/darkside/button.darkside.css
+++ b/@navikt/core/css/darkside/button.darkside.css
@@ -257,7 +257,6 @@
 
 .navds-button:where(:disabled, .navds-button--disabled) {
   cursor: not-allowed;
-  user-select: none;
 }
 
 .navds-button:not(.navds-button--loading):where(:disabled, .navds-button--disabled) {

--- a/@navikt/core/css/darkside/copybutton.darkside.css
+++ b/@navikt/core/css/darkside/copybutton.darkside.css
@@ -31,7 +31,7 @@
 
   &:disabled {
     cursor: not-allowed;
-    opacity: 0.3;
+    opacity: var(--ax-opacity-disabled);
   }
 
   &:disabled:hover {

--- a/@navikt/core/css/darkside/dropdown.darkside.css
+++ b/@navikt/core/css/darkside/dropdown.darkside.css
@@ -74,7 +74,7 @@
 
 .navds-dropdown__item:disabled {
   color: var(--ac-dropdown-item-text, var(--a-text-action));
-  opacity: 0.3;
+  opacity: var(--ax-opacity-disabled);
   background: transparent;
   cursor: not-allowed;
 }

--- a/@navikt/core/css/darkside/form/combobox.darkside.css
+++ b/@navikt/core/css/darkside/form/combobox.darkside.css
@@ -28,7 +28,7 @@
 }
 
 .navds-combobox--disabled {
-  opacity: 0.3;
+  opacity: var(--ax-opacity-disabled);
 
   & .navds-combobox__wrapper {
     & *:hover {

--- a/@navikt/core/css/darkside/form/fieldset.darkside.css
+++ b/@navikt/core/css/darkside/form/fieldset.darkside.css
@@ -32,7 +32,7 @@
 
 .navds-fieldset:disabled > .navds-fieldset__legend,
 .navds-fieldset:disabled > .navds-fieldset__description {
-  opacity: 0.3;
+  opacity: var(--ax-opacity-disabled);
 }
 
 @media (forced-colors: active) {

--- a/@navikt/core/css/darkside/form/form.darkside.css
+++ b/@navikt/core/css/darkside/form/form.darkside.css
@@ -23,7 +23,7 @@
 }
 
 .navds-form-field--disabled {
-  opacity: 0.3;
+  opacity: var(--ax-opacity-disabled);
   cursor: not-allowed;
 }
 

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -172,7 +172,7 @@
 
 .navds-checkbox--disabled,
 .navds-radio--disabled {
-  opacity: 0.3;
+  opacity: var(--ax-opacity-disabled);
 }
 
 .navds-checkbox--disabled > .navds-checkbox__input,

--- a/@navikt/core/css/darkside/form/search.darkside.css
+++ b/@navikt/core/css/darkside/form/search.darkside.css
@@ -81,7 +81,7 @@
   font-size: 1.5rem;
 
   .navds-search--disabled & {
-    opacity: 0.3;
+    opacity: var(--ax-opacity-disabled);
   }
 }
 
@@ -144,7 +144,7 @@
 /* We can't re-use disabled-state for form-fields since opacity multiplies on search-button */
 .navds-search--disabled {
   .navds-search__input {
-    opacity: 0.3;
+    opacity: var(--ax-opacity-disabled);
     cursor: not-allowed;
   }
 }

--- a/@navikt/core/css/darkside/form/switch.darkside.css
+++ b/@navikt/core/css/darkside/form/switch.darkside.css
@@ -169,7 +169,7 @@
 }
 
 .navds-switch--disabled:not(.navds-switch--loading) {
-  opacity: 0.3;
+  opacity: var(--ax-opacity-disabled);
 }
 
 .navds-switch__input:disabled,

--- a/@navikt/core/css/package.json
+++ b/@navikt/core/css/package.json
@@ -29,8 +29,8 @@
     "test:watch": "vitest watch"
   },
   "devDependencies": {
-    "@types/clean-css": "4.2.11",
     "@navikt/ds-tokens": "^7.7.0",
+    "@types/clean-css": "4.2.11",
     "autoprefixer": "^10.4.20",
     "browserslist": "^4.24.2",
     "clean-css": "5.3.3",

--- a/@navikt/core/tokens/darkside/create-configuration.ts
+++ b/@navikt/core/tokens/darkside/create-configuration.ts
@@ -4,6 +4,7 @@ import {
   globalColorDarkModeConfig,
   globalColorLightModeConfig,
 } from "./tokens/global";
+import { opacityTokenConfig } from "./tokens/opacity";
 import { radiusTokenConfig } from "./tokens/radius";
 import { semanticTokenConfig } from "./tokens/semantic";
 import { semanticTokensForAllRolesConfig } from "./tokens/semantic-roles";
@@ -21,10 +22,11 @@ import { mergeConfigs, tokensWithPrefix } from "./util";
 export const lightModeTokens = () => {
   return tokensWithPrefix(
     mergeConfigs([
+      shadowTokenConfig("light"),
+      opacityTokenConfig("light"),
       semanticTokensForAllRolesConfig("light"),
       textContrastTokenConfig(),
       semanticTokenConfig("light"),
-      shadowTokenConfig("light"),
       globalColorLightModeConfig,
     ]),
   );
@@ -37,10 +39,11 @@ export const lightModeTokens = () => {
 export const darkModeTokens = () => {
   return tokensWithPrefix(
     mergeConfigs([
+      shadowTokenConfig("dark"),
+      opacityTokenConfig("dark"),
       semanticTokensForAllRolesConfig("dark"),
       textContrastTokenConfig(),
       semanticTokenConfig("dark"),
-      shadowTokenConfig("dark"),
       globalColorDarkModeConfig,
     ]),
   );

--- a/@navikt/core/tokens/darkside/tokens/opacity.ts
+++ b/@navikt/core/tokens/darkside/tokens/opacity.ts
@@ -1,0 +1,14 @@
+import { ColorTheme, StyleDictionaryTokenConfig } from "../util";
+
+export function opacityTokenConfig(theme: ColorTheme) {
+  return {
+    opacity: {
+      disabled: {
+        value: theme === "light" ? `0.3` : `0.4`,
+        type: "opacity",
+        comment: "Used for setting opacity on disabled elements.",
+        figmaIgnore: true,
+      },
+    },
+  } satisfies StyleDictionaryTokenConfig<"opacity">;
+}

--- a/@navikt/core/tokens/darkside/tokens/semantic.ts
+++ b/@navikt/core/tokens/darkside/tokens/semantic.ts
@@ -39,7 +39,7 @@ export function semanticTokenConfig(theme: ColorTheme) {
         value:
           theme === "light"
             ? "rgba(255, 255, 255, 0.85)"
-            : "rgba(14, 21, 31, 0.50)",
+            : "rgba(7, 9, 13, 0.50)",
         type: "color",
         group: "background",
       },

--- a/@navikt/core/tokens/darkside/util.ts
+++ b/@navikt/core/tokens/darkside/util.ts
@@ -51,6 +51,7 @@ type GlobalColorScale =
 export type TokenTypes =
   | "color"
   | "shadow"
+  | "opacity"
   | "global-color"
   | "global-radius"
   | "global-spacing"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3783,8 +3783,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
   dependencies:
-    "@types/clean-css": "npm:4.2.11"
     "@navikt/ds-tokens": "npm:^7.7.0"
+    "@types/clean-css": "npm:4.2.11"
     autoprefixer: "npm:^10.4.20"
     browserslist: "npm:^4.24.2"
     clean-css: "npm:5.3.3"


### PR DESCRIPTION
### Description

Allows us to use a different opacity based on theme.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
