### PR TITLE
:bug: Using 'loader' inside 'icon'-prop broke layout caused by position absolute

### DIFF
--- a/.changeset/strong-lies-impress.md
+++ b/.changeset/strong-lies-impress.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Button: Using `<Loader />` within `icon`-prop now supported.

--- a/@navikt/core/css/button.css
+++ b/@navikt/core/css/button.css
@@ -497,7 +497,7 @@
 }
 
 /* Loader overrides */
-.navds-button .navds-loader {
+.navds-button > .navds-loader {
   position: absolute;
 }
 

--- a/@navikt/core/css/darkside/button.darkside.css
+++ b/@navikt/core/css/darkside/button.darkside.css
@@ -262,7 +262,7 @@
 }
 
 /* Loader overrides */
-.navds-button .navds-loader {
+.navds-button > .navds-loader {
   position: absolute;
 }
 


### PR DESCRIPTION
### Description

Resolves https://nav-it.slack.com/archives/C7NE7A8UF/p1737462476282339

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
