### PR TITLE
:bug: Types for `children.props` were unknown in Slot for React-19

### DIFF
--- a/.changeset/modern-lobsters-kneel.md
+++ b/.changeset/modern-lobsters-kneel.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+React 19: Resolve unknown-type in Slot.

--- a/@navikt/core/react/src/slot/Slot.tsx
+++ b/@navikt/core/react/src/slot/Slot.tsx
@@ -14,11 +14,11 @@ const Slot = React.forwardRef<HTMLElement, SlotProps>((props, forwardedRef) => {
       children.props,
       "ref",
     )
-      ? children.props.ref // React 19 (children.ref still works, but gives a warning)
+      ? (children.props as any).ref // React 19 (children.ref still works, but gives a warning)
       : (children as any).ref; // React <19
 
     return React.cloneElement<any>(children, {
-      ...mergeProps(slotProps, children.props),
+      ...mergeProps(slotProps, children.props as any),
       ref: forwardedRef ? mergeRefs([forwardedRef, childRef]) : childRef,
     });
   }


### PR DESCRIPTION
### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
