### PR TITLE
[Darkside] Tailwind support

### DIFF
--- a/.changeset/great-beds-jump.md
+++ b/.changeset/great-beds-jump.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-tailwind": patch
+---
+
+Tailwind: Added `darkside`-support with import `@navikt/ds-tailwind/darkside`.

--- a/.changeset/great-beds-jump.md
+++ b/.changeset/great-beds-jump.md
@@ -2,4 +2,4 @@
 "@navikt/ds-tailwind": patch
 ---
 
-Tailwind: Added `darkside`-support with import `@navikt/ds-tailwind/darkside`.
+Tailwind: Added `darkside`-support with import `@navikt/ds-tailwind/darkside-tw3`.

--- a/.storybook/docs/PilotMigration.mdx
+++ b/.storybook/docs/PilotMigration.mdx
@@ -40,6 +40,15 @@ All component-spesific tokens are no longer supported. That means all tokens lik
 
 All component-based tokens are prefixed with `--ac`, so a global search in your codebase should find all of them.
 
+## Tailwind CSS
+
+Since our Tailwind CSS config is tied to our tokens, most changes made to the tokens will affect the Tailwind CSS config.
+We have decided to prefix all our classes with `ax-` in the new config, so it should be possible to use both packages at the same time. We will develop tooling to hopefuly make the migrations easier in the future.
+
+### Removed classes
+
+z-index, maxWidth and spacing classes are removed from the new config.
+
 ## React
 
 We have made some updates to `@navikt/ds-react` that you should be aware of before testing.

--- a/.storybook/docs/PilotSetup.mdx
+++ b/.storybook/docs/PilotSetup.mdx
@@ -123,6 +123,6 @@ Since our implementation is based on CSS, you can easily make custom adjustments
 ```
 // Tailwind v3
 module.exports = {
-  presets: [require("@navikt/ds-tailwind/darkside")],
+  presets: [require("@navikt/ds-tailwind/darkside-tw3")],
 }
 ```

