### PR TITLE
[Website] Fix moduleresolution

### DIFF
--- a/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
+++ b/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
@@ -4,8 +4,6 @@ import { Highlight } from "prism-react-renderer";
 import { useId } from "react";
 import { ChevronDownUpIcon, ChevronUpDownIcon } from "@navikt/aksel-icons";
 import { Button, CopyButton, HStack, Spacer, Tabs } from "@navikt/ds-react";
-
-/* @ts-expect-error Import is valid, workspace just can't resolve it */
 import { TabsList, TabsPanel, TabsTab } from "@navikt/ds-react/Tabs";
 import styles from "./CodeBlock.module.css";
 import {

--- a/aksel.nav.no/website/app/_ui/code-block/CodePrismTheme.ts
+++ b/aksel.nav.no/website/app/_ui/code-block/CodePrismTheme.ts
@@ -9,7 +9,6 @@ import {
   TextNeutralSubtle,
   TextSuccess,
   TextWarning,
-  /* @ts-expect-error Workspace cant resolve valid import */
 } from "@navikt/ds-tokens/darkside-js";
 
 const AkselPrismTheme: PrismTheme = {

--- a/aksel.nav.no/website/app/_ui/footer/Footer.tsx
+++ b/aksel.nav.no/website/app/_ui/footer/Footer.tsx
@@ -1,7 +1,5 @@
 import Link from "next/link";
 import { HGrid, Heading } from "@navikt/ds-react";
-
-/* @ts-expect-error Workspace cant resolve valid import */
 import { PageBlock } from "@navikt/ds-react/Page";
 import { FigmaIcon, GithubIcon, SlackIcon } from "@/assets/Icons";
 import AkselLogo from "@/assets/Logo";

--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.navigation.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.navigation.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { BodyLong } from "@navikt/ds-react";
-
-/* @ts-expect-error Workspace cant resolve valid import */
 import { Chips, ChipsToggle } from "@navikt/ds-react/Chips";
 import { ExtractPortableComponentProps } from "@/app/_sanity/types";
 import { MarkdownText } from "@/app/_ui/typography/MarkdownText";
@@ -37,7 +35,7 @@ function KodeEksemplerNavigation(props: {
               selected={activeExample.current?.navn === fil.navn}
               onClick={() => activeExample.update(fil.navn)}
             >
-              {fil.title}
+              {fil.title ?? ""}
             </ChipsToggle>
           );
         })}

--- a/aksel.nav.no/website/app/_ui/table-v2/TableV2.tsx
+++ b/aksel.nav.no/website/app/_ui/table-v2/TableV2.tsx
@@ -6,7 +6,6 @@ import {
   TableHeader,
   TableHeaderCell,
   TableRow,
-  /* @ts-expect-error: Workspace cant resolve import */
 } from "@navikt/ds-react/Table";
 import { ExtractPortableComponentProps } from "@/app/_sanity/types";
 

--- a/aksel.nav.no/website/app/_ui/typography/WebsiteList.tsx
+++ b/aksel.nav.no/website/app/_ui/typography/WebsiteList.tsx
@@ -2,7 +2,6 @@ import {
   List as AkselList,
   ListItem as AkselListItem,
   ListProps as AkselListProps,
-  /* @ts-expect-error Workspace can't understand these imports yet */
 } from "@navikt/ds-react/List";
 import styles from "./Typography.module.css";
 

--- a/aksel.nav.no/website/app/_ui/website-accordion/WebsiteAccordion.item.tsx
+++ b/aksel.nav.no/website/app/_ui/website-accordion/WebsiteAccordion.item.tsx
@@ -4,7 +4,6 @@ import {
   AccordionContent,
   AccordionHeader,
   AccordionItem,
-  /* @ts-expect-error Workspace cant resolve valid import */
 } from "@navikt/ds-react/Accordion";
 import { useWebsiteAccordion } from "./WebsiteAccordion.provider";
 

--- a/aksel.nav.no/website/app/_ui/website-expansioncard/WebsiteExpansionCard.tsx
+++ b/aksel.nav.no/website/app/_ui/website-expansioncard/WebsiteExpansionCard.tsx
@@ -5,7 +5,6 @@ import {
   ExpansionCardDescription,
   ExpansionCardHeader,
   ExpansionCardTitle,
-  /* @ts-expect-error Workspace cant resolve valid import */
 } from "@navikt/ds-react/ExpansionCard";
 import { CustomPortableText } from "@/app/CustomPortableText";
 import { ExtractPortableComponentProps } from "@/app/_sanity/types";

--- a/aksel.nav.no/website/app/dev/(god-praksis)/god-praksis/layout.tsx
+++ b/aksel.nav.no/website/app/dev/(god-praksis)/god-praksis/layout.tsx
@@ -1,6 +1,4 @@
 import { Box } from "@navikt/ds-react";
-
-/* @ts-expect-error Workspace cant resolve valid import */
 import { Page as AkselPage, PageBlock } from "@navikt/ds-react/Page";
 import Footer from "@/app/_ui/footer/Footer";
 import { Header } from "@/app/_ui/header/Header";

--- a/aksel.nav.no/website/app/dev/(root)/personvernerklaering/page.tsx
+++ b/aksel.nav.no/website/app/dev/(root)/personvernerklaering/page.tsx
@@ -1,6 +1,4 @@
 import { BodyLong, Box, Heading, Link } from "@navikt/ds-react";
-
-/* @ts-expect-error Workspace cant resolve valid imports */
 import { Page as DsPage, PageBlock } from "@navikt/ds-react/Page";
 import { getCookieConsent } from "@/app/_ui/consent-banner/ConsentBanner.utils";
 import Footer from "@/app/_ui/footer/Footer";

--- a/aksel.nav.no/website/pages/api/logger.ts
+++ b/aksel.nav.no/website/pages/api/logger.ts
@@ -1,2 +1,1 @@
-/* @ts-expect-error Project setup cant find perfectly valid module config */
 export { loggingRoute as default } from "@navikt/next-logger/pages";

--- a/aksel.nav.no/website/tsconfig.json
+++ b/aksel.nav.no/website/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
### Description

There has been some issues resolving imports from local packages (and some external). Setting `moduleresolution` from `node` to `bunder`, this seems to resolve itself. I have testet and the default recommended setting is `bundler` from the default nextjs-config. I have not seen this break anything else, so should just work 🤞 

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
