### PR TITLE
[Website] prevent focus trap

### DIFF
--- a/aksel.nav.no/website/app/_ui/compare-images/CompareImages.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/compare-images/CompareImages.provider.tsx
@@ -138,14 +138,17 @@ function CompareImagesProvider({
 
   /* Set on CompareHandle */
   const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-    event.preventDefault();
     if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
+      event.preventDefault();
       movePosition(-5);
     } else if (event.key === "ArrowRight" || event.key === "ArrowUp") {
+      event.preventDefault();
       movePosition(5);
     } else if (event.key === "Home") {
+      event.preventDefault();
       movePosition(-100);
     } else if (event.key === "End") {
+      event.preventDefault();
       movePosition(100);
     }
   };


### PR DESCRIPTION
moving logic from preventing _all_ default key behaviour to just the subset we redefine.