### PR TITLE
:bug: Handle cases where sanity assets are undefined

### DIFF
--- a/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.hit.tsx
+++ b/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.hit.tsx
@@ -63,6 +63,10 @@ function GlobalSearchLink(props: {
       ? `/${hit.item.slug}#${hit.anchor}`
       : `/${hit.item.slug}`;
 
+  const imageUrl = urlFor(hit.item.status?.bilde)
+    ?.auto("format")
+    .url();
+
   return (
     <li className={styles.searchLinkLi}>
       <div className={styles.searchLinkText}>
@@ -88,9 +92,9 @@ function GlobalSearchLink(props: {
       </div>
 
       <div className={styles.searchThumbnail}>
-        {hit.item?.status?.bilde && (
+        {imageUrl && (
           <Image
-            src={urlFor(hit.item.status.bilde).auto("format").url()}
+            src={imageUrl}
             decoding="sync"
             width="96"
             height="96"

--- a/aksel.nav.no/website/components/layout/god-praksis-page/cards/GpFrontpageCard.tsx
+++ b/aksel.nav.no/website/components/layout/god-praksis-page/cards/GpFrontpageCard.tsx
@@ -1,7 +1,9 @@
 import { SanityImageSource } from "@sanity/image-url/lib/types/types";
+import Image from "next/legacy/image";
 import NextLink from "next/link";
 import ErrorBoundary from "@/error-boundary";
 import { FallbackPictogram } from "@/layout/god-praksis-page/FallbackPictogram";
+import { urlFor } from "@/sanity/interface";
 
 type GpFrontpageCardProps = {
   children: React.ReactNode;
@@ -9,11 +11,24 @@ type GpFrontpageCardProps = {
   image?: SanityImageSource;
 };
 
-const GpFrontpageCard = ({ children, href }: GpFrontpageCardProps) => {
+const GpFrontpageCard = ({ image, children, href }: GpFrontpageCardProps) => {
+  const imageUrl = urlFor(image)?.auto("format").url();
+
   return (
     <li className="flex items-center gap-2 px-2 py-4 sm:gap-4 sm:px-6">
       <div className="relative h-8 w-8 shrink-0 sm:h-12 sm:w-12">
-        <FallbackPictogram />
+        {imageUrl ? (
+          <Image
+            src={imageUrl}
+            decoding="sync"
+            layout="fill"
+            objectFit="contain"
+            aria-hidden
+            priority
+          />
+        ) : (
+          <FallbackPictogram />
+        )}
       </div>
       <NextLink
         href={href}

--- a/aksel.nav.no/website/components/layout/god-praksis-page/cards/GpHeroCard.tsx
+++ b/aksel.nav.no/website/components/layout/god-praksis-page/cards/GpHeroCard.tsx
@@ -18,6 +18,7 @@ type GpHeroCardProps = {
 
 const GpHeroCard = forwardRef<HTMLAnchorElement, GpHeroCardProps>(
   ({ href, articleCount, children, image, compact = false, ...rest }, ref) => {
+    const imageUrl = urlFor(image)?.auto("format").url();
     return (
       <Link
         ref={ref}
@@ -37,9 +38,9 @@ const GpHeroCard = forwardRef<HTMLAnchorElement, GpHeroCardProps>(
             "md:size-12": !compact,
           })}
         >
-          {image ? (
+          {imageUrl ? (
             <Image
-              src={urlFor(image).auto("format").url()}
+              src={imageUrl}
               decoding="sync"
               layout="fill"
               objectFit="contain"

--- a/aksel.nav.no/website/components/layout/god-praksis-page/hero/tema-hero/parts/HeroIntro.tsx
+++ b/aksel.nav.no/website/components/layout/god-praksis-page/hero/tema-hero/parts/HeroIntro.tsx
@@ -16,14 +16,16 @@ export function HeroIntro({
   hidden,
   image,
 }: HeroIntroProps) {
+  const imageUrl = urlFor(image)?.auto("format").url();
+
   return (
     <div className="relative z-10 mt-4" aria-hidden={hidden}>
       <div className="flex items-center gap-3">
         {/* To avoid having duplicate images for different backgrounds, we up the contrast instead */}
         <div className="relative my-auto size-8 shrink-0 contrast-200 md:size-12">
-          {image ? (
+          {imageUrl ? (
             <Image
-              src={urlFor(image).auto("format").url()}
+              src={imageUrl}
               decoding="sync"
               layout="fill"
               objectFit="contain"

--- a/aksel.nav.no/website/components/layout/templates/WithSidebar.tsx
+++ b/aksel.nav.no/website/components/layout/templates/WithSidebar.tsx
@@ -30,6 +30,10 @@ export const WithSidebar = ({
   footer?: React.ReactNode;
   variant?: "page" | "landingPage";
 }) => {
+  const imageUrl = urlFor(pageProps.status?.bilde)
+    ?.auto("format")
+    .url();
+
   return (
     <Box
       background="bg-default"
@@ -76,7 +80,7 @@ export const WithSidebar = ({
                 {intro}
               </div>
             </div>
-            {variant === "page" && pageProps.status?.bilde && (
+            {variant === "page" && imageUrl && (
               <div
                 className={cl(
                   "relative hidden aspect-square h-[12.5rem] lg:block xl:mr-40",
@@ -86,9 +90,7 @@ export const WithSidebar = ({
                 )}
               >
                 <Image
-                  src={urlFor(pageProps.status?.bilde)
-                    .auto("format")
-                    .url()}
+                  src={imageUrl}
                   decoding="async"
                   layout="fill"
                   objectFit="contain"

--- a/aksel.nav.no/website/components/sanity-modules/bilde/Bilde.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/bilde/Bilde.tsx
@@ -12,7 +12,9 @@ type BildeProps = {
 };
 
 const Bilde = ({ node, className }: BildeProps) => {
-  if (!node || !node.asset) {
+  const imageUrl = urlFor(node)?.auto("format").url();
+
+  if (!node || !node.asset || !imageUrl) {
     return null;
   }
 
@@ -41,7 +43,7 @@ const Bilde = ({ node, className }: BildeProps) => {
         <img
           alt={!node?.dekorativt ? node.alt : ""}
           decoding="async"
-          src={urlFor(node).auto("format").url()}
+          src={imageUrl}
           className="rounded-lg"
         />
       </div>

--- a/aksel.nav.no/website/components/sanity-modules/compare-images/CompareImages.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/compare-images/CompareImages.tsx
@@ -154,6 +154,13 @@ const CompareImages = ({ node }: CompareImagesProps) => {
       : undefined,
   };
 
+  const imageOneUrl = urlFor(node.image_1.asset)?.auto("format").url();
+  const imageTwoUrl = urlFor(node.image_2.asset)?.auto("format").url();
+
+  if (!imageOneUrl || !imageTwoUrl) {
+    return null;
+  }
+
   return (
     <figure className="m-0 mb-8 flex flex-col group-[.aksel-artikkel]/aksel:mx-auto">
       <div
@@ -170,14 +177,14 @@ const CompareImages = ({ node }: CompareImagesProps) => {
       >
         <CompareItem order="1">
           <img
-            src={urlFor(node.image_1.asset).auto("format").url()}
+            src={imageOneUrl}
             alt={node.image_1.alt}
             className="object-cover object-center"
           />
         </CompareItem>
         <CompareItem order="2">
           <img
-            src={urlFor(node.image_2.asset).auto("format").url()}
+            src={imageTwoUrl}
             alt={node.image_2.alt}
             className="object-cover object-center"
           />

--- a/aksel.nav.no/website/components/sanity-modules/component-overview/ComponentOverview.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/component-overview/ComponentOverview.tsx
@@ -54,94 +54,98 @@ const ComponentOverview = ({ node }: { node: ArticleListT }) => {
   return (
     <div className="mb-8">
       <ul className="grid grid-cols-[repeat(auto-fill,_minmax(min(17rem,_100%),_1fr))] gap-6">
-        {sorted.map((x) => (
-          <li key={x._id}>
-            <div className="group relative min-h-56 rounded-2xl bg-surface-subtle shadow-xsmall focus-within:ring-[3px] focus-within:ring-border-focus hover:shadow-small">
-              <div
-                className={cl(
-                  "flex max-h-44 items-center justify-center overflow-hidden rounded-t-2xl filter",
-                  {
-                    "hue-rotate-[65deg]": x?.status?.tag === "beta",
-                    grayscale: x?.status?.tag === "deprecated",
-                  },
-                )}
-              >
-                {x.status?.bilde ? (
-                  <Image
-                    src={urlFor(x.status?.bilde)
-                      .auto("format")
-                      .url()}
-                    width="200"
-                    height="200"
-                    layout="fixed"
-                    objectFit="contain"
-                    alt={x?.heading + " thumbnail"}
-                    aria-hidden
-                  />
-                ) : (
-                  <svg
-                    width="200"
-                    height="200"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    aria-hidden
-                  >
-                    <path
-                      fill="#3380A5"
-                      d="M85 75h5v5h-5zM80 80h5v5h-5zM60 65h5v5h-5zM65 60h5v5h-5zM70 60h5v5h-5zM75 60h5v5h-5zM80 60h5v5h-5zM85 60h5v5h-5zM90 60h5v5h-5zM95 60h5v5h-5zM100 60h5v5h-5zM105 60h5v5h-5zM110 60h5v5h-5zM115 60h5v5h-5zM120 60h5v5h-5zM125 60h5v5h-5zM130 60h5v5h-5zM60 70h5v5h-5zM60 75h5v5h-5zM60 80h5v5h-5zM60 85h5v5h-5zM60 90h5v5h-5zM60 95h5v5h-5zM60 100h5v5h-5zM60 105h5v5h-5zM60 110h5v5h-5zM60 115h5v5h-5zM60 120h5v5h-5zM60 125h5v5h-5zM60 130h5v5h-5zM80 85h5v5h-5zM80 90h5v5h-5zM85 80h5v5h-5zM85 85h5v5h-5zM85 90h5v5h-5zM105 80h5v5h-5zM105 85h5v5h-5zM105 90h5v5h-5zM105 95h5v5h-5zM100 95h5v5h-5zM100 100h5v5h-5zM100 105h5v5h-5zM100 115h5v5h-5zM100 120h5v5h-5zM95 100h5v5h-5zM95 105h5v5h-5zM95 115h5v5h-5zM95 120h5v5h-5zM110 80h5v5h-5zM110 85h5v5h-5zM110 90h5v5h-5zM110 95h5v5h-5zM90 75h5v5h-5zM95 75h5v5h-5zM100 75h5v5h-5zM105 75h5v5h-5z"
-                    />
-                    <path
-                      fill="#00243A"
-                      d="M70 70h5v5h-5zM90 80h5v5h-5zM90 85h5v5h-5zM90 90h5v5h-5zM90 95h5v5h-5zM85 95h5v5h-5zM95 80h5v5h-5zM100 80h5v5h-5zM115 85h5v5h-5zM115 90h5v5h-5zM115 95h5v5h-5zM115 100h5v5h-5zM110 100h5v5h-5zM105 100h5v5h-5zM105 105h5v5h-5zM105 110h5v5h-5zM105 120h5v5h-5zM105 125h5v5h-5zM125 125h5v5h-5zM100 125h5v5h-5zM70 125h5v5h-5zM100 110h5v5h-5zM125 70h5v5h-5zM135 65h5v5h-5zM135 70h5v5h-5zM135 75h5v5h-5zM135 80h5v5h-5zM135 85h5v5h-5zM135 90h5v5h-5zM135 95h5v5h-5zM135 100h5v5h-5zM135 105h5v5h-5zM135 110h5v5h-5zM135 115h5v5h-5zM135 120h5v5h-5zM135 125h5v5h-5zM135 130h5v5h-5zM135 135h5v5h-5zM130 135h5v5h-5zM125 135h5v5h-5zM120 135h5v5h-5zM115 135h5v5h-5zM110 135h5v5h-5zM105 135h5v5h-5zM100 135h5v5h-5zM95 135h5v5h-5zM90 135h5v5h-5zM85 135h5v5h-5zM80 135h5v5h-5zM75 135h5v5h-5zM70 135h5v5h-5zM65 135h5v5h-5zM60 135h5v5h-5z"
-                    />
-                    <path
-                      fillRule="evenodd"
-                      clipRule="evenodd"
-                      d="M65 65h70v70H65V65Zm65 5h-5v5h5v-5Zm0 60v-5h-5v5h5Zm-20 0v-10h-5v-5h5v-10h10V85h-5v-5h-5v-5H85v5h-5v15h5v5h10v10h5v5h-5v10h5v5h10Zm-15-30V85h10v10h-5v5h-5ZM75 75v-5h-5v5h5Zm0 55v-5h-5v5h5Z"
-                      fill={`url(#${x._id})`}
-                    />
-                    <defs>
-                      <linearGradient
-                        id={x._id}
-                        x1="65"
-                        y1="65"
-                        x2="135"
-                        y2="135"
-                        gradientUnits="userSpaceOnUse"
-                      >
-                        <stop offset=".010417" stopColor="#CCE2F0" />
-                        <stop offset="1" stopColor="#66A3C4" />
-                      </linearGradient>
-                    </defs>
-                  </svg>
-                )}
-              </div>
+        {sorted.map((x) => {
+          const imageUrl = urlFor(x.status?.bilde)
+            ?.auto("format")
+            .url();
 
-              <div className="grid p-6 pt-0">
-                <span className="flex items-center justify-between">
-                  <Nextlink
-                    href={`/${x?.slug.current}`}
-                    passHref
-                    legacyBehavior
-                  >
-                    <Heading
-                      as="a"
-                      size="small"
-                      className="z-10 underline before:absolute before:inset-0 focus:outline-none group-hover:no-underline"
+          return (
+            <li key={x._id}>
+              <div className="group relative min-h-56 rounded-2xl bg-surface-subtle shadow-xsmall focus-within:ring-[3px] focus-within:ring-border-focus hover:shadow-small">
+                <div
+                  className={cl(
+                    "flex max-h-44 items-center justify-center overflow-hidden rounded-t-2xl filter",
+                    {
+                      "hue-rotate-[65deg]": x?.status?.tag === "beta",
+                      grayscale: x?.status?.tag === "deprecated",
+                    },
+                  )}
+                >
+                  {imageUrl ? (
+                    <Image
+                      src={imageUrl}
+                      width="200"
+                      height="200"
+                      layout="fixed"
+                      objectFit="contain"
+                      alt={x?.heading + " thumbnail"}
+                      aria-hidden
+                    />
+                  ) : (
+                    <svg
+                      width="200"
+                      height="200"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      aria-hidden
                     >
-                      {x.heading}
-                      {x?.status?.tag && (
-                        <span className="absolute left-4 top-4">
-                          <StatusTag status={x?.status?.tag} />
-                        </span>
-                      )}
-                    </Heading>
-                  </Nextlink>
-                </span>
+                      <path
+                        fill="#3380A5"
+                        d="M85 75h5v5h-5zM80 80h5v5h-5zM60 65h5v5h-5zM65 60h5v5h-5zM70 60h5v5h-5zM75 60h5v5h-5zM80 60h5v5h-5zM85 60h5v5h-5zM90 60h5v5h-5zM95 60h5v5h-5zM100 60h5v5h-5zM105 60h5v5h-5zM110 60h5v5h-5zM115 60h5v5h-5zM120 60h5v5h-5zM125 60h5v5h-5zM130 60h5v5h-5zM60 70h5v5h-5zM60 75h5v5h-5zM60 80h5v5h-5zM60 85h5v5h-5zM60 90h5v5h-5zM60 95h5v5h-5zM60 100h5v5h-5zM60 105h5v5h-5zM60 110h5v5h-5zM60 115h5v5h-5zM60 120h5v5h-5zM60 125h5v5h-5zM60 130h5v5h-5zM80 85h5v5h-5zM80 90h5v5h-5zM85 80h5v5h-5zM85 85h5v5h-5zM85 90h5v5h-5zM105 80h5v5h-5zM105 85h5v5h-5zM105 90h5v5h-5zM105 95h5v5h-5zM100 95h5v5h-5zM100 100h5v5h-5zM100 105h5v5h-5zM100 115h5v5h-5zM100 120h5v5h-5zM95 100h5v5h-5zM95 105h5v5h-5zM95 115h5v5h-5zM95 120h5v5h-5zM110 80h5v5h-5zM110 85h5v5h-5zM110 90h5v5h-5zM110 95h5v5h-5zM90 75h5v5h-5zM95 75h5v5h-5zM100 75h5v5h-5zM105 75h5v5h-5z"
+                      />
+                      <path
+                        fill="#00243A"
+                        d="M70 70h5v5h-5zM90 80h5v5h-5zM90 85h5v5h-5zM90 90h5v5h-5zM90 95h5v5h-5zM85 95h5v5h-5zM95 80h5v5h-5zM100 80h5v5h-5zM115 85h5v5h-5zM115 90h5v5h-5zM115 95h5v5h-5zM115 100h5v5h-5zM110 100h5v5h-5zM105 100h5v5h-5zM105 105h5v5h-5zM105 110h5v5h-5zM105 120h5v5h-5zM105 125h5v5h-5zM125 125h5v5h-5zM100 125h5v5h-5zM70 125h5v5h-5zM100 110h5v5h-5zM125 70h5v5h-5zM135 65h5v5h-5zM135 70h5v5h-5zM135 75h5v5h-5zM135 80h5v5h-5zM135 85h5v5h-5zM135 90h5v5h-5zM135 95h5v5h-5zM135 100h5v5h-5zM135 105h5v5h-5zM135 110h5v5h-5zM135 115h5v5h-5zM135 120h5v5h-5zM135 125h5v5h-5zM135 130h5v5h-5zM135 135h5v5h-5zM130 135h5v5h-5zM125 135h5v5h-5zM120 135h5v5h-5zM115 135h5v5h-5zM110 135h5v5h-5zM105 135h5v5h-5zM100 135h5v5h-5zM95 135h5v5h-5zM90 135h5v5h-5zM85 135h5v5h-5zM80 135h5v5h-5zM75 135h5v5h-5zM70 135h5v5h-5zM65 135h5v5h-5zM60 135h5v5h-5z"
+                      />
+                      <path
+                        fillRule="evenodd"
+                        clipRule="evenodd"
+                        d="M65 65h70v70H65V65Zm65 5h-5v5h5v-5Zm0 60v-5h-5v5h5Zm-20 0v-10h-5v-5h5v-10h10V85h-5v-5h-5v-5H85v5h-5v15h5v5h10v10h5v5h-5v10h5v5h10Zm-15-30V85h10v10h-5v5h-5ZM75 75v-5h-5v5h5Zm0 55v-5h-5v5h5Z"
+                        fill={`url(#${x._id})`}
+                      />
+                      <defs>
+                        <linearGradient
+                          id={x._id}
+                          x1="65"
+                          y1="65"
+                          x2="135"
+                          y2="135"
+                          gradientUnits="userSpaceOnUse"
+                        >
+                          <stop offset=".010417" stopColor="#CCE2F0" />
+                          <stop offset="1" stopColor="#66A3C4" />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  )}
+                </div>
+
+                <div className="grid p-6 pt-0">
+                  <span className="flex items-center justify-between">
+                    <Nextlink
+                      href={`/${x?.slug.current}`}
+                      passHref
+                      legacyBehavior
+                    >
+                      <Heading
+                        as="a"
+                        size="small"
+                        className="z-10 underline before:absolute before:inset-0 focus:outline-none group-hover:no-underline"
+                      >
+                        {x.heading}
+                        {x?.status?.tag && (
+                          <span className="absolute left-4 top-4">
+                            <StatusTag status={x?.status?.tag} />
+                          </span>
+                        )}
+                      </Heading>
+                    </Nextlink>
+                  </span>
+                </div>
               </div>
-            </div>
-          </li>
-        ))}
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/aksel.nav.no/website/components/sanity-modules/do-dont/DoDont.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/do-dont/DoDont.tsx
@@ -11,7 +11,9 @@ import { urlFor } from "@/sanity/interface";
 import { DoDontT } from "@/types";
 
 const Element = ({ block }: { block: DoDontT["blokker"][number] }) => {
-  if (!block.picture) {
+  const imageUrl = urlFor(block.picture)?.auto("format").url();
+
+  if (!block.picture || !imageUrl) {
     return null;
   }
 
@@ -43,7 +45,7 @@ const Element = ({ block }: { block: DoDontT["blokker"][number] }) => {
           alt={block.alt}
           loading="lazy"
           decoding="async"
-          src={urlFor(block.picture).auto("format").url()}
+          src={imageUrl}
         />
       </div>
       {block.description && (

--- a/aksel.nav.no/website/components/sanity-modules/frontpage-blocks/latest-articles/Card.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/frontpage-blocks/latest-articles/Card.tsx
@@ -44,6 +44,68 @@ const Card = ({ article, visible, index }: CardProps) => {
     "templates_artikkel",
   ].includes(article._type);
 
+  const statusImageUrl = urlFor(article.status?.bilde)
+    ?.auto("format")
+    .url();
+
+  const statusImageBlurUrl = urlFor(article.status?.bilde)
+    ?.width(24)
+    .height(24)
+    .blur(10)
+    .url();
+
+  const fallbackImageUrl = urlFor(article.seo?.image)
+    ?.auto("format")
+    .url();
+
+  const fallbackImageBlurUrl = urlFor(article.seo?.image)
+    ?.width(24)
+    .height(24)
+    .blur(10)
+    .url();
+
+  let Image = (
+    <div className="relative h-[200px] w-full">
+      <NextImage
+        layout="fill"
+        objectFit="cover"
+        src={getImage(article?.heading ?? "", "thumbnail")}
+        alt={article.heading + " thumbnail"}
+        aria-hidden
+        className="rounded-t-lg"
+      />
+    </div>
+  );
+
+  if (statusImageUrl) {
+    Image = (
+      <NextImage
+        src={statusImageUrl}
+        blurDataURL={statusImageBlurUrl}
+        placeholder="blur"
+        width="200"
+        height="200"
+        alt={article.heading + " thumbnail"}
+        aria-hidden
+      />
+    );
+  } else if (fallbackImageUrl) {
+    Image = (
+      <div className="relative h-[200px] w-full">
+        <NextImage
+          src={fallbackImageUrl}
+          blurDataURL={fallbackImageBlurUrl}
+          placeholder="blur"
+          layout="fill"
+          objectFit="cover"
+          alt={article.heading + " thumbnail"}
+          aria-hidden
+          className="rounded-t-lg"
+        />
+      </div>
+    );
+  }
+
   return (
     <div
       className={cl(
@@ -67,53 +129,7 @@ const Card = ({ article, visible, index }: CardProps) => {
             },
           )}
         >
-          {article.status?.bilde ?? article.seo?.image ? (
-            article.status?.bilde ? (
-              <NextImage
-                src={urlFor(article.status.bilde).auto("format").url()}
-                blurDataURL={urlFor(article.status.bilde)
-                  .width(24)
-                  .height(24)
-                  .blur(10)
-                  .url()}
-                placeholder="blur"
-                width="200"
-                height="200"
-                alt={article.heading + " thumbnail"}
-                aria-hidden
-              />
-            ) : (
-              <div className="relative h-[200px] w-full">
-                <NextImage
-                  src={urlFor(article.seo?.image)
-                    .auto("format")
-                    .url()}
-                  blurDataURL={urlFor(article.seo?.image)
-                    .width(24)
-                    .height(24)
-                    .blur(10)
-                    .url()}
-                  placeholder="blur"
-                  layout="fill"
-                  objectFit="cover"
-                  alt={article.heading + " thumbnail"}
-                  aria-hidden
-                  className="rounded-t-lg"
-                />
-              </div>
-            )
-          ) : (
-            <div className="relative h-[200px] w-full">
-              <NextImage
-                layout="fill"
-                objectFit="cover"
-                src={getImage(article?.heading ?? "", "thumbnail")}
-                alt={article.heading + " thumbnail"}
-                aria-hidden
-                className="rounded-t-lg"
-              />
-            </div>
-          )}
+          {Image}
         </div>
       )}
       <div className={cl("p-3 sm:p-5", showFooter && "pb-16 sm:pb-16")}>

--- a/aksel.nav.no/website/components/sanity-modules/frontpage-blocks/latest-articles/Highlight.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/frontpage-blocks/latest-articles/Highlight.tsx
@@ -22,6 +22,28 @@ export const Highlight = ({
 
   const date = useFormatedDate(article?.publishedAt ?? article._createdAt);
 
+  const imageUrl = urlFor(article.status?.bilde)
+    ?.quality(100)
+    .auto("format")
+    .url();
+
+  const imageBlurUrl = urlFor(article.status?.bilde)
+    ?.width(24)
+    .height(24)
+    .blur(10)
+    .url();
+
+  const seoImageUrl = urlFor(article?.seo?.image)
+    ?.quality(100)
+    .auto("format")
+    .url();
+
+  const seoImageBlurUrl = urlFor(article?.seo?.image)
+    ?.width(24)
+    .height(24)
+    .blur(10)
+    .url();
+
   return (
     <section
       aria-label={`Fremhevet artikkel: ${article?.heading}`}
@@ -31,17 +53,10 @@ export const Highlight = ({
       })}
     >
       <div className="relative block aspect-video">
-        {useStatusImage ? (
+        {useStatusImage && imageUrl ? (
           <Image
-            src={urlFor(article.status?.bilde)
-              .quality(100)
-              .auto("format")
-              .url()}
-            blurDataURL={urlFor(article.status?.bilde)
-              .width(24)
-              .height(24)
-              .blur(10)
-              .url()}
+            src={imageUrl}
+            blurDataURL={imageBlurUrl}
             placeholder="blur"
             quality={100}
             layout="fill"
@@ -54,14 +69,10 @@ export const Highlight = ({
             )}
             decoding="auto"
           />
-        ) : article?.seo?.image ? (
+        ) : seoImageUrl ? (
           <Image
-            src={urlFor(article.seo.image).quality(100).auto("format").url()}
-            blurDataURL={urlFor(article.seo.image)
-              .width(24)
-              .height(24)
-              .blur(10)
-              .url()}
+            src={seoImageUrl}
+            blurDataURL={seoImageBlurUrl}
             placeholder="blur"
             quality={100}
             layout="fill"

--- a/aksel.nav.no/website/components/website-modules/blogg-page/parts/BloggList.tsx
+++ b/aksel.nav.no/website/components/website-modules/blogg-page/parts/BloggList.tsx
@@ -12,13 +12,18 @@ export const BloggList = ({
   blogg: ResolveContributorsT<ResolveSlugT<AkselBloggDocT>>;
 }) => {
   const date = useFormatedDate(blogg?.publishedAt ?? blogg._createdAt);
+
+  const imageUrl = urlFor(blogg?.seo?.image)
+    ?.auto("format")
+    .url();
+
   return (
     <li>
       <div className="hidden gap-6 md:flex">
         <div className="relative hidden aspect-square h-[11.75rem] rounded-lg ring-1 ring-border-subtle lg:block">
-          {blogg?.seo?.image ? (
+          {imageUrl ? (
             <Image
-              src={urlFor(blogg.seo.image).auto("format").url()}
+              src={imageUrl}
               layout="fill"
               objectFit="cover"
               aria-hidden

--- a/aksel.nav.no/website/components/website-modules/blogg-page/parts/HighlightedBlogg.tsx
+++ b/aksel.nav.no/website/components/website-modules/blogg-page/parts/HighlightedBlogg.tsx
@@ -12,18 +12,25 @@ export const HighlightedBlogg = ({
   blogg: ResolveContributorsT<ResolveSlugT<AkselBloggDocT>>;
 }) => {
   const date = useFormatedDate(blogg?.publishedAt ?? blogg._createdAt);
+
+  const imageUrl = urlFor(blogg?.seo?.image)
+    ?.quality(100)
+    .auto("format")
+    .url();
+  const imageBlurUrl = urlFor(blogg?.seo?.image)
+    ?.width(24)
+    .height(24)
+    .blur(10)
+    .url();
+
   return (
     <article>
       <div className="col-span-1 hidden md:block">
         <div className="relative mb-10 block aspect-video rounded-lg ring-1 ring-border-subtle">
-          {blogg?.seo?.image ? (
+          {imageUrl ? (
             <Image
-              src={urlFor(blogg.seo.image).quality(100).auto("format").url()}
-              blurDataURL={urlFor(blogg.seo.image)
-                .width(24)
-                .height(24)
-                .blur(10)
-                .url()}
+              src={imageUrl}
+              blurDataURL={imageBlurUrl}
               placeholder="blur"
               quality={100}
               layout="fill"
@@ -65,14 +72,10 @@ export const HighlightedBlogg = ({
       {/* Mobile view */}
       <div className="w-full md:hidden">
         <div className="relative mb-10 block aspect-video rounded-lg ring-1 ring-border-subtle">
-          {blogg?.seo?.image ? (
+          {imageUrl ? (
             <Image
-              src={urlFor(blogg.seo.image).quality(100).auto("format").url()}
-              blurDataURL={urlFor(blogg.seo.image)
-                .width(24)
-                .height(24)
-                .blur(10)
-                .url()}
+              src={imageUrl}
+              blurDataURL={imageBlurUrl}
               placeholder="blur"
               quality={100}
               layout="fill"

--- a/aksel.nav.no/website/components/website-modules/search/parts/Hit.tsx
+++ b/aksel.nav.no/website/components/website-modules/search/parts/Hit.tsx
@@ -26,6 +26,9 @@ export const Hit = forwardRef<
       ? `/${hit.item.slug}#${hit.anchor}`
       : `/${hit.item.slug}`;
 
+  const imageUrl = urlFor(hit?.item?.status?.bilde)
+    ?.auto("format")
+    .url();
   return (
     <li
       ref={ref}
@@ -75,9 +78,9 @@ export const Hit = forwardRef<
 
       {!simple && (
         <div className="hidden aspect-square w-24 sm:block">
-          {hit.item?.status?.bilde && (
+          {imageUrl && (
             <Image
-              src={urlFor(hit.item.status.bilde).auto("format").url()}
+              src={imageUrl}
               decoding="sync"
               width="96"
               height="96"

--- a/aksel.nav.no/website/components/website-modules/seo/SEO.tsx
+++ b/aksel.nav.no/website/components/website-modules/seo/SEO.tsx
@@ -18,6 +18,12 @@ export function SEO({
   fallbackImage,
   canonical,
 }: SEOProps) {
+  const imageUrl = urlFor(image)
+    ?.width(1200)
+    .height(630)
+    .fit("crop")
+    .quality(100)
+    .url();
   return (
     <Head>
       <title>{`${title} - aksel.nav.no`}</title>
@@ -32,17 +38,8 @@ export function SEO({
       {description && (
         <meta property="og:description" content={description} key="ogdesc" />
       )}
-      {image && (
-        <meta
-          property="og:image"
-          content={urlFor(image)
-            .width(1200)
-            .height(630)
-            .fit("crop")
-            .quality(100)
-            .url()}
-          key="ogimage"
-        />
+      {imageUrl && (
+        <meta property="og:image" content={imageUrl} key="ogimage" />
       )}
       {!image && fallbackImage && (
         <meta property="og:image" content={fallbackImage} key="ogimage" />

--- a/aksel.nav.no/website/pages/index.tsx
+++ b/aksel.nav.no/website/pages/index.tsx
@@ -113,8 +113,7 @@ const pageDataQuery = groq`*[_type == "aksel_forside"][0]{
 }.page`;
 
 const temaQuery = groq`*[_type == "aksel_forside"][0]{
-  "tema": *[_type == "gp.tema" && count(*[_type=="aksel_artikkel"
-      && (^._id in undertema[]->tema._ref)]) > 0] | order(lower(title))
+  "tema": *[_type == "gp.tema"] | order(lower(title))
       }.tema`;
 
 export const getServerSideProps: GetServerSideProps = async (

--- a/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
+++ b/aksel.nav.no/website/pages/produktbloggen/[slug].tsx
@@ -80,6 +80,17 @@ const Page = ({ blogg, morePosts, publishDate }: PageProps["props"]) => {
 
   const authors = (blogg?.contributors as any)?.map((x) => x?.title) ?? [];
 
+  const imageUrl = urlFor(blogg?.seo?.image)
+    ?.auto("format")
+    .quality(100)
+    .url();
+
+  const imageBlurUrl = urlFor(blogg?.seo?.image)
+    ?.width(24)
+    .height(24)
+    .blur(10)
+    .url();
+
   return (
     <>
       <SEO
@@ -128,17 +139,10 @@ const Page = ({ blogg, morePosts, publishDate }: PageProps["props"]) => {
             </div>
           </div>
           <div className="relative mx-auto mt-20 aspect-video w-full max-w-3xl rounded-2xl ring-1 ring-border-subtle">
-            {blogg?.seo?.image ? (
+            {imageUrl ? (
               <Image
-                src={urlFor(blogg?.seo?.image)
-                  .auto("format")
-                  .quality(100)
-                  .url()}
-                blurDataURL={urlFor(blogg?.seo?.image)
-                  .width(24)
-                  .height(24)
-                  .blur(10)
-                  .url()}
+                src={imageUrl}
+                blurDataURL={imageBlurUrl}
                 placeholder="blur"
                 decoding="sync"
                 layout="fill"

--- a/aksel.nav.no/website/sanity/interface/interface.ts
+++ b/aksel.nav.no/website/sanity/interface/interface.ts
@@ -3,6 +3,10 @@ import { allArticleDocuments } from "../config";
 import { getClient, noCdnClient, sanityClient } from "./client.server";
 
 export function urlFor(source: any) {
+  // Ensure that source image contains a valid reference
+  if (!source?.asset?._ref) {
+    return undefined;
+  }
   return imageUrlBuilder(sanityClient).image(source);
 }
 


### PR DESCRIPTION
### Description

In cases where assets were "valid", example `{}` the URL-lookup would crash the page. More specifically `.url()` crashed it. This update solves it by returning `undefined` in cases where the image would be invalid.
```
if (!source?.asset?._ref) {
    return undefined;
  }
```

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
