### PR TITLE
:mute: Disabled amplitude logging

### DIFF
--- a/aksel.nav.no/website/components/logging/useAmplitude.ts
+++ b/aksel.nav.no/website/components/logging/useAmplitude.ts
@@ -5,8 +5,9 @@ const batchedEvents: Parameters<Pick<Types.BrowserClient, "track">["track"]>[] =
   [];
 
 export let amplitude: Pick<Types.BrowserClient, "init" | "track"> = {
-  track: (...eventsData) => {
-    batchedEvents.push(eventsData);
+  track: (/* ...eventsData */) => {
+    /* Until re-enabled in _app.tsx, we can skip storing events */
+    /* batchedEvents.push(eventsData); */
     return {
       promise: new Promise<Types.Result>((resolve) =>
         resolve({

--- a/aksel.nav.no/website/pages/_app.tsx
+++ b/aksel.nav.no/website/pages/_app.tsx
@@ -3,13 +3,14 @@ import { useEffect } from "react";
 import { useCheckAuth } from "@/hooks/useCheckAuth";
 import { useHashScroll } from "@/hooks/useHashScroll";
 import { SanityDataContext } from "@/hooks/useSanityData";
-import { useAmplitudeInit } from "@/logging";
 import { BaseSEO } from "@/web/seo/BaseSEO";
 import "../components/styles/index.css";
 
 function App({ Component, pageProps, router }: AppProps) {
   useHashScroll();
-  useAmplitudeInit();
+
+  /* As of 01.01.25, removed until cookie compliance is implemented */
+  /* useAmplitudeInit(); */
 
   useEffect(() => {
     window.location.host === "design.nav.no" &&


### PR DESCRIPTION
### Description

Temp disabled amplitude to comply with new cookie compliance laws. Did a quick check on our use of next-logger, and we only use it for backend/sanity so see no reason to remove it.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
