### PR TITLE
:bug: Disabled expansion-rows now has same hover-effect as other rows

### DIFF
--- a/.changeset/fresh-baboons-make.md
+++ b/.changeset/fresh-baboons-make.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Table: Disabled expansion-rows now has same hover-effect as other rows.

--- a/@navikt/core/css/darkside/table.darkside.css
+++ b/@navikt/core/css/darkside/table.darkside.css
@@ -11,7 +11,7 @@
 .aksel-table__body {
   display: table-row-group;
 
-  & .aksel-table__row--shade-on-hover:not(.aksel-table__expandable-row--expansion-disabled):hover {
+  & .aksel-table__row--shade-on-hover:hover {
     background-color: var(--ax-bg-neutral-moderate-hoverA);
     transition: background-color 70ms cubic-bezier(0.2, 0, 0, 1);
   }

--- a/@navikt/core/css/table.css
+++ b/@navikt/core/css/table.css
@@ -16,7 +16,7 @@
   display: table-row;
 }
 
-.navds-table__body .navds-table__row--shade-on-hover:not(.navds-table__expandable-row--expansion-disabled):hover {
+.navds-table__body .navds-table__row--shade-on-hover:hover {
   background-color: var(--ac-table-row-hover, var(--a-bg-subtle));
 }
 


### PR DESCRIPTION
### Description

Resolves #3694

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
