### PR TITLE
:bug: Single-select combobox assumed that input needed min-width

### DIFF
--- a/.changeset/thin-lemons-turn.md
+++ b/.changeset/thin-lemons-turn.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Combobox: Singleselect selected value now uses the complete input-width when possible.

--- a/@navikt/core/css/darkside/form/combobox.darkside.css
+++ b/@navikt/core/css/darkside/form/combobox.darkside.css
@@ -180,6 +180,10 @@
   .aksel-combobox__selected-options > li:only-child > & {
     margin-left: var(--ax-space-4);
   }
+
+  .aksel-combobox__selected-options[data-type="single"] & {
+    min-width: auto;
+  }
 }
 
 .aksel-combobox__input--hide-caret {

--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -136,6 +136,10 @@
   height: var(--__ac-combobox-input-height);
 }
 
+.navds-combobox__selected-options[data-type="single"] .navds-combobox__input {
+  min-width: auto;
+}
+
 .navds-combobox__input--hide-caret {
   caret-color: transparent;
 }


### PR DESCRIPTION
### Description

By setting `min-width` to `auto` for single-select, we avoid extra wrapping.
https://nav-it.slack.com/archives/C7NE7A8UF/p1744180067018909

Demo: 
![Screenshot 2025-04-10 at 14 31 28](https://github.com/user-attachments/assets/07a5ed69-be8e-4b09-bf6d-ba2e2b0b7fd9)


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
