### PR TITLE
[Timeline]: Earliest date defaulted to current date when found date was later than current day

### DIFF
--- a/.changeset/wise-worms-destroy.md
+++ b/.changeset/wise-worms-destroy.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Timeline: In cases where earliest found date were after current date, timeline-start ended up defaulting to current date.

--- a/@navikt/core/react/src/timeline/hooks/useTimelineRows.ts
+++ b/@navikt/core/react/src/timeline/hooks/useTimelineRows.ts
@@ -139,7 +139,7 @@ export const useEarliestDate = ({
   rows,
 }: {
   startDate?: Date;
-  rows: Omit<Period, "id" | "endInclusive">[][];
+  rows: Pick<Period, "start">[][];
 }) =>
   useMemo(() => {
     if (startDate) {

--- a/@navikt/core/react/src/timeline/hooks/useTimelineRows.ts
+++ b/@navikt/core/react/src/timeline/hooks/useTimelineRows.ts
@@ -134,17 +134,33 @@ export const useTimelineRows = (
     [rows, startDate, endDate, direction],
   );
 
-const earliestDate = (earliest: Date, period: Period) =>
-  period.start < earliest ? period.start : earliest;
+export const useEarliestDate = ({
+  startDate,
+  rows,
+}: {
+  startDate?: Date;
+  rows: Omit<Period, "id" | "endInclusive">[][];
+}) =>
+  useMemo(() => {
+    if (startDate) {
+      return startDate;
+    }
 
-const earliestFomDate = (rader: Period[][]) =>
-  rader.flat().reduce(earliestDate, new Date());
+    const startDates = rows
+      .flat()
+      .filter((period) => period.start)
+      .map((period) => period.start);
 
-export const useEarliestDate = ({ startDate, rows }: any) =>
-  useMemo(
-    () => (startDate ? startDate : earliestFomDate(rows)),
-    [startDate, rows],
-  );
+    if (startDates.length === 0) {
+      return new Date();
+    }
+
+    const earliestDate = startDates.reduce((earliest, current) =>
+      current < earliest ? current : earliest,
+    );
+
+    return earliestDate;
+  }, [startDate, rows]);
 
 const latestDate = (latest: Date, period: Period) =>
   period.end > latest ? period.end : latest;

--- a/@navikt/core/react/src/timeline/tests/useTimelineRows.test.ts
+++ b/@navikt/core/react/src/timeline/tests/useTimelineRows.test.ts
@@ -22,7 +22,6 @@ describe("useEarliestDate", () => {
       [{ start: new Date(2022, 0, 1) }],
     ];
 
-    /* @ts-expect-error asdas */
     const { result } = renderHook(() => useEarliestDate({ rows }));
     expect(result.current).toEqual(new Date(2022, 0, 1));
   });
@@ -34,7 +33,6 @@ describe("useEarliestDate", () => {
       [{ start: addDays(earliestDate, 40) }],
     ];
 
-    /* @ts-expect-error asdas */
     const { result } = renderHook(() => useEarliestDate({ rows }));
     expect(result.current).toEqual(earliestDate);
   });

--- a/@navikt/core/react/src/timeline/tests/useTimelineRows.test.ts
+++ b/@navikt/core/react/src/timeline/tests/useTimelineRows.test.ts
@@ -1,0 +1,133 @@
+import { renderHook } from "@testing-library/react";
+import { addDays, isSameDay } from "date-fns";
+import { describe, expect, test } from "vitest";
+import {
+  useEarliestDate,
+  useLatestDate,
+  useTimelineRows,
+} from "../hooks/useTimelineRows";
+
+describe("useEarliestDate", () => {
+  test("returns the provided startDate if it exists", () => {
+    const startDate = new Date(2023, 0, 1);
+    const { result } = renderHook(() =>
+      useEarliestDate({ startDate, rows: [] }),
+    );
+    expect(result.current).toEqual(startDate);
+  });
+
+  test("returns the earliest date from the rows if startDate is not provided", () => {
+    const rows = [
+      [{ start: new Date(2023, 0, 1) }],
+      [{ start: new Date(2022, 0, 1) }],
+    ];
+
+    /* @ts-expect-error asdas */
+    const { result } = renderHook(() => useEarliestDate({ rows }));
+    expect(result.current).toEqual(new Date(2022, 0, 1));
+  });
+
+  test("returns the earliest date from the rows if startDate is not provided and date is later than todays date", () => {
+    const earliestDate = addDays(new Date(), 400);
+    const rows = [
+      [{ start: earliestDate }],
+      [{ start: addDays(earliestDate, 40) }],
+    ];
+
+    /* @ts-expect-error asdas */
+    const { result } = renderHook(() => useEarliestDate({ rows }));
+    expect(result.current).toEqual(earliestDate);
+  });
+
+  test("returns the current date if no startDate and rows are empty", () => {
+    const { result } = renderHook(() => useEarliestDate({ rows: [] }));
+    expect(isSameDay(result.current, new Date())).toBeTruthy();
+  });
+});
+
+describe("useLatestDate", () => {
+  test("returns the provided endDate if it exists", () => {
+    const endDate = new Date(2023, 0, 1);
+    const { result } = renderHook(() => useLatestDate({ endDate, rows: [] }));
+    expect(result.current).toEqual(endDate);
+  });
+
+  test("returns the latest date from the rows plus one day if endDate is not provided", () => {
+    const rows = [
+      [{ start: new Date(2023, 0, 1), end: new Date(2023, 0, 10) }],
+      [{ start: new Date(2022, 0, 1), end: new Date(2022, 0, 5) }],
+    ];
+    const { result } = renderHook(() => useLatestDate({ rows }));
+    expect(result.current).toEqual(addDays(new Date(2023, 0, 10), 1));
+  });
+
+  test("returns the current date plus one day if no endDate and rows are empty", () => {
+    const { result } = renderHook(() => useLatestDate({ rows: [] }));
+    expect(result.current).toEqual(addDays(new Date(0), 1));
+  });
+});
+
+describe("useTimelineRows", () => {
+  const rows = [
+    {
+      label: "Row 1",
+      periods: [
+        {
+          start: new Date(2023, 0, 1),
+          end: new Date(2023, 0, 10),
+          status: "active",
+        },
+        {
+          start: new Date(2023, 0, 15),
+          end: new Date(2023, 0, 20),
+          status: "inactive",
+        },
+      ],
+    },
+    {
+      label: "Row 2",
+      periods: [
+        {
+          start: new Date(2022, 0, 1),
+          end: new Date(2022, 0, 5),
+          status: "active",
+        },
+      ],
+    },
+  ];
+
+  test("returns the correct timeline rows", () => {
+    const startDate = new Date(2022, 0, 1);
+    const endDate = new Date(2023, 0, 31);
+    const direction = "left";
+    const { result } = renderHook(() =>
+      useTimelineRows(rows, startDate, endDate, direction),
+    );
+
+    expect(result.current).toHaveLength(2);
+    expect(result.current[0].periods).toHaveLength(2);
+    expect(result.current[1].periods).toHaveLength(1);
+  });
+
+  test("handles empty rows", () => {
+    const startDate = new Date(2022, 0, 1);
+    const endDate = new Date(2023, 0, 31);
+    const direction = "left";
+    const { result } = renderHook(() =>
+      useTimelineRows([], startDate, endDate, direction),
+    );
+
+    expect(result.current).toHaveLength(0);
+  });
+
+  test("handles different directions", () => {
+    const startDate = new Date(2022, 0, 1);
+    const endDate = new Date(2023, 0, 31);
+    const direction = "right";
+    const { result } = renderHook(() =>
+      useTimelineRows(rows, startDate, endDate, direction),
+    );
+
+    expect(result.current[0].periods[0].start).toEqual(new Date(2023, 0, 15));
+  });
+});


### PR DESCRIPTION
### Description

Resolves #3457

In short, if earliest date found was "1 jan 2027" and current date is "1 jan 2024" the returned date was "1 jan 2024". This was caused by the "default"-value in reduce being `new Date()`

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
