### PR TITLE
[aksel.nav.no] Make inert-prop in ShowMore work in React 19

### DIFF
--- a/aksel.nav.no/website/components/website-modules/ShowMore.tsx
+++ b/aksel.nav.no/website/components/website-modules/ShowMore.tsx
@@ -3,6 +3,8 @@ import React, { useEffect, useRef, useState, version } from "react";
 import { ChevronDownIcon, ChevronUpIcon } from "@navikt/aksel-icons";
 import { Button, type HeadingProps } from "@navikt/ds-react";
 
+const inertValue = parseInt(version.split(".")[0]) > 18 ? true : ""; // Support for inert was added in React 19
+
 export interface ShowMoreProps
   extends Omit<React.HTMLAttributes<HTMLElement>, "onClick"> {
   /**
@@ -95,8 +97,6 @@ export const ShowMore =
     }, [shouldScroll]);
 
     const ChevronIcon = isOpen ? ChevronUpIcon : ChevronDownIcon;
-
-    const inertValue = parseInt(version.split(".")[0]) > 18 ? true : ""; // Support for inert was added in React 19
 
     return (
       <Component

--- a/aksel.nav.no/website/components/website-modules/ShowMore.tsx
+++ b/aksel.nav.no/website/components/website-modules/ShowMore.tsx
@@ -1,5 +1,5 @@
 import cl from "clsx";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, version } from "react";
 import { ChevronDownIcon, ChevronUpIcon } from "@navikt/aksel-icons";
 import { Button, type HeadingProps } from "@navikt/ds-react";
 
@@ -96,6 +96,8 @@ export const ShowMore =
 
     const ChevronIcon = isOpen ? ChevronUpIcon : ChevronDownIcon;
 
+    const inertValue = parseInt(version.split(".")[0]) > 18 ? true : ""; // Support for inert was added in React 19
+
     return (
       <Component
         ref={localRef}
@@ -137,7 +139,7 @@ export const ShowMore =
           className="navds-show-more__content"
           style={isOpen ? {} : { height: collapsedHeight }}
           // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60822
-          inert={isOpen ? undefined : ""}
+          inert={isOpen ? undefined : inertValue}
         >
           {children}
         </div>

--- a/aksel.nav.no/website/components/website-modules/ShowMore.tsx
+++ b/aksel.nav.no/website/components/website-modules/ShowMore.tsx
@@ -138,7 +138,7 @@ export const ShowMore =
         <div
           className="navds-show-more__content"
           style={isOpen ? {} : { height: collapsedHeight }}
-          // @ts-expect-error https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60822
+          // @ts-expect-error React 18 does not support inert
           inert={isOpen ? undefined : inertValue}
         >
           {children}


### PR DESCRIPTION
Found this bug when working on Pensjonskalkulator, since they have a copy of this component there. They have just migrated to React 19, which turns out now supports `inert` and now "translates" empty string to `false`. So correct value in React 19 is `true`.