### PR TITLE
P2: [Darkside] Migration from spacing -> space for js/ts files

### DIFF
--- a/.changeset/heavy-snails-draws.md
+++ b/.changeset/heavy-snails-draws.md
@@ -1,0 +1,5 @@
+---
+"@navikt/aksel": minor
+---
+
+CLI: Added js/ts migration to new space-tokens. Run `npx @navikt/aksel migration token-spacing-js` to start migrating now. This update is supported for old and new (darkside) system.

--- a/@navikt/aksel/src/codemod/migrations.ts
+++ b/@navikt/aksel/src/codemod/migrations.ts
@@ -110,6 +110,12 @@ export const migrations: {
       value: "token-spacing",
       path: "darkside/token-spacing/spacing",
     },
+    {
+      description:
+        "Updates js-tokens to use new `space`-tokens. (Works with old and new system)",
+      value: "token-spacing-js",
+      path: "darkside/token-spacing-js/spacing",
+    },
   ],
 };
 

--- a/@navikt/aksel/src/codemod/transforms/darkside/darkside.utils.ts
+++ b/@navikt/aksel/src/codemod/transforms/darkside/darkside.utils.ts
@@ -15,8 +15,9 @@ function findComponentImport(input: {
   j: API["j"];
   file: FileInfo;
   name: string;
+  packageType?: "react" | "tokens";
 }) {
-  const { j, file, name: _name } = input;
+  const { j, file, name: _name, packageType = "react" } = input;
 
   /* Account for sub-components */
   const name = _name.includes(".") ? _name.split(".")[0] : _name;
@@ -26,7 +27,11 @@ function findComponentImport(input: {
   let foundName: string | null = null;
 
   root.find(j.ImportDeclaration).forEach((path) => {
-    if (!isAkselReactImport(path)) {
+    if (packageType === "react" && !isAkselReactImport(path)) {
+      return;
+    }
+
+    if (packageType === "tokens" && !isAkselTokensImport(path)) {
       return;
     }
 
@@ -109,6 +114,17 @@ function isAkselReactImport(path: ASTPath<ImportDeclaration>) {
   return (
     typeof importSource === "string" &&
     importSource.startsWith("@navikt/ds-react")
+  );
+}
+
+/**
+ * Checks if an import is from @navikt/ds-tokens.
+ */
+function isAkselTokensImport(path: ASTPath<ImportDeclaration>) {
+  const importSource = path.node.source.value;
+  return (
+    typeof importSource === "string" &&
+    importSource.startsWith("@navikt/ds-tokens")
   );
 }
 

--- a/@navikt/aksel/src/codemod/transforms/darkside/token-spacing-js/spacing.ts
+++ b/@navikt/aksel/src/codemod/transforms/darkside/token-spacing-js/spacing.ts
@@ -1,0 +1,33 @@
+import type { API, FileInfo } from "jscodeshift";
+import { getLineTerminator } from "../../../utils/lineterminator";
+import { translateToken } from "../../../utils/translate-token";
+import { findComponentImport, legacySpacingTokenMap } from "../darkside.utils";
+
+export default function transformer(file: FileInfo, api: API) {
+  const j = api.jscodeshift;
+  let root = j(file.source);
+
+  legacySpacingTokenMap.forEach((newVar, oldVar) => {
+    const oldCSSVar = translateToken(`--a-spacing-${oldVar}`, "js");
+    const newCSSVar = translateToken(`--a-space-${newVar}`, "js");
+
+    const name = findComponentImport({
+      file,
+      j,
+      name: oldCSSVar,
+      packageType: "tokens",
+    });
+
+    if (!name) {
+      return;
+    }
+
+    let code = root.toSource(getLineTerminator(file.source));
+
+    const rgx = new RegExp("(" + oldCSSVar + ")", "gm");
+    code = code.replace(rgx, newCSSVar);
+    root = j(code);
+  });
+
+  return root.toSource(getLineTerminator(file.source));
+}

--- a/@navikt/aksel/src/codemod/transforms/darkside/token-spacing-js/tests/complete.input.js
+++ b/@navikt/aksel/src/codemod/transforms/darkside/token-spacing-js/tests/complete.input.js
@@ -1,0 +1,88 @@
+import styled from "styled-components";
+import {
+  ASpacing16 as abc132,
+  ASpacing32,
+  ASpacing8,
+  ASpacing1Alt,
+} from "@navikt/ds-tokens/dist/tokens";
+import { BodyShort } from "@navikt/ds-react";
+
+const StyledNavLink = styled(NavLink)`
+  border-bottom: 5px solid white;
+  color: inherit;
+  text-align: center;
+  text-decoration: none;
+  width: 100%;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  padding-left: 5px;
+  padding-right: 5px;
+  :hover {
+    border-bottom: 5px solid ${abc132};
+    p {
+      color: ${ASpacing1Alt};
+    }
+  }
+  &.active {
+    background-color: ${ASpacing32};
+    border-bottom: 5px solid ${ASpacing8};
+
+    .typo-normal {
+      font-weight: bold;
+    }
+  }
+`;
+
+const StyledLenketekst = styled(BodyShort)`
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+`;
+
+const StyledTekst = styled(BodyShort)`
+  border-bottom: 5px solid white;
+  color: ${NavdsGlobalColorGray400};
+  text-align: center;
+  text-decoration: none;
+  width: 100%;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  padding-left: 5px;
+  padding-right: 5px;
+`;
+
+const Fane = ({ side, behandlingId, index, deaktivert }) => {
+  const { gåTilUrl } = useApp();
+  const fanenavn = side.navn;
+  return (
+    <>
+      {deaktivert && (
+        <StyledTekst size={"small"}>
+          {index + 1}. {fanenavn}
+        </StyledTekst>
+      )}
+      {!deaktivert && (
+        <StyledNavLink
+          key={side.navn}
+          to={`/behandling/${behandlingId}/${side.href}`}
+          onClick={(e) => {
+            e.preventDefault();
+            gåTilUrl(`/behandling/${behandlingId}/${side.href}`);
+          }}
+        >
+          <StyledLenketekst size={"small"}>
+            {index + 1}. {fanenavn}
+          </StyledLenketekst>
+        </StyledNavLink>
+      )}
+    </>
+  );
+};
+
+export default Fane;

--- a/@navikt/aksel/src/codemod/transforms/darkside/token-spacing-js/tests/complete.output.js
+++ b/@navikt/aksel/src/codemod/transforms/darkside/token-spacing-js/tests/complete.output.js
@@ -1,0 +1,88 @@
+import styled from "styled-components";
+import {
+  ASpace64 as abc132,
+  ASpace128,
+  ASpace32,
+  ASpace6,
+} from "@navikt/ds-tokens/dist/tokens";
+import { BodyShort } from "@navikt/ds-react";
+
+const StyledNavLink = styled(NavLink)`
+  border-bottom: 5px solid white;
+  color: inherit;
+  text-align: center;
+  text-decoration: none;
+  width: 100%;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  padding-left: 5px;
+  padding-right: 5px;
+  :hover {
+    border-bottom: 5px solid ${abc132};
+    p {
+      color: ${ASpace6};
+    }
+  }
+  &.active {
+    background-color: ${ASpace128};
+    border-bottom: 5px solid ${ASpace32};
+
+    .typo-normal {
+      font-weight: bold;
+    }
+  }
+`;
+
+const StyledLenketekst = styled(BodyShort)`
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+`;
+
+const StyledTekst = styled(BodyShort)`
+  border-bottom: 5px solid white;
+  color: ${NavdsGlobalColorGray400};
+  text-align: center;
+  text-decoration: none;
+  width: 100%;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  padding-left: 5px;
+  padding-right: 5px;
+`;
+
+const Fane = ({ side, behandlingId, index, deaktivert }) => {
+  const { gåTilUrl } = useApp();
+  const fanenavn = side.navn;
+  return (
+    <>
+      {deaktivert && (
+        <StyledTekst size={"small"}>
+          {index + 1}. {fanenavn}
+        </StyledTekst>
+      )}
+      {!deaktivert && (
+        <StyledNavLink
+          key={side.navn}
+          to={`/behandling/${behandlingId}/${side.href}`}
+          onClick={(e) => {
+            e.preventDefault();
+            gåTilUrl(`/behandling/${behandlingId}/${side.href}`);
+          }}
+        >
+          <StyledLenketekst size={"small"}>
+            {index + 1}. {fanenavn}
+          </StyledLenketekst>
+        </StyledNavLink>
+      )}
+    </>
+  );
+};
+
+export default Fane;

--- a/@navikt/aksel/src/codemod/transforms/darkside/token-spacing-js/tests/spacing.test.ts
+++ b/@navikt/aksel/src/codemod/transforms/darkside/token-spacing-js/tests/spacing.test.ts
@@ -1,0 +1,12 @@
+import { check } from "../../../../utils/check";
+
+const migration = "spacing";
+const fixtures = ["complete"];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    migration,
+    extension: "js",
+  });
+}


### PR DESCRIPTION
### Description

Users can now run `npx @navikt/aksel migration token-spacing-js` to update all spacing-tokens from `@navikt/ds-tokens` in js/ts files.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
