### PR TITLE
[Darkside] :sparkles: Now adds version-tokens to tokens css

### DIFF
--- a/@navikt/core/tokens/config/version-tag.ts
+++ b/@navikt/core/tokens/config/version-tag.ts
@@ -1,14 +1,19 @@
 import { readFileSync, writeFileSync } from "fs";
 
-const cssFilePath = "./dist/tokens.css";
+const cssFilePaths = ["./dist/tokens.css", "./dist/darkside/tokens.css"];
 const packageJsonPath = "./package.json";
 
 const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
 const version = packageJson.version;
 
-let cssContent = readFileSync(cssFilePath, "utf8");
+for (const path of cssFilePaths) {
+  let cssContent = readFileSync(path, "utf8");
 
-if (!cssContent.includes("--a-version")) {
-  cssContent = cssContent.replace("{", `{\n  --a-version: "${version}";`);
-  writeFileSync(cssFilePath, cssContent);
+  if (!cssContent.includes("--ax-version")) {
+    cssContent = cssContent.replace(
+      ":root, :host {",
+      `:root, :host {\n  --ax-version: "${version}";`,
+    );
+    writeFileSync(path, cssContent);
+  }
 }

--- a/@navikt/core/tokens/config/version-tag.ts
+++ b/@navikt/core/tokens/config/version-tag.ts
@@ -9,11 +9,9 @@ const version = packageJson.version;
 for (const path of cssFilePaths) {
   let cssContent = readFileSync(path, "utf8");
 
-  if (!cssContent.includes("--ax-version")) {
-    cssContent = cssContent.replace(
-      ":root, :host {",
-      `:root, :host {\n  --ax-version: "${version}";`,
-    );
-    writeFileSync(path, cssContent);
-  }
+  cssContent = cssContent.replace(
+    ":root, :host {",
+    `:root, :host {\n  --ax-version: "${version}";`,
+  );
+  writeFileSync(path, cssContent);
 }

--- a/@navikt/core/tokens/package.json
+++ b/@navikt/core/tokens/package.json
@@ -17,7 +17,7 @@
     "docs.json"
   ],
   "scripts": {
-    "build": "tsx ./config/build.ts > /dev/null && tsx ./config/version-tag.ts && yarn build:darkside",
+    "build": "tsx ./config/build.ts > /dev/null && yarn build:darkside && tsx ./config/version-tag.ts",
     "build:darkside": "tsx ./darkside && yarn build:figma-config && yarn build:plugin",
     "build:figma-config": "tsx ./darkside/figma",
     "build:plugin-dev": "esbuild darkside/figma/plugin/plugin.ts --target=es2016 --bundle --define:process.env.NODE_ENV=\\\"development\\\" --outfile='darkside/figma/plugin/plugin.js'",


### PR DESCRIPTION
### Description

For example this token gets added on build:  `--ax-version: "7.8.0";`. This lets us track what version different application are on when inspecting the code 🙌 

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
