### PR TITLE
[Token-docs] Static semantic colors with comments

### DIFF
--- a/@navikt/core/tokens/darkside/index.ts
+++ b/@navikt/core/tokens/darkside/index.ts
@@ -23,7 +23,7 @@ import {
   globalDarkTokens,
   globalLightTokens,
 } from "./tokens/colors/global.tokens";
-import { semanticTokensForRole } from "./tokens/colors/semantic-role.tokens";
+import { semanticRoleConfig } from "./tokens/colors/semantic-role.tokens";
 import { semanticThemedBaseTokens } from "./tokens/colors/semantic-themed-base.tokens";
 
 const DARKSIDE_DIST = "./dist/darkside/";
@@ -138,7 +138,7 @@ async function buildThemedRolesCSS() {
   for (const role of ColorRolesList) {
     const config = [
       globalLightTokens,
-      semanticTokensForRole(role),
+      semanticRoleConfig[role],
       semanticThemedBaseTokens(role),
     ];
 

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
@@ -1,172 +1,40 @@
-import fs from "fs";
 import _ from "lodash";
-import { type SemanticColorRoles } from "../../../types";
-import { ColorRolesList } from "../../../types";
+import { GlobalColorRoles } from "../../../types";
 import { type StyleDictionaryTokenConfig } from "../../tokens.util";
+import { accentSemanticTokenConfig } from "./semantic-roles/accent.tokens";
+import { brandBeigeSemanticTokenConfig } from "./semantic-roles/brand-beige.tokens";
+import { brandBlueSemanticTokenConfig } from "./semantic-roles/brand-blue.tokens";
+import { brandMagentaSemanticTokenConfig } from "./semantic-roles/brand-magenta.tokens";
+import { dangerSemanticTokenConfig } from "./semantic-roles/danger.tokens";
+import { infoSemanticTokenConfig } from "./semantic-roles/info.tokens";
+import { metaLimeSemanticTokenConfig } from "./semantic-roles/meta-lime.tokens";
+import { metaPurpleSemanticTokenConfig } from "./semantic-roles/meta-purple.tokens";
+import { neutralSemanticTokenConfig } from "./semantic-roles/neutral.tokens";
+import { successSemanticTokenConfig } from "./semantic-roles/success.tokens";
+import { warningSemanticTokenConfig } from "./semantic-roles/warning.tokens";
 
-/**
- * Maps the semantic colors to the global color layer for a given role.
- * @note Gray is handled a little differently, as it is visually perceived a little lighter than other colors.
- */
-export function semanticTokensForRole(role: SemanticColorRoles) {
-  return {
-    bg: {
-      [`${role}-soft`]: {
-        value: `{ax.${role}.100.value}`,
-        type: "color",
-        group: `background.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-softA`]: {
-        value: `{ax.${role}.100A.value}`,
-        type: "color",
-        group: `background.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-moderate`]: {
-        value: `{ax.${role}.200.value}`,
-        type: "color",
-        group: `background.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-moderateA`]: {
-        value: `{ax.${role}.200A.value}`,
-        type: "color",
-        group: `background.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-moderate-hover`]: {
-        value: `{ax.${role}.300.value}`,
-        type: "color",
-        group: `background.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-moderate-hoverA`]: {
-        value: `{ax.${role}.300A.value}`,
-        type: "color",
-        group: `background.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-moderate-pressed`]: {
-        value: `{ax.${role}.400.value}`,
-        type: "color",
-        group: `background.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-moderate-pressedA`]: {
-        value: `{ax.${role}.400A.value}`,
-        type: "color",
-        group: `background.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-strong`]: {
-        value:
-          role === "neutral"
-            ? `{ax.${role}.700.value}`
-            : `{ax.${role}.600.value}`,
-        type: "color",
-        group: `background.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-strong-hover`]: {
-        value:
-          role === "neutral"
-            ? `{ax.${role}.800.value}`
-            : `{ax.${role}.700.value}`,
-        type: "color",
-        group: `background.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-strong-pressed`]: {
-        value:
-          role === "neutral"
-            ? `{ax.${role}.900.value}`
-            : `{ax.${role}.800.value}`,
-        type: "color",
-        group: `background.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-    },
-    text: {
-      [role]: {
-        value: `{ax.${role}.1000.value}`,
-        type: "color",
-        group: `text.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-subtle`]: {
-        value:
-          role === "neutral"
-            ? `{ax.${role}.900.value}`
-            : `{ax.${role}.800.value}`,
-        type: "color",
-        group: `text.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-icon`]: {
-        value: `{ax.${role}.600.value}`,
-        type: "color",
-        group: `text.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-contrast`]: {
-        value: "{ax.neutral.000.value}",
-        type: "color",
-        group: `text.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-    },
-    border: {
-      [role]: {
-        value: `{ax.${role}.600.value}`,
-        type: "color",
-        group: `border.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-subtle`]: {
-        value: `{ax.${role}.400.value}`,
-        type: "color",
-        group: `border.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-subtleA`]: {
-        value: `{ax.${role}.400A.value}`,
-        type: "color",
-        group: `border.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-      [`${role}-strong`]: {
-        value: `{ax.${role}.700.value}`,
-        type: "color",
-        group: `border.${role}`,
-        comment: "TODO: Sjur fyller ut",
-      },
-    },
-  } satisfies StyleDictionaryTokenConfig<"color">;
-}
+const semanticRoleConfig: Record<GlobalColorRoles, any> = {
+  accent: accentSemanticTokenConfig,
+  neutral: neutralSemanticTokenConfig,
+  "brand-beige": brandBeigeSemanticTokenConfig,
+  "brand-magenta": brandMagentaSemanticTokenConfig,
+  "brand-blue": brandBlueSemanticTokenConfig,
+  danger: dangerSemanticTokenConfig,
+  success: successSemanticTokenConfig,
+  warning: warningSemanticTokenConfig,
+  info: infoSemanticTokenConfig,
+  "meta-lime": metaLimeSemanticTokenConfig,
+  "meta-purple": metaPurpleSemanticTokenConfig,
+};
 
 /**
  * We need to deep merge the token config for each role to get the complete token config for all roles.
  */
-export const semanticTokensForAllRoles = () => {
-  return ColorRolesList.reduce(
-    (acc, role) => _.merge(acc, semanticTokensForRole(role)),
-    {} as ReturnType<typeof semanticTokensForRole>,
+function semanticTokensForAllRoles() {
+  return Object.values(semanticRoleConfig).reduce(
+    (acc, config) => _.merge(acc, config),
+    {} as StyleDictionaryTokenConfig<"color">,
   );
-};
+}
 
-const createFiles = () => {
-  for (const color of ColorRolesList) {
-    const fileName = `${color}.tokens.ts`;
-    const fileContent = JSON.stringify(semanticTokensForRole(color), null, 2);
-    const filePath = `./semantic-roles/${fileName}`;
-
-    const formatedContent = `import { type StyleDictionaryTokenConfig } from "../../../tokens.util";
-export const warningSemanticTokenConfig = ${fileContent} satisfies StyleDictionaryTokenConfig<"color">;`;
-
-    fs.writeFileSync(filePath, formatedContent);
-    console.info(`File ${fileName} created successfully!`);
-  }
-};
-
-createFiles();
+export { semanticRoleConfig, semanticTokensForAllRoles };

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
@@ -157,11 +157,14 @@ export const semanticTokensForAllRoles = () => {
 
 const createFiles = () => {
   for (const color of ColorRolesList) {
-    const fileName = `semantic-role-${color}.tokens.ts`;
+    const fileName = `${color}.tokens.ts`;
     const fileContent = JSON.stringify(semanticTokensForRole(color), null, 2);
     const filePath = `./semantic-roles/${fileName}`;
 
-    fs.writeFileSync(filePath, fileContent);
+    const formatedContent = `import { type StyleDictionaryTokenConfig } from "../../../tokens.util";
+export const warningSemanticTokenConfig = ${fileContent} satisfies StyleDictionaryTokenConfig<"color">;`;
+
+    fs.writeFileSync(filePath, formatedContent);
     console.info(`File ${fileName} created successfully!`);
   }
 };

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
@@ -14,17 +14,17 @@ import { successSemanticTokenConfig } from "./semantic-roles/success.tokens";
 import { warningSemanticTokenConfig } from "./semantic-roles/warning.tokens";
 
 const semanticRoleConfig: Record<GlobalColorRoles, any> = {
-  accent: accentSemanticTokenConfig,
   neutral: neutralSemanticTokenConfig,
-  "brand-beige": brandBeigeSemanticTokenConfig,
-  "brand-magenta": brandMagentaSemanticTokenConfig,
-  "brand-blue": brandBlueSemanticTokenConfig,
-  danger: dangerSemanticTokenConfig,
+  accent: accentSemanticTokenConfig,
   success: successSemanticTokenConfig,
   warning: warningSemanticTokenConfig,
+  danger: dangerSemanticTokenConfig,
   info: infoSemanticTokenConfig,
-  "meta-lime": metaLimeSemanticTokenConfig,
+  "brand-magenta": brandMagentaSemanticTokenConfig,
+  "brand-beige": brandBeigeSemanticTokenConfig,
+  "brand-blue": brandBlueSemanticTokenConfig,
   "meta-purple": metaPurpleSemanticTokenConfig,
+  "meta-lime": metaLimeSemanticTokenConfig,
 };
 
 /**

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import _ from "lodash";
 import { type SemanticColorRoles } from "../../../types";
 import { ColorRolesList } from "../../../types";
@@ -153,3 +154,16 @@ export const semanticTokensForAllRoles = () => {
     {} as ReturnType<typeof semanticTokensForRole>,
   );
 };
+
+const createFiles = () => {
+  for (const color of ColorRolesList) {
+    const fileName = `semantic-role-${color}.tokens.ts`;
+    const fileContent = JSON.stringify(semanticTokensForRole(color), null, 2);
+    const filePath = `./semantic-roles/${fileName}`;
+
+    fs.writeFileSync(filePath, fileContent);
+    console.info(`File ${fileName} created successfully!`);
+  }
+};
+
+createFiles();

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/accent.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/accent.tokens.ts
@@ -1,0 +1,124 @@
+import { type StyleDictionaryTokenConfig } from "../../../tokens.util";
+
+export const accentSemanticTokenConfig = {
+  bg: {
+    "accent-soft": {
+      value: "{ax.accent.100.value}",
+      type: "color",
+      group: "background.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-softA": {
+      value: "{ax.accent.100A.value}",
+      type: "color",
+      group: "background.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-moderate": {
+      value: "{ax.accent.200.value}",
+      type: "color",
+      group: "background.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-moderateA": {
+      value: "{ax.accent.200A.value}",
+      type: "color",
+      group: "background.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-moderate-hover": {
+      value: "{ax.accent.300.value}",
+      type: "color",
+      group: "background.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-moderate-hoverA": {
+      value: "{ax.accent.300A.value}",
+      type: "color",
+      group: "background.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-moderate-pressed": {
+      value: "{ax.accent.400.value}",
+      type: "color",
+      group: "background.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-moderate-pressedA": {
+      value: "{ax.accent.400A.value}",
+      type: "color",
+      group: "background.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-strong": {
+      value: "{ax.accent.600.value}",
+      type: "color",
+      group: "background.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-strong-hover": {
+      value: "{ax.accent.700.value}",
+      type: "color",
+      group: "background.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-strong-pressed": {
+      value: "{ax.accent.800.value}",
+      type: "color",
+      group: "background.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  text: {
+    accent: {
+      value: "{ax.accent.1000.value}",
+      type: "color",
+      group: "text.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-subtle": {
+      value: "{ax.accent.800.value}",
+      type: "color",
+      group: "text.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-icon": {
+      value: "{ax.accent.600.value}",
+      type: "color",
+      group: "text.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-contrast": {
+      value: "{ax.neutral.000.value}",
+      type: "color",
+      group: "text.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  border: {
+    accent: {
+      value: "{ax.accent.600.value}",
+      type: "color",
+      group: "border.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-subtle": {
+      value: "{ax.accent.400.value}",
+      type: "color",
+      group: "border.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-subtleA": {
+      value: "{ax.accent.400A.value}",
+      type: "color",
+      group: "border.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "accent-strong": {
+      value: "{ax.accent.700.value}",
+      type: "color",
+      group: "border.accent",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+} satisfies StyleDictionaryTokenConfig<"color">;

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/brand-beige.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/brand-beige.tokens.ts
@@ -1,0 +1,124 @@
+import { type StyleDictionaryTokenConfig } from "../../../tokens.util";
+
+export const brandBeigeSemanticTokenConfig = {
+  bg: {
+    "brand-beige-soft": {
+      value: "{ax.brand-beige.100.value}",
+      type: "color",
+      group: "background.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-softA": {
+      value: "{ax.brand-beige.100A.value}",
+      type: "color",
+      group: "background.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-moderate": {
+      value: "{ax.brand-beige.200.value}",
+      type: "color",
+      group: "background.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-moderateA": {
+      value: "{ax.brand-beige.200A.value}",
+      type: "color",
+      group: "background.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-moderate-hover": {
+      value: "{ax.brand-beige.300.value}",
+      type: "color",
+      group: "background.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-moderate-hoverA": {
+      value: "{ax.brand-beige.300A.value}",
+      type: "color",
+      group: "background.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-moderate-pressed": {
+      value: "{ax.brand-beige.400.value}",
+      type: "color",
+      group: "background.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-moderate-pressedA": {
+      value: "{ax.brand-beige.400A.value}",
+      type: "color",
+      group: "background.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-strong": {
+      value: "{ax.brand-beige.600.value}",
+      type: "color",
+      group: "background.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-strong-hover": {
+      value: "{ax.brand-beige.700.value}",
+      type: "color",
+      group: "background.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-strong-pressed": {
+      value: "{ax.brand-beige.800.value}",
+      type: "color",
+      group: "background.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  text: {
+    "brand-beige": {
+      value: "{ax.brand-beige.1000.value}",
+      type: "color",
+      group: "text.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-subtle": {
+      value: "{ax.brand-beige.800.value}",
+      type: "color",
+      group: "text.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-icon": {
+      value: "{ax.brand-beige.600.value}",
+      type: "color",
+      group: "text.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-contrast": {
+      value: "{ax.neutral.000.value}",
+      type: "color",
+      group: "text.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  border: {
+    "brand-beige": {
+      value: "{ax.brand-beige.600.value}",
+      type: "color",
+      group: "border.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-subtle": {
+      value: "{ax.brand-beige.400.value}",
+      type: "color",
+      group: "border.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-subtleA": {
+      value: "{ax.brand-beige.400A.value}",
+      type: "color",
+      group: "border.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-beige-strong": {
+      value: "{ax.brand-beige.700.value}",
+      type: "color",
+      group: "border.brand-beige",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+} satisfies StyleDictionaryTokenConfig<"color">;

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/brand-blue.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/brand-blue.tokens.ts
@@ -1,0 +1,124 @@
+import { type StyleDictionaryTokenConfig } from "../../../tokens.util";
+
+export const brandBlueSemanticTokenConfig = {
+  bg: {
+    "brand-blue-soft": {
+      value: "{ax.brand-blue.100.value}",
+      type: "color",
+      group: "background.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-softA": {
+      value: "{ax.brand-blue.100A.value}",
+      type: "color",
+      group: "background.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-moderate": {
+      value: "{ax.brand-blue.200.value}",
+      type: "color",
+      group: "background.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-moderateA": {
+      value: "{ax.brand-blue.200A.value}",
+      type: "color",
+      group: "background.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-moderate-hover": {
+      value: "{ax.brand-blue.300.value}",
+      type: "color",
+      group: "background.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-moderate-hoverA": {
+      value: "{ax.brand-blue.300A.value}",
+      type: "color",
+      group: "background.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-moderate-pressed": {
+      value: "{ax.brand-blue.400.value}",
+      type: "color",
+      group: "background.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-moderate-pressedA": {
+      value: "{ax.brand-blue.400A.value}",
+      type: "color",
+      group: "background.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-strong": {
+      value: "{ax.brand-blue.600.value}",
+      type: "color",
+      group: "background.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-strong-hover": {
+      value: "{ax.brand-blue.700.value}",
+      type: "color",
+      group: "background.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-strong-pressed": {
+      value: "{ax.brand-blue.800.value}",
+      type: "color",
+      group: "background.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  text: {
+    "brand-blue": {
+      value: "{ax.brand-blue.1000.value}",
+      type: "color",
+      group: "text.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-subtle": {
+      value: "{ax.brand-blue.800.value}",
+      type: "color",
+      group: "text.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-icon": {
+      value: "{ax.brand-blue.600.value}",
+      type: "color",
+      group: "text.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-contrast": {
+      value: "{ax.neutral.000.value}",
+      type: "color",
+      group: "text.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  border: {
+    "brand-blue": {
+      value: "{ax.brand-blue.600.value}",
+      type: "color",
+      group: "border.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-subtle": {
+      value: "{ax.brand-blue.400.value}",
+      type: "color",
+      group: "border.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-subtleA": {
+      value: "{ax.brand-blue.400A.value}",
+      type: "color",
+      group: "border.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-blue-strong": {
+      value: "{ax.brand-blue.700.value}",
+      type: "color",
+      group: "border.brand-blue",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+} satisfies StyleDictionaryTokenConfig<"color">;

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/brand-magenta.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/brand-magenta.tokens.ts
@@ -1,0 +1,124 @@
+import { type StyleDictionaryTokenConfig } from "../../../tokens.util";
+
+export const brandMagentaSemanticTokenConfig = {
+  bg: {
+    "brand-magenta-soft": {
+      value: "{ax.brand-magenta.100.value}",
+      type: "color",
+      group: "background.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-softA": {
+      value: "{ax.brand-magenta.100A.value}",
+      type: "color",
+      group: "background.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-moderate": {
+      value: "{ax.brand-magenta.200.value}",
+      type: "color",
+      group: "background.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-moderateA": {
+      value: "{ax.brand-magenta.200A.value}",
+      type: "color",
+      group: "background.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-moderate-hover": {
+      value: "{ax.brand-magenta.300.value}",
+      type: "color",
+      group: "background.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-moderate-hoverA": {
+      value: "{ax.brand-magenta.300A.value}",
+      type: "color",
+      group: "background.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-moderate-pressed": {
+      value: "{ax.brand-magenta.400.value}",
+      type: "color",
+      group: "background.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-moderate-pressedA": {
+      value: "{ax.brand-magenta.400A.value}",
+      type: "color",
+      group: "background.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-strong": {
+      value: "{ax.brand-magenta.600.value}",
+      type: "color",
+      group: "background.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-strong-hover": {
+      value: "{ax.brand-magenta.700.value}",
+      type: "color",
+      group: "background.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-strong-pressed": {
+      value: "{ax.brand-magenta.800.value}",
+      type: "color",
+      group: "background.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  text: {
+    "brand-magenta": {
+      value: "{ax.brand-magenta.1000.value}",
+      type: "color",
+      group: "text.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-subtle": {
+      value: "{ax.brand-magenta.800.value}",
+      type: "color",
+      group: "text.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-icon": {
+      value: "{ax.brand-magenta.600.value}",
+      type: "color",
+      group: "text.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-contrast": {
+      value: "{ax.neutral.000.value}",
+      type: "color",
+      group: "text.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  border: {
+    "brand-magenta": {
+      value: "{ax.brand-magenta.600.value}",
+      type: "color",
+      group: "border.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-subtle": {
+      value: "{ax.brand-magenta.400.value}",
+      type: "color",
+      group: "border.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-subtleA": {
+      value: "{ax.brand-magenta.400A.value}",
+      type: "color",
+      group: "border.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "brand-magenta-strong": {
+      value: "{ax.brand-magenta.700.value}",
+      type: "color",
+      group: "border.brand-magenta",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+} satisfies StyleDictionaryTokenConfig<"color">;

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/danger.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/danger.tokens.ts
@@ -1,0 +1,124 @@
+import { type StyleDictionaryTokenConfig } from "../../../tokens.util";
+
+export const dangerSemanticTokenConfig = {
+  bg: {
+    "danger-soft": {
+      value: "{ax.danger.100.value}",
+      type: "color",
+      group: "background.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-softA": {
+      value: "{ax.danger.100A.value}",
+      type: "color",
+      group: "background.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-moderate": {
+      value: "{ax.danger.200.value}",
+      type: "color",
+      group: "background.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-moderateA": {
+      value: "{ax.danger.200A.value}",
+      type: "color",
+      group: "background.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-moderate-hover": {
+      value: "{ax.danger.300.value}",
+      type: "color",
+      group: "background.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-moderate-hoverA": {
+      value: "{ax.danger.300A.value}",
+      type: "color",
+      group: "background.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-moderate-pressed": {
+      value: "{ax.danger.400.value}",
+      type: "color",
+      group: "background.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-moderate-pressedA": {
+      value: "{ax.danger.400A.value}",
+      type: "color",
+      group: "background.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-strong": {
+      value: "{ax.danger.600.value}",
+      type: "color",
+      group: "background.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-strong-hover": {
+      value: "{ax.danger.700.value}",
+      type: "color",
+      group: "background.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-strong-pressed": {
+      value: "{ax.danger.800.value}",
+      type: "color",
+      group: "background.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  text: {
+    danger: {
+      value: "{ax.danger.1000.value}",
+      type: "color",
+      group: "text.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-subtle": {
+      value: "{ax.danger.800.value}",
+      type: "color",
+      group: "text.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-icon": {
+      value: "{ax.danger.600.value}",
+      type: "color",
+      group: "text.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-contrast": {
+      value: "{ax.neutral.000.value}",
+      type: "color",
+      group: "text.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  border: {
+    danger: {
+      value: "{ax.danger.600.value}",
+      type: "color",
+      group: "border.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-subtle": {
+      value: "{ax.danger.400.value}",
+      type: "color",
+      group: "border.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-subtleA": {
+      value: "{ax.danger.400A.value}",
+      type: "color",
+      group: "border.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "danger-strong": {
+      value: "{ax.danger.700.value}",
+      type: "color",
+      group: "border.danger",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+} satisfies StyleDictionaryTokenConfig<"color">;

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/info.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/info.tokens.ts
@@ -1,0 +1,124 @@
+import { type StyleDictionaryTokenConfig } from "../../../tokens.util";
+
+export const infoSemanticTokenConfig = {
+  bg: {
+    "info-soft": {
+      value: "{ax.info.100.value}",
+      type: "color",
+      group: "background.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-softA": {
+      value: "{ax.info.100A.value}",
+      type: "color",
+      group: "background.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-moderate": {
+      value: "{ax.info.200.value}",
+      type: "color",
+      group: "background.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-moderateA": {
+      value: "{ax.info.200A.value}",
+      type: "color",
+      group: "background.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-moderate-hover": {
+      value: "{ax.info.300.value}",
+      type: "color",
+      group: "background.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-moderate-hoverA": {
+      value: "{ax.info.300A.value}",
+      type: "color",
+      group: "background.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-moderate-pressed": {
+      value: "{ax.info.400.value}",
+      type: "color",
+      group: "background.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-moderate-pressedA": {
+      value: "{ax.info.400A.value}",
+      type: "color",
+      group: "background.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-strong": {
+      value: "{ax.info.600.value}",
+      type: "color",
+      group: "background.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-strong-hover": {
+      value: "{ax.info.700.value}",
+      type: "color",
+      group: "background.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-strong-pressed": {
+      value: "{ax.info.800.value}",
+      type: "color",
+      group: "background.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  text: {
+    info: {
+      value: "{ax.info.1000.value}",
+      type: "color",
+      group: "text.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-subtle": {
+      value: "{ax.info.800.value}",
+      type: "color",
+      group: "text.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-icon": {
+      value: "{ax.info.600.value}",
+      type: "color",
+      group: "text.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-contrast": {
+      value: "{ax.neutral.000.value}",
+      type: "color",
+      group: "text.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  border: {
+    info: {
+      value: "{ax.info.600.value}",
+      type: "color",
+      group: "border.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-subtle": {
+      value: "{ax.info.400.value}",
+      type: "color",
+      group: "border.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-subtleA": {
+      value: "{ax.info.400A.value}",
+      type: "color",
+      group: "border.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "info-strong": {
+      value: "{ax.info.700.value}",
+      type: "color",
+      group: "border.info",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+} satisfies StyleDictionaryTokenConfig<"color">;

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/meta-lime.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/meta-lime.tokens.ts
@@ -1,0 +1,124 @@
+import { type StyleDictionaryTokenConfig } from "../../../tokens.util";
+
+export const metaLimeSemanticTokenConfig = {
+  bg: {
+    "meta-lime-soft": {
+      value: "{ax.meta-lime.100.value}",
+      type: "color",
+      group: "background.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-softA": {
+      value: "{ax.meta-lime.100A.value}",
+      type: "color",
+      group: "background.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-moderate": {
+      value: "{ax.meta-lime.200.value}",
+      type: "color",
+      group: "background.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-moderateA": {
+      value: "{ax.meta-lime.200A.value}",
+      type: "color",
+      group: "background.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-moderate-hover": {
+      value: "{ax.meta-lime.300.value}",
+      type: "color",
+      group: "background.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-moderate-hoverA": {
+      value: "{ax.meta-lime.300A.value}",
+      type: "color",
+      group: "background.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-moderate-pressed": {
+      value: "{ax.meta-lime.400.value}",
+      type: "color",
+      group: "background.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-moderate-pressedA": {
+      value: "{ax.meta-lime.400A.value}",
+      type: "color",
+      group: "background.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-strong": {
+      value: "{ax.meta-lime.600.value}",
+      type: "color",
+      group: "background.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-strong-hover": {
+      value: "{ax.meta-lime.700.value}",
+      type: "color",
+      group: "background.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-strong-pressed": {
+      value: "{ax.meta-lime.800.value}",
+      type: "color",
+      group: "background.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  text: {
+    "meta-lime": {
+      value: "{ax.meta-lime.1000.value}",
+      type: "color",
+      group: "text.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-subtle": {
+      value: "{ax.meta-lime.800.value}",
+      type: "color",
+      group: "text.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-icon": {
+      value: "{ax.meta-lime.600.value}",
+      type: "color",
+      group: "text.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-contrast": {
+      value: "{ax.neutral.000.value}",
+      type: "color",
+      group: "text.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  border: {
+    "meta-lime": {
+      value: "{ax.meta-lime.600.value}",
+      type: "color",
+      group: "border.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-subtle": {
+      value: "{ax.meta-lime.400.value}",
+      type: "color",
+      group: "border.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-subtleA": {
+      value: "{ax.meta-lime.400A.value}",
+      type: "color",
+      group: "border.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-lime-strong": {
+      value: "{ax.meta-lime.700.value}",
+      type: "color",
+      group: "border.meta-lime",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+} satisfies StyleDictionaryTokenConfig<"color">;

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/meta-purple.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/meta-purple.tokens.ts
@@ -1,0 +1,124 @@
+import { type StyleDictionaryTokenConfig } from "../../../tokens.util";
+
+export const metaPurpleSemanticTokenConfig = {
+  bg: {
+    "meta-purple-soft": {
+      value: "{ax.meta-purple.100.value}",
+      type: "color",
+      group: "background.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-softA": {
+      value: "{ax.meta-purple.100A.value}",
+      type: "color",
+      group: "background.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-moderate": {
+      value: "{ax.meta-purple.200.value}",
+      type: "color",
+      group: "background.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-moderateA": {
+      value: "{ax.meta-purple.200A.value}",
+      type: "color",
+      group: "background.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-moderate-hover": {
+      value: "{ax.meta-purple.300.value}",
+      type: "color",
+      group: "background.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-moderate-hoverA": {
+      value: "{ax.meta-purple.300A.value}",
+      type: "color",
+      group: "background.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-moderate-pressed": {
+      value: "{ax.meta-purple.400.value}",
+      type: "color",
+      group: "background.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-moderate-pressedA": {
+      value: "{ax.meta-purple.400A.value}",
+      type: "color",
+      group: "background.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-strong": {
+      value: "{ax.meta-purple.600.value}",
+      type: "color",
+      group: "background.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-strong-hover": {
+      value: "{ax.meta-purple.700.value}",
+      type: "color",
+      group: "background.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-strong-pressed": {
+      value: "{ax.meta-purple.800.value}",
+      type: "color",
+      group: "background.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  text: {
+    "meta-purple": {
+      value: "{ax.meta-purple.1000.value}",
+      type: "color",
+      group: "text.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-subtle": {
+      value: "{ax.meta-purple.800.value}",
+      type: "color",
+      group: "text.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-icon": {
+      value: "{ax.meta-purple.600.value}",
+      type: "color",
+      group: "text.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-contrast": {
+      value: "{ax.neutral.000.value}",
+      type: "color",
+      group: "text.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  border: {
+    "meta-purple": {
+      value: "{ax.meta-purple.600.value}",
+      type: "color",
+      group: "border.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-subtle": {
+      value: "{ax.meta-purple.400.value}",
+      type: "color",
+      group: "border.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-subtleA": {
+      value: "{ax.meta-purple.400A.value}",
+      type: "color",
+      group: "border.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "meta-purple-strong": {
+      value: "{ax.meta-purple.700.value}",
+      type: "color",
+      group: "border.meta-purple",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+} satisfies StyleDictionaryTokenConfig<"color">;

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/neutral.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/neutral.tokens.ts
@@ -1,0 +1,124 @@
+import { type StyleDictionaryTokenConfig } from "../../../tokens.util";
+
+export const neutralSemanticTokenConfig = {
+  bg: {
+    "neutral-soft": {
+      value: "{ax.neutral.100.value}",
+      type: "color",
+      group: "background.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-softA": {
+      value: "{ax.neutral.100A.value}",
+      type: "color",
+      group: "background.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-moderate": {
+      value: "{ax.neutral.200.value}",
+      type: "color",
+      group: "background.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-moderateA": {
+      value: "{ax.neutral.200A.value}",
+      type: "color",
+      group: "background.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-moderate-hover": {
+      value: "{ax.neutral.300.value}",
+      type: "color",
+      group: "background.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-moderate-hoverA": {
+      value: "{ax.neutral.300A.value}",
+      type: "color",
+      group: "background.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-moderate-pressed": {
+      value: "{ax.neutral.400.value}",
+      type: "color",
+      group: "background.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-moderate-pressedA": {
+      value: "{ax.neutral.400A.value}",
+      type: "color",
+      group: "background.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-strong": {
+      value: "{ax.neutral.700.value}",
+      type: "color",
+      group: "background.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-strong-hover": {
+      value: "{ax.neutral.800.value}",
+      type: "color",
+      group: "background.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-strong-pressed": {
+      value: "{ax.neutral.900.value}",
+      type: "color",
+      group: "background.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  text: {
+    neutral: {
+      value: "{ax.neutral.1000.value}",
+      type: "color",
+      group: "text.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-subtle": {
+      value: "{ax.neutral.900.value}",
+      type: "color",
+      group: "text.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-icon": {
+      value: "{ax.neutral.600.value}",
+      type: "color",
+      group: "text.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-contrast": {
+      value: "{ax.neutral.000.value}",
+      type: "color",
+      group: "text.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  border: {
+    neutral: {
+      value: "{ax.neutral.600.value}",
+      type: "color",
+      group: "border.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-subtle": {
+      value: "{ax.neutral.400.value}",
+      type: "color",
+      group: "border.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-subtleA": {
+      value: "{ax.neutral.400A.value}",
+      type: "color",
+      group: "border.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "neutral-strong": {
+      value: "{ax.neutral.700.value}",
+      type: "color",
+      group: "border.neutral",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+} satisfies StyleDictionaryTokenConfig<"color">;

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/success.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/success.tokens.ts
@@ -1,0 +1,124 @@
+import { type StyleDictionaryTokenConfig } from "../../../tokens.util";
+
+export const successSemanticTokenConfig = {
+  bg: {
+    "success-soft": {
+      value: "{ax.success.100.value}",
+      type: "color",
+      group: "background.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-softA": {
+      value: "{ax.success.100A.value}",
+      type: "color",
+      group: "background.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-moderate": {
+      value: "{ax.success.200.value}",
+      type: "color",
+      group: "background.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-moderateA": {
+      value: "{ax.success.200A.value}",
+      type: "color",
+      group: "background.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-moderate-hover": {
+      value: "{ax.success.300.value}",
+      type: "color",
+      group: "background.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-moderate-hoverA": {
+      value: "{ax.success.300A.value}",
+      type: "color",
+      group: "background.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-moderate-pressed": {
+      value: "{ax.success.400.value}",
+      type: "color",
+      group: "background.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-moderate-pressedA": {
+      value: "{ax.success.400A.value}",
+      type: "color",
+      group: "background.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-strong": {
+      value: "{ax.success.600.value}",
+      type: "color",
+      group: "background.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-strong-hover": {
+      value: "{ax.success.700.value}",
+      type: "color",
+      group: "background.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-strong-pressed": {
+      value: "{ax.success.800.value}",
+      type: "color",
+      group: "background.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  text: {
+    success: {
+      value: "{ax.success.1000.value}",
+      type: "color",
+      group: "text.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-subtle": {
+      value: "{ax.success.800.value}",
+      type: "color",
+      group: "text.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-icon": {
+      value: "{ax.success.600.value}",
+      type: "color",
+      group: "text.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-contrast": {
+      value: "{ax.neutral.000.value}",
+      type: "color",
+      group: "text.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  border: {
+    success: {
+      value: "{ax.success.600.value}",
+      type: "color",
+      group: "border.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-subtle": {
+      value: "{ax.success.400.value}",
+      type: "color",
+      group: "border.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-subtleA": {
+      value: "{ax.success.400A.value}",
+      type: "color",
+      group: "border.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "success-strong": {
+      value: "{ax.success.700.value}",
+      type: "color",
+      group: "border.success",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+} satisfies StyleDictionaryTokenConfig<"color">;

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/warning.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-roles/warning.tokens.ts
@@ -1,0 +1,124 @@
+import { type StyleDictionaryTokenConfig } from "../../../tokens.util";
+
+export const warningSemanticTokenConfig = {
+  bg: {
+    "warning-soft": {
+      value: "{ax.warning.100.value}",
+      type: "color",
+      group: "background.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-softA": {
+      value: "{ax.warning.100A.value}",
+      type: "color",
+      group: "background.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-moderate": {
+      value: "{ax.warning.200.value}",
+      type: "color",
+      group: "background.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-moderateA": {
+      value: "{ax.warning.200A.value}",
+      type: "color",
+      group: "background.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-moderate-hover": {
+      value: "{ax.warning.300.value}",
+      type: "color",
+      group: "background.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-moderate-hoverA": {
+      value: "{ax.warning.300A.value}",
+      type: "color",
+      group: "background.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-moderate-pressed": {
+      value: "{ax.warning.400.value}",
+      type: "color",
+      group: "background.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-moderate-pressedA": {
+      value: "{ax.warning.400A.value}",
+      type: "color",
+      group: "background.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-strong": {
+      value: "{ax.warning.600.value}",
+      type: "color",
+      group: "background.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-strong-hover": {
+      value: "{ax.warning.700.value}",
+      type: "color",
+      group: "background.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-strong-pressed": {
+      value: "{ax.warning.800.value}",
+      type: "color",
+      group: "background.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  text: {
+    warning: {
+      value: "{ax.warning.1000.value}",
+      type: "color",
+      group: "text.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-subtle": {
+      value: "{ax.warning.800.value}",
+      type: "color",
+      group: "text.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-icon": {
+      value: "{ax.warning.600.value}",
+      type: "color",
+      group: "text.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-contrast": {
+      value: "{ax.neutral.000.value}",
+      type: "color",
+      group: "text.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+  border: {
+    warning: {
+      value: "{ax.warning.600.value}",
+      type: "color",
+      group: "border.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-subtle": {
+      value: "{ax.warning.400.value}",
+      type: "color",
+      group: "border.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-subtleA": {
+      value: "{ax.warning.400A.value}",
+      type: "color",
+      group: "border.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+    "warning-strong": {
+      value: "{ax.warning.700.value}",
+      type: "color",
+      group: "border.warning",
+      comment: "TODO: Sjur fyller ut",
+    },
+  },
+} satisfies StyleDictionaryTokenConfig<"color">;


### PR DESCRIPTION
### Description

Allows for editing each semantic color definition by itself

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
