### PR TITLE
Bugfix/combobox chips not wrapping when togglelist button is hidden

### DIFF
--- a/.changeset/social-pianos-slide.md
+++ b/.changeset/social-pianos-slide.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Combobox: Fix wrapping issue when ToggleListButton is hidden

--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -71,11 +71,6 @@
   flex: 2;
 }
 
-.navds-combobox__wrapper-inner > :last-child {
-  display: flex;
-  flex-flow: row nowrap;
-}
-
 .navds-combobox__wrapper-inner:hover {
   cursor: text;
 }


### PR DESCRIPTION
### Description

Some old, unused CSS for Combobox caused issues with chips not wrapping when ToggleListButton was hidden. The CSS could ever only apply to the button or the list of chips, and does nothing for the button, so should be safe to remove.
