### PR TITLE
Inline Alert: `<Link>`-components used within avoids re-colororing

### DIFF
--- a/.changeset/eleven-gorillas-scream.md
+++ b/.changeset/eleven-gorillas-scream.md
@@ -2,4 +2,4 @@
 "@navikt/ds-css": patch
 ---
 
-Alert: Link-components used within Alert variant='inline' now preserves default coloring"
+Alert: Link-components used within Alert variant='inline' now preserves default coloring

--- a/.changeset/eleven-gorillas-scream.md
+++ b/.changeset/eleven-gorillas-scream.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Alert: Link-components used within Alert variant='inline' now preserves default coloring"

--- a/@navikt/core/css/darkside/link.darkside.css
+++ b/@navikt/core/css/darkside/link.darkside.css
@@ -43,7 +43,7 @@
   }
 }
 
-.navds-alert,
+.navds-alert:not(.navds-alert--inline),
 .navds-confirmation-panel {
   & .navds-link {
     color: var(--ax-text-default);

--- a/@navikt/core/css/link.css
+++ b/@navikt/core/css/link.css
@@ -30,7 +30,7 @@
   text-decoration: underline;
 }
 
-.navds-alert .navds-link,
+.navds-alert:not(.navds-alert--inline) .navds-link,
 .navds-confirmation-panel .navds-link {
   color: var(--a-text-default);
 }

--- a/@navikt/core/react/src/alert/alert.stories.tsx
+++ b/@navikt/core/react/src/alert/alert.stories.tsx
@@ -96,8 +96,8 @@ export const Inline: StoryFn = () => {
       <Alert variant="info" inline>
         Id elit esse enim reprehenderit enim nisi veniam nostrud. Id elit esse
         enim reprehenderit enim nisi veniam nostrud. Id elit esse enim
-        reprehenderit enim nisi veniam nostrud. Id elit esse enim reprehenderit
-        enim nisi veniam nostrud.
+        reprehenderit enim nisi veniam nostrud.{" "}
+        <Link href="#">Id elit esse enim reprehenderit</Link>
       </Alert>
       <Alert variant="info" size="small" inline>
         Id elit esse enim reprehenderit enim nisi veniam nostrud.
@@ -105,8 +105,8 @@ export const Inline: StoryFn = () => {
       <Alert variant="info" size="small" inline>
         Id elit esse enim reprehenderit enim nisi veniam nostrud. Id elit esse
         enim reprehenderit enim nisi veniam nostrud. Id elit esse enim
-        reprehenderit enim nisi veniam nostrud. Id elit esse enim reprehenderit
-        enim nisi veniam nostrud.
+        reprehenderit enim nisi veniam nostrud.{" "}
+        <Link href="#">Id elit esse enim reprehenderit</Link>
       </Alert>
     </VStack>
   );


### PR DESCRIPTION
### Description

We currently color all Link-components used within Alert to `text-default` to avoid blue on colored backgrounds. For inline-alerts with no background this is not needed.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
