### PR TITLE
[Aksel.nav.no] More updates to app-router DS-pages, added SEO

### DIFF
--- a/aksel.nav.no/website/app/_sanity/queries.ts
+++ b/aksel.nav.no/website/app/_sanity/queries.ts
@@ -63,6 +63,16 @@ const GRUNNLEGGENDE_BY_SLUG_QUERY =
     },
 }`);
 
+const MONSTER_MALER_BY_SLUG_QUERY =
+  defineQuery(`*[_type == "templates_artikkel" && slug.current == $slug][0]
+  {
+    ...,
+    content[]{
+      ...,
+      ${destructureBlocks}
+    },
+}`);
+
 const BLOGG_BY_SLUG_QUERY =
   defineQuery(`*[_type == "aksel_blogg" && slug.current == $slug][0]
 {
@@ -93,4 +103,5 @@ export {
   SLUG_BY_TYPE_QUERY,
   GRUNNLEGGENDE_BY_SLUG_QUERY,
   BLOGG_BY_SLUG_QUERY,
+  MONSTER_MALER_BY_SLUG_QUERY,
 };

--- a/aksel.nav.no/website/app/_sanity/queries.ts
+++ b/aksel.nav.no/website/app/_sanity/queries.ts
@@ -91,6 +91,13 @@ const TOC_BY_SLUG_QUERY =
   "title": pt::text(@)
 }`);
 
+const METADATA_BY_SLUG_QUERY = defineQuery(`*[slug.current == $slug][0]{
+  heading,
+  ingress,
+  publishedAt,
+  seo
+}`);
+
 const SLUG_BY_TYPE_QUERY = defineQuery(`
   *[_type == $type && defined(slug.current)].slug.current
 `);
@@ -104,4 +111,5 @@ export {
   GRUNNLEGGENDE_BY_SLUG_QUERY,
   BLOGG_BY_SLUG_QUERY,
   MONSTER_MALER_BY_SLUG_QUERY,
+  METADATA_BY_SLUG_QUERY,
 };

--- a/aksel.nav.no/website/app/_sanity/query-types.ts
+++ b/aksel.nav.no/website/app/_sanity/query-types.ts
@@ -7893,6 +7893,79 @@ export type TOC_BY_SLUG_QUERYResult = Array<{
   id: string;
   title: string;
 }> | null;
+// Variable: METADATA_BY_SLUG_QUERY
+// Query: *[slug.current == $slug][0]{  heading,  ingress,  publishedAt,  seo}
+export type METADATA_BY_SLUG_QUERYResult =
+  | {
+      heading: null;
+      ingress: null;
+      publishedAt: null;
+      seo: null;
+    }
+  | {
+      heading: null;
+      ingress: null;
+      publishedAt: null;
+      seo: {
+        meta?: string;
+        image?: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        };
+      } | null;
+    }
+  | {
+      heading: string | null;
+      ingress: null;
+      publishedAt: string | null;
+      seo: null;
+    }
+  | {
+      heading: string | null;
+      ingress: null;
+      publishedAt: string | null;
+      seo: {
+        meta?: string;
+        image?: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        };
+      } | null;
+    }
+  | {
+      heading: string | null;
+      ingress: string | null;
+      publishedAt: string | null;
+      seo: {
+        meta?: string;
+        image?: {
+          asset?: {
+            _ref: string;
+            _type: "reference";
+            _weak?: boolean;
+            [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+          };
+          hotspot?: SanityImageHotspot;
+          crop?: SanityImageCrop;
+          _type: "image";
+        };
+      } | null;
+    }
+  | null;
 // Variable: SLUG_BY_TYPE_QUERY
 // Query: *[_type == $type && defined(slug.current)].slug.current
 export type SLUG_BY_TYPE_QUERYResult = Array<string | null>;
@@ -7907,6 +7980,7 @@ declare module "@sanity/client" {
     '*[_type == "templates_artikkel" && slug.current == $slug][0]\n  {\n    ...,\n    content[]{\n      ...,\n      \n_type == "language" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "alert" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "attachment" =>{\n  ...,\n  "downloadLink": asset->url,\n  "size": asset->size,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "token_ref"=>@->,\n\nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n_type == "intro_komponent" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n},\n_type == "live_demo" =>{\n  ...,\n  "sandbox_ref": sandbox_ref->{...},\n},\n_type == "props_seksjon" =>{\n  ...,\n  komponenter[]{\n    ...,\n    "propref": propref->{...}\n  },\n},\n_type == "installasjon_seksjon" =>{\n  ...,\n  "code_ref": code_ref->{...},\n},\n_type == "spesial_seksjon" =>{\n  ...,\n  "token": token_ref->{...}\n},\n_type == "accordion"=>{\n  ...,\n  list[]{\n    ...,\n    content[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n      \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n    }\n  }\n}\n,\n_type == "expansioncard"=>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n    \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n  }\n},\n\n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n,\n\n    },\n}': MONSTER_MALER_BY_SLUG_QUERYResult;
     '*[_type == "aksel_blogg" && slug.current == $slug][0]\n{\n  ...,\n  "slug": slug.current,\n  content[]{\n    ...,\n    \n_type == "language" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "alert" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "attachment" =>{\n  ...,\n  "downloadLink": asset->url,\n  "size": asset->size,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "token_ref"=>@->,\n\nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n_type == "intro_komponent" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n},\n_type == "live_demo" =>{\n  ...,\n  "sandbox_ref": sandbox_ref->{...},\n},\n_type == "props_seksjon" =>{\n  ...,\n  komponenter[]{\n    ...,\n    "propref": propref->{...}\n  },\n},\n_type == "installasjon_seksjon" =>{\n  ...,\n  "code_ref": code_ref->{...},\n},\n_type == "spesial_seksjon" =>{\n  ...,\n  "token": token_ref->{...}\n},\n_type == "accordion"=>{\n  ...,\n  list[]{\n    ...,\n    content[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n      \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n    }\n  }\n}\n,\n_type == "expansioncard"=>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n    \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n  }\n},\n\n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n,\n\n  },\n  contributors[]->{title}\n}': BLOGG_BY_SLUG_QUERYResult;
     '*[slug.current == $slug][0].content[style match \'h2\'][]{\n  "id": _key,\n  "title": pt::text(@)\n}': TOC_BY_SLUG_QUERYResult;
+    "*[slug.current == $slug][0]{\n  heading,\n  ingress,\n  publishedAt,\n  seo\n}": METADATA_BY_SLUG_QUERYResult;
     "\n  *[_type == $type && defined(slug.current)].slug.current\n": SLUG_BY_TYPE_QUERYResult;
   }
 }

--- a/aksel.nav.no/website/app/_sanity/query-types.ts
+++ b/aksel.nav.no/website/app/_sanity/query-types.ts
@@ -5624,6 +5624,1151 @@ export type GRUNNLEGGENDE_BY_SLUG_QUERYResult = {
     };
   };
 } | null;
+// Variable: MONSTER_MALER_BY_SLUG_QUERY
+// Query: *[_type == "templates_artikkel" && slug.current == $slug][0]  {    ...,    content[]{      ...,      _type == "language" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "alert" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "attachment" =>{  ...,  "downloadLink": asset->url,  "size": asset->size,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "token_ref"=>@->,markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },},_type == "intro_komponent" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }},_type == "live_demo" =>{  ...,  "sandbox_ref": sandbox_ref->{...},},_type == "props_seksjon" =>{  ...,  komponenter[]{    ...,    "propref": propref->{...}  },},_type == "installasjon_seksjon" =>{  ...,  "code_ref": code_ref->{...},},_type == "spesial_seksjon" =>{  ...,  "token": token_ref->{...}},_type == "accordion"=>{  ...,  list[]{    ...,    content[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },},       _type == "bilde" =>{    ...,    floating_text[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "video" =>{    ...,    "webm": {      "url": webm.asset->url,      "extension": webm.asset->extension    },    "fallback": {      "url": fallback.asset->url,      "extension": fallback.asset->extension    },    "track": track.asset->url }, _type == "alert" =>{    ...,    body[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "kode" =>{    ...,    "ref": ref->{...}, }, _type == "kode_eksempler" =>{    ...,    dir->, }, _type == "kode_ref" => @->, _type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }}, _type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }}    }  }},_type == "expansioncard"=>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },},     _type == "bilde" =>{    ...,    floating_text[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "video" =>{    ...,    "webm": {      "url": webm.asset->url,      "extension": webm.asset->extension    },    "fallback": {      "url": fallback.asset->url,      "extension": fallback.asset->extension    },    "track": track.asset->url }, _type == "alert" =>{    ...,    body[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "kode" =>{    ...,    "ref": ref->{...}, }, _type == "kode_eksempler" =>{    ...,    dir->, }, _type == "kode_ref" => @->, _type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }}, _type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }}  }}, _type == "bilde" =>{    ...,    floating_text[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "video" =>{    ...,    "webm": {      "url": webm.asset->url,      "extension": webm.asset->extension    },    "fallback": {      "url": fallback.asset->url,      "extension": fallback.asset->extension    },    "track": track.asset->url }, _type == "alert" =>{    ...,    body[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "kode" =>{    ...,    "ref": ref->{...}, }, _type == "kode_eksempler" =>{    ...,    dir->, }, _type == "kode_ref" => @->, _type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }}, _type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }},    },}
+export type MONSTER_MALER_BY_SLUG_QUERYResult = {
+  _id: string;
+  _type: "templates_artikkel";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  updateInfo?: {
+    lastVerified?: string;
+  };
+  publishedAt?: string;
+  heading?: string;
+  kategori?: "brev" | "soknadsdialog" | "standalone" | "stotte";
+  sidebarindex?: number;
+  slug?: Slug;
+  contributors?: Array<{
+    _ref: string;
+    _type: "reference";
+    _weak?: boolean;
+    _key: string;
+    [internalGroqTypeReferenceTo]?: "editor";
+  }>;
+  status?: {
+    tag?: "beta" | "deprecated" | "new" | "ready";
+    bilde?: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    };
+  };
+  gh_discussions?: string;
+  content: Array<
+    | {
+        _key: string;
+        _type: "accordion";
+        list: Array<{
+          title?: string;
+          content: Array<
+            | {
+                _key: string;
+                _type: "accordion";
+                list?: Array<{
+                  title?: string;
+                  content?: Riktekst_standard;
+                  _type: "element";
+                  _key: string;
+                }>;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "alert";
+                variant?: "error" | "info" | "success" | "warning";
+                heading?: string;
+                heading_level?: "h2" | "h3" | "h4";
+                body: Array<{
+                  children?: Array<{
+                    marks?: Array<string>;
+                    text?: string;
+                    _type: "span";
+                    _key: string;
+                  }>;
+                  style?: "normal";
+                  listItem?: "bullet" | "number";
+                  markDefs: Array<
+                    | {
+                        reference?:
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                            };
+                        _type: "internalLink";
+                        _key: string;
+                        slug: Slug | null;
+                      }
+                    | {
+                        href?: string;
+                        _type: "link";
+                        _key: string;
+                      }
+                  > | null;
+                  level?: number;
+                  _type: "block";
+                  _key: string;
+                }> | null;
+                markDefs: null;
+              }
+            | {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                alt?: string;
+                caption?: string;
+                small?: boolean;
+                kilde?: {
+                  har_kilde?: boolean;
+                  prefix?: "FOTO" | "Kilde";
+                  tekst?: string;
+                  link?: string;
+                };
+                dekorativt?: boolean;
+                border?: boolean;
+                background?: Color;
+                _type: "bilde";
+                _key: string;
+                markDefs: null;
+                floating_text: null;
+              }
+            | {
+                children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+                }>;
+                style?: "h2" | "h3" | "h4" | "normal";
+                listItem?: "bullet" | "number";
+                markDefs: Array<
+                  | {
+                      reference?:
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                          };
+                      _type: "internalLink";
+                      _key: string;
+                      slug: Slug | null;
+                    }
+                  | {
+                      href?: string;
+                      _type: "link";
+                      _key: string;
+                    }
+                > | null;
+                level?: number;
+                _type: "block";
+                _key: string;
+              }
+            | {
+                _key: string;
+                _type: "do_dont";
+                blokker?: Array<
+                  {
+                    _key: string;
+                  } & Do_dont_block
+                >;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "exampletext_block";
+                title?: string;
+                text?: string;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "expansioncard";
+                heading?: string;
+                heading_level?: "h2" | "h3" | "h4";
+                description?: string;
+                body?: Riktekst_accordion;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "kode";
+                code?: Code;
+                title?: string;
+                markDefs: null;
+                ref: null;
+              }
+            | {
+                _key: string;
+                _type: "language";
+                body?: Riktekst_enkel;
+                language?: "en";
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "relatert_innhold";
+                title: string | null;
+                lenker: Array<{
+                  title?: string;
+                  intern?: boolean;
+                  intern_lenke: string | null;
+                  ekstern_link?: string;
+                  ekstern_domene?: boolean;
+                  _type: "lenke";
+                  _key: string;
+                }> | null;
+                markDefs: null;
+              }
+            | {
+                rows?: Array<
+                  {
+                    _key: string;
+                  } & TableRow
+                >;
+                _type: "tabell_v2";
+                _key: string;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "tips";
+                body: Array<{
+                  children?: Array<{
+                    marks?: Array<string>;
+                    text?: string;
+                    _type: "span";
+                    _key: string;
+                  }>;
+                  style?: "normal";
+                  listItem?: "bullet" | "number";
+                  markDefs: Array<
+                    | {
+                        reference?:
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                            };
+                        _type: "internalLink";
+                        _key: string;
+                        slug: Slug | null;
+                      }
+                    | {
+                        href?: string;
+                        _type: "link";
+                        _key: string;
+                      }
+                  > | null;
+                  level?: number;
+                  _type: "block";
+                  _key: string;
+                }> | null;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "video";
+                webm: {
+                  url: string | null;
+                  extension: string | null;
+                };
+                fallback: {
+                  url: string | null;
+                  extension: string | null;
+                };
+                track: string | null;
+                alt?: string;
+                caption?: string;
+                transkripsjon?: string;
+                markDefs: null;
+              }
+          > | null;
+          _type: "element";
+          _key: string;
+        }> | null;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "alert";
+        variant?: "error" | "info" | "success" | "warning";
+        heading?: string;
+        heading_level?: "h2" | "h3" | "h4";
+        body: Array<{
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?: "normal";
+          listItem?: "bullet" | "number";
+          markDefs: Array<
+            | {
+                reference?:
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                    };
+                _type: "internalLink";
+                _key: string;
+                slug: Slug | null;
+              }
+            | {
+                href?: string;
+                _type: "link";
+                _key: string;
+              }
+          > | null;
+          level?: number;
+          _type: "block";
+          _key: string;
+        }> | null;
+        markDefs: null;
+      }
+    | {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        alt?: string;
+        caption?: string;
+        small?: boolean;
+        kilde?: {
+          har_kilde?: boolean;
+          prefix?: "FOTO" | "Kilde";
+          tekst?: string;
+          link?: string;
+        };
+        dekorativt?: boolean;
+        border?: boolean;
+        background?: Color;
+        _type: "bilde";
+        _key: string;
+        markDefs: null;
+        floating_text: null;
+      }
+    | {
+        children?: Array<{
+          marks?: Array<string>;
+          text?: string;
+          _type: "span";
+          _key: string;
+        }>;
+        style?: "h2" | "h3" | "h4" | "normal";
+        listItem?: "bullet" | "number";
+        markDefs: Array<
+          | {
+              reference?:
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                  };
+              _type: "internalLink";
+              _key: string;
+              slug: Slug | null;
+            }
+          | {
+              href?: string;
+              _type: "link";
+              _key: string;
+            }
+        > | null;
+        level?: number;
+        _type: "block";
+        _key: string;
+      }
+    | {
+        _key: string;
+        _type: "do_dont";
+        blokker?: Array<
+          {
+            _key: string;
+          } & Do_dont_block
+        >;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "exampletext_block";
+        title?: string;
+        text?: string;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "expansioncard";
+        heading?: string;
+        heading_level?: "h2" | "h3" | "h4";
+        description?: string;
+        body: Array<
+          | {
+              _key: string;
+              _type: "alert";
+              variant?: "error" | "info" | "success" | "warning";
+              heading?: string;
+              heading_level?: "h2" | "h3" | "h4";
+              body: Array<{
+                children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+                }>;
+                style?: "normal";
+                listItem?: "bullet" | "number";
+                markDefs: Array<
+                  | {
+                      reference?:
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                          };
+                      _type: "internalLink";
+                      _key: string;
+                      slug: Slug | null;
+                    }
+                  | {
+                      href?: string;
+                      _type: "link";
+                      _key: string;
+                    }
+                > | null;
+                level?: number;
+                _type: "block";
+                _key: string;
+              }> | null;
+              markDefs: null;
+            }
+          | {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              alt?: string;
+              caption?: string;
+              small?: boolean;
+              kilde?: {
+                har_kilde?: boolean;
+                prefix?: "FOTO" | "Kilde";
+                tekst?: string;
+                link?: string;
+              };
+              dekorativt?: boolean;
+              border?: boolean;
+              background?: Color;
+              _type: "bilde";
+              _key: string;
+              markDefs: null;
+              floating_text: null;
+            }
+          | {
+              children?: Array<{
+                marks?: Array<string>;
+                text?: string;
+                _type: "span";
+                _key: string;
+              }>;
+              style?: "h2" | "h3" | "h4" | "normal";
+              listItem?: "bullet" | "number";
+              markDefs: Array<
+                | {
+                    reference?:
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                        };
+                    _type: "internalLink";
+                    _key: string;
+                    slug: Slug | null;
+                  }
+                | {
+                    href?: string;
+                    _type: "link";
+                    _key: string;
+                  }
+              > | null;
+              level?: number;
+              _type: "block";
+              _key: string;
+            }
+          | {
+              _key: string;
+              _type: "do_dont";
+              blokker?: Array<
+                {
+                  _key: string;
+                } & Do_dont_block
+              >;
+              markDefs: null;
+            }
+          | {
+              _key: string;
+              _type: "exampletext_block";
+              title?: string;
+              text?: string;
+              markDefs: null;
+            }
+          | {
+              _key: string;
+              _type: "kode";
+              code?: Code;
+              title?: string;
+              markDefs: null;
+              ref: null;
+            }
+          | {
+              _key: string;
+              _type: "relatert_innhold";
+              title: string | null;
+              lenker: Array<{
+                title?: string;
+                intern?: boolean;
+                intern_lenke: string | null;
+                ekstern_link?: string;
+                ekstern_domene?: boolean;
+                _type: "lenke";
+                _key: string;
+              }> | null;
+              markDefs: null;
+            }
+          | {
+              rows?: Array<
+                {
+                  _key: string;
+                } & TableRow
+              >;
+              _type: "tabell_v2";
+              _key: string;
+              markDefs: null;
+            }
+          | {
+              _key: string;
+              _type: "tips";
+              body: Array<{
+                children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+                }>;
+                style?: "normal";
+                listItem?: "bullet" | "number";
+                markDefs: Array<
+                  | {
+                      reference?:
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                          };
+                      _type: "internalLink";
+                      _key: string;
+                      slug: Slug | null;
+                    }
+                  | {
+                      href?: string;
+                      _type: "link";
+                      _key: string;
+                    }
+                > | null;
+                level?: number;
+                _type: "block";
+                _key: string;
+              }> | null;
+              markDefs: null;
+            }
+          | {
+              _key: string;
+              _type: "video";
+              webm: {
+                url: string | null;
+                extension: string | null;
+              };
+              fallback: {
+                url: string | null;
+                extension: string | null;
+              };
+              track: string | null;
+              alt?: string;
+              caption?: string;
+              transkripsjon?: string;
+              markDefs: null;
+            }
+        > | null;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "kode_eksempler";
+        title?: string;
+        dir: {
+          _id: string;
+          _type: "kode_eksempler_fil";
+          _createdAt: string;
+          _updatedAt: string;
+          _rev: string;
+          title?: string;
+          variant?: "eksempler" | "templates";
+          filer?: Array<{
+            title?: string;
+            navn?: string;
+            innhold?: string;
+            description?: string;
+            index?: number;
+            sandboxEnabled?: boolean;
+            sandboxBase64?: string;
+            _type: "fil";
+            _key: string;
+          }>;
+          metadata?: {
+            version?: number;
+            changelog?: Array<{
+              description?: string;
+              version?: number;
+              date?: string;
+              _type: "entry";
+              _key: string;
+            }>;
+          };
+        } | null;
+        compact?: boolean;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "kode";
+        code?: Code;
+        title?: string;
+        markDefs: null;
+        ref: null;
+      }
+    | {
+        _key: string;
+        _type: "language";
+        body: Array<{
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?: "normal";
+          listItem?: "bullet" | "number";
+          markDefs: Array<
+            | {
+                reference?:
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                    };
+                _type: "internalLink";
+                _key: string;
+                slug: Slug | null;
+              }
+            | {
+                href?: string;
+                _type: "link";
+                _key: string;
+              }
+          > | null;
+          level?: number;
+          _type: "block";
+          _key: string;
+        }> | null;
+        language?: "en";
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "relatert_innhold";
+        title: string | null;
+        lenker: Array<{
+          title?: string;
+          intern?: boolean;
+          intern_lenke: string | null;
+          ekstern_link?: string;
+          ekstern_domene?: boolean;
+          _type: "lenke";
+          _key: string;
+        }> | null;
+        markDefs: null;
+      }
+    | {
+        rows?: Array<
+          {
+            _key: string;
+          } & TableRow
+        >;
+        _type: "tabell_v2";
+        _key: string;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "tips";
+        body: Array<{
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?: "normal";
+          listItem?: "bullet" | "number";
+          markDefs: Array<
+            | {
+                reference?:
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                    };
+                _type: "internalLink";
+                _key: string;
+                slug: Slug | null;
+              }
+            | {
+                href?: string;
+                _type: "link";
+                _key: string;
+              }
+          > | null;
+          level?: number;
+          _type: "block";
+          _key: string;
+        }> | null;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "video";
+        webm: {
+          url: string | null;
+          extension: string | null;
+        };
+        fallback: {
+          url: string | null;
+          extension: string | null;
+        };
+        track: string | null;
+        alt?: string;
+        caption?: string;
+        transkripsjon?: string;
+        markDefs: null;
+      }
+  > | null;
+  seo?: {
+    meta?: string;
+    image?: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    };
+  };
+} | null;
 // Variable: BLOGG_BY_SLUG_QUERY
 // Query: *[_type == "aksel_blogg" && slug.current == $slug][0]{  ...,  "slug": slug.current,  content[]{    ...,    _type == "language" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "alert" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "attachment" =>{  ...,  "downloadLink": asset->url,  "size": asset->size,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "token_ref"=>@->,markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },},_type == "intro_komponent" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }},_type == "live_demo" =>{  ...,  "sandbox_ref": sandbox_ref->{...},},_type == "props_seksjon" =>{  ...,  komponenter[]{    ...,    "propref": propref->{...}  },},_type == "installasjon_seksjon" =>{  ...,  "code_ref": code_ref->{...},},_type == "spesial_seksjon" =>{  ...,  "token": token_ref->{...}},_type == "accordion"=>{  ...,  list[]{    ...,    content[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },},       _type == "bilde" =>{    ...,    floating_text[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "video" =>{    ...,    "webm": {      "url": webm.asset->url,      "extension": webm.asset->extension    },    "fallback": {      "url": fallback.asset->url,      "extension": fallback.asset->extension    },    "track": track.asset->url }, _type == "alert" =>{    ...,    body[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "kode" =>{    ...,    "ref": ref->{...}, }, _type == "kode_eksempler" =>{    ...,    dir->, }, _type == "kode_ref" => @->, _type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }}, _type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }}    }  }},_type == "expansioncard"=>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },},     _type == "bilde" =>{    ...,    floating_text[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "video" =>{    ...,    "webm": {      "url": webm.asset->url,      "extension": webm.asset->extension    },    "fallback": {      "url": fallback.asset->url,      "extension": fallback.asset->extension    },    "track": track.asset->url }, _type == "alert" =>{    ...,    body[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "kode" =>{    ...,    "ref": ref->{...}, }, _type == "kode_eksempler" =>{    ...,    dir->, }, _type == "kode_ref" => @->, _type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }}, _type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }}  }}, _type == "bilde" =>{    ...,    floating_text[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "video" =>{    ...,    "webm": {      "url": webm.asset->url,      "extension": webm.asset->extension    },    "fallback": {      "url": fallback.asset->url,      "extension": fallback.asset->extension    },    "track": track.asset->url }, _type == "alert" =>{    ...,    body[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "kode" =>{    ...,    "ref": ref->{...}, }, _type == "kode_eksempler" =>{    ...,    dir->, }, _type == "kode_ref" => @->, _type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }}, _type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }},  },  contributors[]->{title}}
 export type BLOGG_BY_SLUG_QUERYResult = {
@@ -6759,6 +7904,7 @@ declare module "@sanity/client" {
     '*[_type in ["komponent_artikkel",\n  "ds_artikkel",\n  "aksel_artikkel",\n  "aksel_blogg",\n  "aksel_prinsipp",\n  "aksel_standalone",\n  "templates_artikkel"]]{\n  heading,\n  "slug": slug.current,\n  "tema": undertema[]->tema->title,\n  ingress,\n  status,\n  _type,\n  "intro": pt::text(intro.body),\n  content,\n  publishedAt,\n  seo\n}': GLOBAL_SEARCH_QUERY_ALLResult;
     '*[_type == "komponent_artikkel" && slug.current == $slug][0]\n  {\n    ...,\n    intro{\n      ...,\n      body[]{\n        ...,\n      \n_type == "language" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "alert" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "attachment" =>{\n  ...,\n  "downloadLink": asset->url,\n  "size": asset->size,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "token_ref"=>@->,\n\nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n_type == "intro_komponent" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n},\n_type == "live_demo" =>{\n  ...,\n  "sandbox_ref": sandbox_ref->{...},\n},\n_type == "props_seksjon" =>{\n  ...,\n  komponenter[]{\n    ...,\n    "propref": propref->{...}\n  },\n},\n_type == "installasjon_seksjon" =>{\n  ...,\n  "code_ref": code_ref->{...},\n},\n_type == "spesial_seksjon" =>{\n  ...,\n  "token": token_ref->{...}\n},\n_type == "accordion"=>{\n  ...,\n  list[]{\n    ...,\n    content[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n      \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n    }\n  }\n}\n,\n_type == "expansioncard"=>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n    \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n  }\n},\n\n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n,\n\n      }\n    },\n    content[]{\n      ...,\n      \n_type == "language" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "alert" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "attachment" =>{\n  ...,\n  "downloadLink": asset->url,\n  "size": asset->size,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "token_ref"=>@->,\n\nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n_type == "intro_komponent" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n},\n_type == "live_demo" =>{\n  ...,\n  "sandbox_ref": sandbox_ref->{...},\n},\n_type == "props_seksjon" =>{\n  ...,\n  komponenter[]{\n    ...,\n    "propref": propref->{...}\n  },\n},\n_type == "installasjon_seksjon" =>{\n  ...,\n  "code_ref": code_ref->{...},\n},\n_type == "spesial_seksjon" =>{\n  ...,\n  "token": token_ref->{...}\n},\n_type == "accordion"=>{\n  ...,\n  list[]{\n    ...,\n    content[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n      \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n    }\n  }\n}\n,\n_type == "expansioncard"=>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n    \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n  }\n},\n\n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n,\n\n    },\n}': KOMPONENT_BY_SLUG_QUERYResult;
     '*[_type == "ds_artikkel" && slug.current == $slug][0]\n  {\n    ...,\n    content[]{\n      ...,\n      \n_type == "language" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "alert" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "attachment" =>{\n  ...,\n  "downloadLink": asset->url,\n  "size": asset->size,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "token_ref"=>@->,\n\nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n_type == "intro_komponent" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n},\n_type == "live_demo" =>{\n  ...,\n  "sandbox_ref": sandbox_ref->{...},\n},\n_type == "props_seksjon" =>{\n  ...,\n  komponenter[]{\n    ...,\n    "propref": propref->{...}\n  },\n},\n_type == "installasjon_seksjon" =>{\n  ...,\n  "code_ref": code_ref->{...},\n},\n_type == "spesial_seksjon" =>{\n  ...,\n  "token": token_ref->{...}\n},\n_type == "accordion"=>{\n  ...,\n  list[]{\n    ...,\n    content[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n      \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n    }\n  }\n}\n,\n_type == "expansioncard"=>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n    \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n  }\n},\n\n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n,\n\n    },\n}': GRUNNLEGGENDE_BY_SLUG_QUERYResult;
+    '*[_type == "templates_artikkel" && slug.current == $slug][0]\n  {\n    ...,\n    content[]{\n      ...,\n      \n_type == "language" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "alert" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "attachment" =>{\n  ...,\n  "downloadLink": asset->url,\n  "size": asset->size,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "token_ref"=>@->,\n\nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n_type == "intro_komponent" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n},\n_type == "live_demo" =>{\n  ...,\n  "sandbox_ref": sandbox_ref->{...},\n},\n_type == "props_seksjon" =>{\n  ...,\n  komponenter[]{\n    ...,\n    "propref": propref->{...}\n  },\n},\n_type == "installasjon_seksjon" =>{\n  ...,\n  "code_ref": code_ref->{...},\n},\n_type == "spesial_seksjon" =>{\n  ...,\n  "token": token_ref->{...}\n},\n_type == "accordion"=>{\n  ...,\n  list[]{\n    ...,\n    content[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n      \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n    }\n  }\n}\n,\n_type == "expansioncard"=>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n    \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n  }\n},\n\n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n,\n\n    },\n}': MONSTER_MALER_BY_SLUG_QUERYResult;
     '*[_type == "aksel_blogg" && slug.current == $slug][0]\n{\n  ...,\n  "slug": slug.current,\n  content[]{\n    ...,\n    \n_type == "language" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "alert" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "attachment" =>{\n  ...,\n  "downloadLink": asset->url,\n  "size": asset->size,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "token_ref"=>@->,\n\nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n_type == "intro_komponent" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n},\n_type == "live_demo" =>{\n  ...,\n  "sandbox_ref": sandbox_ref->{...},\n},\n_type == "props_seksjon" =>{\n  ...,\n  komponenter[]{\n    ...,\n    "propref": propref->{...}\n  },\n},\n_type == "installasjon_seksjon" =>{\n  ...,\n  "code_ref": code_ref->{...},\n},\n_type == "spesial_seksjon" =>{\n  ...,\n  "token": token_ref->{...}\n},\n_type == "accordion"=>{\n  ...,\n  list[]{\n    ...,\n    content[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n      \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n    }\n  }\n}\n,\n_type == "expansioncard"=>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n    \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n  }\n},\n\n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n,\n\n  },\n  contributors[]->{title}\n}': BLOGG_BY_SLUG_QUERYResult;
     '*[slug.current == $slug][0].content[style match \'h2\'][]{\n  "id": _key,\n  "title": pt::text(@)\n}': TOC_BY_SLUG_QUERYResult;
     "\n  *[_type == $type && defined(slug.current)].slug.current\n": SLUG_BY_TYPE_QUERYResult;

--- a/aksel.nav.no/website/app/_sanity/types.ts
+++ b/aksel.nav.no/website/app/_sanity/types.ts
@@ -3,26 +3,22 @@ import {
   BLOGG_BY_SLUG_QUERYResult,
   GRUNNLEGGENDE_BY_SLUG_QUERYResult,
   KOMPONENT_BY_SLUG_QUERYResult,
+  MONSTER_MALER_BY_SLUG_QUERYResult,
 } from "./query-types";
 
-/* TODO: Currently only handles "komponenter". Extend to cover all doctypes */
+type QueryResults =
+  | KOMPONENT_BY_SLUG_QUERYResult
+  | GRUNNLEGGENDE_BY_SLUG_QUERYResult
+  | MONSTER_MALER_BY_SLUG_QUERYResult
+  | BLOGG_BY_SLUG_QUERYResult;
+
 type PortableContentTypes = NonNullable<
-  NonNullable<
-    | KOMPONENT_BY_SLUG_QUERYResult
-    | GRUNNLEGGENDE_BY_SLUG_QUERYResult
-    | BLOGG_BY_SLUG_QUERYResult
-  >["content"]
+  NonNullable<QueryResults>["content"]
 >[number]["_type"];
 
 // Generic utility type to extract a specific type from the content array
 type ExtractPortableType<T extends PortableContentTypes> = Extract<
-  NonNullable<
-    NonNullable<
-      | KOMPONENT_BY_SLUG_QUERYResult
-      | GRUNNLEGGENDE_BY_SLUG_QUERYResult
-      | BLOGG_BY_SLUG_QUERYResult
-    >["content"]
-  >[number],
+  NonNullable<NonNullable<QueryResults>["content"]>[number],
   { _type: T }
 >;
 

--- a/aksel.nav.no/website/app/_ui/footer/Footer.module.css
+++ b/aksel.nav.no/website/app/_ui/footer/Footer.module.css
@@ -11,7 +11,7 @@
   margin-inline: auto;
   display: grid;
   gap: var(--ax-space-24);
-  grid-template-columns: repeat(auto-fit, minmax(250px, auto));
+  grid-template-columns: 1fr 1fr 1fr 1fr;
 }
 
 .footerLogo {

--- a/aksel.nav.no/website/app/_ui/footer/Footer.tsx
+++ b/aksel.nav.no/website/app/_ui/footer/Footer.tsx
@@ -1,5 +1,8 @@
 import Link from "next/link";
-import { Heading } from "@navikt/ds-react";
+import { HGrid, Heading } from "@navikt/ds-react";
+
+/* @ts-expect-error Workspace cant resolve valid import */
+import { PageBlock } from "@navikt/ds-react/Page";
 import { FigmaIcon, GithubIcon, SlackIcon } from "@/assets/Icons";
 import AkselLogo from "@/assets/Logo";
 import styles from "./Footer.module.css";
@@ -7,70 +10,72 @@ import styles from "./Footer.module.css";
 const Footer = () => {
   return (
     <footer className={`${styles.footer} dark`} id="aksel-footer">
-      <div className={styles.footerLayout}>
-        <div className={styles.footerLogo}>
-          <AkselLogo />
-          <div>
-            <p>&copy; {new Date().getFullYear()} Nav</p>
-            <p>Arbeids- og velferdsetaten</p>
+      <HGrid gap="space-24" asChild columns={{ xs: 1, md: 2, lg: 4 }}>
+        <PageBlock width="2xl">
+          <div className={styles.footerLogo}>
+            <AkselLogo />
+            <div>
+              <p>&copy; {new Date().getFullYear()} Nav</p>
+              <p>Arbeids- og velferdsetaten</p>
+            </div>
           </div>
-        </div>
-        <LinkBlock
-          heading="Snarveier"
-          links={[
-            {
-              url: "/side/skriv-for-aksel",
-              text: "Skriv for Aksel",
-            },
-            {
-              url: "/prinsipper/brukeropplevelse",
-              text: "Prinsipper for brukeropplevelse",
-            },
-            { url: "https://sikkerhet.nav.no/", text: "Security Playbook" },
-            {
-              url: "https://etterlevelse.ansatt.nav.no/",
-              text: "Etterlevelse",
-            },
-          ]}
-        />
-        <LinkBlock
-          heading="Om nettstedet"
-          links={[
-            {
-              url: "/side/om-aksel",
-              text: "Hva er Aksel?",
-            },
-            {
-              url: "/personvernerklaering",
-              text: "Personvernerklæring",
-            },
-            {
-              url: "/side/tilgjengelighetserklaring-for-aksel",
-              text: "Tilgjengelighetserklæring",
-            },
-          ]}
-        />
-        <LinkBlock
-          heading="Finn oss"
-          links={[
-            {
-              url: "https://www.figma.com/@nav_aksel",
-              text: "Figma",
-              icon: <FigmaIcon />,
-            },
-            {
-              url: "https://github.com/navikt/aksel",
-              text: "GitHub",
-              icon: <GithubIcon />,
-            },
-            {
-              url: "https://nav-it.slack.com/archives/C7NE7A8UF",
-              text: "Slack",
-              icon: <SlackIcon />,
-            },
-          ]}
-        />
-      </div>
+          <LinkBlock
+            heading="Snarveier"
+            links={[
+              {
+                url: "/side/skriv-for-aksel",
+                text: "Skriv for Aksel",
+              },
+              {
+                url: "/prinsipper/brukeropplevelse",
+                text: "Prinsipper for brukeropplevelse",
+              },
+              { url: "https://sikkerhet.nav.no/", text: "Security Playbook" },
+              {
+                url: "https://etterlevelse.ansatt.nav.no/",
+                text: "Etterlevelse",
+              },
+            ]}
+          />
+          <LinkBlock
+            heading="Om nettstedet"
+            links={[
+              {
+                url: "/side/om-aksel",
+                text: "Hva er Aksel?",
+              },
+              {
+                url: "/personvernerklaering",
+                text: "Personvernerklæring",
+              },
+              {
+                url: "/side/tilgjengelighetserklaring-for-aksel",
+                text: "Tilgjengelighetserklæring",
+              },
+            ]}
+          />
+          <LinkBlock
+            heading="Finn oss"
+            links={[
+              {
+                url: "https://www.figma.com/@nav_aksel",
+                text: "Figma",
+                icon: <FigmaIcon />,
+              },
+              {
+                url: "https://github.com/navikt/aksel",
+                text: "GitHub",
+                icon: <GithubIcon />,
+              },
+              {
+                url: "https://nav-it.slack.com/archives/C7NE7A8UF",
+                text: "Slack",
+                icon: <SlackIcon />,
+              },
+            ]}
+          />
+        </PageBlock>
+      </HGrid>
     </footer>
   );
 };

--- a/aksel.nav.no/website/app/_ui/header/Header.tsx
+++ b/aksel.nav.no/website/app/_ui/header/Header.tsx
@@ -31,7 +31,7 @@ function Header() {
         </Link>
 
         <Spacer />
-        <Show above="md" asChild>
+        <Show above="lg" asChild>
           <Box
             as="nav"
             paddingInline={{ xs: "0 space-8", lg: "0 space-32" }}
@@ -48,7 +48,7 @@ function Header() {
         </Show>
         <HStack align="center" gap="2">
           <GlobalSearch />
-          <Show below="md">
+          <Show below="lg">
             <MobileNav />
           </Show>
         </HStack>

--- a/aksel.nav.no/website/app/_ui/toc/TableOfContents.tsx
+++ b/aksel.nav.no/website/app/_ui/toc/TableOfContents.tsx
@@ -2,8 +2,8 @@
 
 import cl from "clsx";
 import NextLink from "next/link";
-import { ClockDashedIcon, LightBulbIcon } from "@navikt/aksel-icons";
-import { BodyShort, Detail, Link } from "@navikt/ds-react";
+import { SparklesIcon } from "@navikt/aksel-icons";
+import { BodyShort, Button, Detail } from "@navikt/ds-react";
 import { TOC_BY_SLUG_QUERYResult } from "@/app/_sanity/query-types";
 import { removeEmojies } from "@/utils";
 import styles from "./TableOfContents.module.css";
@@ -23,7 +23,6 @@ type TableOfContentsProps = {
 function TableOfContents({
   toc,
   variant = "default",
-  showChangelogLink,
   feedback,
 }: TableOfContentsProps) {
   const tocCtx = useTableOfContents(toc ?? []);
@@ -82,38 +81,32 @@ function TableOfContents({
           })}
         </ul>
       </div>
-      <TableOfContentsLinks
-        feedback={feedback}
-        showChangelogLink={showChangelogLink}
-      />
+      <TableOfContentsLinks feedback={feedback} />
     </aside>
   );
 }
 
 function TableOfContentsLinks({
   feedback,
-  showChangelogLink,
 }: Pick<TableOfContentsProps, "showChangelogLink" | "feedback">) {
-  if ((!feedback || !feedback.name) && !showChangelogLink) {
+  if (!feedback || !feedback.name) {
     return null;
   }
 
   return (
     <div className={styles.tocAsideLinks}>
       {feedback?.name && (
-        <Link
+        <Button
+          as="a"
+          variant="secondary-neutral"
+          size="small"
+          icon={<SparklesIcon aria-hidden />}
           href={`https://github.com/navikt/aksel/issues/new?labels=foresp%C3%B8rsel+%F0%9F%A5%B0%2Ckomponenter+%F0%9F%A7%A9&template=update-component.yml&title=%5BInnspill+til+komponent%5D%3A+%3C${feedback.name}%20/%3E`}
