### PR TITLE
Fixed Tailwind 4 migration bugs, broken build

### DIFF
--- a/.changeset/gentle-points-greet-2.md
+++ b/.changeset/gentle-points-greet-2.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+ExpansionCard: Removed dynamic padding on button-element.

--- a/.changeset/gentle-points-greet.md
+++ b/.changeset/gentle-points-greet.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Modal: Defaults to `margin: auto` for tailwind 4 support.

--- a/@navikt/core/css/baseline/_inline-reset.css
+++ b/@navikt/core/css/baseline/_inline-reset.css
@@ -9,6 +9,17 @@ html,
   box-sizing: inherit;
 }
 
+*,
+::after,
+::before,
+::backdrop,
+::file-selector-button {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  border: 0 solid;
+}
+
 button,
 input,
 optgroup,

--- a/@navikt/core/css/expansioncard.css
+++ b/@navikt/core/css/expansioncard.css
@@ -121,6 +121,7 @@
   min-width: 3rem;
   font-size: 1.5rem;
   align-self: flex-start;
+  padding: 0;
 }
 
 .navds-expansioncard--small > :where(.navds-expansioncard__header) > :where(.navds-expansioncard__header-button) {

--- a/@navikt/core/css/modal.css
+++ b/@navikt/core/css/modal.css
@@ -18,6 +18,7 @@
   /* In case Modal is opened with `show()`, in eg. Vergic screensharing */
   inset: 0;
   z-index: 9999;
+  margin: auto;
 }
 
 .navds-modal[open] {

--- a/@navikt/core/react/src/tag/tag.stories.tsx
+++ b/@navikt/core/react/src/tag/tag.stories.tsx
@@ -15,8 +15,6 @@ const variants: TagProps["variant"][] = [
   "alt1",
   "alt2",
   "alt3",
-  "meta-1",
-  "meta-2",
   "warning-filled",
   "error-filled",
   "info-filled",
@@ -25,8 +23,6 @@ const variants: TagProps["variant"][] = [
   "alt1-filled",
   "alt2-filled",
   "alt3-filled",
-  "meta-1-filled",
-  "meta-2-filled",
   "warning-moderate",
   "error-moderate",
   "info-moderate",
@@ -35,8 +31,6 @@ const variants: TagProps["variant"][] = [
   "alt1-moderate",
   "alt2-moderate",
   "alt3-moderate",
-  "meta-1-moderate",
-  "meta-2-moderate",
 ];
 
 export default {


### PR DESCRIPTION
### Description

Tailwind 4 sets `margin: 0´ and `padding: 0` on every element. This caused `inset: 0` to no longer work for Modal. 
- Fixed by setting `margin: auto` on Modal
- Fixed dynamic padding on ExpansionCard button`
- Removed build-breaking prop-stories for Tag

Tested by emulating the new Tailwind 4 base-sheet and running chromatic locally to check for discrepancies.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
