### PR TITLE
[Darkside] Removed 'base' as neutral role replacement

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,8 +3,8 @@ import { Preview } from "@storybook/react";
 import React, { useLayoutEffect } from "react";
 // @ts-expect-error - Temporary
 import darksideCss from "../@navikt/core/css/darkside/index.css?inline";
-// @ts-expect-error - Temporary
-import defaultCss from "../@navikt/core/css/index.css?inline";
+
+/* import defaultCss from "../@navikt/core/css/index.css?inline"; */
 import { Provider } from "../@navikt/core/react/src/provider";
 import { Theme } from "../@navikt/core/react/src/theme";
 import en from "../@navikt/core/react/src/util/i18n/locales/en";
@@ -15,12 +15,14 @@ import "./layout.css";
 const ModeDecorator = ({ children, mode, theme }) => {
   useLayoutEffect(() => {
     const style = document.createElement("style");
-    style.innerHTML = mode === "darkside" ? darksideCss : defaultCss;
+    /* style.innerHTML = mode === "darkside" ? darksideCss : defaultCss; */
+    style.innerHTML = darksideCss;
     document.head.appendChild(style);
 
-    if (mode === "darkside") {
+    /* if (mode === "darkside") {
       document.body.style.setProperty("background", "var(--ax-bg-default)");
-    }
+      } */
+    document.body.style.setProperty("background", "var(--ax-bg-default)");
 
     return () => {
       document.head.removeChild(style);
@@ -28,13 +30,19 @@ const ModeDecorator = ({ children, mode, theme }) => {
     };
   }, [mode]);
 
-  return mode === "darkside" ? (
+  return (
+    <Theme theme={theme || undefined} hasBackground={false}>
+      {children}
+    </Theme>
+  );
+
+  /* return mode === "darkside" ? (
     <Theme theme={theme || undefined} hasBackground={false}>
       {children}
     </Theme>
   ) : (
     children
-  );
+  ); */
 };
 
 const translations = {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,8 +3,8 @@ import { Preview } from "@storybook/react";
 import React, { useLayoutEffect } from "react";
 // @ts-expect-error - Temporary
 import darksideCss from "../@navikt/core/css/darkside/index.css?inline";
-
-/* import defaultCss from "../@navikt/core/css/index.css?inline"; */
+// @ts-expect-error - Temporary
+import defaultCss from "../@navikt/core/css/index.css?inline";
 import { Provider } from "../@navikt/core/react/src/provider";
 import { Theme } from "../@navikt/core/react/src/theme";
 import en from "../@navikt/core/react/src/util/i18n/locales/en";
@@ -15,14 +15,12 @@ import "./layout.css";
 const ModeDecorator = ({ children, mode, theme }) => {
   useLayoutEffect(() => {
     const style = document.createElement("style");
-    /* style.innerHTML = mode === "darkside" ? darksideCss : defaultCss; */
-    style.innerHTML = darksideCss;
+    style.innerHTML = mode === "darkside" ? darksideCss : defaultCss;
     document.head.appendChild(style);
 
-    /* if (mode === "darkside") {
+    if (mode === "darkside") {
       document.body.style.setProperty("background", "var(--ax-bg-default)");
-      } */
-    document.body.style.setProperty("background", "var(--ax-bg-default)");
+    }
 
     return () => {
       document.head.removeChild(style);
@@ -30,19 +28,13 @@ const ModeDecorator = ({ children, mode, theme }) => {
     };
   }, [mode]);
 
-  return (
-    <Theme theme={theme || undefined} hasBackground={false}>
-      {children}
-    </Theme>
-  );
-
-  /* return mode === "darkside" ? (
+  return mode === "darkside" ? (
     <Theme theme={theme || undefined} hasBackground={false}>
       {children}
     </Theme>
   ) : (
     children
-  ); */
+  );
 };
 
 const translations = {

--- a/@navikt/core/css/darkside/accordion.darkside.css
+++ b/@navikt/core/css/darkside/accordion.darkside.css
@@ -70,7 +70,7 @@
   right: 0;
   width: 100%;
   height: 1px;
-  background-color: var(--ax-border-subtleA);
+  background-color: var(--ax-border-neutral-subtleA);
 }
 
 .navds-accordion__header::after {
@@ -122,7 +122,7 @@
 }
 
 .navds-accordion--indent > .navds-accordion__item > .navds-accordion__content {
-  box-shadow: -2px 0 0 0 var(--ax-border-subtleA);
+  box-shadow: -2px 0 0 0 var(--ax-border-neutral-subtleA);
 }
 
 .navds-accordion__item {
@@ -151,7 +151,7 @@
       visibility: visible;
       margin-block: var(--ax-space-8);
       margin-block-end: var(--ax-space-24);
-      border-color: var(--ax-border-subtleA);
+      border-color: var(--ax-border-neutral-subtleA);
       opacity: 1;
 
       & .navds-accordion__content-inner {
@@ -160,7 +160,7 @@
     }
 
     &:last-child {
-      border-bottom: 1px solid var(--ax-border-subtleA);
+      border-bottom: 1px solid var(--ax-border-neutral-subtleA);
     }
   }
 }

--- a/@navikt/core/css/darkside/action-menu.darkside.css
+++ b/@navikt/core/css/darkside/action-menu.darkside.css
@@ -2,7 +2,7 @@
 .navds-action-menu__content {
   overflow: hidden;
   border-radius: var(--ax-border-radius-xlarge);
-  border: 1px solid var(--ax-border-subtleA);
+  border: 1px solid var(--ax-border-neutral-subtleA);
   box-shadow: var(--ax-shadow-dialog);
   transition: transform 250ms cubic-bezier(0, 0, 0, 1) allow-discrete;
 
@@ -168,7 +168,7 @@
 .navds-action-menu__divider {
   height: 1px;
   margin-block: var(--ax-space-8);
-  background-color: var(--ax-border-subtleA);
+  background-color: var(--ax-border-neutral-subtleA);
 }
 
 /* -------------------------- ActionMenu indicator -------------------------- */

--- a/@navikt/core/css/darkside/action-menu.darkside.css
+++ b/@navikt/core/css/darkside/action-menu.darkside.css
@@ -94,7 +94,7 @@
   --__axc-action-menu-item-pr: var(--ax-space-2);
 
   &[data-state="open"] {
-    background-color: var(--ax-bg-soft-pressedA);
+    background-color: var(--ax-bg-neutral-soft-pressedA);
   }
 
   &:focus {

--- a/@navikt/core/css/darkside/action-menu.darkside.css
+++ b/@navikt/core/css/darkside/action-menu.darkside.css
@@ -67,7 +67,7 @@
   font-size: var(--ax-font-size-medium);
   scroll-margin-block: var(--__axc-action-menu-content-p);
   line-height: 1.5;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   text-decoration: none;
 
   & svg {
@@ -77,7 +77,7 @@
   &:focus {
     outline: none;
     background-color: var(--ax-bg-accent-moderate-hoverA);
-    color: var(--ax-text-default);
+    color: var(--ax-text-neutral);
   }
 
   &[aria-disabled="true"] {
@@ -139,7 +139,7 @@
 /* --------------------------- ActionMenu shortcut -------------------------- */
 .navds-action-menu__shortcut {
   background-color: var(--ax-bg-moderateA);
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   border-radius: var(--ax-border-radius-small);
   padding: 0 var(--ax-space-4);
   min-width: 1.125rem;
@@ -158,7 +158,7 @@
   min-height: calc(var(--__axc-action-menu-item-height) - 6px);
   padding-right: var(--__axc-action-menu-item-pr);
   padding-left: var(--__axc-action-menu-item-pl);
-  color: var(--ax-text-subtle);
+  color: var(--ax-text-neutral-subtle);
   border-radius: var(--ax-border-radius-medium);
   user-select: none;
   cursor: default;

--- a/@navikt/core/css/darkside/action-menu.darkside.css
+++ b/@navikt/core/css/darkside/action-menu.darkside.css
@@ -138,7 +138,7 @@
 
 /* --------------------------- ActionMenu shortcut -------------------------- */
 .navds-action-menu__shortcut {
-  background-color: var(--ax-bg-moderateA);
+  background-color: var(--ax-bg-neutral-moderateA);
   color: var(--ax-text-neutral);
   border-radius: var(--ax-border-radius-small);
   padding: 0 var(--ax-space-4);

--- a/@navikt/core/css/darkside/button.darkside.css
+++ b/@navikt/core/css/darkside/button.darkside.css
@@ -111,19 +111,19 @@
  * .navds-button--primary-neutral *
  *************************/
 .navds-button--primary-neutral {
-  background-color: var(--ax-bg-strong);
+  background-color: var(--ax-bg-neutral-strong);
   color: var(--ax-text-neutral-contrast);
 
   &:hover {
-    background-color: var(--ax-bg-strong-hover);
+    background-color: var(--ax-bg-neutral-strong-hover);
   }
 
   &:active {
-    background-color: var(--ax-bg-strong-pressed);
+    background-color: var(--ax-bg-neutral-strong-pressed);
   }
 
   &:is(:disabled, .navds-button--disabled) {
-    background-color: var(--ax-bg-strong);
+    background-color: var(--ax-bg-neutral-strong);
   }
 }
 

--- a/@navikt/core/css/darkside/button.darkside.css
+++ b/@navikt/core/css/darkside/button.darkside.css
@@ -161,7 +161,7 @@
   --__axc-button-border-color: var(--ax-border-default);
 
   background-color: transparent;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 
   &:hover {
     --__axc-button-border-color: var(--ax-border-strong);
@@ -176,7 +176,7 @@
   &:is(:disabled, .navds-button--disabled) {
     --__axc-button-border-color: var(--ax-border-default);
 
-    color: var(--ax-text-default);
+    color: var(--ax-text-neutral);
     background-color: transparent;
   }
 }
@@ -207,7 +207,7 @@
  ****************************/
 .navds-button--tertiary-neutral {
   background-color: transparent;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 
   &:hover {
     background-color: var(--ax-bg-moderate-hoverA);
@@ -218,7 +218,7 @@
   }
 
   &:is(:disabled, .navds-button--disabled) {
-    color: var(--ax-text-default);
+    color: var(--ax-text-neutral);
     background-color: transparent;
   }
 }

--- a/@navikt/core/css/darkside/button.darkside.css
+++ b/@navikt/core/css/darkside/button.darkside.css
@@ -112,7 +112,7 @@
  *************************/
 .navds-button--primary-neutral {
   background-color: var(--ax-bg-strong);
-  color: var(--ax-text-contrast);
+  color: var(--ax-text-neutral-contrast);
 
   &:hover {
     background-color: var(--ax-bg-strong-hover);

--- a/@navikt/core/css/darkside/button.darkside.css
+++ b/@navikt/core/css/darkside/button.darkside.css
@@ -166,11 +166,11 @@
   &:hover {
     --__axc-button-border-color: var(--ax-border-strong);
 
-    background-color: var(--ax-bg-moderate-hoverA);
+    background-color: var(--ax-bg-neutral-moderate-hoverA);
   }
 
   &:active {
-    background-color: var(--ax-bg-moderate-pressedA);
+    background-color: var(--ax-bg-neutral-moderate-pressedA);
   }
 
   &:is(:disabled, .navds-button--disabled) {
@@ -210,11 +210,11 @@
   color: var(--ax-text-neutral);
 
   &:hover {
-    background-color: var(--ax-bg-moderate-hoverA);
+    background-color: var(--ax-bg-neutral-moderate-hoverA);
   }
 
   &:active {
-    background-color: var(--ax-bg-moderate-pressedA);
+    background-color: var(--ax-bg-neutral-moderate-pressedA);
   }
 
   &:is(:disabled, .navds-button--disabled) {

--- a/@navikt/core/css/darkside/button.darkside.css
+++ b/@navikt/core/css/darkside/button.darkside.css
@@ -158,7 +158,7 @@
 * .navds-button--secondary-neutral *
  **************************/
 .navds-button--secondary-neutral {
-  --__axc-button-border-color: var(--ax-border-default);
+  --__axc-button-border-color: var(--ax-border-neutral);
 
   background-color: transparent;
   color: var(--ax-text-neutral);
@@ -174,7 +174,7 @@
   }
 
   &:is(:disabled, .navds-button--disabled) {
-    --__axc-button-border-color: var(--ax-border-default);
+    --__axc-button-border-color: var(--ax-border-neutral);
 
     color: var(--ax-text-neutral);
     background-color: transparent;

--- a/@navikt/core/css/darkside/button.darkside.css
+++ b/@navikt/core/css/darkside/button.darkside.css
@@ -164,7 +164,7 @@
   color: var(--ax-text-neutral);
 
   &:hover {
-    --__axc-button-border-color: var(--ax-border-strong);
+    --__axc-button-border-color: var(--ax-border-neutral-strong);
 
     background-color: var(--ax-bg-neutral-moderate-hoverA);
   }

--- a/@navikt/core/css/darkside/chat.darkside.css
+++ b/@navikt/core/css/darkside/chat.darkside.css
@@ -23,7 +23,7 @@
   align-items: center;
   background-color: var(--ax-bg-raised);
   border-radius: var(--ax-border-radius-full);
-  border: 1px solid var(--ax-border-subtleA);
+  border: 1px solid var(--ax-border-neutral-subtleA);
   color: var(--ax-text-neutral);
   display: flex;
   flex-shrink: 0;
@@ -62,7 +62,7 @@
   gap: var(--ax-space-8);
   border-radius: var(--ax-border-radius-xlarge);
   border-bottom-left-radius: var(--ax-border-radius-small);
-  border: 1px solid var(--ax-border-subtleA);
+  border: 1px solid var(--ax-border-neutral-subtleA);
 }
 
 .navds-chat--small .navds-chat__bubble {

--- a/@navikt/core/css/darkside/chat.darkside.css
+++ b/@navikt/core/css/darkside/chat.darkside.css
@@ -80,7 +80,7 @@
 .navds-chat--neutral {
   & .navds-chat__bubble,
   & .navds-chat__avatar {
-    background-color: var(--ax-bg-moderateA);
+    background-color: var(--ax-bg-neutral-moderateA);
   }
 }
 

--- a/@navikt/core/css/darkside/chat.darkside.css
+++ b/@navikt/core/css/darkside/chat.darkside.css
@@ -24,7 +24,7 @@
   background-color: var(--ax-bg-raised);
   border-radius: var(--ax-border-radius-full);
   border: 1px solid var(--ax-border-subtleA);
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   display: flex;
   flex-shrink: 0;
   justify-content: center;
@@ -86,7 +86,7 @@
 
 /* ------------------------------ Chat top text ----------------------------- */
 .navds-chat__top-text {
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   display: flex;
   gap: var(--ax-space-8);
   align-items: baseline;

--- a/@navikt/core/css/darkside/chips.darkside.css
+++ b/@navikt/core/css/darkside/chips.darkside.css
@@ -90,7 +90,7 @@
 }
 
 .navds-chips__toggle--neutral {
-  box-shadow: inset 0 0 0 1px var(--ax-border-subtleA);
+  box-shadow: inset 0 0 0 1px var(--ax-border-neutral-subtleA);
   background-color: var(--ax-bg-neutral-moderate);
   color: var(--ax-text-neutral);
 

--- a/@navikt/core/css/darkside/chips.darkside.css
+++ b/@navikt/core/css/darkside/chips.darkside.css
@@ -101,7 +101,7 @@
   &[data-pressed="true"] {
     box-shadow: none;
     background-color: var(--ax-bg-strong-pressed);
-    color: var(--ax-text-contrast);
+    color: var(--ax-text-neutral-contrast);
 
     &:hover {
       background-color: var(--ax-bg-strong-hover);
@@ -131,7 +131,7 @@
 
 .navds-chips__removable--neutral {
   background: var(--ax-bg-strong-pressed);
-  color: var(--ax-text-contrast);
+  color: var(--ax-text-neutral-contrast);
 
   &:hover {
     background: var(--ax-bg-strong-hover);

--- a/@navikt/core/css/darkside/chips.darkside.css
+++ b/@navikt/core/css/darkside/chips.darkside.css
@@ -100,11 +100,11 @@
 
   &[data-pressed="true"] {
     box-shadow: none;
-    background-color: var(--ax-bg-strong-pressed);
+    background-color: var(--ax-bg-neutral-strong-pressed);
     color: var(--ax-text-neutral-contrast);
 
     &:hover {
-      background-color: var(--ax-bg-strong-hover);
+      background-color: var(--ax-bg-neutral-strong-hover);
     }
   }
 }
@@ -130,11 +130,11 @@
 }
 
 .navds-chips__removable--neutral {
-  background: var(--ax-bg-strong-pressed);
+  background: var(--ax-bg-neutral-strong-pressed);
   color: var(--ax-text-neutral-contrast);
 
   &:hover {
-    background: var(--ax-bg-strong-hover);
+    background: var(--ax-bg-neutral-strong-hover);
   }
 }
 

--- a/@navikt/core/css/darkside/chips.darkside.css
+++ b/@navikt/core/css/darkside/chips.darkside.css
@@ -92,7 +92,7 @@
 .navds-chips__toggle--neutral {
   box-shadow: inset 0 0 0 1px var(--ax-border-subtleA);
   background-color: var(--ax-bg-moderate);
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 
   &:hover {
     background-color: var(--ax-bg-moderate-hover);

--- a/@navikt/core/css/darkside/chips.darkside.css
+++ b/@navikt/core/css/darkside/chips.darkside.css
@@ -35,7 +35,7 @@
 
 .navds-chips--readonly {
   .navds-chips__chip {
-    background-color: var(--ax-bg-moderateA);
+    background-color: var(--ax-bg-neutral-moderateA);
   }
 }
 
@@ -91,11 +91,11 @@
 
 .navds-chips__toggle--neutral {
   box-shadow: inset 0 0 0 1px var(--ax-border-subtleA);
-  background-color: var(--ax-bg-moderate);
+  background-color: var(--ax-bg-neutral-moderate);
   color: var(--ax-text-neutral);
 
   &:hover {
-    background-color: var(--ax-bg-moderate-hover);
+    background-color: var(--ax-bg-neutral-moderate-hover);
   }
 
   &[data-pressed="true"] {

--- a/@navikt/core/css/darkside/date.darkside.css
+++ b/@navikt/core/css/darkside/date.darkside.css
@@ -3,14 +3,14 @@
 
   .rdp-day_range_middle {
     &.rdp-day_disabled {
-      color: var(--ax-text-default);
+      color: var(--ax-text-neutral);
       background: var(--ax-bg-moderateA);
     }
 
     &.rdp-day_selected {
       background-color: var(--ax-bg-accent-soft-pressedA);
       box-shadow: inset 0 0 0 1px var(--ax-border-accent-subtleA);
-      color: var(--ax-text-default);
+      color: var(--ax-text-neutral);
     }
   }
 
@@ -68,7 +68,7 @@
     cursor: not-allowed;
     text-decoration: line-through;
     background-color: var(--ax-bg-moderateA);
-    color: var(--ax-text-subtle);
+    color: var(--ax-text-neutral-subtle);
   }
 
   .rdp-button:where(:not(.rdp-day_selected, [disabled])):hover,
@@ -126,7 +126,7 @@
 .navds-date__caption-button {
   width: 2rem;
   height: 2rem;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 }
 
 .navds-date__caption__month .navds-select__container select {
@@ -183,7 +183,7 @@
   right: 0.0625rem;
   top: 50%;
   transform: translateY(-50%);
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   display: inline-flex;
   cursor: pointer;
   margin: 0;
@@ -237,7 +237,7 @@
 
 .navds-date__weeknumber-number {
   font-size: 0.875rem;
-  color: var(--ax-text-subtle);
+  color: var(--ax-text-neutral-subtle);
 
   .navds-date__weeknumber:active & {
     color: var(--ax-text-contrast);

--- a/@navikt/core/css/darkside/date.darkside.css
+++ b/@navikt/core/css/darkside/date.darkside.css
@@ -4,7 +4,7 @@
   .rdp-day_range_middle {
     &.rdp-day_disabled {
       color: var(--ax-text-neutral);
-      background: var(--ax-bg-moderateA);
+      background: var(--ax-bg-neutral-moderateA);
     }
 
     &.rdp-day_selected {
@@ -67,7 +67,7 @@
   .rdp-day_disabled {
     cursor: not-allowed;
     text-decoration: line-through;
-    background-color: var(--ax-bg-moderateA);
+    background-color: var(--ax-bg-neutral-moderateA);
     color: var(--ax-text-neutral-subtle);
   }
 

--- a/@navikt/core/css/darkside/date.darkside.css
+++ b/@navikt/core/css/darkside/date.darkside.css
@@ -238,10 +238,6 @@
 .navds-date__weeknumber-number {
   font-size: 0.875rem;
   color: var(--ax-text-neutral-subtle);
-
-  .navds-date__weeknumber:active & {
-    color: var(--ax-text-contrast);
-  }
 }
 
 .navds-date__week-wrapper {

--- a/@navikt/core/css/darkside/expansioncard.darkside.css
+++ b/@navikt/core/css/darkside/expansioncard.darkside.css
@@ -45,7 +45,7 @@
   justify-content: space-between;
 
   &:hover {
-    background-color: var(--ax-bg-soft-hoverA);
+    background-color: var(--ax-bg-neutral-soft-hoverA);
   }
 
   &[data-open="true"] {

--- a/@navikt/core/css/darkside/expansioncard.darkside.css
+++ b/@navikt/core/css/darkside/expansioncard.darkside.css
@@ -114,7 +114,7 @@
 }
 
 .navds-expansioncard__header:hover > .navds-expansioncard__header-button {
-  background-color: var(--ax-bg-moderate-hoverA);
+  background-color: var(--ax-bg-neutral-moderate-hoverA);
 }
 
 .navds-expansioncard__header-chevron {

--- a/@navikt/core/css/darkside/expansioncard.darkside.css
+++ b/@navikt/core/css/darkside/expansioncard.darkside.css
@@ -9,8 +9,8 @@
   border: 1px solid var(--ax-border-neutral);
 
   &:has(.navds-expansioncard__header:hover) {
-    box-shadow: 0 0 0 1px var(--ax-border-strong);
-    border-color: var(--ax-border-strong);
+    box-shadow: 0 0 0 1px var(--ax-border-neutral-strong);
+    border-color: var(--ax-border-neutral-strong);
   }
 }
 

--- a/@navikt/core/css/darkside/expansioncard.darkside.css
+++ b/@navikt/core/css/darkside/expansioncard.darkside.css
@@ -6,7 +6,7 @@
   border-radius: var(--ax-border-radius-xlarge);
   background-color: var(--ax-bg-raised);
   height: fit-content;
-  border: 1px solid var(--ax-border-default);
+  border: 1px solid var(--ax-border-neutral);
 
   &:has(.navds-expansioncard__header:hover) {
     box-shadow: 0 0 0 1px var(--ax-border-strong);

--- a/@navikt/core/css/darkside/expansioncard.darkside.css
+++ b/@navikt/core/css/darkside/expansioncard.darkside.css
@@ -55,7 +55,7 @@
     /* Divider between header and content */
     &::after {
       content: "";
-      background-color: var(--ax-border-subtleA);
+      background-color: var(--ax-border-neutral-subtleA);
       bottom: 0;
       left: var(--__axc-expansioncard-padding-inline);
       height: 1px;

--- a/@navikt/core/css/darkside/form/combobox.darkside.css
+++ b/@navikt/core/css/darkside/form/combobox.darkside.css
@@ -63,7 +63,7 @@
   }
 
   & .navds-combobox__wrapper {
-    border-color: var(--ax-border-subtle);
+    border-color: var(--ax-border-neutral-subtle);
     overflow: clip;
   }
 
@@ -244,7 +244,7 @@
   right: 0;
   z-index: 10;
   top: calc(100% + var(--ax-space-8));
-  border: 1px solid var(--ax-border-subtleA);
+  border: 1px solid var(--ax-border-neutral-subtleA);
   display: flex;
   flex-direction: column;
   border-radius: var(--ax-border-radius-large);
@@ -292,7 +292,7 @@
   background-color: var(--ax-bg-neutral-moderateA);
   margin: 0;
   border-radius: 0;
-  border-bottom: 1px solid var(--ax-border-subtle);
+  border-bottom: 1px solid var(--ax-border-neutral-subtle);
   padding-block: var(--ax-space-8);
   line-height: var(--ax-font-line-height-large);
 }

--- a/@navikt/core/css/darkside/form/combobox.darkside.css
+++ b/@navikt/core/css/darkside/form/combobox.darkside.css
@@ -215,7 +215,7 @@
 }
 
 .navds-combobox__button-toggle-list {
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -249,7 +249,7 @@
   flex-direction: column;
   border-radius: var(--ax-border-radius-large);
   background-color: var(--ax-bg-raised);
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   overscroll-behavior: contain;
   box-shadow: var(--ax-shadow-dialog);
 
@@ -327,11 +327,11 @@
   & mark {
     background-color: transparent;
     font-weight: var(--ax-font-weight-bold);
-    color: var(--ax-text-default);
+    color: var(--ax-text-neutral);
   }
 
   & svg {
-    color: var(--ax-text-default);
+    color: var(--ax-text-neutral);
   }
 }
 
@@ -354,7 +354,7 @@
   margin-block-start: calc(var(--ax-space-4) * -1);
 
   & svg {
-    color: var(--ax-text-default);
+    color: var(--ax-text-neutral);
   }
 
   &:only-child {

--- a/@navikt/core/css/darkside/form/combobox.darkside.css
+++ b/@navikt/core/css/darkside/form/combobox.darkside.css
@@ -32,7 +32,7 @@
 
   & .navds-combobox__wrapper {
     &:hover {
-      border-color: var(--ax-border-default);
+      border-color: var(--ax-border-neutral);
     }
 
     & *:hover {
@@ -80,7 +80,7 @@
 }
 
 .navds-combobox__wrapper-inner {
-  border: 1px solid var(--ax-border-default);
+  border: 1px solid var(--ax-border-neutral);
   border-radius: var(--ax-border-radius-large);
 
   &:has(.navds-combobox__input:focus-visible) {
@@ -91,7 +91,7 @@
 
   &:has(.navds-combobox__input:focus-visible).navds-combobox__wrapper-inner--virtually-unfocused {
     outline: none;
-    border-color: var(--ax-border-default);
+    border-color: var(--ax-border-neutral);
   }
 
   &.navds-text-field__input {
@@ -119,7 +119,7 @@
   }
 
   .navds-combobox--disabled &:hover {
-    border-color: var(--ax-border-default);
+    border-color: var(--ax-border-neutral);
   }
 }
 

--- a/@navikt/core/css/darkside/form/combobox.darkside.css
+++ b/@navikt/core/css/darkside/form/combobox.darkside.css
@@ -54,12 +54,12 @@
 
   & .navds-combobox__selected-options {
     & .navds-chips__chip {
-      background-color: var(--ax-bg-moderateA);
+      background-color: var(--ax-bg-neutral-moderateA);
     }
   }
 
   & .navds-combobox__button-toggle-list {
-    color: var(--ax-bg-moderate);
+    color: var(--ax-bg-neutral-moderate);
   }
 
   & .navds-combobox__wrapper {
@@ -69,7 +69,7 @@
 
   & .navds-text-field__input,
   & .navds-combobox__input {
-    background-color: var(--ax-bg-moderate);
+    background-color: var(--ax-bg-neutral-moderate);
   }
 }
 
@@ -289,7 +289,7 @@
 }
 
 .navds-combobox__list-item--max-selected {
-  background-color: var(--ax-bg-moderateA);
+  background-color: var(--ax-bg-neutral-moderateA);
   margin: 0;
   border-radius: 0;
   border-bottom: 1px solid var(--ax-border-subtle);

--- a/@navikt/core/css/darkside/form/fieldset.darkside.css
+++ b/@navikt/core/css/darkside/form/fieldset.darkside.css
@@ -10,7 +10,7 @@
 }
 
 .navds-fieldset__description {
-  color: var(--ax-text-subtle);
+  color: var(--ax-text-neutral-subtle);
 }
 
 .navds-fieldset > .navds-fieldset__description:not(:empty) {

--- a/@navikt/core/css/darkside/form/file-upload.darkside.css
+++ b/@navikt/core/css/darkside/form/file-upload.darkside.css
@@ -42,7 +42,7 @@
   &[data-disabled="true"] {
     --__axc-dropzone-background: var(--ax-bg-neutral-soft);
 
-    border-color: var(--ax-border-subtleA);
+    border-color: var(--ax-border-neutral-subtleA);
     cursor: default;
   }
 }
@@ -158,7 +158,7 @@ li.navds-file-item {
 
 .navds-file-item__inner {
   background-color: var(--ax-bg-raised);
-  border: 1px solid var(--ax-border-subtleA);
+  border: 1px solid var(--ax-border-neutral-subtleA);
   outline-offset: -1px;
   transition: outline-color 250ms cubic-bezier(0, 0.3, 0.15, 1);
   border-radius: var(--ax-border-radius-xlarge);

--- a/@navikt/core/css/darkside/form/file-upload.darkside.css
+++ b/@navikt/core/css/darkside/form/file-upload.darkside.css
@@ -15,7 +15,7 @@
   gap: var(--ax-space-16);
   text-align: center;
   padding: var(--ax-space-16) var(--ax-space-20);
-  border: 1px dashed var(--ax-border-default);
+  border: 1px dashed var(--ax-border-neutral);
   border-radius: var(--ax-border-radius-xlarge);
   background-color: var(--__axc-dropzone-background);
   color: var(--ax-text-neutral);

--- a/@navikt/core/css/darkside/form/file-upload.darkside.css
+++ b/@navikt/core/css/darkside/form/file-upload.darkside.css
@@ -40,7 +40,7 @@
   }
 
   &[data-disabled="true"] {
-    --__axc-dropzone-background: var(--ax-bg-soft);
+    --__axc-dropzone-background: var(--ax-bg-neutral-soft);
 
     border-color: var(--ax-border-subtleA);
     cursor: default;

--- a/@navikt/core/css/darkside/form/file-upload.darkside.css
+++ b/@navikt/core/css/darkside/form/file-upload.darkside.css
@@ -112,7 +112,7 @@
   display: grid;
   padding: var(--__axc-dropzone-icon-padding);
   border-radius: var(--ax-border-radius-full);
-  background-color: var(--ax-bg-moderateA);
+  background-color: var(--ax-bg-neutral-moderateA);
   transition:
     background-color 300ms var(--__axc-dropzone-animation-ease-out),
     font-size 300ms var(--__axc-dropzone-animation-ease-out);
@@ -173,7 +173,7 @@ li.navds-file-item {
 }
 
 .navds-file-item__icon {
-  background-color: var(--ax-bg-moderateA);
+  background-color: var(--ax-bg-neutral-moderateA);
   color: var(--ax-text-neutral);
   border-radius: var(--ax-border-radius-full);
   min-height: 2.5rem;

--- a/@navikt/core/css/darkside/form/file-upload.darkside.css
+++ b/@navikt/core/css/darkside/form/file-upload.darkside.css
@@ -18,7 +18,7 @@
   border: 1px dashed var(--ax-border-default);
   border-radius: var(--ax-border-radius-xlarge);
   background-color: var(--__axc-dropzone-background);
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   transition: background-color var(--__axc-dropzone-animation-length-short) var(--__axc-dropzone-animation-ease-out);
   cursor: pointer;
 
@@ -140,7 +140,7 @@
 }
 
 .navds-dropzone__area-disabled {
-  color: var(--ax-text-subtle);
+  color: var(--ax-text-neutral-subtle);
   display: flex;
   align-items: center;
   flex-direction: column;
@@ -174,7 +174,7 @@ li.navds-file-item {
 
 .navds-file-item__icon {
   background-color: var(--ax-bg-moderateA);
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   border-radius: var(--ax-border-radius-full);
   min-height: 2.5rem;
   min-width: 2.5rem;

--- a/@navikt/core/css/darkside/form/form-progress.darkside.css
+++ b/@navikt/core/css/darkside/form/form-progress.darkside.css
@@ -23,7 +23,7 @@
   display: grid;
   visibility: hidden;
   overflow: hidden;
-  border: 1px solid var(--ax-border-subtleA);
+  border: 1px solid var(--ax-border-neutral-subtleA);
   border-radius: var(--ax-border-radius-xlarge);
   background: var(--ax-bg-raised);
   padding-inline: var(--ax-space-20);

--- a/@navikt/core/css/darkside/form/form-summary.darkside.css
+++ b/@navikt/core/css/darkside/form/form-summary.darkside.css
@@ -1,6 +1,6 @@
 .navds-form-summary {
   overflow: hidden;
-  border: 1px solid var(--ax-border-subtleA);
+  border: 1px solid var(--ax-border-neutral-subtleA);
   border-radius: var(--ax-border-radius-xlarge);
   background: var(--ax-bg-raised);
 }
@@ -27,7 +27,7 @@
 }
 
 .navds-form-summary > .navds-form-summary__answers {
-  border-top: 1px solid var(--ax-border-subtleA);
+  border-top: 1px solid var(--ax-border-neutral-subtleA);
 }
 
 .navds-form-summary__answers {
@@ -44,7 +44,7 @@
 .navds-form-summary__answer:not(:last-child) {
   margin-bottom: var(--ax-space-16);
   padding-bottom: var(--ax-space-16);
-  border-bottom: 1px solid var(--ax-border-subtleA);
+  border-bottom: 1px solid var(--ax-border-neutral-subtleA);
 }
 
 .navds-form-summary__answer:has(.navds-form-summary__answer) {

--- a/@navikt/core/css/darkside/form/form-summary.darkside.css
+++ b/@navikt/core/css/darkside/form/form-summary.darkside.css
@@ -6,7 +6,7 @@
 }
 
 .navds-form-summary__header {
-  background: var(--ax-bg-moderateA);
+  background: var(--ax-bg-neutral-moderateA);
   padding: var(--ax-space-20) var(--ax-space-20) var(--ax-space-16) var(--ax-space-20);
   display: flex;
   justify-content: space-between;

--- a/@navikt/core/css/darkside/form/form.darkside.css
+++ b/@navikt/core/css/darkside/form/form.darkside.css
@@ -6,7 +6,7 @@
 
 .navds-form-field__description {
   margin-top: -0.375rem;
-  color: var(--ax-text-subtle);
+  color: var(--ax-text-neutral-subtle);
 }
 
 .navds-form-field--disabled {
@@ -19,7 +19,7 @@
 }
 
 .navds-form-field__subdescription {
-  color: var(--ax-text-subtle);
+  color: var(--ax-text-neutral-subtle);
 }
 
 .navds-form-field--readonly > :where(.navds-form-field__label) {

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -24,7 +24,7 @@
   gap: var(--ax-space-8);
 
   --__axc-radio-checkbox-readonly-bg: var(--ax-bg-neutral-moderate);
-  --__axc-radio-checkbox-readonly-border: var(--ax-border-subtle);
+  --__axc-radio-checkbox-readonly-border: var(--ax-border-neutral-subtle);
 }
 
 .navds-checkbox__label::before,
@@ -233,7 +233,7 @@
   background-color: var(--ax-bg-neutral-strong);
   border-width: 0;
   box-shadow:
-    inset 0 0 0 2px var(--ax-border-subtle),
+    inset 0 0 0 2px var(--ax-border-neutral-subtle),
     inset 0 0 0 8px var(--ax-bg-neutral-moderate);
 }
 

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -230,7 +230,7 @@
 }
 
 .navds-radio--readonly > .navds-radio__input:checked + .navds-radio__label::before {
-  background-color: var(--ax-bg-strong);
+  background-color: var(--ax-bg-neutral-strong);
   border-width: 0;
   box-shadow:
     inset 0 0 0 2px var(--ax-border-subtle),

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -209,7 +209,7 @@
 
 .navds-checkbox--readonly > .navds-checkbox__input:hover + .navds-checkbox__label,
 .navds-radio--readonly > .navds-radio__input:hover + .navds-radio__label {
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 }
 
 .navds-checkbox--readonly > .navds-checkbox__input:not(:disabled) + .navds-checkbox__label::before,
@@ -226,7 +226,7 @@
 }
 
 .navds-checkbox--readonly > .navds-checkbox__input:checked + .navds-checkbox__label > .navds-checkbox__icon {
-  color: var(--ax-text-subtle);
+  color: var(--ax-text-neutral-subtle);
 }
 
 .navds-radio--readonly > .navds-radio__input:checked + .navds-radio__label::before {
@@ -238,7 +238,7 @@
 }
 
 .navds-checkbox--readonly > .navds-checkbox__input:indeterminate + .navds-checkbox__label > .navds-checkbox__icon-indeterminate {
-  background-color: var(--ax-text-subtle);
+  background-color: var(--ax-text-neutral-subtle);
 }
 
 @media (forced-colors: active) {

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -35,7 +35,7 @@
   flex-shrink: 0;
   width: 1.5rem;
   height: 1.5rem;
-  border: 2px solid var(--ax-border-default);
+  border: 2px solid var(--ax-border-neutral);
 }
 
 .navds-radio__label::before {

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -23,7 +23,7 @@
   display: flex;
   gap: var(--ax-space-8);
 
-  --__axc-radio-checkbox-readonly-bg: var(--ax-bg-moderate);
+  --__axc-radio-checkbox-readonly-bg: var(--ax-bg-neutral-moderate);
   --__axc-radio-checkbox-readonly-border: var(--ax-border-subtle);
 }
 
@@ -234,7 +234,7 @@
   border-width: 0;
   box-shadow:
     inset 0 0 0 2px var(--ax-border-subtle),
-    inset 0 0 0 8px var(--ax-bg-moderate);
+    inset 0 0 0 8px var(--ax-bg-neutral-moderate);
 }
 
 .navds-checkbox--readonly > .navds-checkbox__input:indeterminate + .navds-checkbox__label > .navds-checkbox__icon-indeterminate {

--- a/@navikt/core/css/darkside/form/search.darkside.css
+++ b/@navikt/core/css/darkside/form/search.darkside.css
@@ -103,7 +103,7 @@
 
 .navds-search__button-search.navds-button--secondary {
   --__axc-button-border-width: 1px;
-  --__axc-button-border-color: var(--ax-border-default);
+  --__axc-button-border-color: var(--ax-border-neutral);
 
   &:not(:hover, :active) {
     background-color: var(--ax-bg-input);

--- a/@navikt/core/css/darkside/form/select.darkside.css
+++ b/@navikt/core/css/darkside/form/select.darkside.css
@@ -2,7 +2,7 @@
   appearance: none;
   background-color: var(--ax-bg-input);
   border-radius: var(--ax-border-radius-large);
-  border: 1px solid var(--ax-border-default);
+  border: 1px solid var(--ax-border-neutral);
   color: var(--ax-text-neutral);
   width: 100%;
   box-sizing: border-box;
@@ -80,7 +80,7 @@
 /* ----------------------------- Select disabled ---------------------------- */
 .navds-select__input:disabled {
   background-color: var(--ax-bg-input);
-  border: 1px solid var(--ax-border-default);
+  border: 1px solid var(--ax-border-neutral);
   box-shadow: none;
   cursor: not-allowed;
 

--- a/@navikt/core/css/darkside/form/select.darkside.css
+++ b/@navikt/core/css/darkside/form/select.darkside.css
@@ -102,7 +102,7 @@
 /* ----------------------------- Select Readonly ---------------------------- */
 .navds-select--readonly {
   & .navds-select__input {
-    background-color: var(--ax-bg-moderate);
+    background-color: var(--ax-bg-neutral-moderate);
     border-color: var(--ax-border-subtleA);
     cursor: default;
 

--- a/@navikt/core/css/darkside/form/select.darkside.css
+++ b/@navikt/core/css/darkside/form/select.darkside.css
@@ -103,7 +103,7 @@
 .navds-select--readonly {
   & .navds-select__input {
     background-color: var(--ax-bg-neutral-moderate);
-    border-color: var(--ax-border-subtleA);
+    border-color: var(--ax-border-neutral-subtleA);
     cursor: default;
 
     @media (forced-colors: active) {

--- a/@navikt/core/css/darkside/form/select.darkside.css
+++ b/@navikt/core/css/darkside/form/select.darkside.css
@@ -3,7 +3,7 @@
   background-color: var(--ax-bg-input);
   border-radius: var(--ax-border-radius-large);
   border: 1px solid var(--ax-border-default);
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   width: 100%;
   box-sizing: border-box;
   min-height: 3rem;
@@ -36,7 +36,7 @@
   position: relative;
   display: flex;
   width: 100%;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 }
 
 /* ------------------------------- Select Icon ------------------------------ */
@@ -46,7 +46,7 @@
   right: var(--ax-space-8);
   pointer-events: none;
   align-self: center;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 
   @media (forced-colors: active) {
     & {
@@ -86,10 +86,10 @@
 
   /* Chrome-fix */
   opacity: 1;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 
   & > option {
-    color: var(--ax-text-default);
+    color: var(--ax-text-neutral);
   }
 
   @media (forced-colors: active) {
@@ -116,6 +116,6 @@
   }
 
   & .navds-select__chevron {
-    color: var(--ax-text-subtle);
+    color: var(--ax-text-neutral-subtle);
   }
 }

--- a/@navikt/core/css/darkside/form/switch.darkside.css
+++ b/@navikt/core/css/darkside/form/switch.darkside.css
@@ -86,7 +86,7 @@
   top: var(--ax-space-12);
   left: 0;
   border-radius: var(--ax-border-radius-full);
-  border: 2px solid var(--ax-border-default);
+  border: 2px solid var(--ax-border-neutral);
   transition-property: background-color, border-color;
   transition-duration: 100ms;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
@@ -107,7 +107,7 @@
 
   .navds-switch__input:disabled ~ & {
     background-color: var(--ax-bg-input);
-    border-color: var(--ax-border-default);
+    border-color: var(--ax-border-neutral);
   }
 
   .navds-switch__input:checked:disabled ~ & {

--- a/@navikt/core/css/darkside/form/switch.darkside.css
+++ b/@navikt/core/css/darkside/form/switch.darkside.css
@@ -222,7 +222,7 @@
 
   & > .navds-switch__input:checked ~ .navds-switch__track > .navds-switch__thumb {
     background-color: var(--ax-bg-strong);
-    color: var(--ax-text-contrast);
+    color: var(--ax-text-neutral-contrast);
   }
 
   @media (hover: hover) and (pointer: fine) {

--- a/@navikt/core/css/darkside/form/switch.darkside.css
+++ b/@navikt/core/css/darkside/form/switch.darkside.css
@@ -27,7 +27,7 @@
 /* -------------------------- Switch content/label -------------------------- */
 .navds-switch__label-wrapper {
   cursor: pointer;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 }
 
 .navds-switch__content {
@@ -209,7 +209,7 @@
 
   & > .navds-switch__input:hover ~ .navds-switch__label-wrapper,
   & .navds-switch__label-wrapper:hover {
-    color: var(--ax-text-default);
+    color: var(--ax-text-neutral);
   }
 
   & .navds-switch__label {

--- a/@navikt/core/css/darkside/form/switch.darkside.css
+++ b/@navikt/core/css/darkside/form/switch.darkside.css
@@ -123,7 +123,7 @@
 
 /* ------------------------------ Switch Thumb ------------------------------ */
 .navds-switch__thumb {
-  background-color: var(--ax-bg-strong);
+  background-color: var(--ax-bg-neutral-strong);
   border-radius: var(--ax-border-radius-full);
   width: 1.125rem;
   height: 1.125rem;
@@ -217,11 +217,11 @@
   }
 
   & .navds-switch__thumb {
-    background-color: var(--ax-bg-strong);
+    background-color: var(--ax-bg-neutral-strong);
   }
 
   & > .navds-switch__input:checked ~ .navds-switch__track > .navds-switch__thumb {
-    background-color: var(--ax-bg-strong);
+    background-color: var(--ax-bg-neutral-strong);
     color: var(--ax-text-neutral-contrast);
   }
 

--- a/@navikt/core/css/darkside/form/switch.darkside.css
+++ b/@navikt/core/css/darkside/form/switch.darkside.css
@@ -198,7 +198,7 @@
   & > .navds-switch__input:hover ~ .navds-switch__track,
   & > .navds-switch__input:checked ~ .navds-switch__track,
   & > .navds-switch__input:checked:hover ~ .navds-switch__track {
-    background-color: var(--ax-bg-moderate);
+    background-color: var(--ax-bg-neutral-moderate);
     border-color: var(--ax-border-subtleA);
   }
 

--- a/@navikt/core/css/darkside/form/switch.darkside.css
+++ b/@navikt/core/css/darkside/form/switch.darkside.css
@@ -199,7 +199,7 @@
   & > .navds-switch__input:checked ~ .navds-switch__track,
   & > .navds-switch__input:checked:hover ~ .navds-switch__track {
     background-color: var(--ax-bg-neutral-moderate);
-    border-color: var(--ax-border-subtleA);
+    border-color: var(--ax-border-neutral-subtleA);
   }
 
   & > .navds-switch__label-wrapper,

--- a/@navikt/core/css/darkside/form/text-field.darkside.css
+++ b/@navikt/core/css/darkside/form/text-field.darkside.css
@@ -44,7 +44,7 @@
 }
 
 .navds-text-field--readonly .navds-text-field__input {
-  background-color: var(--ax-bg-moderate);
+  background-color: var(--ax-bg-neutral-moderate);
   border-color: var(--ax-border-subtleA);
   cursor: default;
 }

--- a/@navikt/core/css/darkside/form/text-field.darkside.css
+++ b/@navikt/core/css/darkside/form/text-field.darkside.css
@@ -3,7 +3,7 @@
   padding: var(--ax-space-8);
   background: var(--ax-bg-input);
   border-radius: var(--ax-border-radius-large);
-  border: 1px solid var(--ax-border-default);
+  border: 1px solid var(--ax-border-neutral);
   min-height: 3rem;
   width: 100%;
   color: var(--ax-text-neutral);
@@ -20,7 +20,7 @@
 
   &:disabled {
     background-color: var(--ax-bg-input);
-    border-color: var(--ax-border-default);
+    border-color: var(--ax-border-neutral);
     cursor: not-allowed;
   }
 

--- a/@navikt/core/css/darkside/form/text-field.darkside.css
+++ b/@navikt/core/css/darkside/form/text-field.darkside.css
@@ -6,7 +6,7 @@
   border: 1px solid var(--ax-border-default);
   min-height: 3rem;
   width: 100%;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 
   &:hover {
     border-color: var(--ax-border-accent-strong);
@@ -25,7 +25,7 @@
   }
 
   &::placeholder {
-    color: var(--ax-text-subtle);
+    color: var(--ax-text-neutral-subtle);
   }
 
   &[size] {

--- a/@navikt/core/css/darkside/form/text-field.darkside.css
+++ b/@navikt/core/css/darkside/form/text-field.darkside.css
@@ -45,7 +45,7 @@
 
 .navds-text-field--readonly .navds-text-field__input {
   background-color: var(--ax-bg-neutral-moderate);
-  border-color: var(--ax-border-subtleA);
+  border-color: var(--ax-border-neutral-subtleA);
   cursor: default;
 }
 

--- a/@navikt/core/css/darkside/form/textarea.darkside.css
+++ b/@navikt/core/css/darkside/form/textarea.darkside.css
@@ -5,7 +5,7 @@
   padding: var(--ax-space-8);
   background-color: var(--ax-bg-input);
   border-radius: var(--ax-border-radius-large);
-  border: 1px solid var(--ax-border-default);
+  border: 1px solid var(--ax-border-neutral);
   resize: none;
   width: 100%;
   display: block;
@@ -27,7 +27,7 @@
 
   &:disabled {
     background-color: var(--ax-bg-input);
-    border-color: var(--ax-border-default);
+    border-color: var(--ax-border-neutral);
     cursor: not-allowed;
   }
 

--- a/@navikt/core/css/darkside/form/textarea.darkside.css
+++ b/@navikt/core/css/darkside/form/textarea.darkside.css
@@ -36,7 +36,7 @@
   }
 
   .navds-textarea--readonly & {
-    background-color: var(--ax-bg-moderate);
+    background-color: var(--ax-bg-neutral-moderate);
     border-color: var(--ax-border-subtleA);
     cursor: default;
   }

--- a/@navikt/core/css/darkside/form/textarea.darkside.css
+++ b/@navikt/core/css/darkside/form/textarea.darkside.css
@@ -9,10 +9,10 @@
   resize: none;
   width: 100%;
   display: block;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 
   &::placeholder {
-    color: var(--ax-text-subtle);
+    color: var(--ax-text-neutral-subtle);
   }
 
   &:hover {
@@ -44,7 +44,7 @@
 
 .navds-textarea__counter {
   margin-top: -0.25rem;
-  color: var(--ax-text-subtle);
+  color: var(--ax-text-neutral-subtle);
 }
 
 .navds-textarea__counter--error {

--- a/@navikt/core/css/darkside/form/textarea.darkside.css
+++ b/@navikt/core/css/darkside/form/textarea.darkside.css
@@ -37,7 +37,7 @@
 
   .navds-textarea--readonly & {
     background-color: var(--ax-bg-neutral-moderate);
-    border-color: var(--ax-border-subtleA);
+    border-color: var(--ax-border-neutral-subtleA);
     cursor: default;
   }
 }

--- a/@navikt/core/css/darkside/internalheader.darkside.css
+++ b/@navikt/core/css/darkside/internalheader.darkside.css
@@ -36,7 +36,7 @@
   }
 
   &:hover {
-    background: var(--ax-bg-moderate-hoverA);
+    background: var(--ax-bg-neutral-moderate-hoverA);
   }
 
   &:is(:hover, :active):not(button, a) {
@@ -69,7 +69,7 @@
   color: var(--ax-text-neutral);
 
   &:hover {
-    background: var(--ax-bg-moderate-hoverA);
+    background: var(--ax-bg-neutral-moderate-hoverA);
   }
 }
 
@@ -91,7 +91,7 @@
   }
 
   &:active {
-    background: var(--ax-bg-moderate-pressedA);
+    background: var(--ax-bg-neutral-moderate-pressedA);
   }
 }
 

--- a/@navikt/core/css/darkside/internalheader.darkside.css
+++ b/@navikt/core/css/darkside/internalheader.darkside.css
@@ -29,7 +29,7 @@
   align-items: center;
   text-decoration: none;
   margin: 0;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 
   &:is(button) {
     cursor: pointer;
@@ -66,7 +66,7 @@
   justify-self: center;
   gap: var(--ax-space-8);
   border-left: 1px solid var(--ax-border-subtleA);
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 
   &:hover {
     background: var(--ax-bg-moderate-hoverA);

--- a/@navikt/core/css/darkside/internalheader.darkside.css
+++ b/@navikt/core/css/darkside/internalheader.darkside.css
@@ -3,7 +3,7 @@
   align-self: stretch;
   background: var(--ax-bg-raised);
   min-height: 3rem;
-  border-bottom: 1px solid var(--ax-border-subtleA);
+  border-bottom: 1px solid var(--ax-border-neutral-subtleA);
 }
 
 @media (forced-colors: active) {
@@ -24,7 +24,7 @@
   text-align: left;
   padding-block: 0;
   padding-inline: var(--ax-space-24) var(--ax-space-20);
-  border-right: 1px solid var(--ax-border-subtleA);
+  border-right: 1px solid var(--ax-border-neutral-subtleA);
   display: flex;
   align-items: center;
   text-decoration: none;
@@ -46,7 +46,7 @@
 
 .navds-internalheader__user {
   padding: 0 var(--ax-space-20);
-  border-left: 1px solid var(--ax-border-subtleA);
+  border-left: 1px solid var(--ax-border-neutral-subtleA);
   display: flex;
   align-items: center;
 }
@@ -65,7 +65,7 @@
   align-items: center;
   justify-self: center;
   gap: var(--ax-space-8);
-  border-left: 1px solid var(--ax-border-subtleA);
+  border-left: 1px solid var(--ax-border-neutral-subtleA);
   color: var(--ax-text-neutral);
 
   &:hover {

--- a/@navikt/core/css/darkside/link.darkside.css
+++ b/@navikt/core/css/darkside/link.darkside.css
@@ -47,7 +47,7 @@
 .navds-alert:not(.navds-alert--inline),
 .navds-confirmation-panel {
   & .navds-link {
-    color: var(--ax-text-default);
+    color: var(--ax-text-neutral);
   }
 }
 
@@ -56,9 +56,9 @@
 }
 
 .navds-link--neutral {
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 }
 
 .navds-link--subtle {
-  color: var(--ax-text-subtle);
+  color: var(--ax-text-neutral-subtle);
 }

--- a/@navikt/core/css/darkside/loader.darkside.css
+++ b/@navikt/core/css/darkside/loader.darkside.css
@@ -61,7 +61,7 @@
   animation: loader-dasharray 1.5s ease-in-out infinite;
   stroke-dasharray: 80px, 200px;
   stroke-dashoffset: 0;
-  stroke: var(--ax-border-strong);
+  stroke: var(--ax-border-neutral-strong);
   stroke-linecap: round;
   stroke-width: var(--__axc-loader-stroke-width);
 }
@@ -73,7 +73,7 @@
 
 .navds-loader--neutral {
   & .navds-loader__foreground {
-    stroke: var(--ax-border-strong);
+    stroke: var(--ax-border-neutral-strong);
   }
 }
 
@@ -93,7 +93,7 @@
   }
 
   & .navds-loader__background {
-    stroke: var(--ax-border-strong);
+    stroke: var(--ax-border-neutral-strong);
   }
 }
 

--- a/@navikt/core/css/darkside/loader.darkside.css
+++ b/@navikt/core/css/darkside/loader.darkside.css
@@ -67,7 +67,7 @@
 }
 
 .navds-loader__background {
-  stroke: var(--ax-border-subtleA);
+  stroke: var(--ax-border-neutral-subtleA);
   stroke-width: var(--__axc-loader-stroke-width);
 }
 
@@ -89,7 +89,7 @@
 
 .navds-loader--inverted {
   & .navds-loader__foreground {
-    stroke: var(--ax-border-subtle);
+    stroke: var(--ax-border-neutral-subtle);
   }
 
   & .navds-loader__background {

--- a/@navikt/core/css/darkside/modal.darkside.css
+++ b/@navikt/core/css/darkside/modal.darkside.css
@@ -6,7 +6,7 @@
   --__axc-modal-bg: var(--ax-bg-raised);
 
   background-color: var(--__axc-modal-bg);
-  border: 1px solid var(--ax-border-subtleA);
+  border: 1px solid var(--ax-border-neutral-subtleA);
   border-radius: var(--ax-border-radius-xlarge);
   box-shadow: var(--ax-shadow-dialog);
   padding: 0;

--- a/@navikt/core/css/darkside/modal.darkside.css
+++ b/@navikt/core/css/darkside/modal.darkside.css
@@ -13,7 +13,7 @@
   position: fixed;
   max-height: 100%;
   max-width: 100%;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   margin: auto;
 
   &[open] {
@@ -135,7 +135,7 @@
 
 .navds-modal__label {
   font-weight: var(--ax-font-weight-bold);
-  color: var(--ax-text-subtle);
+  color: var(--ax-text-neutral-subtle);
 }
 
 .navds-modal__body {

--- a/@navikt/core/css/darkside/pagination.darkside.css
+++ b/@navikt/core/css/darkside/pagination.darkside.css
@@ -32,7 +32,7 @@
 }
 
 .navds-pagination__item[data-selected="true"] {
-  background-color: var(--ax-bg-strong-pressed);
+  background-color: var(--ax-bg-neutral-strong-pressed);
   color: var(--ax-text-neutral-contrast);
 }
 

--- a/@navikt/core/css/darkside/pagination.darkside.css
+++ b/@navikt/core/css/darkside/pagination.darkside.css
@@ -33,7 +33,7 @@
 
 .navds-pagination__item[data-selected="true"] {
   background-color: var(--ax-bg-strong-pressed);
-  color: var(--ax-text-contrast);
+  color: var(--ax-text-neutral-contrast);
 }
 
 .navds-pagination--invisible {

--- a/@navikt/core/css/darkside/popover.darkside.css
+++ b/@navikt/core/css/darkside/popover.darkside.css
@@ -2,7 +2,7 @@
   z-index: 1000;
   background: var(--ax-bg-raised);
   box-shadow: var(--ax-shadow-dialog);
-  border: 1px solid var(--ax-border-subtleA);
+  border: 1px solid var(--ax-border-neutral-subtleA);
   border-radius: var(--ax-border-radius-xlarge);
 
   /* Creates a small gutter between screen-edges on smaller devices */

--- a/@navikt/core/css/darkside/progress-bar.darkside.css
+++ b/@navikt/core/css/darkside/progress-bar.darkside.css
@@ -3,7 +3,7 @@
   position: relative;
   border-radius: var(--ax-border-radius-full);
   overflow: hidden;
-  box-shadow: inset 0 0 0 1px var(--ax-border-subtleA);
+  box-shadow: inset 0 0 0 1px var(--ax-border-neutral-subtleA);
 }
 
 .navds-progress-bar--small {

--- a/@navikt/core/css/darkside/progress-bar.darkside.css
+++ b/@navikt/core/css/darkside/progress-bar.darkside.css
@@ -1,5 +1,5 @@
 .navds-progress-bar {
-  background: var(--ax-bg-moderateA);
+  background: var(--ax-bg-neutral-moderateA);
   position: relative;
   border-radius: var(--ax-border-radius-full);
   overflow: hidden;

--- a/@navikt/core/css/darkside/read-more.darkside.css
+++ b/@navikt/core/css/darkside/read-more.darkside.css
@@ -65,7 +65,7 @@
 /* ---------------------------- ReadMore Content ---------------------------- */
 .navds-read-more__content {
   margin-top: var(--ax-space-8);
-  border-left: 2px solid var(--ax-border-subtleA);
+  border-left: 2px solid var(--ax-border-neutral-subtleA);
   color: var(--ax-text-neutral);
   margin-left: calc(var(--__axc-read-more-pi-start) + var(--__axc-read-more-icon-size) / 2 - 1px);
   padding-left: calc(var(--__axc-read-more-icon-size) / 2 - 1px + var(--ax-space-4));

--- a/@navikt/core/css/darkside/read-more.darkside.css
+++ b/@navikt/core/css/darkside/read-more.darkside.css
@@ -34,7 +34,7 @@
     border-radius: var(--ax-border-radius-medium);
 
     &:hover {
-      background-color: var(--ax-bg-soft-hoverA);
+      background-color: var(--ax-bg-neutral-soft-hoverA);
     }
   }
 }

--- a/@navikt/core/css/darkside/read-more.darkside.css
+++ b/@navikt/core/css/darkside/read-more.darkside.css
@@ -66,7 +66,7 @@
 .navds-read-more__content {
   margin-top: var(--ax-space-8);
   border-left: 2px solid var(--ax-border-subtleA);
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   margin-left: calc(var(--__axc-read-more-pi-start) + var(--__axc-read-more-icon-size) / 2 - 1px);
   padding-left: calc(var(--__axc-read-more-icon-size) / 2 - 1px + var(--ax-space-4));
 

--- a/@navikt/core/css/darkside/skeleton.darkside.css
+++ b/@navikt/core/css/darkside/skeleton.darkside.css
@@ -1,5 +1,5 @@
 .navds-skeleton {
-  background-color: var(--ax-bg-moderateA);
+  background-color: var(--ax-bg-neutral-moderateA);
   height: 1.3em;
   animation: akselSkeletonAnimation 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
   pointer-events: none;

--- a/@navikt/core/css/darkside/stepper.darkside.css
+++ b/@navikt/core/css/darkside/stepper.darkside.css
@@ -163,8 +163,8 @@
   &[data-active="true"] {
     & .navds-stepper__circle {
       color: var(--ax-text-neutral-contrast);
-      background-color: var(--ax-bg-strong-pressed);
-      border-color: var(--ax-bg-strong-pressed);
+      background-color: var(--ax-bg-neutral-strong-pressed);
+      border-color: var(--ax-bg-neutral-strong-pressed);
     }
   }
 }

--- a/@navikt/core/css/darkside/stepper.darkside.css
+++ b/@navikt/core/css/darkside/stepper.darkside.css
@@ -153,7 +153,7 @@
 }
 
 .navds-stepper__step[data-interactive="false"] {
-  color: var(--ax-text-subtle);
+  color: var(--ax-text-neutral-subtle);
   cursor: default;
 
   & .navds-stepper__circle {

--- a/@navikt/core/css/darkside/stepper.darkside.css
+++ b/@navikt/core/css/darkside/stepper.darkside.css
@@ -30,14 +30,14 @@
   grid-column: 1;
 
   .navds-stepper__item--non-interactive & {
-    background-color: var(--ax-border-strong);
+    background-color: var(--ax-border-neutral-strong);
   }
 }
 
 /* Line before non-interactive step */
 .navds-stepper__item:has(+ .navds-stepper__item > .navds-stepper__step[data-interactive="false"]) {
   .navds-stepper__line--2 {
-    background-color: var(--ax-border-strong);
+    background-color: var(--ax-border-neutral-strong);
   }
 }
 
@@ -157,7 +157,7 @@
   cursor: default;
 
   & .navds-stepper__circle {
-    border-color: var(--ax-border-strong);
+    border-color: var(--ax-border-neutral-strong);
   }
 
   &[data-active="true"] {

--- a/@navikt/core/css/darkside/stepper.darkside.css
+++ b/@navikt/core/css/darkside/stepper.darkside.css
@@ -162,7 +162,7 @@
 
   &[data-active="true"] {
     & .navds-stepper__circle {
-      color: var(--ax-text-contrast);
+      color: var(--ax-text-neutral-contrast);
       background-color: var(--ax-bg-strong-pressed);
       border-color: var(--ax-bg-strong-pressed);
     }

--- a/@navikt/core/css/darkside/table.darkside.css
+++ b/@navikt/core/css/darkside/table.darkside.css
@@ -55,7 +55,7 @@
 .navds-table__data-cell {
   display: table-cell;
   padding: var(--ax-space-12) var(--ax-space-8);
-  border-bottom: 1px solid var(--ax-border-subtleA);
+  border-bottom: 1px solid var(--ax-border-neutral-subtleA);
   text-align: left;
 }
 
@@ -233,7 +233,7 @@
 /* -------------------------- Table ExpandableRow -------------------------- */
 .navds-table__expanded-row-collapse:not([style*="height: 0px;"]),
 .navds-table__expanded-row-collapse[style*="transition:"] {
-  border-bottom: 1px solid var(--ax-border-subtleA);
+  border-bottom: 1px solid var(--ax-border-neutral-subtleA);
 }
 
 .navds-table__expanded-row-content {

--- a/@navikt/core/css/darkside/table.darkside.css
+++ b/@navikt/core/css/darkside/table.darkside.css
@@ -12,7 +12,7 @@
   display: table-row-group;
 
   & .navds-table__row--shade-on-hover:not(.navds-table__expandable-row--expansion-disabled):hover {
-    background-color: var(--ax-bg-soft-hoverA);
+    background-color: var(--ax-bg-neutral-soft-hoverA);
     transition: background-color 70ms cubic-bezier(0.2, 0, 0, 1);
   }
 
@@ -35,7 +35,7 @@
 
 .navds-table--zebra-stripes {
   & .navds-table__body :where(.navds-table__row:nth-child(odd):not(.navds-table__row--selected)) {
-    background-color: var(--ax-bg-softA);
+    background-color: var(--ax-bg-neutral-softA);
   }
 
   & .navds-table__body :where(.navds-table__expandable-row:nth-child(4n + 1):not(.navds-table__row--selected)) {
@@ -43,7 +43,7 @@
   }
 
   & .navds-table__body .navds-table__expanded-row:nth-child(4n) {
-    background-color: var(--ax-bg-softA);
+    background-color: var(--ax-bg-neutral-softA);
   }
 
   & .navds-table__row--selected + .navds-table__expanded-row:nth-child(4n) {
@@ -131,7 +131,7 @@
 }
 
 .navds-table__sort-button:hover {
-  background-color: var(--ax-bg-soft-hoverA);
+  background-color: var(--ax-bg-neutral-soft-hoverA);
 }
 
 .navds-table__sort-button:focus-visible {
@@ -211,7 +211,7 @@
 .navds-table__toggle-expand-button:hover,
 .navds-table__toggle-expand-cell:hover > .navds-table__toggle-expand-button,
 .navds-table__expandable-row--clickable:hover .navds-table__toggle-expand-button {
-  background-color: var(--ax-bg-soft-hoverA);
+  background-color: var(--ax-bg-neutral-soft-hoverA);
 }
 
 .navds-table__toggle-expand-cell--open > :where(.navds-table__toggle-expand-button) :where(.navds-table__expandable-icon) {

--- a/@navikt/core/css/darkside/tabs.darkside.css
+++ b/@navikt/core/css/darkside/tabs.darkside.css
@@ -49,7 +49,7 @@
   align-items: center;
   background: none;
   border: none;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   cursor: pointer;
 
   --__axc-tabs-line-width: 0;

--- a/@navikt/core/css/darkside/tabs.darkside.css
+++ b/@navikt/core/css/darkside/tabs.darkside.css
@@ -1,5 +1,5 @@
 .navds-tabs__tablist-wrapper {
-  box-shadow: inset 0 -1px var(--ax-border-subtleA);
+  box-shadow: inset 0 -1px var(--ax-border-neutral-subtleA);
   width: 100%;
   display: flex;
 }
@@ -53,7 +53,7 @@
   cursor: pointer;
 
   --__axc-tabs-line-width: 0;
-  --__axc-tabs-line-color: var(--ax-border-subtleA);
+  --__axc-tabs-line-color: var(--ax-border-neutral-subtleA);
 
   box-shadow: inset 0 var(--__axc-tabs-line-width) var(--__axc-tabs-line-color);
   transition: box-shadow 200ms cubic-bezier(0.2, 0, 0, 1);

--- a/@navikt/core/css/darkside/tag.darkside.css
+++ b/@navikt/core/css/darkside/tag.darkside.css
@@ -54,7 +54,7 @@
 }
 
 .navds-tag--neutral {
-  --__axc-tag-border: var(--ax-border-default);
+  --__axc-tag-border: var(--ax-border-neutral);
   --__axc-tag-bg: var(--ax-bg-neutral-moderateA);
   --__axc-tag-bg-strong: var(--ax-bg-neutral-strong);
   --__axc-tag-text: var(--ax-text-neutral);

--- a/@navikt/core/css/darkside/tag.darkside.css
+++ b/@navikt/core/css/darkside/tag.darkside.css
@@ -56,7 +56,7 @@
 .navds-tag--neutral {
   --__axc-tag-border: var(--ax-border-default);
   --__axc-tag-bg: var(--ax-bg-neutral-moderateA);
-  --__axc-tag-bg-strong: var(--ax-bg-strong);
+  --__axc-tag-bg-strong: var(--ax-bg-neutral-strong);
   --__axc-tag-text: var(--ax-text-neutral);
   --__axc-tag-text-strong: var(--ax-text-neutral-contrast);
 }

--- a/@navikt/core/css/darkside/tag.darkside.css
+++ b/@navikt/core/css/darkside/tag.darkside.css
@@ -55,7 +55,7 @@
 
 .navds-tag--neutral {
   --__axc-tag-border: var(--ax-border-default);
-  --__axc-tag-bg: var(--ax-bg-moderateA);
+  --__axc-tag-bg: var(--ax-bg-neutral-moderateA);
   --__axc-tag-bg-strong: var(--ax-bg-strong);
   --__axc-tag-text: var(--ax-text-neutral);
   --__axc-tag-text-strong: var(--ax-text-neutral-contrast);

--- a/@navikt/core/css/darkside/tag.darkside.css
+++ b/@navikt/core/css/darkside/tag.darkside.css
@@ -58,7 +58,7 @@
   --__axc-tag-bg: var(--ax-bg-moderateA);
   --__axc-tag-bg-strong: var(--ax-bg-strong);
   --__axc-tag-text: var(--ax-text-neutral);
-  --__axc-tag-text-strong: var(--ax-text-contrast);
+  --__axc-tag-text-strong: var(--ax-text-neutral-contrast);
 }
 
 .navds-tag--meta-1,

--- a/@navikt/core/css/darkside/tag.darkside.css
+++ b/@navikt/core/css/darkside/tag.darkside.css
@@ -57,7 +57,7 @@
   --__axc-tag-border: var(--ax-border-default);
   --__axc-tag-bg: var(--ax-bg-moderateA);
   --__axc-tag-bg-strong: var(--ax-bg-strong);
-  --__axc-tag-text: var(--ax-text-default);
+  --__axc-tag-text: var(--ax-text-neutral);
   --__axc-tag-text-strong: var(--ax-text-contrast);
 }
 

--- a/@navikt/core/css/darkside/theme.darkside.css
+++ b/@navikt/core/css/darkside/theme.darkside.css
@@ -1,5 +1,5 @@
 .navds-theme {
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
 
   &[data-background="true"] {
     background-color: var(--ax-bg-default);

--- a/@navikt/core/css/darkside/timeline.darkside.css
+++ b/@navikt/core/css/darkside/timeline.darkside.css
@@ -321,7 +321,7 @@
   background-color: var(--ax-bg-raised);
   box-shadow: var(--ax-shadow-dialog);
   border: 1px solid;
-  border-color: var(--ax-border-subtleA);
+  border-color: var(--ax-border-neutral-subtleA);
   border-radius: var(--ax-border-radius-large);
   padding: var(--ax-space-16) var(--ax-space-20);
 }

--- a/@navikt/core/css/darkside/timeline.darkside.css
+++ b/@navikt/core/css/darkside/timeline.darkside.css
@@ -172,7 +172,7 @@
 
 .navds-timeline__period--neutral {
   background: var(--ax-bg-neutral-moderate);
-  border: solid 1px var(--ax-border-default);
+  border: solid 1px var(--ax-border-neutral);
   color: var(--ax-text-neutral-icon);
 
   &.navds-timeline__period--clickable:hover {
@@ -268,7 +268,7 @@
   all: unset;
   cursor: pointer;
   padding: 6px 9px 6px 8px;
-  border: 1px solid var(--ax-border-default);
+  border: 1px solid var(--ax-border-neutral);
   border-width: 1px 0 1px 1px;
   background: var(--ax-bg-default);
 }

--- a/@navikt/core/css/darkside/timeline.darkside.css
+++ b/@navikt/core/css/darkside/timeline.darkside.css
@@ -181,7 +181,7 @@
   }
 
   &.navds-timeline__period--clickable.navds-timeline__period--selected {
-    background: var(--ax-bg-strong-pressed);
+    background: var(--ax-bg-neutral-strong-pressed);
     border: none;
     color: var(--ax-text-neutral-contrast);
   }
@@ -291,8 +291,8 @@
 }
 
 .navds-timeline__zoom-button[aria-pressed="true"] {
-  background: var(--ax-bg-strong-pressed);
-  border-color: var(--ax-bg-strong-pressed);
+  background: var(--ax-bg-neutral-strong-pressed);
+  border-color: var(--ax-bg-neutral-strong-pressed);
   color: var(--ax-text-neutral-contrast);
 }
 

--- a/@navikt/core/css/darkside/timeline.darkside.css
+++ b/@navikt/core/css/darkside/timeline.darkside.css
@@ -183,7 +183,7 @@
   &.navds-timeline__period--clickable.navds-timeline__period--selected {
     background: var(--ax-bg-strong-pressed);
     border: none;
-    color: var(--ax-text-contrast);
+    color: var(--ax-text-neutral-contrast);
   }
 }
 
@@ -293,7 +293,7 @@
 .navds-timeline__zoom-button[aria-pressed="true"] {
   background: var(--ax-bg-strong-pressed);
   border-color: var(--ax-bg-strong-pressed);
-  color: var(--ax-text-contrast);
+  color: var(--ax-text-neutral-contrast);
 }
 
 .navds-timeline__zoom li:focus-within {

--- a/@navikt/core/css/darkside/timeline.darkside.css
+++ b/@navikt/core/css/darkside/timeline.darkside.css
@@ -32,7 +32,7 @@
 
 .navds-timeline__axislabels-label {
   position: absolute;
-  color: var(--ax-text-subtle);
+  color: var(--ax-text-neutral-subtle);
   white-space: nowrap;
 }
 

--- a/@navikt/core/css/darkside/timeline.darkside.css
+++ b/@navikt/core/css/darkside/timeline.darkside.css
@@ -171,12 +171,12 @@
 }
 
 .navds-timeline__period--neutral {
-  background: var(--ax-bg-moderate);
+  background: var(--ax-bg-neutral-moderate);
   border: solid 1px var(--ax-border-default);
   color: var(--ax-text-neutral-icon);
 
   &.navds-timeline__period--clickable:hover {
-    background: var(--ax-bg-moderate-hover);
+    background: var(--ax-bg-neutral-moderate-hover);
     border-color: var(--ax-border-strong);
   }
 
@@ -287,7 +287,7 @@
 }
 
 .navds-timeline__zoom-button:not([aria-pressed="true"]):hover {
-  background: var(--ax-bg-moderate-hoverA);
+  background: var(--ax-bg-neutral-moderate-hoverA);
 }
 
 .navds-timeline__zoom-button[aria-pressed="true"] {

--- a/@navikt/core/css/darkside/timeline.darkside.css
+++ b/@navikt/core/css/darkside/timeline.darkside.css
@@ -173,7 +173,7 @@
 .navds-timeline__period--neutral {
   background: var(--ax-bg-moderate);
   border: solid 1px var(--ax-border-default);
-  color: var(--ax-text-icon);
+  color: var(--ax-text-neutral-icon);
 
   &.navds-timeline__period--clickable:hover {
     background: var(--ax-bg-moderate-hover);

--- a/@navikt/core/css/darkside/timeline.darkside.css
+++ b/@navikt/core/css/darkside/timeline.darkside.css
@@ -38,7 +38,7 @@
 
 .navds-timeline__row {
   display: flex;
-  background: var(--ax-bg-softA);
+  background: var(--ax-bg-neutral-softA);
   margin: var(--ax-space-16) 0;
   grid-column: 2;
 }

--- a/@navikt/core/css/darkside/timeline.darkside.css
+++ b/@navikt/core/css/darkside/timeline.darkside.css
@@ -177,7 +177,7 @@
 
   &.navds-timeline__period--clickable:hover {
     background: var(--ax-bg-neutral-moderate-hover);
-    border-color: var(--ax-border-strong);
+    border-color: var(--ax-border-neutral-strong);
   }
 
   &.navds-timeline__period--clickable.navds-timeline__period--selected {
@@ -254,7 +254,7 @@
   height: calc(100% - var(--navdsc-timeline-pin-size) * 2);
   width: 1px;
   margin: 0 auto;
-  background: var(--ax-border-strong);
+  background: var(--ax-border-neutral-strong);
 }
 
 .navds-timeline__zoom {

--- a/@navikt/core/css/darkside/toggle-group.darkside.css
+++ b/@navikt/core/css/darkside/toggle-group.darkside.css
@@ -29,14 +29,14 @@
   border: none;
   cursor: pointer;
   background-color: transparent;
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   border-radius: var(--ax-border-radius-large);
   min-width: fit-content;
   position: relative;
 
   &:hover {
     background-color: var(--ax-bg-accent-moderate-hoverA);
-    color: var(--ax-text-default);
+    color: var(--ax-text-neutral);
   }
 
   &:focus-visible {

--- a/@navikt/core/css/darkside/toggle-group.darkside.css
+++ b/@navikt/core/css/darkside/toggle-group.darkside.css
@@ -82,7 +82,7 @@
   }
 
   &[data-selected="true"] {
-    background-color: var(--ax-bg-strong-pressed);
+    background-color: var(--ax-bg-neutral-strong-pressed);
     color: var(--ax-text-neutral-contrast);
   }
 }

--- a/@navikt/core/css/darkside/toggle-group.darkside.css
+++ b/@navikt/core/css/darkside/toggle-group.darkside.css
@@ -55,7 +55,7 @@
     display: block;
     width: 1px;
     height: 50%;
-    background-color: var(--ax-border-subtleA);
+    background-color: var(--ax-border-neutral-subtleA);
     left: -1px;
     position: absolute;
   }

--- a/@navikt/core/css/darkside/toggle-group.darkside.css
+++ b/@navikt/core/css/darkside/toggle-group.darkside.css
@@ -83,7 +83,7 @@
 
   &[data-selected="true"] {
     background-color: var(--ax-bg-strong-pressed);
-    color: var(--ax-text-contrast);
+    color: var(--ax-text-neutral-contrast);
   }
 }
 

--- a/@navikt/core/css/darkside/toggle-group.darkside.css
+++ b/@navikt/core/css/darkside/toggle-group.darkside.css
@@ -78,7 +78,7 @@
 /* Modifier neutral variant */
 :where(.navds-toggle-group--neutral) .navds-toggle-group__button {
   &:hover {
-    background-color: var(--ax-bg-moderate-hoverA);
+    background-color: var(--ax-bg-neutral-moderate-hoverA);
   }
 
   &[data-selected="true"] {

--- a/@navikt/core/css/darkside/toggle-group.darkside.css
+++ b/@navikt/core/css/darkside/toggle-group.darkside.css
@@ -12,7 +12,7 @@
 .navds-toggle-group {
   border-radius: var(--ax-border-radius-large);
   background-color: transparent;
-  box-shadow: inset 0 0 0 1px var(--ax-border-default);
+  box-shadow: inset 0 0 0 1px var(--ax-border-neutral);
   display: inline-grid;
   grid-auto-flow: column;
   grid-auto-columns: 1fr;

--- a/@navikt/core/css/darkside/tooltip.darkside.css
+++ b/@navikt/core/css/darkside/tooltip.darkside.css
@@ -10,7 +10,7 @@
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   animation-duration: 150ms;
   text-align: center;
-  border: 1px solid var(--ax-border-subtleA);
+  border: 1px solid var(--ax-border-neutral-subtleA);
   box-shadow: var(--ax-shadow-dialog);
 }
 

--- a/@navikt/core/css/darkside/tooltip.darkside.css
+++ b/@navikt/core/css/darkside/tooltip.darkside.css
@@ -1,7 +1,7 @@
 .navds-tooltip {
   z-index: 3000;
   background-color: var(--ax-bg-raised);
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   border-radius: var(--ax-border-radius-medium);
   padding: 0 var(--ax-space-6);
   align-items: center;
@@ -88,7 +88,7 @@
 
 .navds-tooltip__key {
   font-family: var(--ax-font-family);
-  color: var(--ax-text-default);
+  color: var(--ax-text-neutral);
   padding: 0 var(--ax-space-4);
   min-width: 1.125rem;
   height: 1.125rem;

--- a/@navikt/core/css/darkside/tooltip.darkside.css
+++ b/@navikt/core/css/darkside/tooltip.darkside.css
@@ -96,7 +96,7 @@
   align-items: center;
   justify-content: center;
   border-radius: var(--ax-border-radius-small);
-  background: var(--ax-bg-moderateA);
+  background: var(--ax-bg-neutral-moderateA);
 
   @media (forced-colors: active) {
     & {

--- a/@navikt/core/css/darkside/typography.darkside.css
+++ b/@navikt/core/css/darkside/typography.darkside.css
@@ -258,5 +258,5 @@
 }
 
 .navds-typo--color-subtle {
-  color: var(--ax-text-subtle);
+  color: var(--ax-text-neutral-subtle);
 }

--- a/@navikt/core/react/src/chips/Toggle.tsx
+++ b/@navikt/core/react/src/chips/Toggle.tsx
@@ -78,7 +78,7 @@ export const ToggleChips: OverridableComponent<
                 fill={`var(${
                   variant === "action"
                     ? "--ax-text-accent"
-                    : "--ax-text-default"
+                    : "--ax-text-neutral"
                 }, var(--ac-chip-toggle-circle-border, var(--a-border-default)))`}
               />
             )}

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -634,7 +634,7 @@ export const ActionMenuCheckboxItem = forwardRef<
                   width="24"
                   height="24"
                   rx="4"
-                  fill="var(--ax-border-default, var(--a-border-default))"
+                  fill="var(--ax-border-neutral, var(--a-border-default))"
                 />
                 <rect
                   x="1"
@@ -771,7 +771,7 @@ export const ActionMenuRadioItem = forwardRef<
                   width="24"
                   height="24"
                   rx="12"
-                  fill="var(--ax-border-default, var(--a-border-default))"
+                  fill="var(--ax-border-neutral, var(--a-border-default))"
                 />
                 <rect
                   x="1"

--- a/@navikt/core/tokens/darkside/tokens/semantic-roles.ts
+++ b/@navikt/core/tokens/darkside/tokens/semantic-roles.ts
@@ -2,6 +2,10 @@ import _ from "lodash";
 import { ColorRolesList, type SemanticColorRoles } from "../../types";
 import { type StyleDictionaryTokenConfig } from "../tokens.util";
 
+/**
+ * Gray colors are percieved a little lighter than other colored versions,
+ * so we make some adjustments for neutral colors.
+ */
 const configForRole = (role: SemanticColorRoles) => {
   return {
     bg: {
@@ -66,17 +70,26 @@ const configForRole = (role: SemanticColorRoles) => {
         group: `background.${role}`,
       },
       [`${role}-strong`]: {
-        value: `{ax.${role}.600.value}`,
+        value:
+          role === "neutral"
+            ? `{ax.${role}.700.value}`
+            : `{ax.${role}.600.value}`,
         type: "color",
         group: `background.${role}`,
       },
       [`${role}-strong-hover`]: {
-        value: `{ax.${role}.700.value}`,
+        value:
+          role === "neutral"
+            ? `{ax.${role}.800.value}`
+            : `{ax.${role}.700.value}`,
         type: "color",
         group: `background.${role}`,
       },
       [`${role}-strong-pressed`]: {
-        value: `{ax.${role}.800.value}`,
+        value:
+          role === "neutral"
+            ? `{ax.${role}.900.value}`
+            : `{ax.${role}.800.value}`,
         type: "color",
         group: `background.${role}`,
       },
@@ -88,7 +101,6 @@ const configForRole = (role: SemanticColorRoles) => {
         group: `text.${role}`,
       },
       [`${role}-subtle`]: {
-        /* Gray colors are percieved a little lighter than other colored versions. */
         value:
           role === "neutral"
             ? `{ax.${role}.900.value}`

--- a/@navikt/core/tokens/darkside/tokens/semantic.ts
+++ b/@navikt/core/tokens/darkside/tokens/semantic.ts
@@ -2,7 +2,6 @@ import {
   type BorderColorKeys,
   type ColorTheme,
   type DefaultTextColorKeys,
-  type StatefulDefaultBgKeys,
   type StaticDefaultBgKeys,
 } from "../../types";
 import { type StyleDictionaryToken } from "../tokens.util";
@@ -10,28 +9,8 @@ import { type StyleDictionaryToken } from "../tokens.util";
 export function semanticTokenConfig(theme: ColorTheme) {
   return {
     text: {
-      default: {
-        value: "{ax.neutral.1000.value}",
-        type: "color",
-        group: "text",
-      },
-      subtle: {
-        value: "{ax.neutral.900.value}",
-        type: "color",
-        group: "text",
-      },
-      icon: {
-        value: "{ax.neutral.600.value}",
-        type: "color",
-        group: "text",
-      },
       logo: {
         value: theme === "light" ? "#C30000" : "{ax.neutral.1000.value}",
-        type: "color",
-        group: "text",
-      },
-      contrast: {
-        value: "{ax.neutral.000.value}",
         type: "color",
         group: "text",
       },
@@ -73,107 +52,8 @@ export function semanticTokenConfig(theme: ColorTheme) {
         type: "color",
         group: "background",
       },
-      soft: {
-        value: `{ax.neutral.100.value}`,
-        type: "color",
-        group: `background`,
-      },
-      softA: {
-        value: `{ax.neutral.100A.value}`,
-        type: "color",
-        group: `background`,
-      },
-      "soft-hover": {
-        value: `{ax.neutral.200.value}`,
-        type: "color",
-        group: `background`,
-      },
-      "soft-hoverA": {
-        value: `{ax.neutral.200A.value}`,
-        type: "color",
-        group: `background`,
-      },
-      "soft-pressed": {
-        value: `{ax.neutral.300.value}`,
-        type: "color",
-        group: `background`,
-      },
-      "soft-pressedA": {
-        value: `{ax.neutral.300A.value}`,
-        type: "color",
-        group: `background`,
-      },
-      moderate: {
-        value: `{ax.neutral.200.value}`,
-        type: "color",
-        group: `background`,
-      },
-      moderateA: {
-        value: `{ax.neutral.200A.value}`,
-        type: "color",
-        group: `background`,
-      },
-      "moderate-hover": {
-        value: `{ax.neutral.300.value}`,
-        type: "color",
-        group: `background`,
-      },
-      "moderate-hoverA": {
-        value: `{ax.neutral.300A.value}`,
-        type: "color",
-        group: `background`,
-      },
-      "moderate-pressed": {
-        value: `{ax.neutral.400.value}`,
-        type: "color",
-        group: `background`,
-      },
-      "moderate-pressedA": {
-        value: `{ax.neutral.400A.value}`,
-        type: "color",
-        group: `background`,
-      },
-      strong: {
-        value: `{ax.neutral.700.value}`,
-        type: "color",
-        group: `background`,
-      },
-      "strong-hover": {
-        value: `{ax.neutral.800.value}`,
-        type: "color",
-        group: `background`,
-      },
-      "strong-pressed": {
-        value: `{ax.neutral.900.value}`,
-        type: "color",
-        group: `background`,
-      },
     },
     border: {
-      default: {
-        value: "{ax.neutral.600.value}",
-        type: "color",
-        group: "border",
-      },
-      subtle: {
-        value: "{ax.neutral.400.value}",
-        type: "color",
-        group: "border",
-      },
-      subtleA: {
-        value: "{ax.neutral.400A.value}",
-        type: "color",
-        group: "border",
-      },
-      strong: {
-        value: "{ax.neutral.700.value}",
-        type: "color",
-        group: "border",
-      },
-      /**
-       * TODO: Need to verify this value
-       * - Discuss with brand
-       */
       focus: {
         value: "{ax.neutral.1000.value}",
         type: "color",
@@ -185,10 +65,7 @@ export function semanticTokenConfig(theme: ColorTheme) {
       },
     },
   } satisfies {
-    bg: Record<
-      StaticDefaultBgKeys | StatefulDefaultBgKeys,
-      StyleDictionaryToken<"color">
-    >;
+    bg: Record<StaticDefaultBgKeys, StyleDictionaryToken<"color">>;
     border: Record<BorderColorKeys, StyleDictionaryToken<"color">>;
     text: Record<DefaultTextColorKeys, StyleDictionaryToken<"color">>;
   };

--- a/@navikt/core/tokens/darkside/tokens/text-contrast.ts
+++ b/@navikt/core/tokens/darkside/tokens/text-contrast.ts
@@ -4,6 +4,11 @@ import { type StyleDictionaryToken } from "../tokens.util";
 export const textContrastTokenConfig = {
   text: {
     /* core */
+    "neutral-contrast": {
+      value: "{ax.neutral.000.value}",
+      type: "color",
+      group: `text.accent`,
+    },
     "accent-contrast": {
       value: "{ax.neutral.000.value}",
       type: "color",

--- a/@navikt/core/tokens/types.ts
+++ b/@navikt/core/tokens/types.ts
@@ -48,24 +48,7 @@ export type StaticDefaultBgKeys =
   | "input"
   | "raised"
   | "sunken"
-  | "overlay"
-  | "soft"
-  | "softA"
-  | "moderate"
-  | "moderateA"
-  | "strong";
-
-export type StatefulDefaultBgKeys =
-  | "soft-hover"
-  | "soft-hoverA"
-  | "soft-pressed"
-  | "soft-pressedA"
-  | "moderate-hover"
-  | "moderate-hoverA"
-  | "moderate-pressed"
-  | "moderate-pressedA"
-  | "strong-hover"
-  | "strong-pressed";
+  | "overlay";
 
 export type StaticBgKeys =
   | `${SemanticColorRoles}-soft`
@@ -86,12 +69,7 @@ export type StatefulBgKeys =
   | `${SemanticColorRoles}-strong-hover`
   | `${SemanticColorRoles}-strong-pressed`;
 
-export type DefaultTextColorKeys =
-  | "default"
-  | "subtle"
-  | "icon"
-  | "logo"
-  | "contrast";
+export type DefaultTextColorKeys = "logo";
 
 export type TextColorKeys =
   | SemanticColorRoles
@@ -99,12 +77,7 @@ export type TextColorKeys =
   | `${SemanticColorRoles}-icon`
   | `${SemanticColorRoles}-contrast`;
 
-export type BorderColorKeys =
-  | "default"
-  | "subtle"
-  | "subtleA"
-  | "strong"
-  | "focus";
+export type BorderColorKeys = "focus";
 
 export type BorderColorWithRoleKeys =
   | SemanticColorRoles

--- a/examples/referansesider/src/components/MiniTag.tsx
+++ b/examples/referansesider/src/components/MiniTag.tsx
@@ -5,7 +5,7 @@ const bgMap = {
   info: tokens.BgInfoSoft,
   warning: tokens.BgWarningSoft,
   success: tokens.BgSuccessSoft,
-  neutral: tokens.BgModerate,
+  neutral: tokens.BgNeutralModerate,
   ["info-moderate"]: tokens.BgInfoModerate,
   ["warning-moderate"]: tokens.BgWarningModerate,
   ["success-moderate"]: tokens.BgSuccessModerate,
@@ -13,14 +13,14 @@ const bgMap = {
   ["info-strong"]: tokens.BgInfoStrong,
   ["warning-strong"]: tokens.BgWarningStrong,
   ["success-strong"]: tokens.BgSuccessStrong,
-  ["neutral-strong"]: tokens.BgModeratePressed,
+  ["neutral-strong"]: tokens.BgNeutralModeratePressed,
 };
 
 const fgMap = {
   info: tokens.TextInfoSubtle,
   warning: tokens.TextWarningSubtle,
   success: tokens.TextSuccessSubtle,
-  neutral: tokens.BgModerate,
+  neutral: tokens.BgNeutralModerate,
   ["info-moderate"]: tokens.TextInfo,
   ["warning-moderate"]: tokens.TextWarning,
   ["success-moderate"]: tokens.TextSuccess,
@@ -28,14 +28,14 @@ const fgMap = {
   ["info-strong"]: tokens.TextInfo,
   ["warning-strong"]: tokens.TextWarning,
   ["success-strong"]: tokens.TextSuccess,
-  ["neutral-strong"]: tokens.BgModeratePressed,
+  ["neutral-strong"]: tokens.BgNeutralModeratePressed,
 };
 
 const borderMap = {
   info: tokens.BorderInfo,
   warning: tokens.BorderWarning,
   success: tokens.BorderSuccess,
-  neutral: tokens.BorderDefault,
+  neutral: tokens.BorderNeutral,
 };
 
 export const MiniTag = styled.span<{

--- a/examples/referansesider/src/components/aktivitetsplan/ActivityCard.tsx
+++ b/examples/referansesider/src/components/aktivitetsplan/ActivityCard.tsx
@@ -6,7 +6,7 @@ const ActivityCard = ({ children }: { children: ReactNode }) => {
     <Box.New
       className="activity-card"
       background="raised"
-      borderColor="subtleA"
+      borderColor="neutral-subtleA"
       borderRadius="xlarge"
       borderWidth="1"
       paddingInline="space-16"

--- a/examples/referansesider/src/components/aktivitetsplan/ActivityColumn.tsx
+++ b/examples/referansesider/src/components/aktivitetsplan/ActivityColumn.tsx
@@ -13,7 +13,7 @@ const ActivityColumn = ({
   return (
     <Box.New
       background="sunken"
-      borderColor="subtleA"
+      borderColor="neutral-subtleA"
       borderWidth="1"
       borderRadius="xlarge"
       padding="space-12"

--- a/examples/referansesider/src/components/aktivitetsplan/MainCard.tsx
+++ b/examples/referansesider/src/components/aktivitetsplan/MainCard.tsx
@@ -4,7 +4,7 @@ import { Box, HStack } from "@navikt/ds-react";
 const MainCard = ({ children }: { children: ReactNode }) => (
   <Box.New
     background="raised"
-    borderColor="subtleA"
+    borderColor="neutral-subtleA"
     borderWidth="1"
     borderRadius="xlarge"
     padding="space-16"

--- a/examples/referansesider/src/components/aktivitetsplan/modal/JobInterestBox.tsx
+++ b/examples/referansesider/src/components/aktivitetsplan/modal/JobInterestBox.tsx
@@ -22,11 +22,11 @@ const JobInterestBox = ({
   const [shouldSave, setShouldSave] = React.useState(undefined);
   return (
     <Box.New
-      borderColor="subtleA"
+      borderColor="neutral-subtleA"
       borderWidth="1"
       borderRadius="xlarge"
       padding="space-12"
-      background="softA"
+      background="neutral-softA"
     >
       <VStack gap="4">
         <Heading size="small" as="h2">

--- a/examples/referansesider/src/routes/sykepenger.tsx
+++ b/examples/referansesider/src/routes/sykepenger.tsx
@@ -16,7 +16,7 @@ import { Page } from "../components/Page";
 import { ThemeProviderContext } from "../theme/ThemeContext";
 
 const EyeBrowText = styled.span`
-  color: ${tokens.TextSubtle};
+  color: ${tokens.TextNeutralSubtle};
   font-size: 20px;
   font-weight: 400;
   line-height: 20px;
@@ -218,8 +218,8 @@ let PlainOrderedList: ReactNode;
 let AccordionItem: ReactNode;
 {
   const ScDetails = styled.details`
-    border-top: 1px solid ${tokens.BorderSubtle};
-    border-bottom: 1px solid ${tokens.BorderSubtle};
+    border-top: 1px solid ${tokens.BorderNeutralSubtle};
+    border-bottom: 1px solid ${tokens.BorderNeutralSubtle};
 
     &:hover,
     &:focus-within {
@@ -308,7 +308,7 @@ let MiniCard: ReactNode;
   const ScSubtitle = styled.span`
     font-variant-caps: all-small-caps;
     font-size: 20px;
-    color: ${tokens.TextSubtle};
+    color: ${tokens.TextNeutralSubtle};
   `;
 
   const ScTitle = styled.span`

--- a/examples/referansesider/yarn.lock
+++ b/examples/referansesider/yarn.lock
@@ -800,14 +800,14 @@ __metadata:
 
 "@navikt/ds-css@file:../../@navikt/core/css::locator=referansesider%40workspace%3A.":
   version: 7.11.0
-  resolution: "@navikt/ds-css@file:../../@navikt/core/css#../../@navikt/core/css::hash=5839e3&locator=referansesider%40workspace%3A."
-  checksum: 10/a5a55307bd199c43d71b296042882dd7b8301e59200639da00358e3cddd3f7e57d4047a237bf5516f1968962a3c895ca3bcabf340419e6035676d38e8c6a3ac1
+  resolution: "@navikt/ds-css@file:../../@navikt/core/css#../../@navikt/core/css::hash=ebd133&locator=referansesider%40workspace%3A."
+  checksum: 10/99fe96ffed8ef2501edc931e6c4d55ea415a6f84c5b3ec562ad626503afa0c3fd028abb2b915fd72c22dd309f1e0db4253b7dca0e6233d3c1798610eedf801db
   languageName: node
   linkType: hard
 
 "@navikt/ds-react@file:../../@navikt/core/react::locator=referansesider%40workspace%3A.":
   version: 7.11.0
-  resolution: "@navikt/ds-react@file:../../@navikt/core/react#../../@navikt/core/react::hash=b4e778&locator=referansesider%40workspace%3A."
+  resolution: "@navikt/ds-react@file:../../@navikt/core/react#../../@navikt/core/react::hash=238abe&locator=referansesider%40workspace%3A."
   dependencies:
     "@floating-ui/react": "npm:0.25.4"
     "@floating-ui/react-dom": "npm:^2.0.9"
@@ -822,14 +822,14 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ac65c5f17b8b85f80d210324bf7ec76264351aa9324bf001682543436bc0bd1ff0dc95390a5f199ef342ff69894524677b187261e600fce5949e40b695088ef9
+  checksum: 10/e15199c1a167d08033344a062b739306f0579e79f3872b3207c79a5bf84c0a2a70df27aae4da181046b623dd3b48cec7c96d79016baed4393a8d9cb90daff50b
   languageName: node
   linkType: hard
 
 "@navikt/ds-tokens@file:../../@navikt/core/tokens::locator=referansesider%40workspace%3A.":
   version: 7.11.0
-  resolution: "@navikt/ds-tokens@file:../../@navikt/core/tokens#../../@navikt/core/tokens::hash=7948b3&locator=referansesider%40workspace%3A."
-  checksum: 10/095b0311b58150adc39c3ea4cbc55634a1fe4fd595832bfa0e1ae23782cd3ae2a61ec9cf4fa08500f41c9c90ee17d3d98a06fb4d299b08d8a219d13ad9c25dd5
+  resolution: "@navikt/ds-tokens@file:../../@navikt/core/tokens#../../@navikt/core/tokens::hash=9ed997&locator=referansesider%40workspace%3A."
+  checksum: 10/341e8cd508d509bf2af6b34ba7d58585318bce71e59d664ee546b1cf413fb9ab72e58fe29c72d377b9e6a98505e75846060492ef8c7f11233780938b165da288
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Now explicitly require `neutral`-role to be used for "neutral"-color tokens

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
