### PR TITLE
Update ExternalLinkFill.yml

### DIFF
--- a/@navikt/aksel-icons/icons/ExternalLinkFill.yml
+++ b/@navikt/aksel-icons/icons/ExternalLinkFill.yml
@@ -5,7 +5,6 @@ keywords:
   - lenke
   - kobling
   - videresending
-  - new tab
   - ekstern side
   - eksternt
 variant: Fill


### PR DESCRIPTION
Bug: icon was marked as "new tab" but the icon for new tab is an box with the arrow stopping at the border. Having the new tab synonym here will cause missunderstandings. Found when working on 

### Description

Removed "new tab", found as issue when working on pattern for "external links"

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
