### PR TITLE
[Darkside] :sparkles: Added migration for css, less and scss

### DIFF
--- a/@navikt/aksel/src/codemod/migrations.ts
+++ b/@navikt/aksel/src/codemod/migrations.ts
@@ -107,7 +107,7 @@ export const migrations: {
     {
       description:
         "Updates css, scss and less-variables to use new `space`-tokens. (Works with old and new system)",
-      value: "css-spacing",
+      value: "token-spacing",
       path: "darkside/token-spacing/spacing",
     },
   ],

--- a/@navikt/aksel/src/codemod/migrations.ts
+++ b/@navikt/aksel/src/codemod/migrations.ts
@@ -104,6 +104,12 @@ export const migrations: {
       value: "primitive-spacing",
       path: "darkside/primitives-spacing/spacing",
     },
+    {
+      description:
+        "Updates css, scss and less-variables to use new `space`-tokens. (Works with old and new system)",
+      value: "css-spacing",
+      path: "darkside/token-spacing/spacing",
+    },
   ],
 };
 

--- a/@navikt/aksel/src/codemod/transforms/darkside/darkside.utils.ts
+++ b/@navikt/aksel/src/codemod/transforms/darkside/darkside.utils.ts
@@ -112,4 +112,41 @@ function isAkselReactImport(path: ASTPath<ImportDeclaration>) {
   );
 }
 
-export { findComponentImport, findJSXElement, findProp };
+/**
+ * Maps old spacing-token values to new space-tokens
+ */
+const legacySpacingTokenMap = new Map<string, string>([
+  ["32", "128"],
+  ["24", "96"],
+  ["20", "80"],
+  ["18", "72"],
+  ["16", "64"],
+  ["14", "56"],
+  ["12", "48"],
+  ["11", "44"],
+  ["10", "40"],
+  ["9", "36"],
+  ["8", "32"],
+  ["7", "28"],
+  ["6", "24"],
+  ["5", "20"],
+  ["4", "16"],
+  ["3", "12"],
+  ["2", "8"],
+  ["1-alt", "6"],
+  ["1", "4"],
+  ["05", "2"],
+  ["0", "0"],
+]);
+
+function convertSpacingToSpace(spacing: string): string | null {
+  return legacySpacingTokenMap.get(spacing) || null;
+}
+
+export {
+  findComponentImport,
+  findJSXElement,
+  findProp,
+  convertSpacingToSpace,
+  legacySpacingTokenMap,
+};

--- a/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/spacing.ts
+++ b/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/spacing.ts
@@ -1,0 +1,28 @@
+import type { FileInfo } from "jscodeshift";
+import { translateToken } from "../../../utils/translate-token";
+import { legacySpacingTokenMap } from "../darkside.utils";
+
+export default function transformer(file: FileInfo) {
+  let src = file.source;
+
+  legacySpacingTokenMap.forEach((newVar, oldVar) => {
+    const oldCSSVar = `--a-spacing-${oldVar}`;
+    const newCSSVar = `--a-space-${newVar}`;
+
+    const CSSRgx = new RegExp("(" + oldCSSVar + ")", "gm");
+    const SCSSRgx = new RegExp(
+      "(\\" + translateToken(oldCSSVar, "scss") + ")",
+      "gm",
+    );
+    const LESSRgx = new RegExp(
+      "(" + translateToken(oldCSSVar, "less") + ")",
+      "gm",
+    );
+
+    src = src.replace(CSSRgx, newCSSVar);
+    src = src.replace(SCSSRgx, translateToken(newCSSVar, "scss"));
+    src = src.replace(LESSRgx, translateToken(newCSSVar, "less"));
+  });
+
+  return src;
+}

--- a/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/complete.input.css
+++ b/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/complete.input.css
@@ -1,0 +1,7 @@
+.test {
+  margin: var(--a-spacing-4);
+  padding: var(--a-spacing-16);
+  padding: var(--a-spacing-0);
+  padding: var(--a-spacing-1-alt);
+  padding: var(--a-spacing-05);
+}

--- a/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/complete.input.less
+++ b/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/complete.input.less
@@ -1,0 +1,7 @@
+.test {
+  margin: @a-spacing-4;
+  padding: @a-spacing-16;
+  padding: @a-spacing-0;
+  padding: @a-spacing-1-alt;
+  padding: @a-spacing-05;
+}

--- a/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/complete.input.scss
+++ b/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/complete.input.scss
@@ -1,0 +1,7 @@
+.test {
+  margin: $a-spacing-4;
+  padding: $a-spacing-16;
+  padding: $a-spacing-0;
+  padding: common.$a-spacing-1-alt;
+  padding: common.$a-spacing-05;
+}

--- a/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/complete.output.css
+++ b/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/complete.output.css
@@ -1,0 +1,7 @@
+.test {
+  margin: var(--a-space-16);
+  padding: var(--a-space-64);
+  padding: var(--a-space-0);
+  padding: var(--a-space-6);
+  padding: var(--a-space-2);
+}

--- a/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/complete.output.less
+++ b/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/complete.output.less
@@ -1,0 +1,7 @@
+.test {
+  margin: @a-space-16;
+  padding: @a-space-64;
+  padding: @a-space-0;
+  padding: @a-space-6;
+  padding: @a-space-2;
+}

--- a/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/complete.output.scss
+++ b/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/complete.output.scss
@@ -1,0 +1,7 @@
+.test {
+  margin: $a-space-16;
+  padding: $a-space-64;
+  padding: $a-space-0;
+  padding: common.$a-space-6;
+  padding: common.$a-space-2;
+}

--- a/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/spacing.test.ts
+++ b/@navikt/aksel/src/codemod/transforms/darkside/token-spacing/tests/spacing.test.ts
@@ -1,0 +1,24 @@
+import { check } from "../../../../utils/check";
+
+const migration = "spacing";
+const fixtures = ["complete"];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    migration,
+    extension: "css",
+  });
+
+  check(__dirname, {
+    fixture,
+    migration,
+    extension: "scss",
+  });
+
+  check(__dirname, {
+    fixture,
+    migration,
+    extension: "less",
+  });
+}


### PR DESCRIPTION
### Description

This allows user to migrate all css, less and scss variants of their spacing-tokens to new space-values.
- scss: $a-spacing-x
- less: @a-spacing-x
- css: var(--a-spacing-x)

Next up is adding js-support for migration. There are some teams that frequently import spacing-tokens from the js-export.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
