### PR TITLE
[List] Deprecate listprops `title`, `headingTag` and `description`

### DIFF
--- a/.changeset/lemon-falcons-retire.md
+++ b/.changeset/lemon-falcons-retire.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+List: Marked `title`, `headingTag` and `description` properties as deprecated. These will not be supported in future versions and should be migrated from when possible.

--- a/@navikt/core/css/darkside/list.darkside.css
+++ b/@navikt/core/css/darkside/list.darkside.css
@@ -1,12 +1,7 @@
 .navds-list ul,
 .navds-list ol {
   padding: 0;
-  margin-block: var(--ax-space-16);
-}
-
-.navds-list--small ul,
-.navds-list--small ol {
-  margin-block: var(--ax-space-12);
+  margin: 0;
 }
 
 .navds-list {

--- a/@navikt/core/react/src/list/List.Item.tsx
+++ b/@navikt/core/react/src/list/List.Item.tsx
@@ -1,8 +1,8 @@
 import cl from "clsx";
 import React, { forwardRef, useContext } from "react";
 import { BodyLong } from "../typography";
-import { ListContext } from "./context";
-import type { ListItemProps } from "./types";
+import { ListContext } from "./List.context";
+import type { ListItemProps } from "./List.types";
 
 /**
  * @see 🏷️ {@link ListItemProps}

--- a/@navikt/core/react/src/list/List.context.ts
+++ b/@navikt/core/react/src/list/List.context.ts
@@ -1,5 +1,5 @@
 import { createContext } from "react";
-import { ListProps } from "./types";
+import { ListProps } from "./List.types";
 
 interface ListContextProps {
   listType: Exclude<ListProps["as"], undefined>;

--- a/@navikt/core/react/src/list/List.tsx
+++ b/@navikt/core/react/src/list/List.tsx
@@ -1,10 +1,11 @@
 import cl from "clsx";
 import React, { forwardRef, useContext } from "react";
+import { useThemeInternal } from "../theme/Theme";
 import { BodyLong, BodyShort, Heading, HeadingProps } from "../typography";
-import { ListItem } from "./ListItem";
-import { ListContext } from "./context";
+import { ListItem } from "./List.Item";
+import { ListContext } from "./List.context";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import type { ListItemProps, ListProps } from "./types";
+import type { ListItemProps, ListProps } from "./List.types";
 
 const headingSizeMap: Record<
   Exclude<ListProps["size"], undefined>,
@@ -56,7 +57,40 @@ export const List = forwardRef<HTMLDivElement, ListProps>(
   ) => {
     const { size: contextSize } = useContext(ListContext);
 
+    const themeContext = useThemeInternal(false);
+
     const listSize = size ?? contextSize;
+
+    if (themeContext) {
+      if (
+        process.env.NODE_ENV !== "production" &&
+        (title || description || headingTag)
+      ) {
+        console.warn(
+          "List: title, description and headingTag are deprecated and will not work with updated theme for Aksel.",
+        );
+      }
+
+      return (
+        <ListContext.Provider
+          value={{
+            listType: ListTag,
+            size: listSize,
+          }}
+        >
+          <BodyLong
+            as="div"
+            {...rest}
+            size={listSize}
+            ref={ref}
+            className={cl("navds-list", `navds-list--${listSize}`, className)}
+          >
+            <ListTag role="list">{children}</ListTag>
+          </BodyLong>
+        </ListContext.Provider>
+      );
+    }
+
     return (
       <ListContext.Provider
         value={{

--- a/@navikt/core/react/src/list/List.types.ts
+++ b/@navikt/core/react/src/list/List.types.ts
@@ -7,15 +7,18 @@ export interface ListProps extends React.HTMLAttributes<HTMLDivElement> {
   as?: "ul" | "ol";
   /**
    * List heading title.
+   * @deprecated Prop will be removed in future versions.
    */
   title?: string;
   /**
    * List heading description.
+   * @deprecated Prop will be removed in future versions.
    */
   description?: string;
   /**
    * Allows setting a different HTML h-tag.
    * @default "h3"
+   * @deprecated Prop will be removed in future versions.
    */
   headingTag?: React.ElementType<any>;
   /**

--- a/@navikt/core/react/src/list/index.ts
+++ b/@navikt/core/react/src/list/index.ts
@@ -1,4 +1,4 @@
 "use client";
 export { default as List } from "./List";
-export type { ListProps, ListItemProps } from "./types";
-export { default as ListItem } from "./ListItem";
+export type { ListProps, ListItemProps } from "./List.types";
+export { default as ListItem } from "./List.Item";


### PR DESCRIPTION
### Description

Also removed built-in spacing for List in `darkside` based on Figma updates and previous discussions within the team. Would like to remove the redundant `div` wrapping now, but will break some code in production now so need to wait for that until an actual major-release.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
