### PR TITLE
:bug: Use option-value as id instead of label in Combobox

### DIFF
--- a/.changeset/busy-hairs-wonder.md
+++ b/.changeset/busy-hairs-wonder.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": minor
+"@navikt/ds-css": minor
+---
+
+Combobox: Use option-value as `id` instead of `label`.

--- a/@navikt/core/css/darkside/form/combobox.darkside.css
+++ b/@navikt/core/css/darkside/form/combobox.darkside.css
@@ -315,6 +315,12 @@
   outline: 2px solid var(--ax-border-focus);
 }
 
+.aksel-combobox__list-item--focus,
+.aksel-combobox__list--with-hover
+  .aksel-combobox__list-item:not([data-no-focus="true"], .aksel-combobox__list-item--new-option):hover {
+  cursor: pointer;
+}
+
 .aksel-combobox__list-item {
   user-select: none;
 

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptionsItem.tsx
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptionsItem.tsx
@@ -43,29 +43,25 @@ const FilteredOptionsItem = ({ option }: { option: ComboboxOption }) => {
   const isDisabled = (_option: ComboboxOption) =>
     maxSelected.isLimitReached && !isInList(_option.value, selectedOptions);
 
+  const optionId = filteredOptionsUtil.getOptionId(id, option.value);
+  const isActive = activeDecendantId === optionId;
+
   return (
     <li
       className={cn("navds-combobox__list-item", {
-        "navds-combobox__list-item--focus":
-          activeDecendantId ===
-          filteredOptionsUtil.getOptionId(id, option.label),
+        "navds-combobox__list-item--focus": isActive,
         "navds-combobox__list-item--selected": isInList(
           option.value,
           selectedOptions,
         ),
       })}
       data-no-focus={isDisabled(option) || undefined}
-      id={filteredOptionsUtil.getOptionId(id, option.label)}
+      id={optionId}
       key={option.label}
       tabIndex={-1}
       onMouseMove={() => {
-        if (
-          activeDecendantId !==
-          filteredOptionsUtil.getOptionId(id, option.label)
-        ) {
-          virtualFocus.moveFocusToElement(
-            filteredOptionsUtil.getOptionId(id, option.label),
-          );
+        if (!isActive) {
+          virtualFocus.moveFocusToElement(optionId);
           setIsMouseLastUsedInputDevice(true);
         }
       }}

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptionsItem.tsx
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptionsItem.tsx
@@ -57,7 +57,7 @@ const FilteredOptionsItem = ({ option }: { option: ComboboxOption }) => {
       })}
       data-no-focus={isDisabled(option) || undefined}
       id={optionId}
-      key={option.label}
+      key={optionId}
       tabIndex={-1}
       onMouseMove={() => {
         if (!isActive) {

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/filteredOptionsContext.tsx
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/filteredOptionsContext.tsx
@@ -91,7 +91,7 @@ const FilteredOptionsProvider = ({
         ? toComboboxOption(value)
         : undefined,
       ...customOptions.reduce((acc, customOption) => {
-        const _id = filteredOptionsUtils.getOptionId(id, customOption.label);
+        const _id = filteredOptionsUtils.getOptionId(id, customOption.value);
         acc[_id] = customOption;
         return acc;
       }, {}),
@@ -99,7 +99,7 @@ const FilteredOptionsProvider = ({
 
     // Add the options to the map
     const finalMap = options.reduce((map, _option) => {
-      const _id = filteredOptionsUtils.getOptionId(id, _option.label);
+      const _id = filteredOptionsUtils.getOptionId(id, _option.value);
       map[_id] = _option;
       return map;
     }, initialMap);
@@ -171,7 +171,7 @@ const FilteredOptionsProvider = ({
       if (shouldAutocomplete && filteredOptions[0]) {
         activeOption = filteredOptionsUtils.getOptionId(
           id,
-          filteredOptions[0].label,
+          filteredOptions[0].value,
         );
       } else if (isListOpen && isLoading) {
         activeOption = filteredOptionsUtils.getIsLoadingId(id);


### PR DESCRIPTION
### Description

https://nav-it.slack.com/archives/C7NE7A8UF/p1744272492133039

Combobox now uses the `option.value` to generate option-Id instead of label

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
