### PR TITLE
[Aksel.nav.no] Added PortableText marks support

### DIFF
--- a/aksel.nav.no/website/app/_ui/portable-text/CustomPortableText.components.tsx
+++ b/aksel.nav.no/website/app/_ui/portable-text/CustomPortableText.components.tsx
@@ -1,9 +1,14 @@
 import {
   PortableTextBlockComponent,
   type PortableTextComponents,
+  PortableTextMarkComponent,
 } from "next-sanity";
 import { Children } from "react";
 import { BodyLong, BodyShort, Detail, Heading } from "@navikt/ds-react";
+import { Kbd } from "../kbd/Kbd";
+import { Code } from "../typography/Code";
+import { List, ListItem } from "../typography/List";
+import { WebsiteLink } from "../typography/WebsiteLink";
 import styles from "./CustomPortableText.module.css";
 
 type CustomPortableTextComponentsProps = {
@@ -17,11 +22,45 @@ function customPortableTextComponents({
   typoConfig,
 }: CustomPortableTextComponentsProps): PortableTextComponents {
   const block = blockComponents({ typoConfig });
+  const marks = marksComponents();
+
   return {
     block,
+    list: {
+      bullet: ({ children }) => <List as="ul">{children}</List>,
+      number: ({ children }) => <List as="ol">{children}</List>,
+    },
+    listItem: {
+      bullet: ({ children }) => <ListItem icon>{children}</ListItem>,
+      number: ({ children }) => <ListItem>{children}</ListItem>,
+    },
+    marks,
     unknownBlockStyle: ({ children }) =>
       withSanitizedBlock(<BodyShort spacing>{children}</BodyShort>),
+    unknownType: () => null,
+    unknownMark: () => null,
   };
+}
+
+function marksComponents() {
+  return {
+    kbd: ({ text }) => <Kbd>{text}</Kbd>,
+    quote: ({ text }) => <q>{text}</q>,
+    code: ({ text }) => <Code>{text}</Code>,
+
+    link: ({ text, value: { href } }) => {
+      if (!href) {
+        return <span>{text}</span>;
+      }
+      return <WebsiteLink href={href}>{text}</WebsiteLink>;
+    },
+    internalLink: ({ text, value: { slug } }) => {
+      if (!slug || !slug.current) {
+        return <span>{text}</span>;
+      }
+      return <WebsiteLink href={`/${slug.current}`}>{text}</WebsiteLink>;
+    },
+  } satisfies Record<string, PortableTextMarkComponent>;
 }
 
 function blockComponents({


### PR DESCRIPTION
### Description

This pull request includes updates to the `CustomPortableText.components.tsx` file to enhance the rendering of portable text components. The changes focus on adding support for new text marks and list handling.

Enhancements to portable text components:

* Added new imports for `Kbd`, `Code`, `List`, `ListItem`, and `WebsiteLink` components to support additional text formatting options.
* Introduced a `marksComponents` function to define custom mark components for `kbd`, `quote`, `code`, `link`, and `internalLink`.
* Updated the `customPortableTextComponents` function to include new list and list item handling, as well as the newly defined marks.
* Added handling for unknown block styles, types, and marks to ensure graceful degradation when encountering unsupported content.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
