### PR TITLE
[Select] :bug: Focus-border no longer cancels out error-border.

### DIFF
--- a/.changeset/late-turkeys-drive.md
+++ b/.changeset/late-turkeys-drive.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Select: :bug: Focus-border no longer cancels out error-border.

--- a/.changeset/young-goats-smash.md
+++ b/.changeset/young-goats-smash.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Textarea: :bug: Focus-border no longer cancels out error-border.

--- a/@navikt/core/css/form/select.css
+++ b/@navikt/core/css/form/select.css
@@ -78,6 +78,13 @@
   border-color: var(--ac-select-error-border, var(--a-surface-danger));
 }
 
+.navds-select--error .navds-select__input:focus {
+  border-color: var(--ac-select-error-border, var(--a-surface-danger));
+  box-shadow:
+    0 0 0 1px var(--a-border-danger),
+    var(--a-shadow-focus);
+}
+
 /**
   Disabled
 */

--- a/@navikt/core/css/form/select.css
+++ b/@navikt/core/css/form/select.css
@@ -73,16 +73,13 @@
 /**
   Error handling
 */
-.navds-select--error > * select:not(:hover, :focus, :disabled) {
+.navds-select--error > * .navds-select__input:not(:hover, :disabled) {
   box-shadow: 0 0 0 1px var(--ac-select-error-border, var(--a-surface-danger));
   border-color: var(--ac-select-error-border, var(--a-surface-danger));
 }
 
 .navds-select--error .navds-select__input:focus {
-  border-color: var(--ac-select-error-border, var(--a-surface-danger));
-  box-shadow:
-    0 0 0 1px var(--a-border-danger),
-    var(--a-shadow-focus);
+  box-shadow: var(--a-shadow-focus);
 }
 
 /**

--- a/@navikt/core/css/form/textarea.css
+++ b/@navikt/core/css/form/textarea.css
@@ -111,16 +111,13 @@
 /**
   Error handling
 */
-.navds-textarea--error .navds-textarea__input:not(:hover, :focus-visible, :disabled) {
+.navds-textarea--error .navds-textarea__input:not(:hover, :disabled) {
   box-shadow: 0 0 0 1px var(--ac-textarea-error-border, var(--__ac-textarea-error-border, var(--a-border-danger)));
   border-color: var(--ac-textarea-error-border, var(--__ac-textarea-error-border, var(--a-border-danger)));
 }
 
-@supports not selector(:focus-visible) {
-  .navds-textarea--error .navds-textarea__input:not(:hover, :focus, :disabled) {
-    box-shadow: 0 0 0 1px var(--ac-textarea-error-border, var(--__ac-textarea-error-border, var(--a-border-danger)));
-    border-color: var(--ac-textarea-error-border, var(--__ac-textarea-error-border, var(--a-border-danger)));
-  }
+.navds-textarea--error .navds-textarea__input:focus-visible {
+  box-shadow: var(--a-shadow-focus);
 }
 
 .navds-textarea__input:disabled {


### PR DESCRIPTION
### Description

https://nav-it.slack.com/archives/C7NE7A8UF/p1734441582223079

After
<img width="783" alt="Screenshot 2024-12-17 at 14 43 09" src="https://github.com/user-attachments/assets/16597228-8acd-4dca-93d1-1e07ef58d091" />

Before
<img width="772" alt="Screenshot 2024-12-17 at 14 43 18" src="https://github.com/user-attachments/assets/ccd08c3b-534b-4490-8b4e-9f42a6a3cf5c" />


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
