### PR TITLE
Chat: Add prop to control toptext heading level

### DIFF
--- a/.changeset/petite-results-sleep.md
+++ b/.changeset/petite-results-sleep.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+Chat: Add 'toptextHeadingLevel'-prop to allow changing h-level based on semantics.

--- a/@navikt/core/react/src/chat/Bubble.tsx
+++ b/@navikt/core/react/src/chat/Bubble.tsx
@@ -21,6 +21,7 @@ export interface ChatBubbleProps extends HTMLAttributes<HTMLDivElement> {
   toptextPosition?: "left" | "right";
   /**
    * The heading level for the toptext.
+   * @default "3"
    */
   toptextHeadingLevel?: Exclude<HeadingProps["level"], "1">;
 }

--- a/@navikt/core/react/src/chat/Bubble.tsx
+++ b/@navikt/core/react/src/chat/Bubble.tsx
@@ -33,7 +33,7 @@ const Bubble = forwardRef<HTMLDivElement, ChatBubbleProps>(
       name,
       timestamp,
       toptextPosition,
-      toptextHeadingLevel,
+      toptextHeadingLevel = "3",
       ...rest
     },
     ref,

--- a/@navikt/core/react/src/chat/Bubble.tsx
+++ b/@navikt/core/react/src/chat/Bubble.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes, forwardRef } from "react";
 import { useRenameCSS } from "../theme/Theme";
-import { Detail } from "../typography";
+import { Detail, Heading, HeadingProps } from "../typography";
 
 export interface ChatBubbleProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -19,16 +19,33 @@ export interface ChatBubbleProps extends HTMLAttributes<HTMLDivElement> {
    * Overrides hoizontal position of toptext.
    */
   toptextPosition?: "left" | "right";
+  /**
+   * The heading level for the toptext.
+   */
+  toptextHeadingLevel?: Exclude<HeadingProps["level"], "1">;
 }
 
 const Bubble = forwardRef<HTMLDivElement, ChatBubbleProps>(
-  ({ children, className, name, timestamp, toptextPosition, ...rest }, ref) => {
+  (
+    {
+      children,
+      className,
+      name,
+      timestamp,
+      toptextPosition,
+      toptextHeadingLevel,
+      ...rest
+    },
+    ref,
+  ) => {
     const { cn } = useRenameCSS();
 
     return (
       <div ref={ref} className={cn("navds-chat__bubble", className)} {...rest}>
         {(timestamp || name) && (
-          <h3
+          <Heading
+            size="xsmall"
+            level={toptextHeadingLevel}
             className={cn(
               `navds-chat__top-text`,
               toptextPosition && `navds-chat__top-text--${toptextPosition}`,
@@ -41,7 +58,7 @@ const Bubble = forwardRef<HTMLDivElement, ChatBubbleProps>(
               </Detail>
             )}
             {timestamp && <Detail as="span">{timestamp}</Detail>}
-          </h3>
+          </Heading>
         )}
         {children}
       </div>

--- a/@navikt/core/react/src/chat/Chat.tsx
+++ b/@navikt/core/react/src/chat/Chat.tsx
@@ -48,7 +48,7 @@ export interface ChatProps extends HTMLAttributes<HTMLDivElement> {
    */
   size?: (typeof SIZES)[number];
   /**
-   * The heading level for the toptext
+   * The heading level for the toptext.
    * @default "3"
    */
   toptextHeadingLevel?: Exclude<HeadingProps["level"], "1">;

--- a/@navikt/core/react/src/chat/Chat.tsx
+++ b/@navikt/core/react/src/chat/Chat.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes, forwardRef } from "react";
 import { useRenameCSS } from "../theme/Theme";
-import { BodyLong } from "../typography";
+import { BodyLong, HeadingProps } from "../typography";
 import Bubble from "./Bubble";
 
 export const VARIANTS = ["subtle", "info", "neutral"] as const;
@@ -47,6 +47,11 @@ export interface ChatProps extends HTMLAttributes<HTMLDivElement> {
    * @default "medium"
    */
   size?: (typeof SIZES)[number];
+  /**
+   * The heading level for the toptext
+   * @default "3"
+   */
+  toptextHeadingLevel?: Exclude<HeadingProps["level"], "1">;
 }
 
 interface ChatComponent
@@ -88,6 +93,7 @@ export const Chat = forwardRef<HTMLDivElement, ChatProps>(
       variant = "neutral",
       toptextPosition,
       size = "medium",
+      toptextHeadingLevel = "3",
       ...rest
     }: ChatProps,
     ref,
@@ -120,6 +126,7 @@ export const Chat = forwardRef<HTMLDivElement, ChatProps>(
                   {React.cloneElement(child, {
                     name: name && i === 0 ? name : undefined,
                     timestamp: timestamp && i === 0 ? timestamp : undefined,
+                    toptextHeadingLevel,
                     ...child.props,
                   })}
                 </BodyLong>

--- a/@navikt/core/react/src/chat/chat.stories.tsx
+++ b/@navikt/core/react/src/chat/chat.stories.tsx
@@ -45,7 +45,7 @@ export const Controls: Story = {
     },
     toptextHeadingLevel: {
       control: { type: "radio" },
-      options: ["1", "2", "3", "4", "5", "6"],
+      options: ["2", "3", "4", "5", "6"],
     },
     size: {
       control: { type: "radio" },

--- a/@navikt/core/react/src/chat/chat.stories.tsx
+++ b/@navikt/core/react/src/chat/chat.stories.tsx
@@ -43,6 +43,10 @@ export const Controls: Story = {
       control: { type: "radio" },
       options: [...POSITIONS],
     },
+    toptextHeadingLevel: {
+      control: { type: "radio" },
+      options: ["1", "2", "3", "4", "5", "6"],
+    },
     size: {
       control: { type: "radio" },
       options: [...SIZES],


### PR DESCRIPTION
### Description

Currently, the `Chat` and `Chat.Bubble` component is hard-coded to use `<h3/>` for the toptext. This
gives very little flexibility when trying to maintain a consistent and working hierarchy for
accessibility on a page.

This PR is a basic proposal to modify this using a `<Heading>` in place of the `<h3>` with a
configurable `toptextHeadingLevel` prop. I kept the className passed to the component and just
naively replaced the component. Let med know if I should do it another way and I'm glad to fix it
up if the implementation makes sense.

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation / Decision Records
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] Component tokens (`@navikt/core/css/tokens.json`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
