### PR TITLE
🎨 Small refactor of translateTokenStringToCSS function for readability

### DIFF
--- a/@navikt/core/react/src/layout/utilities/css.ts
+++ b/@navikt/core/react/src/layout/utilities/css.ts
@@ -67,12 +67,15 @@ const translateTokenStringToCSS = (
     .split(" ")
     .map((propValue, _, arr) => {
       // Handle special layout cases
-      if (specialLayout === "margin-inline" && propValue === "full")
+      if (specialLayout === "margin-inline" && propValue === "full") {
         return `calc((100vw - ${100 / arr.length}%)/-2)`;
-      if (specialLayout === "padding-inline" && propValue === "full")
+      }
+      if (specialLayout === "padding-inline" && propValue === "full") {
         return `calc((100vw - ${100 / arr.length}%)/2)`;
-      if (["mi", "mb"].includes(specialLayout) && propValue === "auto")
+      }
+      if (["mi", "mb"].includes(specialLayout) && propValue === "auto") {
         return "auto";
+      }
 
       // Handle exceptions and space tokens
       let output = `var(--${prefix}-${tokenSubgroup}-${propValue})`;


### PR DESCRIPTION
I cleaned a little in the translateTokenStringToCSS function. I think it could use a bigger refactor, but this was just a quick attempt to do something before i put it away. 

- Removed translateExceptionToCSS since it was only used once and could be a single line
- Stricter typic for tokenSubgroup parameter, which only ever has two options right now. 
- The first three if clauses should be easier to read
- Made comment sections since the function does a few different things