### PR TITLE
[ExpansionCard] :bug: Fixed bug where '@media print' would hide header content.

### DIFF
--- a/.changeset/fast-dryers-tie.md
+++ b/.changeset/fast-dryers-tie.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+ExpansionCard: Fixed bug where `@media print` would hide header content.

--- a/@navikt/core/css/darkside/expansioncard.darkside.css
+++ b/@navikt/core/css/darkside/expansioncard.darkside.css
@@ -110,6 +110,9 @@
     height: 100%;
     width: 100%;
     cursor: pointer;
+
+    /* Avoid @media print from styling after-element */
+    opacity: 0;
   }
 }
 

--- a/@navikt/core/css/expansioncard.css
+++ b/@navikt/core/css/expansioncard.css
@@ -172,6 +172,9 @@
   height: 100%;
   width: 100%;
   cursor: pointer;
+
+  /* Avoid @media print from styling after-element */
+  opacity: 0;
 }
 
 /*************************


### PR DESCRIPTION
### Description

Since `@media print` sets background to `white !important`, the after element suddenly became visible. This is easily fixed by setting the default opacity to 0.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
