### PR TITLE
[Aksel.nav.no] Add support for "standalone" articles

### DIFF
--- a/aksel.nav.no/website/components/layout/sidebar/Sidebar.tsx
+++ b/aksel.nav.no/website/components/layout/sidebar/Sidebar.tsx
@@ -4,32 +4,21 @@ import { useRouter } from "next/router";
 import React, { useContext, useId, useState } from "react";
 import { ChevronDownIcon } from "@navikt/aksel-icons";
 import { BodyShort, Detail } from "@navikt/ds-react";
+import {
+  DesignsystemSidebarSectionT,
+  SidebarGroupedPagesT,
+  SidebarPageT,
+} from "@/types";
 import { StatusTag } from "@/web/StatusTag";
 import styles from "./Sidebar.module.css";
 
-type SidebarInputNodeT = {
-  heading: string;
-  slug: string;
-  kategori: string;
-  tag: "beta" | "new" | "ready" | "deprecated";
-  sidebarindex: number | null;
-};
-
-type SidebarPageT = Pick<SidebarInputNodeT, "heading" | "slug" | "tag">;
-
-type SidebarGroupedPagesT = {
-  title: string;
-  value: string;
-  pages: SidebarPageT[];
-};
-
-type DesignsystemSectionT = {
+type DesignsystemSidebarGroupT = {
   label: string;
-  links: (SidebarPageT | SidebarGroupedPagesT)[];
+  links: DesignsystemSidebarSectionT;
 };
 
 type SidebarProps = {
-  sidebarData: DesignsystemSectionT[];
+  sidebarData: DesignsystemSidebarGroupT[];
   layout?: "sidebar" | "mobile";
 } & React.HTMLAttributes<HTMLDivElement>;
 
@@ -72,7 +61,7 @@ function SidebarDivider() {
   return <li aria-hidden className={styles.navListDivider} />;
 }
 
-function SidebarGroup(props: DesignsystemSectionT) {
+function SidebarGroup(props: DesignsystemSidebarGroupT) {
   const { label, links } = props;
   const id = useId();
   const layout = useContext(SidebarContext);

--- a/aksel.nav.no/website/components/layout/templates/WithSidebar.tsx
+++ b/aksel.nav.no/website/components/layout/templates/WithSidebar.tsx
@@ -1,10 +1,8 @@
 import cl from "clsx";
 import Image from "next/legacy/image";
-import NextLink from "next/link";
-import { Box, Detail, Heading, Link, Show } from "@navikt/ds-react";
+import { Box, Heading, Show } from "@navikt/ds-react";
 import { urlFor } from "@/sanity/interface";
-import { SidebarT, TableOfContentsT } from "@/types";
-import { capitalize } from "@/utils";
+import { DesignsystemSidebarSectionT, TableOfContentsT } from "@/types";
 import { TableOfContents } from "@/web/toc/TableOfContents";
 import { Sidebar } from "../sidebar/Sidebar";
 
@@ -19,7 +17,7 @@ export const WithSidebar = ({
   toc,
 }: {
   children: React.ReactNode;
-  sidebar: SidebarT;
+  sidebar: DesignsystemSidebarSectionT;
   toc?: TableOfContentsT;
   pageType: {
     type: "komponenter" | "grunnleggende" | "templates";
@@ -60,17 +58,6 @@ export const WithSidebar = ({
             )}
           >
             <div className="z-[1]">
-              {variant === "page" && pageProps?.kategori && (
-                <Detail as="div" className="mb-2">
-                  <NextLink href={pageType.rootUrl} passHref legacyBehavior>
-                    <Link className="text-text-default">
-                      {pageType.rootTitle}
-                    </Link>
-                  </NextLink>{" "}
-                  / {capitalize(pageProps.kategori)}
-                </Detail>
-              )}
-
               <Heading
                 level="1"
                 size="xlarge"

--- a/aksel.nav.no/website/components/types/sanity-schema.ts
+++ b/aksel.nav.no/website/components/types/sanity-schema.ts
@@ -152,16 +152,18 @@ export type SidebarInputNodeT = {
   sidebarindex: number | null;
 };
 
-export type SidebarOutputNodeT = Pick<
-  SidebarInputNodeT,
-  "heading" | "slug" | "tag"
->;
+export type SidebarPageT = Pick<SidebarInputNodeT, "heading" | "slug" | "tag">;
 
-export type SidebarT = {
-  pages: SidebarOutputNodeT[];
+export type SidebarGroupedPagesT = {
   title: string;
   value: string;
-}[];
+  pages: SidebarPageT[];
+};
+
+export type DesignsystemSidebarSectionT = (
+  | SidebarPageT
+  | SidebarGroupedPagesT
+)[];
 
 export type ArticleListT = {
   _id: string;

--- a/aksel.nav.no/website/components/utils/__tests__/generate-sidebar.test.ts
+++ b/aksel.nav.no/website/components/utils/__tests__/generate-sidebar.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { SidebarInputNodeT, SidebarT } from "../../types/sanity-schema";
+import { DesignsystemSidebarSectionT, SidebarInputNodeT } from "@/types";
 import {
   generateSidebar,
   sortDeprecated,
@@ -50,7 +50,7 @@ const outputIndex = [
   { ...baseItem, kategori: "core", heading: "c", tag: "deprecated" as const },
 ];
 
-const outputComplete: SidebarT = [
+const outputComplete: DesignsystemSidebarSectionT = [
   {
     pages: [
       { slug: "/123", tag: "beta", heading: "f" },
@@ -89,5 +89,57 @@ describe("generateSidebar function", () => {
 
   test("generated output is correct", () => {
     expect(generateSidebar(input, "komponenter")).toEqual(outputComplete);
+  });
+
+  test("should place standalone articles on top", () => {
+    expect(
+      generateSidebar(
+        [
+          ...input,
+          {
+            ...baseItem,
+            kategori: "standalone",
+            heading: "B",
+          },
+          {
+            ...baseItem,
+            kategori: "standalone",
+            heading: "A",
+          },
+        ],
+        "komponenter",
+      ),
+    ).toEqual([
+      { slug: "/123", tag: "beta", heading: "A" },
+      { slug: "/123", tag: "beta", heading: "B" },
+      ...outputComplete,
+    ]);
+  });
+
+  test("should sort standalone articles by index", () => {
+    expect(
+      generateSidebar(
+        [
+          ...input,
+          {
+            ...baseItem,
+            kategori: "standalone",
+            heading: "B",
+            sidebarindex: 0,
+          },
+          {
+            ...baseItem,
+            kategori: "standalone",
+            heading: "A",
+            sidebarindex: 1,
+          },
+        ],
+        "komponenter",
+      ),
+    ).toEqual([
+      { slug: "/123", tag: "beta", heading: "B" },
+      { slug: "/123", tag: "beta", heading: "A" },
+      ...outputComplete,
+    ]);
   });
 });

--- a/aksel.nav.no/website/components/utils/generate-sidebar.ts
+++ b/aksel.nav.no/website/components/utils/generate-sidebar.ts
@@ -1,11 +1,30 @@
+import {
+  DesignsystemSidebarSectionT,
+  SidebarInputNodeT,
+  SidebarPageT,
+} from "@/types";
 import { sanityCategoryLookup } from "../../sanity/config";
-import { SidebarInputNodeT, SidebarT } from "../types";
 
 export function generateSidebar(
   input: SidebarInputNodeT[],
   type: "komponenter" | "grunnleggende" | "templates",
-): SidebarT {
-  return sanityCategoryLookup(type)
+): DesignsystemSidebarSectionT {
+  const categories = sanityCategoryLookup(type);
+
+  const standalonePages: SidebarPageT[] = input
+    .filter((page) => page.kategori === "standalone")
+    .sort((a, b) => {
+      return a?.heading.localeCompare(b?.heading);
+    })
+    .sort(sortIndex)
+    .sort(sortDeprecated)
+    .map((page) => ({
+      heading: page.heading,
+      slug: page.slug,
+      tag: page.tag,
+    }));
+
+  const groupedPages = categories
     .map((x) => ({
       ...x,
       pages: input
@@ -25,6 +44,8 @@ export function generateSidebar(
         tag: page.tag,
       })),
     }));
+
+  return [...standalonePages, ...groupedPages];
 }
 
 export function sortDeprecated(a: SidebarInputNodeT, b: SidebarInputNodeT) {

--- a/aksel.nav.no/website/pages/grunnleggende/[...slug].tsx
+++ b/aksel.nav.no/website/pages/grunnleggende/[...slug].tsx
@@ -11,10 +11,10 @@ import { destructureBlocks, sidebarQuery } from "@/sanity/queries";
 import {
   AkselGrunnleggendeDocT,
   ArticleListT,
+  DesignsystemSidebarSectionT,
   NextPageT,
   ResolveContributorsT,
   ResolveSlugT,
-  SidebarT,
   TableOfContentsT,
 } from "@/types";
 import { dateStr, generateSidebar, generateTableOfContents } from "@/utils";
@@ -25,7 +25,7 @@ import NotFotfund from "../404";
 
 type PageProps = NextPageT<{
   page: ResolveContributorsT<ResolveSlugT<AkselGrunnleggendeDocT>>;
-  sidebar: SidebarT;
+  sidebar: DesignsystemSidebarSectionT;
   seo: any;
   refs: ArticleListT;
   publishDate: string;

--- a/aksel.nav.no/website/pages/grunnleggende/index.tsx
+++ b/aksel.nav.no/website/pages/grunnleggende/index.tsx
@@ -11,8 +11,8 @@ import { landingPageQuery, sidebarQuery } from "@/sanity/queries";
 import {
   AkselLandingPageDocT,
   ArticleListT,
+  DesignsystemSidebarSectionT,
   NextPageT,
-  SidebarT,
 } from "@/types";
 import { generateSidebar } from "@/utils";
 import { TextWithMarkdown } from "@/web/TextWithMarkdown";
@@ -22,7 +22,7 @@ import { grunnleggendeKategorier } from "../../sanity/config";
 
 type PageProps = NextPageT<{
   page: AkselLandingPageDocT;
-  sidebar: SidebarT;
+  sidebar: DesignsystemSidebarSectionT;
   links: ArticleListT;
 }>;
 

--- a/aksel.nav.no/website/pages/komponenter/[...slug].tsx
+++ b/aksel.nav.no/website/pages/komponenter/[...slug].tsx
@@ -13,10 +13,10 @@ import { destructureBlocks, sidebarQuery } from "@/sanity/queries";
 import {
   AkselKomponentDocT,
   ArticleListT,
+  DesignsystemSidebarSectionT,
   NextPageT,
   ResolveContributorsT,
   ResolveSlugT,
-  SidebarT,
   TableOfContentsT,
 } from "@/types";
 import { dateStr, generateSidebar, generateTableOfContents } from "@/utils";
@@ -55,7 +55,7 @@ const kodepakker = {
 
 type PageProps = NextPageT<{
   page: ResolveContributorsT<ResolveSlugT<AkselKomponentDocT>>;
-  sidebar: SidebarT;
+  sidebar: DesignsystemSidebarSectionT;
   seo: any;
   refs: ArticleListT;
   publishDate: string;

--- a/aksel.nav.no/website/pages/komponenter/index.tsx
+++ b/aksel.nav.no/website/pages/komponenter/index.tsx
@@ -19,8 +19,8 @@ import { landingPageQuery, sidebarQuery } from "@/sanity/queries";
 import {
   AkselLandingPageDocT,
   ArticleListT,
+  DesignsystemSidebarSectionT,
   NextPageT,
-  SidebarT,
 } from "@/types";
 import { generateSidebar } from "@/utils";
 import { IntroCards } from "@/web/IntroCards";
@@ -31,7 +31,7 @@ import { komponentKategorier } from "../../sanity/config";
 
 type PageProps = NextPageT<{
   page: AkselLandingPageDocT;
-  sidebar: SidebarT;
+  sidebar: DesignsystemSidebarSectionT;
   links: ArticleListT;
 }>;
 

--- a/aksel.nav.no/website/pages/monster-maler/[...slug].tsx
+++ b/aksel.nav.no/website/pages/monster-maler/[...slug].tsx
@@ -12,10 +12,10 @@ import {
   AkselTemplatesDocT,
   ArticleListT,
   CodeExampleSchemaT,
+  DesignsystemSidebarSectionT,
   NextPageT,
   ResolveContributorsT,
   ResolveSlugT,
-  SidebarT,
   TableOfContentsT,
 } from "@/types";
 import { dateStr, generateSidebar, generateTableOfContents } from "@/utils";
@@ -29,7 +29,7 @@ import NotFotfund from "../404";
 
 type PageProps = NextPageT<{
   page: ResolveContributorsT<ResolveSlugT<AkselTemplatesDocT>>;
-  sidebar: SidebarT;
+  sidebar: DesignsystemSidebarSectionT;
   seo: any;
   refs: ArticleListT;
   publishDate: string;

--- a/aksel.nav.no/website/pages/monster-maler/index.tsx
+++ b/aksel.nav.no/website/pages/monster-maler/index.tsx
@@ -11,8 +11,8 @@ import { landingPageQuery, sidebarQuery } from "@/sanity/queries";
 import {
   AkselLandingPageDocT,
   ArticleListT,
+  DesignsystemSidebarSectionT,
   NextPageT,
-  SidebarT,
 } from "@/types";
 import { generateSidebar } from "@/utils";
 import { TextWithMarkdown } from "@/web/TextWithMarkdown";
@@ -22,7 +22,7 @@ import { templatesKategorier } from "../../sanity/config";
 
 type PageProps = NextPageT<{
   page: AkselLandingPageDocT;
-  sidebar: SidebarT;
+  sidebar: DesignsystemSidebarSectionT;
   links: ArticleListT;
 }>;
 

--- a/aksel.nav.no/website/sanity/config.ts
+++ b/aksel.nav.no/website/sanity/config.ts
@@ -46,7 +46,7 @@ export const komponentKategorier = [
   { title: "Primitives", value: "primitives" },
   { title: "Core", value: "core" },
   { title: "Alpha", value: "alpha" },
-  { title: "Legacy", value: "legacy" },
+  { title: "Avviklet", value: "legacy" },
 ];
 
 export const grunnleggendeKategorier = [

--- a/aksel.nav.no/website/sanity/schema/documents/grunnleggende/artikkel.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/grunnleggende/artikkel.tsx
@@ -28,10 +28,13 @@ export const GrunnleggendeArtikkel = defineType({
       type: "string",
       validation: (Rule) => Rule.required(),
       options: {
-        list: grunnleggendeKategorier.map((x) => ({
-          title: x.title,
-          value: x.value,
-        })),
+        list: [
+          ...grunnleggendeKategorier.map((x) => ({
+            title: x.title,
+            value: x.value,
+          })),
+          { title: "Frittstående", value: "standalone" },
+        ],
         layout: "radio",
       },
     }),

--- a/aksel.nav.no/website/sanity/schema/documents/grunnleggende/artikkel.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/grunnleggende/artikkel.tsx
@@ -21,7 +21,7 @@ export const GrunnleggendeArtikkel = defineType({
     oppdateringsvarsel,
     ...hiddenFields,
     titleField,
-    editorField,
+
     defineField({
       title: "Kategori",
       name: "kategori",
@@ -35,7 +35,16 @@ export const GrunnleggendeArtikkel = defineType({
         layout: "radio",
       },
     }),
+    defineField({
+      title: "Sidebar index",
+      description:
+        "Overstyrer sortering av artikler i sidebar. Hvis feltet er tomt, sorteres den alfabetisk.",
+      name: "sidebarindex",
+      type: "number",
+      group: "settings",
+    }),
     kategoriSlug(prefix),
+    editorField,
     defineField({
       title: "Metadata",
       name: "status",
@@ -52,7 +61,7 @@ export const GrunnleggendeArtikkel = defineType({
               { title: "Beta", value: "beta" },
               { title: "New", value: "new" },
               { title: "Stable", value: "ready" },
-              { title: "Deprecated", value: "deprecated" },
+              { title: "Legacy", value: "deprecated" },
             ],
             layout: "radio",
           },
@@ -64,14 +73,7 @@ export const GrunnleggendeArtikkel = defineType({
         },
       ],
     }),
-    defineField({
-      title: "Sidebar index",
-      description:
-        "Overstyrer sortering av artikler i sidebar. Hvis feltet er tomt, sorteres den alfabetisk.",
-      name: "sidebarindex",
-      type: "number",
-      group: "settings",
-    }),
+
     defineField({
       title: "Innhold",
       description:

--- a/aksel.nav.no/website/sanity/schema/documents/komponenter/artikkel.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/komponenter/artikkel.tsx
@@ -29,10 +29,13 @@ export const KomponentArtikkel = defineType({
       type: "string",
       validation: (Rule) => Rule.required(),
       options: {
-        list: komponentKategorier.map((x) => ({
-          title: x.title,
-          value: x.value,
-        })),
+        list: [
+          ...komponentKategorier.map((x) => ({
+            title: x.title,
+            value: x.value,
+          })),
+          { title: "Frittstående", value: "standalone" },
+        ],
         layout: "radio",
       },
     }),

--- a/aksel.nav.no/website/sanity/schema/documents/komponenter/artikkel.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/komponenter/artikkel.tsx
@@ -22,7 +22,7 @@ export const KomponentArtikkel = defineType({
     oppdateringsvarsel,
     ...hiddenFields,
     titleField,
-    editorField,
+
     defineField({
       title: "Kategori",
       name: "kategori",
@@ -36,8 +36,16 @@ export const KomponentArtikkel = defineType({
         layout: "radio",
       },
     }),
+    defineField({
+      title: "Sidebar index",
+      description:
+        "Overstyrer sortering av artikler i sidebar. Hvis feltet er tomt, sorteres den alfabetisk.",
+      name: "sidebarindex",
+      type: "number",
+      group: "settings",
+    }),
     kategoriSlug(prefix),
-
+    editorField,
     defineField({
       title: "Metadata",
       name: "status",
@@ -54,7 +62,7 @@ export const KomponentArtikkel = defineType({
               { title: "Beta", value: "beta" },
               { title: "New", value: "new" },
               { title: "Stable", value: "ready" },
-              { title: "Deprecated", value: "deprecated" },
+              { title: "Legacy", value: "deprecated" },
             ],
             layout: "radio",
           },
@@ -81,14 +89,7 @@ export const KomponentArtikkel = defineType({
         }),
       ],
     }),
-    defineField({
-      title: "Sidebar index",
-      description:
-        "Overstyrer sortering av artikler i sidebar. Hvis feltet er tomt, sorteres den alfabetisk.",
-      name: "sidebarindex",
-      type: "number",
-      group: "settings",
-    }),
+
     defineField({
       title: "Ikke vis 'Send innspill'-modul på siden",
       name: "hide_feedback",

--- a/aksel.nav.no/website/sanity/schema/documents/presets/slug.ts
+++ b/aksel.nav.no/website/sanity/schema/documents/presets/slug.ts
@@ -59,6 +59,7 @@ export const validateKategoriSlug = (Rule: SlugRule, prefix: string) =>
     const slugLength = (slug.current.match(/\//g) || []).length;
 
     if (isStandalone(document)) {
+      return "Frittstående artikler er ikke støttet enda";
       if (!slug?.current?.startsWith(`${prefix}`)) {
         return `Slug må være: '${prefix}navn' for frittstående artikler`;
       }

--- a/aksel.nav.no/website/sanity/schema/documents/presets/slug.ts
+++ b/aksel.nav.no/website/sanity/schema/documents/presets/slug.ts
@@ -59,7 +59,6 @@ export const validateKategoriSlug = (Rule: SlugRule, prefix: string) =>
     const slugLength = (slug.current.match(/\//g) || []).length;
 
     if (isStandalone(document)) {
-      return "Frittstående artikler er ikke støttet enda";
       if (!slug?.current?.startsWith(`${prefix}`)) {
         return `Slug må være: '${prefix}navn' for frittstående artikler`;
       }

--- a/aksel.nav.no/website/sanity/schema/documents/presets/slug.ts
+++ b/aksel.nav.no/website/sanity/schema/documents/presets/slug.ts
@@ -71,7 +71,7 @@ export const validateKategoriSlug = (Rule: SlugRule, prefix: string) =>
         ...grunnleggendeKategorier,
         ...templatesKategorier,
       ]) {
-        if (slug.current === `${prefix}${section.value}`) {
+        if (slug?.current === `${prefix}${section.value}`) {
           return `Slug kan ikke være lik kategori: ${section.value}`;
         }
       }

--- a/aksel.nav.no/website/sanity/schema/documents/presets/slug.ts
+++ b/aksel.nav.no/website/sanity/schema/documents/presets/slug.ts
@@ -1,5 +1,10 @@
 import { SlugIsUniqueValidator, SlugRule, defineField } from "sanity";
-import { SANITY_API_VERSION } from "@/sanity/config";
+import {
+  SANITY_API_VERSION,
+  grunnleggendeKategorier,
+  komponentKategorier,
+  templatesKategorier,
+} from "@/sanity/config";
 import { sanitizeSlug } from "../../../util";
 
 export const validateSlug = (Rule: SlugRule, prefix: string, nesting: number) =>
@@ -60,6 +65,17 @@ export const validateKategoriSlug = (Rule: SlugRule, prefix: string) =>
       if (slugLength !== 1) {
         return `Slug må være på 1 nivå for frittstående artikler`;
       }
+
+      for (const section of [
+        ...komponentKategorier,
+        ...grunnleggendeKategorier,
+        ...templatesKategorier,
+      ]) {
+        if (slug.current === `${prefix}${section.value}`) {
+          return `Slug kan ikke være lik kategori: ${section.value}`;
+        }
+      }
+
       return true;
     }
 

--- a/aksel.nav.no/website/sanity/schema/documents/templates/artikkel.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/templates/artikkel.tsx
@@ -21,7 +21,7 @@ export const TemplatesArtikkel = defineType({
     oppdateringsvarsel,
     ...hiddenFields,
     titleField,
-    editorField,
+
     defineField({
       title: "Kategori",
       name: "kategori",
@@ -35,7 +35,16 @@ export const TemplatesArtikkel = defineType({
         layout: "radio",
       },
     }),
+    defineField({
+      title: "Sidebar index",
+      description:
+        "Overstyrer sortering av artikler i sidebar. Hvis feltet er tomt, sorteres den alfabetisk.",
+      name: "sidebarindex",
+      type: "number",
+      group: "settings",
+    }),
     kategoriSlug(prefix),
+    editorField,
     defineField({
       title: "Metadata",
       name: "status",
@@ -52,7 +61,7 @@ export const TemplatesArtikkel = defineType({
               { title: "Beta", value: "beta" },
               { title: "New", value: "new" },
               { title: "Stable", value: "ready" },
-              { title: "Deprecated", value: "deprecated" },
+              { title: "Legacy", value: "deprecated" },
             ],
             layout: "radio",
           },
@@ -74,14 +83,7 @@ export const TemplatesArtikkel = defineType({
       type: "url",
       group: "settings",
     }),
-    defineField({
-      title: "Sidebar index",
-      description:
-        "Overstyrer sortering av artikler i sidebar. Hvis feltet er tomt, sorteres den alfabetisk.",
-      name: "sidebarindex",
-      type: "number",
-      group: "settings",
-    }),
+
     defineField({
       title: "Innhold",
       description:

--- a/aksel.nav.no/website/sanity/schema/documents/templates/artikkel.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/templates/artikkel.tsx
@@ -28,10 +28,13 @@ export const TemplatesArtikkel = defineType({
       type: "string",
       validation: (Rule) => Rule.required(),
       options: {
-        list: templatesKategorier.map((x) => ({
-          title: x.title,
-          value: x.value,
-        })),
+        list: [
+          ...templatesKategorier.map((x) => ({
+            title: x.title,
+            value: x.value,
+          })),
+          { title: "Frittstående", value: "standalone" },
+        ],
         layout: "radio",
       },
     }),


### PR DESCRIPTION
### Description

This allows articles to be placed at the same level as "sections" in the sidebar.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
