### PR TITLE
:bug: Removed default tokens added to tailwind, added opacity-token

### DIFF
--- a/@navikt/core/tailwind/darkside.ts
+++ b/@navikt/core/tailwind/darkside.ts
@@ -4,9 +4,12 @@ import { kebabCaseForAlpha } from "../tokens/config/kebabCase";
 import { breakpointsTokenConfig } from "../tokens/darkside/tokens/breakpoints";
 
 const transformedTokens = Object.fromEntries(
-  Object.entries(TokensBuild).map(([key, value]) => {
-    return [kebabCaseForAlpha(key), value];
-  }),
+  Object.entries(TokensBuild)
+    .map(([key, value]) => {
+      return [kebabCaseForAlpha(key), value];
+    })
+    /* "* as" imports incldes key "default" where value is every token  */
+    .filter(([key]) => key !== "default"),
 );
 
 const nonColorTokens = [
@@ -18,6 +21,7 @@ const nonColorTokens = [
   "font-family",
   "border-radius",
   "breakpoint",
+  "opacity",
 ];
 /*
  * Assumes that all remaining names not in nonColorTokens are colors
@@ -50,6 +54,7 @@ export const config = {
       lineHeight: extractTokensForCategory("font-line-height"),
       fontFamily: extractTokensForCategory("font-family"),
       borderRadius: extractTokensForCategory("border-radius"),
+      opacity: extractTokensForCategory("opacity"),
     },
   },
 };


### PR DESCRIPTION
### Description

`import * as TokenBuild` adds a "default" key with every token. We filter this to avoid extras

Added opacity-token for disabled to while at it.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
