### PR TITLE
:memo: Update Textfield example for readonly after feedback

### DIFF
--- a/@navikt/core/css/darkside/form/form.darkside.css
+++ b/@navikt/core/css/darkside/form/form.darkside.css
@@ -41,7 +41,7 @@
 
 .navds-form-field__readonly-icon {
   margin-top: var(--ax-spacing-05);
-  margin-right: var(--ax-spacing-2);
+  margin-right: var(--ax-spacing-1);
   flex-shrink: 0;
   align-self: flex-start;
 }

--- a/aksel.nav.no/website/pages/eksempler/textfield/readonly.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textfield/readonly.tsx
@@ -2,7 +2,14 @@ import { TextField } from "@navikt/ds-react";
 import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
-  return <TextField label="Har du noen tilbakemeldinger?" readOnly />;
+  return (
+    <TextField
+      label="Adresse"
+      description="Hentet fra Folkeregisteret"
+      value="Portveien 2"
+      readOnly
+    />
+  );
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE


### PR DESCRIPTION
### Description

While updating, we (dev and designer) decided to try reducing spacing right for the "lock"-icon since it seemed a little off now.

### Component Checklist 📝

- [ ] JSDoc
- [x] Examples
- [x] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
