### PR TITLE
:recycle: Cookie-tracking bug

### DIFF
--- a/aksel.nav.no/website/components/website-modules/ConsentBanner.tsx
+++ b/aksel.nav.no/website/components/website-modules/ConsentBanner.tsx
@@ -77,11 +77,6 @@ export const ConsentBanner = ({
               onClick={() => {
                 updateConsent("accepted");
                 setShowBanner(false);
-                // NOTE: umami _should_ exist on window object here (loaded via <Script>)
-                // we call track manually this _one_ time to ensure the current page is
-                // accounted for, any new page loads will be captured by data-auto-track
-                // https://umami.is/docs/tracker-configuration
-                // umami.track();
               }}
             >
               Godkjenn alle

--- a/aksel.nav.no/website/components/website-modules/ConsentBanner.tsx
+++ b/aksel.nav.no/website/components/website-modules/ConsentBanner.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import getConfig from "next/config";
 import NextLink from "next/link";
-import Script from "next/script";
 import { useEffect, useState } from "react";
 import {
   BodyLong,
@@ -13,8 +11,7 @@ import {
   Page,
   Stack,
 } from "@navikt/ds-react";
-import { classifyTraffic } from "../utils/get-current-environment";
-import useConsent from "./useConsent";
+import { useCookies } from "./CookieProvider";
 
 export const ConsentBanner = ({
   defaultShow = false,
@@ -23,94 +20,75 @@ export const ConsentBanner = ({
   defaultShow?: boolean;
   hide?: boolean;
 }) => {
-  const [umamiTag, setUmamiTag] = useState<string | undefined>();
-  const [clientAcceptsTracking, setClientAcceptsTracking] = useState(false);
-  const [showConsentBanner, setShowConsentBanner] = useState(defaultShow);
-  const { consent, updateConsent } = useConsent();
-  const trackingId = getConfig().publicRuntimeConfig.UMAMI_TRACKING_ID;
+  const [showBanner, setShowBanner] = useState(defaultShow);
+  const { consent, updateConsent } = useCookies();
 
   useEffect(() => {
-    let showConsent = true;
-    if (["accepted", "rejected"].includes(consent)) {
-      showConsent = false;
-    }
-    setShowConsentBanner(showConsent);
-
-    setUmamiTag(classifyTraffic());
-    setClientAcceptsTracking(consent === "accepted");
+    setShowBanner(!["accepted", "rejected"].includes(consent));
   }, [consent]);
+
+  if (hide || !showBanner) {
+    return null;
+  }
 
   return (
     <div className="relative z-10 bg-[#ECEDEF]">
-      {umamiTag && (
-        <Script
-          defer
-          src="https://cdn.nav.no/team-researchops/sporing/sporing.js"
-          data-host-url="https://umami.nav.no"
-          data-website-id={trackingId}
-          data-auto-track={clientAcceptsTracking}
-          data-tag={umamiTag}
-        ></Script>
-      )}
+      <Page.Block width="2xl" aria-labelledby="cookie_heading" as="section">
+        <Stack
+          gap={{ xs: "4", lg: "8" }}
+          wrap={false}
+          className="px-6 py-10"
+          align={{ xs: "start", lg: "center" }}
+          direction={{ xs: "column", lg: "row" }}
+        >
+          <div>
+            <Heading id="cookie_heading" size="small" level="2">
+              Vi bruker cookies
+            </Heading>
+            <BodyLong className="mb-2">
+              Nødvendige informasjonskapsler sørger for at nettstedet fungerer
+              og er sikkert, og kan ikke velges bort. Andre brukes til
+              statistikk og analyse. Godkjenner du alle, hjelper du oss å lage
+              bedre nettsider og tjenester.{" "}
+              <Link as={NextLink} href="/personvernerklaering">
+                Mer om våre informasjonskapsler.
+              </Link>
+            </BodyLong>
+          </div>
 
-      {!hide && showConsentBanner && (
-        <Page.Block width="2xl" aria-labelledby="cookie_heading" as="section">
-          <Stack
-            gap={{ xs: "4", lg: "8" }}
-            wrap={false}
-            className="px-6 py-10"
+          <HStack
+            gap="2"
             align={{ xs: "start", lg: "center" }}
-            direction={{ xs: "column", lg: "row" }}
+            className="min-w-fit"
           >
-            <div>
-              <Heading id="cookie_heading" size="small" level="2">
-                Vi bruker cookies
-              </Heading>
-              <BodyLong className="mb-2">
-                Nødvendige informasjonskapsler sørger for at nettstedet fungerer
-                og er sikkert, og kan ikke velges bort. Andre brukes til
-                statistikk og analyse. Godkjenner du alle, hjelper du oss å lage
-                bedre nettsider og tjenester.{" "}
-                <Link as={NextLink} href="/personvernerklaering">
-                  Mer om våre informasjonskapsler.
-                </Link>
-              </BodyLong>
-            </div>
-
-            <HStack
-              gap="2"
-              align={{ xs: "start", lg: "center" }}
-              className="min-w-fit"
+            <Button
+              className="h-fit min-w-fit"
+              type="button"
+              onClick={() => {
+                updateConsent("rejected");
+                setShowBanner(false);
+              }}
             >
-              <Button
-                className="h-fit min-w-fit"
-                type="button"
-                onClick={() => {
-                  updateConsent("rejected");
-                  setShowConsentBanner(false);
-                }}
-              >
-                Bare nødvendige
-              </Button>
-              <Button
-                className="h-fit min-w-fit"
-                type="button"
-                onClick={() => {
-                  updateConsent("accepted");
-                  setShowConsentBanner(false);
-                  // NOTE: umami _should_ exist on window object here (loaded via <Script>)
-                  // we call track manually this _one_ time to ensure the current page is
-                  // accounted for, any new page loads will be captured by data-auto-track
-                  // https://umami.is/docs/tracker-configuration
-                  umami.track();
-                }}
-              >
-                Godkjenn alle
-              </Button>
-            </HStack>
-          </Stack>
-        </Page.Block>
-      )}
+              Bare nødvendige
+            </Button>
+            <Button
+              className="h-fit min-w-fit"
+              type="button"
+              onClick={() => {
+                updateConsent("accepted");
+                setShowBanner(false);
+                // NOTE: umami _should_ exist on window object here (loaded via <Script>)
+                // we call track manually this _one_ time to ensure the current page is
+                // accounted for, any new page loads will be captured by data-auto-track
+                // https://umami.is/docs/tracker-configuration
+                // umami.track();
+              }}
+            >
+              Godkjenn alle
+            </Button>
+          </HStack>
+        </Stack>
+      </Page.Block>
     </div>
   );
 };

--- a/aksel.nav.no/website/components/website-modules/CookieProvider.tsx
+++ b/aksel.nav.no/website/components/website-modules/CookieProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { Cookies } from "typescript-cookie";
 
 export const CONSENT_TRACKER_ID = "aksel-consent";
@@ -71,13 +71,15 @@ export const CookieProvider = ({ children }: { children: React.ReactNode }) => {
     setConsent(state);
   };
 
+  const contextValue = useMemo(() => {
+    return {
+      consent,
+      updateConsent,
+    };
+  }, [consent]);
+
   return (
-    <CookieContext.Provider
-      value={{
-        consent,
-        updateConsent,
-      }}
-    >
+    <CookieContext.Provider value={contextValue}>
       {children}
     </CookieContext.Provider>
   );

--- a/aksel.nav.no/website/components/website-modules/CookieProvider.tsx
+++ b/aksel.nav.no/website/components/website-modules/CookieProvider.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useState } from "react";
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
 import { Cookies } from "typescript-cookie";
 
 export const CONSENT_TRACKER_ID = "aksel-consent";
@@ -18,7 +20,7 @@ type CookieData = {
   };
 };
 
-const getStorageAcceptedTracking = () => {
+const getCookieConsent = () => {
   const rawState = Cookies.get(CONSENT_TRACKER_ID) as string;
 
   if (!rawState) {
@@ -30,7 +32,7 @@ const getStorageAcceptedTracking = () => {
   return cookieData.consents.tracking as CONSENT_TRACKER_STATE;
 };
 
-const updateConsent = (state: CONSENT_TRACKER_STATE) => {
+const updateCookieConsent = (state: CONSENT_TRACKER_STATE) => {
   const cookieData: CookieData = {
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
@@ -48,16 +50,45 @@ const updateConsent = (state: CONSENT_TRACKER_STATE) => {
   });
 };
 
-const useConsent = () => {
+type CookieContextType = {
+  consent: CONSENT_TRACKER_STATE;
+  updateConsent: (state: CONSENT_TRACKER_STATE) => void;
+};
+
+const CookieContext = createContext<CookieContextType | null>(null);
+
+export const CookieProvider = ({ children }: { children: React.ReactNode }) => {
   const [consent, setConsent] = useState<CONSENT_TRACKER_STATE>("undecided");
 
   useEffect(() => {
-    const acceptedTracking = getStorageAcceptedTracking();
+    const acceptedTracking = getCookieConsent();
 
     setConsent(acceptedTracking);
   }, []);
 
-  return { consent, updateConsent };
+  const updateConsent = (state: CONSENT_TRACKER_STATE) => {
+    updateCookieConsent(state);
+    setConsent(state);
+  };
+
+  return (
+    <CookieContext.Provider
+      value={{
+        consent,
+        updateConsent,
+      }}
+    >
+      {children}
+    </CookieContext.Provider>
+  );
 };
 
-export default useConsent;
+export const useCookies = () => {
+  const context = useContext(CookieContext);
+
+  if (!context) {
+    throw new Error("useCookies must be used within a CookieProvider");
+  }
+
+  return context;
+};

--- a/aksel.nav.no/website/components/website-modules/Umami.tsx
+++ b/aksel.nav.no/website/components/website-modules/Umami.tsx
@@ -3,24 +3,28 @@
 import getConfig from "next/config";
 import Script from "next/script";
 import { useEffect, useState } from "react";
-
-/* import { useCookies } from "./CookieProvider"; */
+import { useCookies } from "./CookieProvider";
 
 export const Umami = () => {
   const trackingId = getConfig().publicRuntimeConfig.UMAMI_TRACKING_ID;
   const [umamiTag, setUmamiTag] = useState<string | undefined>();
-  /* const { consent } = useCookies(); */
+  const [umamiDomain, setUmamiDomain] = useState("aksel.ansatt.dev.nav.no");
+
+  const { consent } = useCookies();
 
   useEffect(() => {
+    if (window?.location?.hostname === "aksel.nav.no") {
+      setUmamiDomain("aksel.nav.no");
+    }
+
     setUmamiTag(classifyTraffic());
   }, []);
 
   /* We only track with umami if optional cookies are accepted */
-  /* if (consent !== "accepted" || !trackingId || !umamiTag) {
+  if (consent !== "accepted" || !trackingId || !umamiTag) {
     return null;
-  } */
+  }
 
-  /* TODO: Test this in prod */
   return (
     <Script
       defer
@@ -28,6 +32,7 @@ export const Umami = () => {
       data-host-url="https://umami.nav.no"
       data-website-id={trackingId}
       data-tag={umamiTag}
+      data-domains={umamiDomain}
     />
   );
 };

--- a/aksel.nav.no/website/components/website-modules/Umami.tsx
+++ b/aksel.nav.no/website/components/website-modules/Umami.tsx
@@ -1,15 +1,42 @@
 "use client";
 
+import getConfig from "next/config";
+import Script from "next/script";
+import { useEffect, useState } from "react";
+import { useCookies } from "./CookieProvider";
+
+export const Umami = () => {
+  const trackingId = getConfig().publicRuntimeConfig.UMAMI_TRACKING_ID;
+  const [umamiTag, setUmamiTag] = useState<string | undefined>();
+  const { consent } = useCookies();
+
+  useEffect(() => {
+    setUmamiTag(classifyTraffic());
+  }, []);
+
+  /* We only track with umami if optional cookies are accepted */
+  if (consent !== "accepted") {
+    return null;
+  }
+
+  return (
+    <Script
+      defer
+      src="https://cdn.nav.no/team-researchops/sporing/sporing.js"
+      data-host-url="https://umami.nav.no"
+      data-website-id={trackingId}
+      data-tag={umamiTag}
+    />
+  );
+};
+
 /**
  * Classifies the current traffic as either "organic" or "polluted"
  *
  * Organic traffic: Production traffic from real users on the main site
  * Polluted traffic: Traffic from preview environments, example pages, templates, admin pages, or non-production environments
- *
- * @returns {"organic" | "polluted"} Traffic classification
  */
-
-export const classifyTraffic = () => {
+function classifyTraffic() {
   const isProdUrl = () => window.location.host === "aksel.nav.no";
   const isPreview = () => !!document.getElementById("exit-preview-id");
   const isExample = () => window.location.pathname.startsWith("/eksempler/");
@@ -26,4 +53,4 @@ export const classifyTraffic = () => {
     return "organic";
   }
   return "polluted";
-};
+}

--- a/aksel.nav.no/website/components/website-modules/Umami.tsx
+++ b/aksel.nav.no/website/components/website-modules/Umami.tsx
@@ -25,7 +25,7 @@ export const Umami = () => {
     return null;
   }
 
-  console.info("Tracking enabled");
+  console.info("Tracking enabled", trackingId, umamiTag, umamiDomain);
 
   return (
     <Script

--- a/aksel.nav.no/website/components/website-modules/Umami.tsx
+++ b/aksel.nav.no/website/components/website-modules/Umami.tsx
@@ -3,22 +3,24 @@
 import getConfig from "next/config";
 import Script from "next/script";
 import { useEffect, useState } from "react";
-import { useCookies } from "./CookieProvider";
+
+/* import { useCookies } from "./CookieProvider"; */
 
 export const Umami = () => {
   const trackingId = getConfig().publicRuntimeConfig.UMAMI_TRACKING_ID;
   const [umamiTag, setUmamiTag] = useState<string | undefined>();
-  const { consent } = useCookies();
+  /* const { consent } = useCookies(); */
 
   useEffect(() => {
     setUmamiTag(classifyTraffic());
   }, []);
 
   /* We only track with umami if optional cookies are accepted */
-  if (consent !== "accepted" || !trackingId || !umamiTag) {
+  /* if (consent !== "accepted" || !trackingId || !umamiTag) {
     return null;
-  }
+  } */
 
+  /* TODO: Test this in prod */
   return (
     <Script
       defer

--- a/aksel.nav.no/website/components/website-modules/Umami.tsx
+++ b/aksel.nav.no/website/components/website-modules/Umami.tsx
@@ -25,6 +25,8 @@ export const Umami = () => {
     return null;
   }
 
+  console.info("Tracking enabled");
+
   return (
     <Script
       defer

--- a/aksel.nav.no/website/components/website-modules/Umami.tsx
+++ b/aksel.nav.no/website/components/website-modules/Umami.tsx
@@ -15,7 +15,7 @@ export const Umami = () => {
   }, []);
 
   /* We only track with umami if optional cookies are accepted */
-  if (consent !== "accepted") {
+  if (consent !== "accepted" || !trackingId || !umamiTag) {
     return null;
   }
 

--- a/aksel.nav.no/website/components/website-modules/Umami.tsx
+++ b/aksel.nav.no/website/components/website-modules/Umami.tsx
@@ -8,15 +8,10 @@ import { useCookies } from "./CookieProvider";
 export const Umami = () => {
   const trackingId = getConfig().publicRuntimeConfig.UMAMI_TRACKING_ID;
   const [umamiTag, setUmamiTag] = useState<string | undefined>();
-  const [umamiDomain, setUmamiDomain] = useState("aksel.ansatt.dev.nav.no");
 
   const { consent } = useCookies();
 
   useEffect(() => {
-    if (window?.location?.hostname === "aksel.nav.no") {
-      setUmamiDomain("aksel.nav.no");
-    }
-
     setUmamiTag(classifyTraffic());
   }, []);
 
@@ -25,8 +20,6 @@ export const Umami = () => {
     return null;
   }
 
-  console.info("Tracking enabled", trackingId, umamiTag, umamiDomain);
-
   return (
     <Script
       defer
@@ -34,7 +27,6 @@ export const Umami = () => {
       data-host-url="https://umami.nav.no"
       data-website-id={trackingId}
       data-tag={umamiTag}
-      data-domains={umamiDomain}
     />
   );
 };

--- a/aksel.nav.no/website/next.config.js
+++ b/aksel.nav.no/website/next.config.js
@@ -15,7 +15,7 @@ const ContentSecurityPolicy = `
   connect-src 'self' ${dekoratorUrl} ${cdnUrl} ${hotjarUrl} https://*.hotjar.io wss://*.hotjar.com https://raw.githubusercontent.com/navikt/ https://hnbe3yhs.apicdn.sanity.io wss://hnbe3yhs.api.sanity.io cdn.sanity.io *.api.sanity.io https://umami.nav.no https://in2.taskanalytics.com/03346;
   frame-ancestors 'self' localhost:3000;
   media-src 'self' ${cdnUrl} cdn.sanity.io;
-  frame-src 'self' https://web.microsoftstream.com localhost:3000 https://aksel.ekstern.dev.nav.no;
+  frame-src 'self' https://web.microsoftstream.com localhost:3000 https://aksel.ansatt.dev.nav.no;
 `;
 
 const securityHeaders = [

--- a/aksel.nav.no/website/next.config.js
+++ b/aksel.nav.no/website/next.config.js
@@ -12,7 +12,7 @@ const ContentSecurityPolicy = `
   img-src 'self' cdn.sanity.io ${dekoratorUrl} https://avatars.githubusercontent.com data: ${cdnUrl} ${hotjarUrl};
   script-src 'self' ${dekoratorUrl} ${cdnUrl} ${hotjarUrl} https://in2.taskanalytics.com/tm.js 'nonce-4e1aa203a32e' 'unsafe-eval';
   style-src 'self' ${dekoratorUrl} ${cdnUrl} ${hotjarUrl} 'unsafe-inline';
-  connect-src 'self' ${dekoratorUrl} ${cdnUrl} ${hotjarUrl} https://*.hotjar.io wss://*.hotjar.com https://raw.githubusercontent.com/navikt/ https://hnbe3yhs.apicdn.sanity.io wss://hnbe3yhs.api.sanity.io cdn.sanity.io *.api.sanity.io https://umami.nav.no https://in2.taskanalytics.com/03346;
+  connect-src 'self' ${dekoratorUrl} ${cdnUrl} ${hotjarUrl} https://*.hotjar.io wss://*.hotjar.com https://raw.githubusercontent.com/navikt/ https://hnbe3yhs.apicdn.sanity.io wss://hnbe3yhs.api.sanity.io cdn.sanity.io *.api.sanity.io https://umami.nav.no https://in2.taskanalytics.com/03346 https://main--66b4b3beb91603ed0ab5c45e.chromatic.com;
   frame-ancestors 'self' localhost:3000;
   media-src 'self' ${cdnUrl} cdn.sanity.io;
   frame-src 'self' https://web.microsoftstream.com localhost:3000 https://aksel.ansatt.dev.nav.no;

--- a/aksel.nav.no/website/pages/_app.tsx
+++ b/aksel.nav.no/website/pages/_app.tsx
@@ -5,25 +5,17 @@ import { useCheckAuth } from "@/hooks/useCheckAuth";
 import { useHashScroll } from "@/hooks/useHashScroll";
 import { SanityDataContext } from "@/hooks/useSanityData";
 import { ConsentBanner } from "@/web/ConsentBanner";
+import { CookieProvider } from "@/web/CookieProvider";
+import { Umami } from "@/web/Umami";
 import { BaseSEO } from "@/web/seo/BaseSEO";
 import "../components/styles/index.css";
 
 function App({ Component, pageProps, router }: AppProps) {
   useHashScroll();
 
-  /* As of 01.01.25, removed until cookie compliance is implemented */
-  /* useAmplitudeInit(); */
-
   useEffect(() => {
     window.location.host === "design.nav.no" &&
       window.location.replace(`http://aksel.nav.no`);
-
-    /**
-     * Midlertidig utkommentert for å unngå lasting av hotjar-bundle
-     * Package.json: "react-hotjar": "^6.1.0",
-     * Import: import { hotjar } from "react-hotjar";
-     * Script: hotjar.initialize(148751, 6);
-     */
   }, []);
 
   const useGlobalStyles =
@@ -33,15 +25,16 @@ function App({ Component, pageProps, router }: AppProps) {
   const validUser = useCheckAuth(!useGlobalStyles);
 
   return (
-    <>
-      <ConsentBanner
-        hide={!useGlobalStyles}
-        defaultShow={pageProps.showCookieBanner}
-      />
-      <BaseSEO path={router.asPath} />
+    <CookieProvider>
       <SanityDataContext.Provider
         value={{ id: pageProps?.id ?? pageProps?.page?._id, validUser }}
       >
+        <BaseSEO path={router.asPath} />
+        <Umami />
+        <ConsentBanner
+          hide={!useGlobalStyles}
+          defaultShow={pageProps.showCookieBanner}
+        />
         {useGlobalStyles ? (
           <div className="globalstyles">
             <Component {...pageProps} />
@@ -50,7 +43,7 @@ function App({ Component, pageProps, router }: AppProps) {
           <Component {...pageProps} />
         )}
       </SanityDataContext.Provider>
-    </>
+    </CookieProvider>
   );
 }
 

--- a/aksel.nav.no/website/pages/index.tsx
+++ b/aksel.nav.no/website/pages/index.tsx
@@ -31,10 +31,10 @@ import { getClient } from "@/sanity/client.server";
 import { contributorsAll } from "@/sanity/queries";
 import { NextPageT } from "@/types";
 import { userPrefersReducedMotion } from "@/utils";
+import { CONSENT_TRACKER_ID } from "@/web/CookieProvider";
 import { IntroCards } from "@/web/IntroCards";
 import { AkselCubeAnimated } from "@/web/aksel-cube/AkselCube";
 import { SEO } from "@/web/seo/SEO";
-import { CONSENT_TRACKER_ID } from "@/web/useConsent";
 
 type PageProps = NextPageT<{
   tema: {

--- a/aksel.nav.no/website/pages/personvernerklaering.tsx
+++ b/aksel.nav.no/website/pages/personvernerklaering.tsx
@@ -11,13 +11,13 @@ import {
 } from "@navikt/ds-react";
 import Footer from "@/layout/footer/Footer";
 import Header from "@/layout/header/Header";
-import useConsent from "@/web/useConsent";
+import { useCookies } from "@/web/CookieProvider";
 
 type TRACKING_CHOICES = "tracking_yes" | "tracking_no" | "";
 
 const Page = () => {
   const [userPreference, setUserPreference] = useState<TRACKING_CHOICES>("");
-  const { consent, updateConsent } = useConsent();
+  const { consent, updateConsent } = useCookies();
 
   const handleChange = (event: TRACKING_CHOICES) => {
     setUserPreference(event);


### PR DESCRIPTION
### Description

Noticed that the current tracking did not end up sending post-requests for tracking after the initial logging when accepting cookies. Testing a fix trough this update.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
