### PR TITLE
[Darkside] :dizzy: Updated default Modal animation

### DIFF
--- a/@navikt/core/css/darkside/modal.darkside.css
+++ b/@navikt/core/css/darkside/modal.darkside.css
@@ -19,7 +19,7 @@
   &[open] {
     display: flex;
     flex-direction: column;
-    animation: akselModalFadeIn 0.35s cubic-bezier(0.15, 1, 0.3, 1);
+    animation: akselModalFadeIn 0.6s cubic-bezier(0.15, 1, 0.3, 1);
   }
 }
 
@@ -101,7 +101,7 @@
    * TODO: Check that overlay-color is correct after the new colors is set in stone.
    */
   background: #0214317d;
-  animation: akselModalBackdropFadeIn 0.35s cubic-bezier(0.15, 1, 0.3, 1);
+  animation: akselModalBackdropFadeIn 0.8s cubic-bezier(0.15, 1, 0.3, 1);
 }
 
 .navds-modal--polyfilled + .backdrop /* Cannot be combined with ::backdrop selector */ {
@@ -182,8 +182,8 @@
 
 @keyframes akselModalFadeIn {
   0% {
-    opacity: 0.0001; /* Safari will not set focus inside the modal when it opens if we set this to 0 */
-    transform: translate3d(0, calc(2% + 4px), 0);
+    opacity: 0.01; /* Safari will not set focus inside the modal when it opens if we set this to 0 */
+    transform: scale(103%);
   }
 
   50% {
@@ -191,7 +191,7 @@
   }
 
   100% {
-    transform: none;
+    transform: scale(100%);
   }
 }
 


### PR DESCRIPTION
### Description

Based on experiences made while testing "referansesider", we noticed that our current animation could be perceived as a little "aggressive" when opened and closed a lot (like in "Aktivitetsplanen"). This test is a little slower, and "top-down" meaning you get less vertical movement.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
