### PR TITLE
:sparkles: Page layouts for new DS-pages

### DIFF
--- a/aksel.nav.no/website/app/_ui/sidebar/Sidebar.module.css
+++ b/aksel.nav.no/website/app/_ui/sidebar/Sidebar.module.css
@@ -15,6 +15,11 @@
     top: var(--website-header-height-width-border);
     max-height: calc(100vh - var(--website-header-height-width-border));
     overscroll-behavior: contain;
+
+    /* stylelint-disable-next-line media-feature-range-notation */
+    @media (width < 1024px) {
+      display: none;
+    }
   }
 
   &[data-layout="mobile"] {

--- a/aksel.nav.no/website/app/dev/(designsystemet)/PageLayout.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/PageLayout.tsx
@@ -1,0 +1,23 @@
+import styles from "./layout.module.css";
+
+type DesignsystemetPageLayoutProps = {
+  children: React.ReactNode;
+  layout?: "with-toc";
+};
+
+function DesignsystemetPageLayout({
+  children,
+  layout,
+}: DesignsystemetPageLayoutProps) {
+  return (
+    <main
+      id="hovedinnhold"
+      className={styles.pageLayoutMain}
+      data-layout={layout}
+    >
+      {children}
+    </main>
+  );
+}
+
+export { DesignsystemetPageLayout };

--- a/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/page.tsx
@@ -1,21 +1,41 @@
 /* import { client } from "@/app/_sanity/client"; */
-/* import { disableDraftMode, enableDraftMode } from "@/app/actions"; */
 
-export default async function Page() {
+/* import { disableDraftMode, enableDraftMode } from "@/app/actions"; */
+import { DesignsystemetPageLayout } from "../PageLayout";
+
+/* https://nextjs.org/docs/app/api-reference/file-conventions/page#props */
+export default async function Page(/* {
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+} */) {
   /* const data = await client.fetch(
     "*[_type == 'komponent_artikkel'][0].heading",
     undefined,
     { useCdn: false, perspective: "drafts" },
   ); */
 
-  return (
-    <div>
-      {/* <button onClick={enableDraftMode}>on</button>
-      <hr />
-      <button onClick={disableDraftMode}>off</button>
+  /* <button onClick={enableDraftMode}>on</button>
+  <hr />
+  <button onClick={disableDraftMode}>off</button>
 
-      <pre>{data}</pre> */}
-      DEV
-    </div>
+  <pre>{data}</pre> */
+
+  return (
+    <DesignsystemetPageLayout>
+      <div style={{ background: "red", width: "100%", height: 50 }}></div>
+      <div style={{ background: "blue", width: "240px", height: 50 }}></div>
+    </DesignsystemetPageLayout>
   );
 }
+
+/*
+
+*[_type == "komponent_artikkel"][2]{
+  "TOC": content[style match 'h2'][]{
+    _key,
+    "text": pt::text(@)
+  }
+}
+
+*/

--- a/aksel.nav.no/website/app/dev/(designsystemet)/layout.module.css
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/layout.module.css
@@ -12,8 +12,24 @@
   min-height: calc(100vh - var(--website-header-height-width-border));
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   .pageLayout {
     grid-template-columns: 16rem 1fr;
+  }
+}
+
+.pageLayoutMain {
+  width: 100%;
+  margin: 0 auto;
+  padding-block: var(--ax-space-24);
+  padding-inline: var(--ax-space-40);
+  display: grid;
+  grid-template-columns: minmax(0, 1024px);
+  gap: var(--ax-space-40);
+}
+
+@media (min-width: 1280px) {
+  .pageLayoutMain[data-layout="with-toc"] {
+    grid-template-columns: minmax(0, 1024px) 1fr;
   }
 }

--- a/aksel.nav.no/website/app/dev/(designsystemet)/layout.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/layout.tsx
@@ -14,9 +14,7 @@ export default async function DesignsystemLayout({
 
       <div className={styles.pageLayout}>
         <Sidebar />
-        <main id="hovedinnhold" className="flex w-full flex-auto py-6">
-          {children}
-        </main>
+        {children}
       </div>
       <Footer />
     </div>

--- a/aksel.nav.no/website/public/robots.txt
+++ b/aksel.nav.no/website/public/robots.txt
@@ -21,5 +21,6 @@ Disallow: /templates
 Disallow: /sandbox
 Disallow: /admin
 Disallow: /gp
+Disallow: /dev
 
 Sitemap: https://aksel.nav.no/sitemap.xml


### PR DESCRIPTION
### Description

Uses grid-layouts to place content and TOC. Allows for layouts without TOC, but will have to test this for the landing-pages when ready in Figma

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