-          variant="neutral"
+          data-umami-event="feedback-designsystem"
+          data-umami-event-kilde="toc"
         >
-          <LightBulbIcon fontSize="1.5rem" aria-hidden />
           {`${feedback.text}`}
-        </Link>
-      )}
-      {showChangelogLink && (
-        <Link href="/grunnleggende/kode/endringslogg" variant="neutral">
-          <ClockDashedIcon fontSize="1.5rem" aria-hidden />
-          Endringslogg
-        </Link>
+        </Button>
       )}
     </div>
   );

--- a/aksel.nav.no/website/app/_ui/toc/TableOfContents.tsx
+++ b/aksel.nav.no/website/app/_ui/toc/TableOfContents.tsx
@@ -104,6 +104,8 @@ function TableOfContentsLinks({
           href={`https://github.com/navikt/aksel/issues/new?labels=foresp%C3%B8rsel+%F0%9F%A5%B0%2Ckomponenter+%F0%9F%A7%A9&template=update-component.yml&title=%5BInnspill+til+komponent%5D%3A+%3C${feedback.name}%20/%3E`}
           data-umami-event="feedback-designsystem"
           data-umami-event-kilde="toc"
+          target="_blank"
+          rel="noreferrer"
         >
           {`${feedback.text}`}
         </Button>

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/Designsystemet.intro.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/Designsystemet.intro.tsx
@@ -3,7 +3,7 @@ import { KOMPONENT_BY_SLUG_QUERYResult } from "@/app/_sanity/query-types";
 import { MarkdownText } from "@/app/_ui/typography/MarkdownText";
 import { WebsiteList, WebsiteListItem } from "@/app/_ui/typography/WebsiteList";
 
-function DesignsytemetKomponentIntro({
+function DesignsystemetKomponentIntro({
   data,
 }: {
   data: KOMPONENT_BY_SLUG_QUERYResult;
@@ -55,4 +55,4 @@ function DesignsytemetKomponentIntro({
   );
 }
 
-export { DesignsytemetKomponentIntro };
+export { DesignsystemetKomponentIntro };

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/Designsystemet.intro.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/Designsystemet.intro.tsx
@@ -18,10 +18,10 @@ function DesignsytemetKomponentIntro({
   const internal = data?.status?.internal;
 
   return (
-    <VStack gap="space-8" data-block-margin="space-28">
+    <VStack gap="space-24" data-block-margin="space-28">
       {useFor && (
         <div>
-          <Heading size="small" level="3">
+          <Heading size="small" level="3" spacing>
             Egnet til:
           </Heading>
 
@@ -39,7 +39,7 @@ function DesignsytemetKomponentIntro({
       )}
       {avoidUseFor && (
         <div>
-          <Heading size="small" level="3">
+          <Heading size="small" level="3" spacing>
             Uegnet til:
           </Heading>
           <WebsiteList as="ul">

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/Designsystemet.module.css
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/Designsystemet.module.css
@@ -28,7 +28,7 @@
 .pageLayoutMain {
   width: fit-content;
   margin: 0 auto;
-  padding-block: var(--ax-space-24);
+  padding-block: var(--ax-space-24) var(--ax-space-128);
   padding-inline: var(--ax-space-40);
   display: grid;
   column-gap: var(--ax-space-40);

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/Designsystemet.module.css
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/Designsystemet.module.css
@@ -10,7 +10,6 @@
   grid-template-columns: 1fr;
   margin-inline: auto;
   width: 100%;
-  gap: var(--ax-space-24);
   z-index: 0;
   position: relative;
   max-width: 1920px;
@@ -21,7 +20,7 @@
 
 @media (min-width: 1024px) {
   .pageLayout {
-    grid-template-columns: 16rem 1fr;
+    grid-template-columns: min-content 1fr;
   }
 }
 
@@ -32,6 +31,10 @@
   padding-inline: var(--ax-space-40);
   display: grid;
   column-gap: var(--ax-space-40);
+
+  /* TODO: For new icon-page: max-width: unsure, but right-panel is a little larger than TOC so adjust accordingly with designer */
+
+  /* TODO: For page-overview templates: max-width 1280px, only 1 column always since there is no TOC */
   grid-template-columns: minmax(0, 960px);
   grid-template-rows: min-content min-content;
   /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
@@ -1,3 +1,4 @@
+import { ClockDashedIcon } from "@navikt/aksel-icons";
 import { HStack, Link } from "@navikt/ds-react";
 import { KOMPONENT_BY_SLUG_QUERYResult } from "@/app/_sanity/query-types";
 import { FigmaIcon, GithubIcon } from "@/assets/Icons";
@@ -46,6 +47,7 @@ function KomponentLinks({ data }: { data: KOMPONENT_BY_SLUG_QUERYResult }) {
           href={gitConfig.git}
           data-umami-event="navigere"
           data-umami-event-url={gitConfig.git}
+          data-umami-event-kilde="komponent-header"
           variant="subtle"
         >
           <GithubIcon /> Github
@@ -58,11 +60,21 @@ function KomponentLinks({ data }: { data: KOMPONENT_BY_SLUG_QUERYResult }) {
           href={data.figma_link}
           data-umami-event="navigere"
           data-umami-event-url={data.figma_link}
+          data-umami-event-kilde="komponent-header"
           variant="subtle"
         >
           <FigmaIcon /> Figma
         </Link>
       )}
+      <Link
+        href="/grunnleggende/kode/endringslogg"
+        variant="subtle"
+        data-umami-event="navigere"
+        data-umami-event-kilde="komponent-header"
+      >
+        <ClockDashedIcon fontSize="1.5rem" aria-hidden />
+        Endringslogg
+      </Link>
     </HStack>
   );
 }

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/DesignsystemetPage.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/DesignsystemetPage.tsx
@@ -3,6 +3,7 @@ import { Detail, HStack, Heading, Tag } from "@navikt/ds-react";
 import {
   GRUNNLEGGENDE_BY_SLUG_QUERYResult,
   KOMPONENT_BY_SLUG_QUERYResult,
+  MONSTER_MALER_BY_SLUG_QUERYResult,
 } from "@/app/_sanity/query-types";
 import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
 import { getStatusTag } from "@/app/_ui/theme-config";
@@ -32,7 +33,10 @@ function DesignsystemetPageLayout({
 }
 
 type DesignsystemetPageT = {
-  data: KOMPONENT_BY_SLUG_QUERYResult | GRUNNLEGGENDE_BY_SLUG_QUERYResult;
+  data:
+    | KOMPONENT_BY_SLUG_QUERYResult
+    | GRUNNLEGGENDE_BY_SLUG_QUERYResult
+    | MONSTER_MALER_BY_SLUG_QUERYResult;
 };
 
 async function DesignsystemetPageHeader({ data }: DesignsystemetPageT) {

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/sidebar/Sidebar.module.css
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/sidebar/Sidebar.module.css
@@ -102,6 +102,14 @@
   }
 }
 
+.navListSubButtonIcon {
+  transition: transform 250ms cubic-bezier(0.2, 0, 0, 1);
+
+  .navListSubButton[aria-expanded="true"] > & {
+    transform: rotateX(-180deg);
+  }
+}
+
 .navListNotch {
   &::before {
     content: "";

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/sidebar/Sidebar.subnav.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/sidebar/Sidebar.subnav.tsx
@@ -3,7 +3,7 @@
 import cl from "clsx";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
-import { ChevronDownIcon, ChevronUpIcon } from "@navikt/aksel-icons";
+import { ChevronDownIcon } from "@navikt/aksel-icons";
 import { SidebarGroupedPagesT } from "@/types";
 import { DesignsystemSidebarItem } from "./Sidebar.item";
 import styles from "./Sidebar.module.css";
@@ -33,7 +33,7 @@ function DesignsystemSidebarSubNav(
         data-umami-event-kategori={title}
       >
         {title}
-        {open ? <ChevronUpIcon aria-hidden /> : <ChevronDownIcon aria-hidden />}
+        <ChevronDownIcon aria-hidden className={styles.navListSubButtonIcon} />
       </button>
       <ul hidden={!open}>
         {pages.map((page) => (

--- a/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[...slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[...slug]/page.tsx
@@ -1,10 +1,14 @@
+import { Metadata, ResolvingMetadata } from "next";
 import { PortableTextBlock } from "next-sanity";
 import { notFound } from "next/navigation";
+import type { Image } from "sanity";
 import { sanityFetch } from "@/app/_sanity/live";
 import {
   GRUNNLEGGENDE_BY_SLUG_QUERY,
+  METADATA_BY_SLUG_QUERY,
   TOC_BY_SLUG_QUERY,
 } from "@/app/_sanity/queries";
+import { urlForOpenGraphImage } from "@/app/_sanity/utils";
 import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
 import { TableOfContents } from "@/app/_ui/toc/TableOfContents";
 import {
@@ -16,6 +20,38 @@ import { getStaticParamsSlugs, parseDesignsystemSlug } from "../../slug";
 type Props = {
   params: Promise<{ slug: string[] }>;
 };
+
+export async function generateMetadata(
+  { params }: Props,
+  parent: ResolvingMetadata,
+): Promise<Metadata> {
+  const { slug } = await params;
+
+  const { data: page } = await sanityFetch({
+    query: METADATA_BY_SLUG_QUERY,
+    params: { slug: parseDesignsystemSlug(slug, "grunnleggende") },
+    stega: false,
+  });
+
+  if (!page) {
+    return {
+      title: "Aksel.nav.no",
+    };
+  }
+
+  const ogImages = (await parent).openGraph?.images || [];
+  const pageOgImage = urlForOpenGraphImage(page?.seo?.image as Image);
+
+  pageOgImage && ogImages.push(pageOgImage);
+
+  return {
+    title: `${page?.heading} - Aksel.nav.no`,
+    description: page?.seo?.meta,
+    openGraph: {
+      images: ogImages,
+    },
+  };
+}
 
 export async function generateStaticParams() {
   return await getStaticParamsSlugs("ds_artikkel");

--- a/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[...slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[...slug]/page.tsx
@@ -42,7 +42,7 @@ export async function generateMetadata(
   const ogImages = (await parent).openGraph?.images || [];
   const pageOgImage = urlForOpenGraphImage(page?.seo?.image as Image);
 
-  pageOgImage && ogImages.push(pageOgImage);
+  pageOgImage && ogImages.unshift(pageOgImage);
 
   return {
     title: `${page?.heading} - Aksel.nav.no`,

--- a/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[...slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[...slug]/page.tsx
@@ -33,19 +33,13 @@ export async function generateMetadata(
     stega: false,
   });
 
-  if (!page) {
-    return {
-      title: "Aksel.nav.no",
-    };
-  }
-
   const ogImages = (await parent).openGraph?.images || [];
   const pageOgImage = urlForOpenGraphImage(page?.seo?.image as Image);
 
   pageOgImage && ogImages.unshift(pageOgImage);
 
   return {
-    title: `${page?.heading} - Aksel.nav.no`,
+    title: page?.heading,
     description: page?.seo?.meta,
     openGraph: {
       images: ogImages,

--- a/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[...slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[...slug]/page.tsx
@@ -1,10 +1,14 @@
+import { Metadata, ResolvingMetadata } from "next";
 import { PortableTextBlock } from "next-sanity";
 import { notFound } from "next/navigation";
+import type { Image } from "sanity";
 import { sanityFetch } from "@/app/_sanity/live";
 import {
   KOMPONENT_BY_SLUG_QUERY,
+  METADATA_BY_SLUG_QUERY,
   TOC_BY_SLUG_QUERY,
 } from "@/app/_sanity/queries";
+import { urlForOpenGraphImage } from "@/app/_sanity/utils";
 import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
 import { TableOfContents } from "@/app/_ui/toc/TableOfContents";
 import { DesignsytemetKomponentIntro } from "../../_ui/Designsystemet.intro";
@@ -17,6 +21,38 @@ import { getStaticParamsSlugs, parseDesignsystemSlug } from "../../slug";
 type Props = {
   params: Promise<{ slug: string[] }>;
 };
+
+export async function generateMetadata(
+  { params }: Props,
+  parent: ResolvingMetadata,
+): Promise<Metadata> {
+  const { slug } = await params;
+
+  const { data: page } = await sanityFetch({
+    query: METADATA_BY_SLUG_QUERY,
+    params: { slug: parseDesignsystemSlug(slug, "komponenter") },
+    stega: false,
+  });
+
+  if (!page) {
+    return {
+      title: "Aksel.nav.no",
+    };
+  }
+
+  const ogImages = (await parent).openGraph?.images || [];
+  const pageOgImage = urlForOpenGraphImage(page?.seo?.image as Image);
+
+  pageOgImage && ogImages.push(pageOgImage);
+
+  return {
+    title: `${page?.heading} - Aksel.nav.no`,
+    description: page?.seo?.meta,
+    openGraph: {
+      images: ogImages,
+    },
+  };
+}
 
 export async function generateStaticParams() {
   return await getStaticParamsSlugs("komponent_artikkel");

--- a/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[...slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[...slug]/page.tsx
@@ -49,9 +49,8 @@ export default async function Page({ params }: Props) {
       <TableOfContents
         feedback={{
           name: page.heading,
-          text: "Innspill til siden",
+          text: "Send innspill",
         }}
-        showChangelogLink
         toc={toc}
       />
       <div>

--- a/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[...slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[...slug]/page.tsx
@@ -43,7 +43,7 @@ export async function generateMetadata(
   const ogImages = (await parent).openGraph?.images || [];
   const pageOgImage = urlForOpenGraphImage(page?.seo?.image as Image);
 
-  pageOgImage && ogImages.push(pageOgImage);
+  pageOgImage && ogImages.unshift(pageOgImage);
 
   return {
     title: `${page?.heading} - Aksel.nav.no`,

--- a/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[...slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[...slug]/page.tsx
@@ -34,19 +34,13 @@ export async function generateMetadata(
     stega: false,
   });
 
-  if (!page) {
-    return {
-      title: "Aksel.nav.no",
-    };
-  }
-
   const ogImages = (await parent).openGraph?.images || [];
   const pageOgImage = urlForOpenGraphImage(page?.seo?.image as Image);
 
   pageOgImage && ogImages.unshift(pageOgImage);
 
   return {
-    title: `${page?.heading} - Aksel.nav.no`,
+    title: page?.heading,
     description: page?.seo?.meta,
     openGraph: {
       images: ogImages,

--- a/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[...slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[...slug]/page.tsx
@@ -11,7 +11,7 @@ import {
 import { urlForOpenGraphImage } from "@/app/_sanity/utils";
 import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
 import { TableOfContents } from "@/app/_ui/toc/TableOfContents";
-import { DesignsytemetKomponentIntro } from "../../_ui/Designsystemet.intro";
+import { DesignsystemetKomponentIntro } from "../../_ui/Designsystemet.intro";
 import {
   DesignsystemetPageHeader,
   DesignsystemetPageLayout,
@@ -84,7 +84,7 @@ export default async function Page({ params }: Props) {
         toc={toc}
       />
       <div>
-        <DesignsytemetKomponentIntro data={page} />
+        <DesignsystemetKomponentIntro data={page} />
         <CustomPortableText value={page.content as PortableTextBlock[]} />
       </div>
     </DesignsystemetPageLayout>

--- a/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[...slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[...slug]/page.tsx
@@ -2,7 +2,7 @@ import { PortableTextBlock } from "next-sanity";
 import { notFound } from "next/navigation";
 import { sanityFetch } from "@/app/_sanity/live";
 import {
-  GRUNNLEGGENDE_BY_SLUG_QUERY,
+  MONSTER_MALER_BY_SLUG_QUERY,
   TOC_BY_SLUG_QUERY,
 } from "@/app/_sanity/queries";
 import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
@@ -18,18 +18,18 @@ type Props = {
 };
 
 export async function generateStaticParams() {
-  return await getStaticParamsSlugs("ds_artikkel");
+  return await getStaticParamsSlugs("templates_artikkel");
 }
 
 /* https://nextjs.org/docs/app/api-reference/file-conventions/page#props */
 export default async function Page({ params }: Props) {
   const { slug } = await params;
 
-  const parsedSlug = parseDesignsystemSlug(slug, "grunnleggende");
+  const parsedSlug = parseDesignsystemSlug(slug, "monster-maler");
 
   const [{ data: page }, { data: toc = [] }] = await Promise.all([
     sanityFetch({
-      query: GRUNNLEGGENDE_BY_SLUG_QUERY,
+      query: MONSTER_MALER_BY_SLUG_QUERY,
       params: { slug: parsedSlug },
     }),
     sanityFetch({

--- a/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[...slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[...slug]/page.tsx
@@ -39,19 +39,13 @@ export async function generateMetadata(
     stega: false,
   });
 
-  if (!page) {
-    return {
-      title: "Aksel.nav.no",
-    };
-  }
-
   const ogImages = (await parent).openGraph?.images || [];
   const pageOgImage = urlForOpenGraphImage(page?.seo?.image as Image);
 
   pageOgImage && ogImages.unshift(pageOgImage);
 
   return {
-    title: `${page?.heading} - Aksel.nav.no`,
+    title: page?.heading,
     description: page?.seo?.meta,
     openGraph: {
       images: ogImages,

--- a/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[...slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[...slug]/page.tsx
@@ -1,12 +1,18 @@
 import { PortableTextBlock } from "next-sanity";
 import { notFound } from "next/navigation";
+import { Heading } from "@navikt/ds-react";
 import { sanityFetch } from "@/app/_sanity/live";
 import {
   MONSTER_MALER_BY_SLUG_QUERY,
   TOC_BY_SLUG_QUERY,
 } from "@/app/_sanity/queries";
 import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
+import styles from "@/app/_ui/portable-text/CustomPortableText.module.css";
 import { TableOfContents } from "@/app/_ui/toc/TableOfContents";
+import {
+  WebsiteTable,
+  WebsiteTableRow,
+} from "@/app/_ui/website-table/WebsiteTable";
 import {
   DesignsystemetPageHeader,
   DesignsystemetPageLayout,
@@ -42,6 +48,9 @@ export default async function Page({ params }: Props) {
     notFound();
   }
 
+  const metadata = page.content?.find((x) => x._type === "kode_eksempler")?.dir
+    ?.metadata;
+
   return (
     <DesignsystemetPageLayout layout="with-toc">
       <DesignsystemetPageHeader data={page} />
@@ -56,6 +65,36 @@ export default async function Page({ params }: Props) {
         value={page.content as PortableTextBlock[]}
         data-block-margin="space-28"
       />
+      {metadata?.changelog && (
+        <div>
+          <Heading
+            className={styles.headingElement}
+            tabIndex={-1}
+            id="changelog"
+            level="2"
+            size="large"
+            data-level="2"
+          >
+            Endringer
+          </Heading>
+          <WebsiteTable
+            th={[{ text: "Dato" }, { text: "Versjon" }, { text: "Endringer" }]}
+          >
+            {metadata.changelog
+              .sort((a, b) => (a.version ?? 0) - (b.version ?? 0))
+              .map((log) => (
+                <WebsiteTableRow
+                  key={log.version}
+                  tr={[
+                    { text: log.date },
+                    { text: log.version },
+                    { text: log.description },
+                  ]}
+                />
+              ))}
+          </WebsiteTable>
+        </div>
+      )}
     </DesignsystemetPageLayout>
   );
 }

--- a/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[...slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[...slug]/page.tsx
@@ -48,7 +48,7 @@ export async function generateMetadata(
   const ogImages = (await parent).openGraph?.images || [];
   const pageOgImage = urlForOpenGraphImage(page?.seo?.image as Image);
 
-  pageOgImage && ogImages.push(pageOgImage);
+  pageOgImage && ogImages.unshift(pageOgImage);
 
   return {
     title: `${page?.heading} - Aksel.nav.no`,

--- a/aksel.nav.no/website/app/globals.css
+++ b/aksel.nav.no/website/app/globals.css
@@ -12,6 +12,11 @@
     "Ubuntu Monospace", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
 }
 
+/* Prevents scroll-rubberbanding on Apple devices  */
+body {
+  overscroll-behavior: none;
+}
+
 [data-block-margin] {
   &[data-block-margin="space-28"] {
     margin-block: var(--ax-space-28);

--- a/aksel.nav.no/website/app/layout.tsx
+++ b/aksel.nav.no/website/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from "next";
+import { Metadata, Viewport } from "next";
 import { VisualEditing } from "next-sanity";
 import { draftMode } from "next/headers";
 import { Theme } from "@navikt/ds-react";
@@ -11,10 +11,13 @@ export const metadata: Metadata = {
     template: "%s - Aksel.nav.no",
     default: "Aksel.nav.no",
   },
-  themeColor: "#00243A",
   icons: {
     icon: "/favicon.svg",
   },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#00243A",
 };
 
 export default async function RootLayout({

--- a/aksel.nav.no/website/app/layout.tsx
+++ b/aksel.nav.no/website/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from "next";
 import { VisualEditing } from "next-sanity";
 import { draftMode } from "next/headers";
 import { Theme } from "@navikt/ds-react";
@@ -5,15 +6,27 @@ import "@navikt/ds-tokens/darkside-css";
 import { SanityLive } from "@/app/_sanity/live";
 import "./globals.css";
 
+export const metadata: Metadata = {
+  title: {
+    template: "%s - Aksel.nav.no",
+    default: "Aksel.nav.no",
+  },
+  themeColor: "#00243A",
+  icons: {
+    icon: "/favicon.svg",
+  },
+};
+
 export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const isDraftMode = (await draftMode()).isEnabled;
+
   return (
     <html lang="no">
-      {/* <head>
-        <meta name="theme-color" content="#00243A" />
+      <head>
         <link
           rel="preload"
           href="https://cdn.nav.no/aksel/fonts/SourceSans3-normal.woff2"
@@ -21,12 +34,12 @@ export default async function RootLayout({
           type="font/woff2"
           crossOrigin="anonymous"
         />
-      </head> */}
+      </head>
       <Theme asChild theme="light">
         <body className="aksel antialiased">
           {children}
           <SanityLive />
-          {(await draftMode()).isEnabled && <VisualEditing />}
+          {isDraftMode && <VisualEditing />}
         </body>
       </Theme>
     </html>

--- a/aksel.nav.no/website/sanity/sanity-typegen.json
+++ b/aksel.nav.no/website/sanity/sanity-typegen.json
@@ -1,5 +1,5 @@
 {
   "path": "../app/**/*.{ts,tsx,js,jsx}",
-  "schema": "schema.json",
+  "schema": "sanity-schema.json",
   "generates": "../app/_sanity/query-types.ts"
 }


### PR DESCRIPTION
### Description

This pull request introduces several updates and improvements to the `aksel.nav.no` website, focusing on query definitions, metadata generation, and UI component adjustments. Below is a summary of the most important changes:

### Query Definitions

* Added `MONSTER_MALER_BY_SLUG_QUERY` and `METADATA_BY_SLUG_QUERY` to `aksel.nav.no/website/app/_sanity/queries.ts` to fetch template articles and metadata by slug. [[1]](diffhunk://#diff-24f88c09aee96e652f27e8b22cbb647096cce702c980f8c136fa015efa308b66R66-R75) [[2]](diffhunk://#diff-24f88c09aee96e652f27e8b22cbb647096cce702c980f8c136fa015efa308b66R94-R100) [[3]](diffhunk://#diff-24f88c09aee96e652f27e8b22cbb647096cce702c980f8c136fa015efa308b66R113-R114)

### Metadata Generation

* Implemented `generateMetadata` functions in `grunnleggende/[...slug]/page.tsx` and `komponenter/[...slug]/page.tsx` to dynamically generate metadata for pages based on their slug, including Open Graph images for better SEO. ([aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[...slug]/page.tsxR1-R11](diffhunk://#diff-0972b85b01bbb26eeb164fe2f04051ad1cbd80d87836a26085d4b4c82575b591R1-R11), [aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[...slug]/page.tsxR1-R11](diffhunk://#diff-dd31964c5c1528839ade5156e5be5990e31b23863020b0f9d45a16430cae9d58R1-R11))

### UI Component Adjustments

* Updated the `TableOfContents` component to remove the changelog link and replace the feedback link with a button featuring a `SparklesIcon`. [[1]](diffhunk://#diff-67cb33b8cb2d0654ea38e10eca0c7e322e5abf70137420933086c5737006a390L5-R6) [[2]](diffhunk://#diff-67cb33b8cb2d0654ea38e10eca0c7e322e5abf70137420933086c5737006a390L26) [[3]](diffhunk://#diff-67cb33b8cb2d0654ea38e10eca0c7e322e5abf70137420933086c5737006a390L85-R109)
* Adjusted the layout and spacing in `Designsystemet.intro.tsx` and `Designsystemet.module.css` for better visual consistency. [[1]](diffhunk://#diff-45fe7c2008fb3485cf80860aa731c9f561891a698ed65813b1d6d5dc9a2fdb6cL21-R24) [[2]](diffhunk://#diff-45fe7c2008fb3485cf80860aa731c9f561891a698ed65813b1d6d5dc9a2fdb6cL42-R42) [[3]](diffhunk://#diff-1bbc845ec5c449d2b286b3372c24033ce38af77559fa69307adcf749eb211142L13) [[4]](diffhunk://#diff-1bbc845ec5c449d2b286b3372c24033ce38af77559fa69307adcf749eb211142L24-R37)
* Enhanced the `Sidebar` component with a transition effect on the chevron icon to indicate expanded state. [[1]](diffhunk://#diff-ef12089a2fa7b2a6cdb5d1a919a15692a59c2db683441872bd1cc80db38fbc71R105-R112) [[2]](diffhunk://#diff-f505cc5b4a65937406b7d961885be27dc7f8a1fb638d5c70fb821a0086795836L6-R6) [[3]](diffhunk://#diff-f505cc5b4a65937406b7d961885be27dc7f8a1fb638d5c70fb821a0086795836L36-R36)

These changes aim to improve the functionality and user experience of the website by adding new query capabilities, enhancing metadata handling, and refining the UI components.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
