### PR TITLE
Selecting an indeterminate checkbox checks all child items

### DIFF
--- a/aksel.nav.no/website/pages/eksempler/checkbox/indeterminate.tsx
+++ b/aksel.nav.no/website/pages/eksempler/checkbox/indeterminate.tsx
@@ -23,7 +23,7 @@ const Example = () => {
                 selectedRows.length > 0 && selectedRows.length !== data.length
               }
               onChange={() => {
-                selectedRows.length
+                selectedRows.length === data.length
                   ? setSelectedRows([])
                   : setSelectedRows(data.map(({ fnr }) => fnr));
               }}


### PR DESCRIPTION
Ref. https://m3.material.io/components/checkbox/guidelines#26cbff1c-7a56-4237-b563-5593573e6cf4

> If some, but not all, child checkboxes are checked, the parent checkbox becomes an indeterminate checkbox. Selecting an indeterminate checkbox checks all child items.