--- a/.storybook/docs/PilotSetup.mdx
+++ b/.storybook/docs/PilotSetup.mdx
@@ -117,3 +117,12 @@ Since our implementation is based on CSS, you can easily make custom adjustments
   }
 }
 ```
+
+## Tailwind CSS
+
+```
+// Tailwind v3
+module.exports = {
+  presets: [require("@navikt/ds-tailwind/darkside")],
+}
+```

--- a/.storybook/docs/PilotsIntro.mdx
+++ b/.storybook/docs/PilotsIntro.mdx
@@ -44,6 +44,7 @@ We welcome all forms of feedback:
 - **Design tokens**: A complete re-write of our design tokens to allow for dark mode.
 - **Dark mode**: A new dark mode implementation.
 - **Updated CSS**: Now uses new tokens, built-in CSS-layers support and most components are re-written.
+- **Updated Tailwind CSS config**: Now uses new tokens, now comes with built-in `ax`-prefix for easier separation between Aksel and your own config.
 - **Updated components**: Components use the new tokens and CSS.
 - **New Theme-component**: A new `<Theme/>`-component to handle the theming-switch locally.
 - **Updated documentation**: Updated documentation for the new implementation.
@@ -82,6 +83,11 @@ We have updated our CSS to be based on the new tokens for theming.
 - All custom overrides targeting `.navds`-classes might have to be updated locally.
 - You will not be able to use the old CSS and the new CSS at the same time.
 - Component-based tokens are no longer avaliable.
+
+### Tailwind CSS
+
+We have made a new Tailwind CSS config based on the new tokens. Based on previous iterations, we have decided to try prefixing all our classes with `ax-`.
+While this will be a little more verbose, it makes it easier to separate your own config from ours, and hopefully makes it easier to maintain.
 
 ### React components
 

--- a/@navikt/core/tailwind/darkside.test.ts
+++ b/@navikt/core/tailwind/darkside.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { breakpointTokenConfig } from "../tokens/darkside/tokens/breakpoint";
-import { config, extractTokensForCategory } from "./darkside";
+import { config } from "./darkside";
 
 describe("Darkside tailwind config", () => {
   test("should have correct color tokens", () => {
@@ -13,51 +12,5 @@ describe("Darkside tailwind config", () => {
     expect(colorKeys).not.toContain("font-family");
     expect(colorKeys).not.toContain("border-radius");
     expect(colorKeys).not.toContain("breakpoint");
-  });
-
-  test("should have correct screen breakpoints", () => {
-    expect(config.theme.screens.sm).toBe(
-      breakpointTokenConfig.breakpoint.sm.value,
-    );
-    expect(config.theme.screens.md).toBe(
-      breakpointTokenConfig.breakpoint.md.value,
-    );
-    expect(config.theme.screens.lg).toBe(
-      breakpointTokenConfig.breakpoint.lg.value,
-    );
-    expect(config.theme.screens.xl).toBe(
-      breakpointTokenConfig.breakpoint.xl.value,
-    );
-    expect(config.theme.screens["2xl"]).toBe(
-      breakpointTokenConfig.breakpoint["2xl"].value,
-    );
-  });
-
-  test("should have correct extended properties", () => {
-    expect(config.theme.extend.shadow).toEqual(
-      extractTokensForCategory("shadow"),
-    );
-    expect(config.theme.extend.fontWeight).toEqual(
-      extractTokensForCategory("font-weight"),
-    );
-    expect(config.theme.extend.fontSize).toEqual(
-      extractTokensForCategory("font-size"),
-    );
-    expect(config.theme.extend.lineHeight).toEqual(
-      extractTokensForCategory("font-line-height"),
-    );
-    expect(config.theme.extend.fontFamily).toEqual(
-      extractTokensForCategory("font-family"),
-    );
-    expect(config.theme.extend.borderRadius).toEqual(
-      extractTokensForCategory("border-radius"),
-    );
-  });
-
-  test("should extract tokens correctly for a given category", () => {
-    const spacingTokens = extractTokensForCategory("spacing");
-    Object.entries(spacingTokens).forEach(([key]) => {
-      expect(key).not.toContain("spacing-");
-    });
   });
 });

--- a/@navikt/core/tailwind/darkside.ts
+++ b/@navikt/core/tailwind/darkside.ts
@@ -29,28 +29,26 @@ const nonColorTokens = [
 const colorTokensEntries = Object.entries(transformedTokens).filter(([key]) => {
   return !nonColorTokens.find((prefix) => key.toLowerCase().includes(prefix));
 });
-const colors = Object.fromEntries(colorTokensEntries);
+const colors = Object.fromEntries(colorTokensEntries) as Record<string, string>;
 
 export const config = {
   theme: {
-    ax: {
-      colors,
-      screens: {
-        sm: breakpointTokenConfig.breakpoint.sm.value,
-        md: breakpointTokenConfig.breakpoint.md.value,
-        lg: breakpointTokenConfig.breakpoint.lg.value,
-        xl: breakpointTokenConfig.breakpoint.xl.value,
-        "2xl": breakpointTokenConfig.breakpoint["2xl"].value,
-      },
-      extend: {
-        shadow: extractTokensForCategory("shadow"),
-        fontWeight: extractTokensForCategory("font-weight"),
-        fontSize: extractTokensForCategory("font-size"),
-        lineHeight: extractTokensForCategory("font-line-height"),
-        fontFamily: extractTokensForCategory("font-family"),
-        borderRadius: extractTokensForCategory("border-radius"),
-        opacity: extractTokensForCategory("opacity"),
-      },
+    colors: prefixTokens(colors),
+    screens: prefixTokens({
+      sm: breakpointTokenConfig.breakpoint.sm.value,
+      md: breakpointTokenConfig.breakpoint.md.value,
+      lg: breakpointTokenConfig.breakpoint.lg.value,
+      xl: breakpointTokenConfig.breakpoint.xl.value,
+      "2xl": breakpointTokenConfig.breakpoint["2xl"].value,
+    }),
+    extend: {
+      boxShadow: prefixTokens(extractTokensForCategory("shadow")),
+      fontWeight: prefixTokens(extractTokensForCategory("font-weight")),
+      fontSize: prefixTokens(extractTokensForCategory("font-size")),
+      lineHeight: prefixTokens(extractTokensForCategory("font-line-height")),
+      fontFamily: prefixTokens(extractTokensForCategory("font-family")),
+      borderRadius: prefixTokens(extractTokensForCategory("border-radius")),
+      opacity: prefixTokens(extractTokensForCategory("opacity")),
     },
   },
 };
@@ -71,4 +69,17 @@ export function extractTokensForCategory(tokenName: string) {
     .map(([key, value]) => [key.replace(`${tokenName}-`, ""), value]);
 
   return Object.fromEntries(tokens);
+}
+
+/**
+ * Prefixes all keys in a token object with "ax-" to avoid conflicts with TailwindCSS
+ * While making the token more verbose, it communicates better that the token is from Aksel and not locally defined.
+ */
+function prefixTokens(tokens: Record<string, string>) {
+  const withPrefix: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(tokens)) {
+    withPrefix[`ax-${key}`] = value;
+  }
+  return withPrefix;
 }

--- a/@navikt/core/tailwind/darkside.ts
+++ b/@navikt/core/tailwind/darkside.ts
@@ -33,22 +33,24 @@ const colors = Object.fromEntries(colorTokensEntries);
 
 export const config = {
   theme: {
-    colors,
-    screens: {
-      sm: breakpointTokenConfig.breakpoint.sm.value,
-      md: breakpointTokenConfig.breakpoint.md.value,
-      lg: breakpointTokenConfig.breakpoint.lg.value,
-      xl: breakpointTokenConfig.breakpoint.xl.value,
-      "2xl": breakpointTokenConfig.breakpoint["2xl"].value,
-    },
-    extend: {
-      shadow: extractTokensForCategory("shadow"),
-      fontWeight: extractTokensForCategory("font-weight"),
-      fontSize: extractTokensForCategory("font-size"),
-      lineHeight: extractTokensForCategory("font-line-height"),
-      fontFamily: extractTokensForCategory("font-family"),
-      borderRadius: extractTokensForCategory("border-radius"),
-      opacity: extractTokensForCategory("opacity"),
+    ax: {
+      colors,
+      screens: {
+        sm: breakpointTokenConfig.breakpoint.sm.value,
+        md: breakpointTokenConfig.breakpoint.md.value,
+        lg: breakpointTokenConfig.breakpoint.lg.value,
+        xl: breakpointTokenConfig.breakpoint.xl.value,
+        "2xl": breakpointTokenConfig.breakpoint["2xl"].value,
+      },
+      extend: {
+        shadow: extractTokensForCategory("shadow"),
+        fontWeight: extractTokensForCategory("font-weight"),
+        fontSize: extractTokensForCategory("font-size"),
+        lineHeight: extractTokensForCategory("font-line-height"),
+        fontFamily: extractTokensForCategory("font-family"),
+        borderRadius: extractTokensForCategory("border-radius"),
+        opacity: extractTokensForCategory("opacity"),
+      },
     },
   },
 };

--- a/@navikt/core/tailwind/package.json
+++ b/@navikt/core/tailwind/package.json
@@ -50,7 +50,7 @@
         "default": "./tailwind.config.js"
       }
     },
-    "./darkside": {
+    "./darkside-tw3": {
       "import": {
         "types": "./tailwind.config.d.ts",
         "default": "./tailwind.darkside.config.js"

--- a/@navikt/core/tailwind/package.json
+++ b/@navikt/core/tailwind/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "files": [
     "tailwind.config.js",
-    "tailwind.config.d.ts"
+    "tailwind.config.d.ts",
+    "tailwind.darkside.config.js"
   ],
   "scripts": {
     "build": "tsx ./src && yarn build:darkside",

--- a/@navikt/core/tailwind/package.json
+++ b/@navikt/core/tailwind/package.json
@@ -48,6 +48,16 @@
         "types": "./tailwind.config.d.ts",
         "default": "./tailwind.config.js"
       }
+    },
+    "./darkside": {
+      "import": {
+        "types": "./tailwind.config.d.ts",
+        "default": "./tailwind.darkside.config.js"
+      },
+      "require": {
+        "types": "./tailwind.config.d.ts",
+        "default": "./tailwind.darkside.config.js"
+      }
     }
   }
 }

--- a/aksel.nav.no/website/tailwind.config.js
+++ b/aksel.nav.no/website/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  presets: [require("@navikt/ds-tailwind")],
+  presets: [require("@navikt/ds-tailwind/darkside")],
   content: [
     "./pages/**/*.{js,ts,jsx,tsx}",
     "./sanity/**/*.{js,ts,jsx,tsx}",

--- a/aksel.nav.no/website/tailwind.config.js
+++ b/aksel.nav.no/website/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  presets: [require("@navikt/ds-tailwind/darkside")],
+  presets: [require("@navikt/ds-tailwind")],
   content: [
     "./pages/**/*.{js,ts,jsx,tsx}",
     "./sanity/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
### Description

Added tailwind-support for new tokens. They are all now prefixed with "ax", so for example `bg-ax-bg-accent-soft` will be how you write the tokens now. While this is a little verbose, it communicates better that the token is custom and where it originates from.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
