### PR TITLE
[App router] :sparkles: Update Standalone, prinsipper and error/404 pages

### DIFF
--- a/aksel.nav.no/website/app/_sanity/queries.ts
+++ b/aksel.nav.no/website/app/_sanity/queries.ts
@@ -209,6 +209,30 @@ const GOD_PRAKSIS_ARTICLE_BY_SLUG_QUERY = defineQuery(
   }`,
 );
 
+/* ---------------------------- Standalone pages ---------------------------- */
+
+const SIDE_ARTICLE_BY_SLUG_QUERY = defineQuery(`
+*[slug.current == $slug && _type == "aksel_standalone"][0]
+  {
+    ...,
+    content[]{
+      ...,
+      ${destructureBlocks}
+    }
+  }
+`);
+
+/* ------------------------------- Prinsipper ------------------------------- */
+const PRINSIPPER_BY_SLUG_QUERY = defineQuery(`
+  *[slug.current == $slug && _type == "aksel_prinsipp"][0]{
+  ...,
+  content[]{
+    ...,
+    ${destructureBlocks}
+  },
+  ${contributorsAll}
+}`);
+
 /* --------------------------------- Slack --------------------------------- */
 
 const DOCUMENT_BY_ID_FOR_SLACK_QUERY = defineQuery(`*[_id == $id][0]{
@@ -241,4 +265,6 @@ export {
   GOD_PRAKSIS_ARTICLES_BY_TEMA_QUERY,
   GOD_PRAKSIS_ARTICLE_BY_SLUG_QUERY,
   DOCUMENT_BY_ID_FOR_SLACK_QUERY,
+  SIDE_ARTICLE_BY_SLUG_QUERY,
+  PRINSIPPER_BY_SLUG_QUERY,
 };

--- a/aksel.nav.no/website/app/_sanity/query-types.ts
+++ b/aksel.nav.no/website/app/_sanity/query-types.ts
@@ -9475,6 +9475,2162 @@ export type GOD_PRAKSIS_ARTICLE_BY_SLUG_QUERYResult = {
   };
   writeHelp?: string;
 } | null;
+// Variable: SIDE_ARTICLE_BY_SLUG_QUERY
+// Query: *[slug.current == $slug && _type == "aksel_standalone"][0]  {    ...,    content[]{      ...,      _type == "language" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "alert" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "attachment" =>{  ...,  "downloadLink": asset->url,  "size": asset->size,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "token_ref"=>@->,markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },},_type == "intro_komponent" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }},_type == "live_demo" =>{  ...,  "sandbox_ref": sandbox_ref->{...},},_type == "props_seksjon" =>{  ...,  komponenter[]{    ...,    "propref": propref->{...}  },},_type == "installasjon_seksjon" =>{  ...,  "code_ref": code_ref->{...},},_type == "spesial_seksjon" =>{  ...,  "token": token_ref->{...}},_type == "accordion"=>{  ...,  list[]{    ...,    content[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },},       _type == "bilde" =>{    ...,    floating_text[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "video" =>{    ...,    "webm": {      "url": webm.asset->url,      "extension": webm.asset->extension    },    "fallback": {      "url": fallback.asset->url,      "extension": fallback.asset->extension    },    "track": track.asset->url }, _type == "alert" =>{    ...,    body[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "kode" =>{    ...,    "ref": ref->{...}, }, _type == "kode_eksempler" =>{    ...,    dir->, }, _type == "kode_ref" => @->, _type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }}, _type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }}    }  }},_type == "expansioncard"=>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },},     _type == "bilde" =>{    ...,    floating_text[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "video" =>{    ...,    "webm": {      "url": webm.asset->url,      "extension": webm.asset->extension    },    "fallback": {      "url": fallback.asset->url,      "extension": fallback.asset->extension    },    "track": track.asset->url }, _type == "alert" =>{    ...,    body[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "kode" =>{    ...,    "ref": ref->{...}, }, _type == "kode_eksempler" =>{    ...,    dir->, }, _type == "kode_ref" => @->, _type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }}, _type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }}  }}, _type == "bilde" =>{    ...,    floating_text[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "video" =>{    ...,    "webm": {      "url": webm.asset->url,      "extension": webm.asset->extension    },    "fallback": {      "url": fallback.asset->url,      "extension": fallback.asset->extension    },    "track": track.asset->url }, _type == "alert" =>{    ...,    body[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "kode" =>{    ...,    "ref": ref->{...}, }, _type == "kode_eksempler" =>{    ...,    dir->, }, _type == "kode_ref" => @->, _type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }}, _type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }},    }  }
+export type SIDE_ARTICLE_BY_SLUG_QUERYResult = {
+  _id: string;
+  _type: "aksel_standalone";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  publishedAt?: string;
+  heading?: string;
+  slug?: Slug;
+  content: Array<
+    | {
+        _key: string;
+        _type: "accordion";
+        list: Array<{
+          title?: string;
+          content: Array<
+            | {
+                _key: string;
+                _type: "accordion";
+                list?: Array<{
+                  title?: string;
+                  content?: Riktekst_standard;
+                  _type: "element";
+                  _key: string;
+                }>;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "alert";
+                variant?: "error" | "info" | "success" | "warning";
+                heading?: string;
+                heading_level?: "h2" | "h3" | "h4";
+                body: Array<{
+                  children?: Array<{
+                    marks?: Array<string>;
+                    text?: string;
+                    _type: "span";
+                    _key: string;
+                  }>;
+                  style?: "normal";
+                  listItem?: "bullet" | "number";
+                  markDefs: Array<
+                    | {
+                        reference?:
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                            };
+                        _type: "internalLink";
+                        _key: string;
+                        slug: Slug | null;
+                      }
+                    | {
+                        href?: string;
+                        _type: "link";
+                        _key: string;
+                      }
+                  > | null;
+                  level?: number;
+                  _type: "block";
+                  _key: string;
+                }> | null;
+                markDefs: null;
+              }
+            | {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                alt?: string;
+                caption?: string;
+                small?: boolean;
+                kilde?: {
+                  har_kilde?: boolean;
+                  prefix?: "FOTO" | "Kilde";
+                  tekst?: string;
+                  link?: string;
+                };
+                dekorativt?: boolean;
+                border?: boolean;
+                background?: Color;
+                _type: "bilde";
+                _key: string;
+                markDefs: null;
+                floating_text: null;
+              }
+            | {
+                children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+                }>;
+                style?: "h2" | "h3" | "h4" | "normal";
+                listItem?: "bullet" | "number";
+                markDefs: Array<
+                  | {
+                      reference?:
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                          };
+                      _type: "internalLink";
+                      _key: string;
+                      slug: Slug | null;
+                    }
+                  | {
+                      href?: string;
+                      _type: "link";
+                      _key: string;
+                    }
+                > | null;
+                level?: number;
+                _type: "block";
+                _key: string;
+              }
+            | {
+                _key: string;
+                _type: "do_dont";
+                blokker?: Array<
+                  {
+                    _key: string;
+                  } & Do_dont_block
+                >;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "exampletext_block";
+                title?: string;
+                text?: string;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "expansioncard";
+                heading?: string;
+                heading_level?: "h2" | "h3" | "h4";
+                description?: string;
+                body?: Riktekst_accordion;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "kode";
+                code?: Code;
+                title?: string;
+                markDefs: null;
+                ref: null;
+              }
+            | {
+                _key: string;
+                _type: "language";
+                body?: Riktekst_enkel;
+                language?: "en";
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "relatert_innhold";
+                title: string | null;
+                lenker: Array<{
+                  title?: string;
+                  intern?: boolean;
+                  intern_lenke: string | null;
+                  ekstern_link?: string;
+                  ekstern_domene?: boolean;
+                  _type: "lenke";
+                  _key: string;
+                }> | null;
+                markDefs: null;
+              }
+            | {
+                rows?: Array<
+                  {
+                    _key: string;
+                  } & TableRow
+                >;
+                _type: "tabell_v2";
+                _key: string;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "tips";
+                body: Array<{
+                  children?: Array<{
+                    marks?: Array<string>;
+                    text?: string;
+                    _type: "span";
+                    _key: string;
+                  }>;
+                  style?: "normal";
+                  listItem?: "bullet" | "number";
+                  markDefs: Array<
+                    | {
+                        reference?:
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                            };
+                        _type: "internalLink";
+                        _key: string;
+                        slug: Slug | null;
+                      }
+                    | {
+                        href?: string;
+                        _type: "link";
+                        _key: string;
+                      }
+                  > | null;
+                  level?: number;
+                  _type: "block";
+                  _key: string;
+                }> | null;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "video";
+                webm: {
+                  url: string | null;
+                  extension: string | null;
+                };
+                fallback: {
+                  url: string | null;
+                  extension: string | null;
+                };
+                track: string | null;
+                alt?: string;
+                caption?: string;
+                transkripsjon?: string;
+                markDefs: null;
+              }
+          > | null;
+          _type: "element";
+          _key: string;
+        }> | null;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "alert";
+        variant?: "error" | "info" | "success" | "warning";
+        heading?: string;
+        heading_level?: "h2" | "h3" | "h4";
+        body: Array<{
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?: "normal";
+          listItem?: "bullet" | "number";
+          markDefs: Array<
+            | {
+                reference?:
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                    };
+                _type: "internalLink";
+                _key: string;
+                slug: Slug | null;
+              }
+            | {
+                href?: string;
+                _type: "link";
+                _key: string;
+              }
+          > | null;
+          level?: number;
+          _type: "block";
+          _key: string;
+        }> | null;
+        markDefs: null;
+      }
+    | {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        alt?: string;
+        caption?: string;
+        small?: boolean;
+        kilde?: {
+          har_kilde?: boolean;
+          prefix?: "FOTO" | "Kilde";
+          tekst?: string;
+          link?: string;
+        };
+        dekorativt?: boolean;
+        border?: boolean;
+        background?: Color;
+        _type: "bilde";
+        _key: string;
+        markDefs: null;
+        floating_text: null;
+      }
+    | {
+        children?: Array<{
+          marks?: Array<string>;
+          text?: string;
+          _type: "span";
+          _key: string;
+        }>;
+        style?: "h2" | "h3" | "h4" | "normal";
+        listItem?: "bullet" | "number";
+        markDefs: Array<
+          | {
+              reference?:
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                  };
+              _type: "internalLink";
+              _key: string;
+              slug: Slug | null;
+            }
+          | {
+              href?: string;
+              _type: "link";
+              _key: string;
+            }
+        > | null;
+        level?: number;
+        _type: "block";
+        _key: string;
+      }
+    | {
+        _key: string;
+        _type: "do_dont";
+        blokker?: Array<
+          {
+            _key: string;
+          } & Do_dont_block
+        >;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "exampletext_block";
+        title?: string;
+        text?: string;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "expansioncard";
+        heading?: string;
+        heading_level?: "h2" | "h3" | "h4";
+        description?: string;
+        body: Array<
+          | {
+              _key: string;
+              _type: "alert";
+              variant?: "error" | "info" | "success" | "warning";
+              heading?: string;
+              heading_level?: "h2" | "h3" | "h4";
+              body: Array<{
+                children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+                }>;
+                style?: "normal";
+                listItem?: "bullet" | "number";
+                markDefs: Array<
+                  | {
+                      reference?:
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                          };
+                      _type: "internalLink";
+                      _key: string;
+                      slug: Slug | null;
+                    }
+                  | {
+                      href?: string;
+                      _type: "link";
+                      _key: string;
+                    }
+                > | null;
+                level?: number;
+                _type: "block";
+                _key: string;
+              }> | null;
+              markDefs: null;
+            }
+          | {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              alt?: string;
+              caption?: string;
+              small?: boolean;
+              kilde?: {
+                har_kilde?: boolean;
+                prefix?: "FOTO" | "Kilde";
+                tekst?: string;
+                link?: string;
+              };
+              dekorativt?: boolean;
+              border?: boolean;
+              background?: Color;
+              _type: "bilde";
+              _key: string;
+              markDefs: null;
+              floating_text: null;
+            }
+          | {
+              children?: Array<{
+                marks?: Array<string>;
+                text?: string;
+                _type: "span";
+                _key: string;
+              }>;
+              style?: "h2" | "h3" | "h4" | "normal";
+              listItem?: "bullet" | "number";
+              markDefs: Array<
+                | {
+                    reference?:
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                        };
+                    _type: "internalLink";
+                    _key: string;
+                    slug: Slug | null;
+                  }
+                | {
+                    href?: string;
+                    _type: "link";
+                    _key: string;
+                  }
+              > | null;
+              level?: number;
+              _type: "block";
+              _key: string;
+            }
+          | {
+              _key: string;
+              _type: "do_dont";
+              blokker?: Array<
+                {
+                  _key: string;
+                } & Do_dont_block
+              >;
+              markDefs: null;
+            }
+          | {
+              _key: string;
+              _type: "exampletext_block";
+              title?: string;
+              text?: string;
+              markDefs: null;
+            }
+          | {
+              _key: string;
+              _type: "kode";
+              code?: Code;
+              title?: string;
+              markDefs: null;
+              ref: null;
+            }
+          | {
+              _key: string;
+              _type: "relatert_innhold";
+              title: string | null;
+              lenker: Array<{
+                title?: string;
+                intern?: boolean;
+                intern_lenke: string | null;
+                ekstern_link?: string;
+                ekstern_domene?: boolean;
+                _type: "lenke";
+                _key: string;
+              }> | null;
+              markDefs: null;
+            }
+          | {
+              rows?: Array<
+                {
+                  _key: string;
+                } & TableRow
+              >;
+              _type: "tabell_v2";
+              _key: string;
+              markDefs: null;
+            }
+          | {
+              _key: string;
+              _type: "tips";
+              body: Array<{
+                children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+                }>;
+                style?: "normal";
+                listItem?: "bullet" | "number";
+                markDefs: Array<
+                  | {
+                      reference?:
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                          };
+                      _type: "internalLink";
+                      _key: string;
+                      slug: Slug | null;
+                    }
+                  | {
+                      href?: string;
+                      _type: "link";
+                      _key: string;
+                    }
+                > | null;
+                level?: number;
+                _type: "block";
+                _key: string;
+              }> | null;
+              markDefs: null;
+            }
+          | {
+              _key: string;
+              _type: "video";
+              webm: {
+                url: string | null;
+                extension: string | null;
+              };
+              fallback: {
+                url: string | null;
+                extension: string | null;
+              };
+              track: string | null;
+              alt?: string;
+              caption?: string;
+              transkripsjon?: string;
+              markDefs: null;
+            }
+        > | null;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "kode";
+        code?: Code;
+        title?: string;
+        markDefs: null;
+        ref: null;
+      }
+    | {
+        _key: string;
+        _type: "language";
+        body: Array<{
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?: "normal";
+          listItem?: "bullet" | "number";
+          markDefs: Array<
+            | {
+                reference?:
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                    };
+                _type: "internalLink";
+                _key: string;
+                slug: Slug | null;
+              }
+            | {
+                href?: string;
+                _type: "link";
+                _key: string;
+              }
+          > | null;
+          level?: number;
+          _type: "block";
+          _key: string;
+        }> | null;
+        language?: "en";
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "relatert_innhold";
+        title: string | null;
+        lenker: Array<{
+          title?: string;
+          intern?: boolean;
+          intern_lenke: string | null;
+          ekstern_link?: string;
+          ekstern_domene?: boolean;
+          _type: "lenke";
+          _key: string;
+        }> | null;
+        markDefs: null;
+      }
+    | {
+        rows?: Array<
+          {
+            _key: string;
+          } & TableRow
+        >;
+        _type: "tabell_v2";
+        _key: string;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "tips";
+        body: Array<{
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?: "normal";
+          listItem?: "bullet" | "number";
+          markDefs: Array<
+            | {
+                reference?:
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                    };
+                _type: "internalLink";
+                _key: string;
+                slug: Slug | null;
+              }
+            | {
+                href?: string;
+                _type: "link";
+                _key: string;
+              }
+          > | null;
+          level?: number;
+          _type: "block";
+          _key: string;
+        }> | null;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "video";
+        webm: {
+          url: string | null;
+          extension: string | null;
+        };
+        fallback: {
+          url: string | null;
+          extension: string | null;
+        };
+        track: string | null;
+        alt?: string;
+        caption?: string;
+        transkripsjon?: string;
+        markDefs: null;
+      }
+  > | null;
+} | null;
+// Variable: PRINSIPPER_BY_SLUG_QUERY
+// Query: *[slug.current == $slug && _type == "aksel_prinsipp"][0]{  ...,  content[]{    ...,    _type == "language" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "alert" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "attachment" =>{  ...,  "downloadLink": asset->url,  "size": asset->size,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "token_ref"=>@->,markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },},_type == "intro_komponent" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }},_type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }},_type == "live_demo" =>{  ...,  "sandbox_ref": sandbox_ref->{...},},_type == "props_seksjon" =>{  ...,  komponenter[]{    ...,    "propref": propref->{...}  },},_type == "installasjon_seksjon" =>{  ...,  "code_ref": code_ref->{...},},_type == "spesial_seksjon" =>{  ...,  "token": token_ref->{...}},_type == "accordion"=>{  ...,  list[]{    ...,    content[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },},       _type == "bilde" =>{    ...,    floating_text[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "video" =>{    ...,    "webm": {      "url": webm.asset->url,      "extension": webm.asset->extension    },    "fallback": {      "url": fallback.asset->url,      "extension": fallback.asset->extension    },    "track": track.asset->url }, _type == "alert" =>{    ...,    body[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "kode" =>{    ...,    "ref": ref->{...}, }, _type == "kode_eksempler" =>{    ...,    dir->, }, _type == "kode_ref" => @->, _type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }}, _type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }}    }  }},_type == "expansioncard"=>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },},     _type == "bilde" =>{    ...,    floating_text[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "video" =>{    ...,    "webm": {      "url": webm.asset->url,      "extension": webm.asset->extension    },    "fallback": {      "url": fallback.asset->url,      "extension": fallback.asset->extension    },    "track": track.asset->url }, _type == "alert" =>{    ...,    body[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "kode" =>{    ...,    "ref": ref->{...}, }, _type == "kode_eksempler" =>{    ...,    dir->, }, _type == "kode_ref" => @->, _type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }}, _type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }}  }}, _type == "bilde" =>{    ...,    floating_text[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "video" =>{    ...,    "webm": {      "url": webm.asset->url,      "extension": webm.asset->extension    },    "fallback": {      "url": fallback.asset->url,      "extension": fallback.asset->extension    },    "track": track.asset->url }, _type == "alert" =>{    ...,    body[]{      ...,      markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}    } }, _type == "kode" =>{    ...,    "ref": ref->{...}, }, _type == "kode_eksempler" =>{    ...,    dir->, }, _type == "kode_ref" => @->, _type == "tips" =>{  ...,  body[]{    ...,    markDefs[]{  ...,  _type == 'internalLink' => {      "slug": @.reference->slug,  },}  }}, _type == "relatert_innhold" =>{  title,  lenker[]{    ...,    "intern_lenke": intern_lenke->slug.current,  }},  },  contributors[]->{title}}
+export type PRINSIPPER_BY_SLUG_QUERYResult = {
+  _id: string;
+  _type: "aksel_prinsipp";
+  _createdAt: string;
+  _updatedAt: string;
+  _rev: string;
+  publishedAt?: string;
+  heading?: string;
+  contributors: Array<{
+    title: string | null;
+  }> | null;
+  slug?: Slug;
+  prinsipp?: {
+    prinsippvalg?: "brukeropplevelse";
+    hovedside?: boolean;
+  };
+  ingress?: string;
+  content: Array<
+    | {
+        _key: string;
+        _type: "accordion";
+        list: Array<{
+          title?: string;
+          content: Array<
+            | {
+                _key: string;
+                _type: "accordion";
+                list?: Array<{
+                  title?: string;
+                  content?: Riktekst_standard;
+                  _type: "element";
+                  _key: string;
+                }>;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "alert";
+                variant?: "error" | "info" | "success" | "warning";
+                heading?: string;
+                heading_level?: "h2" | "h3" | "h4";
+                body: Array<{
+                  children?: Array<{
+                    marks?: Array<string>;
+                    text?: string;
+                    _type: "span";
+                    _key: string;
+                  }>;
+                  style?: "normal";
+                  listItem?: "bullet" | "number";
+                  markDefs: Array<
+                    | {
+                        reference?:
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                            };
+                        _type: "internalLink";
+                        _key: string;
+                        slug: Slug | null;
+                      }
+                    | {
+                        href?: string;
+                        _type: "link";
+                        _key: string;
+                      }
+                  > | null;
+                  level?: number;
+                  _type: "block";
+                  _key: string;
+                }> | null;
+                markDefs: null;
+              }
+            | {
+                asset?: {
+                  _ref: string;
+                  _type: "reference";
+                  _weak?: boolean;
+                  [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+                };
+                hotspot?: SanityImageHotspot;
+                crop?: SanityImageCrop;
+                alt?: string;
+                caption?: string;
+                small?: boolean;
+                kilde?: {
+                  har_kilde?: boolean;
+                  prefix?: "FOTO" | "Kilde";
+                  tekst?: string;
+                  link?: string;
+                };
+                dekorativt?: boolean;
+                border?: boolean;
+                background?: Color;
+                _type: "bilde";
+                _key: string;
+                markDefs: null;
+                floating_text: null;
+              }
+            | {
+                children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+                }>;
+                style?: "h2" | "h3" | "h4" | "normal";
+                listItem?: "bullet" | "number";
+                markDefs: Array<
+                  | {
+                      reference?:
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                          };
+                      _type: "internalLink";
+                      _key: string;
+                      slug: Slug | null;
+                    }
+                  | {
+                      href?: string;
+                      _type: "link";
+                      _key: string;
+                    }
+                > | null;
+                level?: number;
+                _type: "block";
+                _key: string;
+              }
+            | {
+                _key: string;
+                _type: "do_dont";
+                blokker?: Array<
+                  {
+                    _key: string;
+                  } & Do_dont_block
+                >;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "exampletext_block";
+                title?: string;
+                text?: string;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "expansioncard";
+                heading?: string;
+                heading_level?: "h2" | "h3" | "h4";
+                description?: string;
+                body?: Riktekst_accordion;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "kode";
+                code?: Code;
+                title?: string;
+                markDefs: null;
+                ref: null;
+              }
+            | {
+                _key: string;
+                _type: "language";
+                body?: Riktekst_enkel;
+                language?: "en";
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "relatert_innhold";
+                title: string | null;
+                lenker: Array<{
+                  title?: string;
+                  intern?: boolean;
+                  intern_lenke: string | null;
+                  ekstern_link?: string;
+                  ekstern_domene?: boolean;
+                  _type: "lenke";
+                  _key: string;
+                }> | null;
+                markDefs: null;
+              }
+            | {
+                rows?: Array<
+                  {
+                    _key: string;
+                  } & TableRow
+                >;
+                _type: "tabell_v2";
+                _key: string;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "tips";
+                body: Array<{
+                  children?: Array<{
+                    marks?: Array<string>;
+                    text?: string;
+                    _type: "span";
+                    _key: string;
+                  }>;
+                  style?: "normal";
+                  listItem?: "bullet" | "number";
+                  markDefs: Array<
+                    | {
+                        reference?:
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                            }
+                          | {
+                              _ref: string;
+                              _type: "reference";
+                              _weak?: boolean;
+                              [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                            };
+                        _type: "internalLink";
+                        _key: string;
+                        slug: Slug | null;
+                      }
+                    | {
+                        href?: string;
+                        _type: "link";
+                        _key: string;
+                      }
+                  > | null;
+                  level?: number;
+                  _type: "block";
+                  _key: string;
+                }> | null;
+                markDefs: null;
+              }
+            | {
+                _key: string;
+                _type: "video";
+                webm: {
+                  url: string | null;
+                  extension: string | null;
+                };
+                fallback: {
+                  url: string | null;
+                  extension: string | null;
+                };
+                track: string | null;
+                alt?: string;
+                caption?: string;
+                transkripsjon?: string;
+                markDefs: null;
+              }
+          > | null;
+          _type: "element";
+          _key: string;
+        }> | null;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "alert";
+        variant?: "error" | "info" | "success" | "warning";
+        heading?: string;
+        heading_level?: "h2" | "h3" | "h4";
+        body: Array<{
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?: "normal";
+          listItem?: "bullet" | "number";
+          markDefs: Array<
+            | {
+                reference?:
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                    };
+                _type: "internalLink";
+                _key: string;
+                slug: Slug | null;
+              }
+            | {
+                href?: string;
+                _type: "link";
+                _key: string;
+              }
+          > | null;
+          level?: number;
+          _type: "block";
+          _key: string;
+        }> | null;
+        markDefs: null;
+      }
+    | {
+        asset?: {
+          _ref: string;
+          _type: "reference";
+          _weak?: boolean;
+          [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+        };
+        hotspot?: SanityImageHotspot;
+        crop?: SanityImageCrop;
+        alt?: string;
+        caption?: string;
+        small?: boolean;
+        kilde?: {
+          har_kilde?: boolean;
+          prefix?: "FOTO" | "Kilde";
+          tekst?: string;
+          link?: string;
+        };
+        dekorativt?: boolean;
+        border?: boolean;
+        background?: Color;
+        _type: "bilde";
+        _key: string;
+        markDefs: null;
+        floating_text: null;
+      }
+    | {
+        children?: Array<{
+          marks?: Array<string>;
+          text?: string;
+          _type: "span";
+          _key: string;
+        }>;
+        style?: "h2" | "h3" | "h4" | "normal";
+        listItem?: "bullet" | "number";
+        markDefs: Array<
+          | {
+              reference?:
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                  }
+                | {
+                    _ref: string;
+                    _type: "reference";
+                    _weak?: boolean;
+                    [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                  };
+              _type: "internalLink";
+              _key: string;
+              slug: Slug | null;
+            }
+          | {
+              href?: string;
+              _type: "link";
+              _key: string;
+            }
+        > | null;
+        level?: number;
+        _type: "block";
+        _key: string;
+      }
+    | {
+        _key: string;
+        _type: "do_dont";
+        blokker?: Array<
+          {
+            _key: string;
+          } & Do_dont_block
+        >;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "exampletext_block";
+        title?: string;
+        text?: string;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "expansioncard";
+        heading?: string;
+        heading_level?: "h2" | "h3" | "h4";
+        description?: string;
+        body: Array<
+          | {
+              _key: string;
+              _type: "alert";
+              variant?: "error" | "info" | "success" | "warning";
+              heading?: string;
+              heading_level?: "h2" | "h3" | "h4";
+              body: Array<{
+                children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+                }>;
+                style?: "normal";
+                listItem?: "bullet" | "number";
+                markDefs: Array<
+                  | {
+                      reference?:
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                          };
+                      _type: "internalLink";
+                      _key: string;
+                      slug: Slug | null;
+                    }
+                  | {
+                      href?: string;
+                      _type: "link";
+                      _key: string;
+                    }
+                > | null;
+                level?: number;
+                _type: "block";
+                _key: string;
+              }> | null;
+              markDefs: null;
+            }
+          | {
+              asset?: {
+                _ref: string;
+                _type: "reference";
+                _weak?: boolean;
+                [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+              };
+              hotspot?: SanityImageHotspot;
+              crop?: SanityImageCrop;
+              alt?: string;
+              caption?: string;
+              small?: boolean;
+              kilde?: {
+                har_kilde?: boolean;
+                prefix?: "FOTO" | "Kilde";
+                tekst?: string;
+                link?: string;
+              };
+              dekorativt?: boolean;
+              border?: boolean;
+              background?: Color;
+              _type: "bilde";
+              _key: string;
+              markDefs: null;
+              floating_text: null;
+            }
+          | {
+              children?: Array<{
+                marks?: Array<string>;
+                text?: string;
+                _type: "span";
+                _key: string;
+              }>;
+              style?: "h2" | "h3" | "h4" | "normal";
+              listItem?: "bullet" | "number";
+              markDefs: Array<
+                | {
+                    reference?:
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                        }
+                      | {
+                          _ref: string;
+                          _type: "reference";
+                          _weak?: boolean;
+                          [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                        };
+                    _type: "internalLink";
+                    _key: string;
+                    slug: Slug | null;
+                  }
+                | {
+                    href?: string;
+                    _type: "link";
+                    _key: string;
+                  }
+              > | null;
+              level?: number;
+              _type: "block";
+              _key: string;
+            }
+          | {
+              _key: string;
+              _type: "do_dont";
+              blokker?: Array<
+                {
+                  _key: string;
+                } & Do_dont_block
+              >;
+              markDefs: null;
+            }
+          | {
+              _key: string;
+              _type: "exampletext_block";
+              title?: string;
+              text?: string;
+              markDefs: null;
+            }
+          | {
+              _key: string;
+              _type: "kode";
+              code?: Code;
+              title?: string;
+              markDefs: null;
+              ref: null;
+            }
+          | {
+              _key: string;
+              _type: "relatert_innhold";
+              title: string | null;
+              lenker: Array<{
+                title?: string;
+                intern?: boolean;
+                intern_lenke: string | null;
+                ekstern_link?: string;
+                ekstern_domene?: boolean;
+                _type: "lenke";
+                _key: string;
+              }> | null;
+              markDefs: null;
+            }
+          | {
+              rows?: Array<
+                {
+                  _key: string;
+                } & TableRow
+              >;
+              _type: "tabell_v2";
+              _key: string;
+              markDefs: null;
+            }
+          | {
+              _key: string;
+              _type: "tips";
+              body: Array<{
+                children?: Array<{
+                  marks?: Array<string>;
+                  text?: string;
+                  _type: "span";
+                  _key: string;
+                }>;
+                style?: "normal";
+                listItem?: "bullet" | "number";
+                markDefs: Array<
+                  | {
+                      reference?:
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                          }
+                        | {
+                            _ref: string;
+                            _type: "reference";
+                            _weak?: boolean;
+                            [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                          };
+                      _type: "internalLink";
+                      _key: string;
+                      slug: Slug | null;
+                    }
+                  | {
+                      href?: string;
+                      _type: "link";
+                      _key: string;
+                    }
+                > | null;
+                level?: number;
+                _type: "block";
+                _key: string;
+              }> | null;
+              markDefs: null;
+            }
+          | {
+              _key: string;
+              _type: "video";
+              webm: {
+                url: string | null;
+                extension: string | null;
+              };
+              fallback: {
+                url: string | null;
+                extension: string | null;
+              };
+              track: string | null;
+              alt?: string;
+              caption?: string;
+              transkripsjon?: string;
+              markDefs: null;
+            }
+        > | null;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "kode";
+        code?: Code;
+        title?: string;
+        markDefs: null;
+        ref: null;
+      }
+    | {
+        _key: string;
+        _type: "language";
+        body: Array<{
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?: "normal";
+          listItem?: "bullet" | "number";
+          markDefs: Array<
+            | {
+                reference?:
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                    };
+                _type: "internalLink";
+                _key: string;
+                slug: Slug | null;
+              }
+            | {
+                href?: string;
+                _type: "link";
+                _key: string;
+              }
+          > | null;
+          level?: number;
+          _type: "block";
+          _key: string;
+        }> | null;
+        language?: "en";
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "relatert_innhold";
+        title: string | null;
+        lenker: Array<{
+          title?: string;
+          intern?: boolean;
+          intern_lenke: string | null;
+          ekstern_link?: string;
+          ekstern_domene?: boolean;
+          _type: "lenke";
+          _key: string;
+        }> | null;
+        markDefs: null;
+      }
+    | {
+        rows?: Array<
+          {
+            _key: string;
+          } & TableRow
+        >;
+        _type: "tabell_v2";
+        _key: string;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "tips";
+        body: Array<{
+          children?: Array<{
+            marks?: Array<string>;
+            text?: string;
+            _type: "span";
+            _key: string;
+          }>;
+          style?: "normal";
+          listItem?: "bullet" | "number";
+          markDefs: Array<
+            | {
+                reference?:
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_blogg";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_prinsipp";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "aksel_standalone";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "ds_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "komponent_artikkel";
+                    }
+                  | {
+                      _ref: string;
+                      _type: "reference";
+                      _weak?: boolean;
+                      [internalGroqTypeReferenceTo]?: "templates_artikkel";
+                    };
+                _type: "internalLink";
+                _key: string;
+                slug: Slug | null;
+              }
+            | {
+                href?: string;
+                _type: "link";
+                _key: string;
+              }
+          > | null;
+          level?: number;
+          _type: "block";
+          _key: string;
+        }> | null;
+        markDefs: null;
+      }
+    | {
+        _key: string;
+        _type: "video";
+        webm: {
+          url: string | null;
+          extension: string | null;
+        };
+        fallback: {
+          url: string | null;
+          extension: string | null;
+        };
+        track: string | null;
+        alt?: string;
+        caption?: string;
+        transkripsjon?: string;
+        markDefs: null;
+      }
+  > | null;
+  seo?: {
+    meta?: string;
+    image?: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      _type: "image";
+    };
+  };
+} | null;
 // Variable: DOCUMENT_BY_ID_FOR_SLACK_QUERY
 // Query: *[_id == $id][0]{      "id": _id,      "title": heading,      "editors": contributors[]->email,      "slug": slug.current,      "contacts": undertema[]->tema->contacts[]->email    }
 export type DOCUMENT_BY_ID_FOR_SLACK_QUERYResult =
@@ -9537,6 +11693,8 @@ declare module "@sanity/client" {
     '*[_type == "gp.tema" && slug.current == $slug][0]{\n    ...,\n    "undertema": *[_type == "gp.tema.undertema" && tema->slug.current == $slug]{\n      title,\n      description\n    },\n  }': GOD_PRAKSIS_TEMA_BY_SLUG_QUERYResult;
     '*[_type == "aksel_artikkel" && defined(undertema) && $slug in undertema[]->tema->slug.current] | order(updateInfo.lastVerified desc) {\n    _id,\n    heading,\n    "displayDate": updateInfo.lastVerified,\n    "description": ingress,\n    "undertema": undertema[]->{title, "temaTitle": tema->title},\n    "innholdstype": innholdstype->title,\n    "slug": slug.current,\n  }': GOD_PRAKSIS_ARTICLES_BY_TEMA_QUERYResult;
     '*[slug.current == $slug && _type == "aksel_artikkel"][0]\n  {\n    ...,\n    content[]{\n      ...,\n      \n_type == "language" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "alert" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "attachment" =>{\n  ...,\n  "downloadLink": asset->url,\n  "size": asset->size,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "token_ref"=>@->,\n\nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n_type == "intro_komponent" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n},\n_type == "live_demo" =>{\n  ...,\n  "sandbox_ref": sandbox_ref->{...},\n},\n_type == "props_seksjon" =>{\n  ...,\n  komponenter[]{\n    ...,\n    "propref": propref->{...}\n  },\n},\n_type == "installasjon_seksjon" =>{\n  ...,\n  "code_ref": code_ref->{...},\n},\n_type == "spesial_seksjon" =>{\n  ...,\n  "token": token_ref->{...}\n},\n_type == "accordion"=>{\n  ...,\n  list[]{\n    ...,\n    content[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n      \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n    }\n  }\n}\n,\n_type == "expansioncard"=>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n    \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n  }\n},\n\n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n,\n\n    },\n    "innholdstype": innholdstype->title,\n    "undertema": undertema[]->{\n      title,\n      "tema": tema->{\n        title,\n        "slug": slug.current,\n        "image": seo.image\n      }\n    },\n    contributors[]->{title},\n    relevante_artikler[]->{\n      heading,\n      ingress,\n      slug,\n      "innholdstype": innholdstype->title,\n    }\n  }': GOD_PRAKSIS_ARTICLE_BY_SLUG_QUERYResult;
+    '\n*[slug.current == $slug && _type == "aksel_standalone"][0]\n  {\n    ...,\n    content[]{\n      ...,\n      \n_type == "language" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "alert" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "attachment" =>{\n  ...,\n  "downloadLink": asset->url,\n  "size": asset->size,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "token_ref"=>@->,\n\nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n_type == "intro_komponent" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n},\n_type == "live_demo" =>{\n  ...,\n  "sandbox_ref": sandbox_ref->{...},\n},\n_type == "props_seksjon" =>{\n  ...,\n  komponenter[]{\n    ...,\n    "propref": propref->{...}\n  },\n},\n_type == "installasjon_seksjon" =>{\n  ...,\n  "code_ref": code_ref->{...},\n},\n_type == "spesial_seksjon" =>{\n  ...,\n  "token": token_ref->{...}\n},\n_type == "accordion"=>{\n  ...,\n  list[]{\n    ...,\n    content[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n      \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n    }\n  }\n}\n,\n_type == "expansioncard"=>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n    \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n  }\n},\n\n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n,\n\n    }\n  }\n': SIDE_ARTICLE_BY_SLUG_QUERYResult;
+    '\n  *[slug.current == $slug && _type == "aksel_prinsipp"][0]{\n  ...,\n  content[]{\n    ...,\n    \n_type == "language" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "alert" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "attachment" =>{\n  ...,\n  "downloadLink": asset->url,\n  "size": asset->size,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "token_ref"=>@->,\n\nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n_type == "intro_komponent" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n_type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n},\n_type == "live_demo" =>{\n  ...,\n  "sandbox_ref": sandbox_ref->{...},\n},\n_type == "props_seksjon" =>{\n  ...,\n  komponenter[]{\n    ...,\n    "propref": propref->{...}\n  },\n},\n_type == "installasjon_seksjon" =>{\n  ...,\n  "code_ref": code_ref->{...},\n},\n_type == "spesial_seksjon" =>{\n  ...,\n  "token": token_ref->{...}\n},\n_type == "accordion"=>{\n  ...,\n  list[]{\n    ...,\n    content[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n      \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n    }\n  }\n}\n,\n_type == "expansioncard"=>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n},\n    \n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n\n  }\n},\n\n _type == "bilde" =>{\n    ...,\n    floating_text[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "video" =>{\n    ...,\n    "webm": {\n      "url": webm.asset->url,\n      "extension": webm.asset->extension\n    },\n    "fallback": {\n      "url": fallback.asset->url,\n      "extension": fallback.asset->extension\n    },\n    "track": track.asset->url\n },\n _type == "alert" =>{\n    ...,\n    body[]{\n      ...,\n      \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n    }\n },\n _type == "kode" =>{\n    ...,\n    "ref": ref->{...},\n },\n _type == "kode_eksempler" =>{\n    ...,\n    dir->,\n },\n _type == "kode_ref" => @->,\n _type == "tips" =>{\n  ...,\n  body[]{\n    ...,\n    \nmarkDefs[]{\n  ...,\n  _type == \'internalLink\' => {\n      "slug": @.reference->slug,\n  },\n}\n  }\n},\n _type == "relatert_innhold" =>{\n  title,\n  lenker[]{\n    ...,\n    "intern_lenke": intern_lenke->slug.current,\n  }\n}\n,\n\n  },\n  contributors[]->{title}\n}': PRINSIPPER_BY_SLUG_QUERYResult;
     '*[_id == $id][0]{\n      "id": _id,\n      "title": heading,\n      "editors": contributors[]->email,\n      "slug": slug.current,\n      "contacts": undertema[]->tema->contacts[]->email\n    }': DOCUMENT_BY_ID_FOR_SLACK_QUERYResult;
   }
 }

--- a/aksel.nav.no/website/app/_ui/umami/Umami.log.tsx
+++ b/aksel.nav.no/website/app/_ui/umami/Umami.log.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Sometimes we need to track that a spesific page was visited, but since Umami is client-side only, we can't use the `page.tsx` file to track it.
+ */
+function UmamiNotFoundPageLog() {
+  useEffect(() => {
+    window.umami && umami.track("404", { url: window.location.pathname });
+  }, []);
+
+  return null;
+}
+
+export { UmamiNotFoundPageLog };

--- a/aksel.nav.no/website/app/dev/(prinsipper)/prinsipper/[[...prinsipp]]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(prinsipper)/prinsipper/[[...prinsipp]]/page.tsx
@@ -1,0 +1,80 @@
+import { Metadata } from "next";
+import { PortableTextBlock } from "next-sanity";
+import { notFound } from "next/navigation";
+import { Image } from "sanity";
+import { BodyLong, BodyShort, HStack, Heading, VStack } from "@navikt/ds-react";
+import { CustomPortableText } from "@/app/CustomPortableText";
+import { sanityFetch } from "@/app/_sanity/live";
+import { PRINSIPPER_BY_SLUG_QUERY } from "@/app/_sanity/queries";
+import { urlForOpenGraphImage } from "@/app/_sanity/utils";
+
+type Props = {
+  params: Promise<{ prinsipp: string[] }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { prinsipp } = await params;
+
+  const { data: seoData } = await sanityFetch({
+    query: PRINSIPPER_BY_SLUG_QUERY,
+    params: { slug: `prinsipper/${prinsipp.join("/")}` },
+    stega: false,
+  });
+
+  return {
+    title: seoData?.heading,
+    description: seoData?.seo?.meta,
+    openGraph: {
+      images: urlForOpenGraphImage(seoData?.seo?.image as Image),
+    },
+  };
+}
+
+export default async function Page({ params }: Props) {
+  const { prinsipp } = await params;
+
+  const { data: pageData } = await sanityFetch({
+    query: PRINSIPPER_BY_SLUG_QUERY,
+    params: { slug: `prinsipper/${prinsipp.join("/")}` },
+  });
+
+  if (!pageData || !pageData.content || !pageData.heading) {
+    notFound();
+  }
+
+  const authors =
+    pageData?.contributors
+      ?.filter((auth) => !!auth.title)
+      .map((auth) => auth.title ?? "") ?? [];
+
+  return (
+    <div>
+      <Heading level="1" size="xlarge" data-aksel-heading-color spacing>
+        {pageData.heading}
+      </Heading>
+      {pageData?.ingress && (
+        <BodyLong size="large" spacing>
+          {pageData?.ingress}
+        </BodyLong>
+      )}
+      <CustomPortableText
+        value={(pageData.content ?? []) as PortableTextBlock[]}
+      />
+      <VStack gap="space-8" marginBlock="space-48">
+        <BodyShort size="large" weight="semibold" data-aksel-heading-color>
+          Kontakt
+        </BodyShort>
+        <HStack gap="space-4" asChild>
+          <BodyShort textColor="subtle" as="div">
+            {authors.map((x, y) => (
+              <address key={x}>
+                {x}
+                {y !== authors.length - 1 && ", "}
+              </address>
+            ))}
+          </BodyShort>
+        </HStack>
+      </VStack>
+    </div>
+  );
+}

--- a/aksel.nav.no/website/app/dev/(prinsipper)/prinsipper/layout.tsx
+++ b/aksel.nav.no/website/app/dev/(prinsipper)/prinsipper/layout.tsx
@@ -3,7 +3,7 @@ import { Page as AkselPage, PageBlock } from "@navikt/ds-react/Page";
 import Footer from "@/app/_ui/footer/Footer";
 import { Header } from "@/app/_ui/header/Header";
 
-export default async function GodPraksisLayout({
+export default async function StandaloneLayout({
   children,
 }: {
   children: React.ReactNode;
@@ -12,7 +12,7 @@ export default async function GodPraksisLayout({
     <AkselPage footer={<Footer />} footerPosition="belowFold">
       <Header />
       <Box paddingBlock="space-40" tabIndex={-1} id="hovedinnhold" asChild>
-        <PageBlock width="xl" gutters as="main">
+        <PageBlock width="md" gutters as="main">
           {children}
         </PageBlock>
       </Box>

--- a/aksel.nav.no/website/app/dev/(standalone)/side/[slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(standalone)/side/[slug]/page.tsx
@@ -1,0 +1,52 @@
+import { Metadata } from "next";
+import { PortableTextBlock } from "next-sanity";
+import { notFound } from "next/navigation";
+import { Heading } from "@navikt/ds-react";
+import { CustomPortableText } from "@/app/CustomPortableText";
+import { sanityFetch } from "@/app/_sanity/live";
+import { SIDE_ARTICLE_BY_SLUG_QUERY } from "@/app/_sanity/queries";
+import { getImage } from "@/utils";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+
+  const { data: pageData } = await sanityFetch({
+    query: SIDE_ARTICLE_BY_SLUG_QUERY,
+    params: { slug: `side/${slug}` },
+  });
+
+  return {
+    title: pageData?.heading,
+    openGraph: {
+      images: getImage(pageData?.heading ?? "", "thumbnail"),
+    },
+  };
+}
+
+export default async function Page({ params }: Props) {
+  const { slug } = await params;
+
+  const { data: pageData } = await sanityFetch({
+    query: SIDE_ARTICLE_BY_SLUG_QUERY,
+    params: { slug: `side/${slug}` },
+  });
+
+  if (!pageData || !pageData.content || !pageData.heading) {
+    notFound();
+  }
+
+  return (
+    <div>
+      <Heading level="1" size="xlarge" data-aksel-heading-color spacing>
+        {pageData.heading}
+      </Heading>
+      <CustomPortableText
+        value={(pageData.content ?? []) as PortableTextBlock[]}
+      />
+    </div>
+  );
+}

--- a/aksel.nav.no/website/app/dev/(standalone)/side/layout.tsx
+++ b/aksel.nav.no/website/app/dev/(standalone)/side/layout.tsx
@@ -3,7 +3,7 @@ import { Page as AkselPage, PageBlock } from "@navikt/ds-react/Page";
 import Footer from "@/app/_ui/footer/Footer";
 import { Header } from "@/app/_ui/header/Header";
 
-export default async function GodPraksisLayout({
+export default async function PrinsippLayout({
   children,
 }: {
   children: React.ReactNode;
@@ -12,7 +12,7 @@ export default async function GodPraksisLayout({
     <AkselPage footer={<Footer />} footerPosition="belowFold">
       <Header />
       <Box paddingBlock="space-40" tabIndex={-1} id="hovedinnhold" asChild>
-        <PageBlock width="xl" gutters as="main">
+        <PageBlock width="md" gutters as="main">
           {children}
         </PageBlock>
       </Box>

--- a/aksel.nav.no/website/app/dev/produktbloggen/layout.tsx
+++ b/aksel.nav.no/website/app/dev/produktbloggen/layout.tsx
@@ -4,7 +4,7 @@ import Footer from "@/app/_ui/footer/Footer";
 import { Header } from "@/app/_ui/header/Header";
 import styles from "./_ui/Produktbloggen.module.css";
 
-export default async function DesignsystemLayout({
+export default async function ProduktbloggenLayout({
   children,
 }: {
   children: React.ReactNode;

--- a/aksel.nav.no/website/app/error.tsx
+++ b/aksel.nav.no/website/app/error.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { ReactElement, useEffect } from "react";
+import { BodyShort, Box, Heading, Link, VStack } from "@navikt/ds-react";
+import { Page } from "@navikt/ds-react/Page";
+import { logger } from "@navikt/next-logger";
+import { WebsiteList, WebsiteListItem } from "@/app/_ui/typography/WebsiteList";
+
+export default function Error({
+  error,
+}: {
+  error: Error & { digest?: string };
+}): ReactElement {
+  useEffect(() => {
+    logger.error(error);
+  }, [error]);
+
+  useEffect(() => {
+    window.umami &&
+      umami.track("client-error", { url: window.location.pathname });
+  }, []);
+
+  return (
+    <Page data-aksel-template="500-v2" className="vk-error">
+      <Page.Block as="main" width="xl" gutters>
+        <Box paddingBlock="space-80 space-32">
+          <VStack gap="space-64">
+            <VStack gap="space-48" align="start">
+              <div>
+                <Heading
+                  level="1"
+                  size="large"
+                  spacing
+                  data-aksel-heading-color
+                >
+                  Beklager, noe gikk galt.
+                </Heading>
+                <BodyShort spacing>
+                  En teknisk feil på våre servere gjør at siden er
+                  utilgjengelig. Dette skyldes ikke noe du gjorde.
+                </BodyShort>
+                <BodyShort spacing>Du kan prøve å</BodyShort>
+                <WebsiteList>
+                  <WebsiteListItem icon>
+                    vente noen minutter og{" "}
+                    <Link href="#" onClick={() => location.reload()}>
+                      laste siden på nytt
+                    </Link>
+                  </WebsiteListItem>
+                  <WebsiteListItem icon>
+                    {history && history.length > 1 ? (
+                      <Link href="#" onClick={() => history.back()}>
+                        gå tilbake til forrige side
+                      </Link>
+                    ) : (
+                      "gå tilbake til forrige side"
+                    )}
+                  </WebsiteListItem>
+                </WebsiteList>
+                <BodyShort>
+                  Hvis problemet vedvarer, kan du{" "}
+                  <Link
+                    href="https://github.com/navikt/aksel/issues/new?assignees=&labels=bug+%F0%9F%90%9B&projects=&template=bug-report.md&title=[Aksel.nav.no%20-%20500]"
+                    target="_blank"
+                  >
+                    kontakte oss (åpnes i ny fane)
+                  </Link>
+                  .
+                </BodyShort>
+              </div>
+            </VStack>
+            <div>
+              <Heading level="1" size="large" spacing data-aksel-heading-color>
+                Something went wrong
+              </Heading>
+              <BodyShort spacing>
+                This was caused by a technical fault on our servers. Please
+                refresh this page or try again in a few minutes.{" "}
+              </BodyShort>
+              <BodyShort>
+                <Link
+                  target="_blank"
+                  href="https://github.com/navikt/aksel/issues/new?assignees=&labels=bug+%F0%9F%90%9B&projects=&template=bug-report.md&title=[Aksel.nav.no%20-%20500]"
+                >
+                  Contact us (opens in new tab)
+                </Link>{" "}
+                if the problem persists.
+              </BodyShort>
+            </div>
+          </VStack>
+        </Box>
+      </Page.Block>
+    </Page>
+  );
+}

--- a/aksel.nav.no/website/app/not-found.tsx
+++ b/aksel.nav.no/website/app/not-found.tsx
@@ -1,0 +1,63 @@
+import { BugIcon } from "@navikt/aksel-icons";
+import { BodyShort, Box, Heading, Link, VStack } from "@navikt/ds-react";
+import { Page, PageBlock } from "@navikt/ds-react/Page";
+import Footer from "@/app/_ui/footer/Footer";
+import { Header } from "@/app/_ui/header/Header";
+import { WebsiteList, WebsiteListItem } from "@/app/_ui/typography/WebsiteList";
+import { UmamiNotFoundPageLog } from "@/app/_ui/umami/Umami.log";
+
+export default function NotFound() {
+  return (
+    <Page data-aksel-template="404-v2" footer={<Footer />} className="vk-error">
+      <UmamiNotFoundPageLog />
+      <Header />
+      <PageBlock as="main" width="xl" gutters>
+        <Box paddingBlock="space-80 space-64">
+          <VStack gap="space-64">
+            <VStack gap="space-48" align="start">
+              <div>
+                <Heading
+                  level="1"
+                  size="large"
+                  spacing
+                  data-aksel-heading-color
+                >
+                  Beklager, vi fant ikke siden
+                </Heading>
+                <BodyShort spacing>
+                  Denne siden kan være slettet eller flyttet, eller det er en
+                  feil i lenken.
+                </BodyShort>
+                <WebsiteList>
+                  <WebsiteListItem icon>
+                    Bruk søket eller menyen
+                  </WebsiteListItem>
+                  <WebsiteListItem icon>
+                    <Link href="/">Gå til forsiden</Link>
+                  </WebsiteListItem>
+                </WebsiteList>
+              </div>
+              <Link href="https://github.com/navikt/aksel/issues/new?assignees=&labels=bug+%F0%9F%90%9B&projects=&template=bug-report.md&title=[Aksel.nav.no%20-%20404]">
+                <BugIcon aria-hidden />
+                Meld gjerne fra om at lenken ikke virker
+              </Link>
+            </VStack>
+
+            <div>
+              <Heading level="2" size="large" spacing data-aksel-heading-color>
+                Page not found
+              </Heading>
+              <BodyShort spacing>
+                The page you requested cannot be found.
+              </BodyShort>
+              <BodyShort>
+                Go to the <Link href="/">front page</Link>, or use one of the
+                links in the menu.
+              </BodyShort>
+            </div>
+          </VStack>
+        </Box>
+      </PageBlock>
+    </Page>
+  );
+}


### PR DESCRIPTION
### Description

This pull request introduces several enhancements and new features for the `aksel.nav.no` website, including new query definitions, improved error handling, and additional layouts for standalone pages. The changes are grouped into three main themes: query additions, page and layout enhancements, and error handling improvements.

### Query Additions:
* Added `SIDE_ARTICLE_BY_SLUG_QUERY` and `PRINSIPPER_BY_SLUG_QUERY` to support fetching standalone and "prinsipper" pages by slug. These queries include destructured blocks and contributors where applicable. (`aksel.nav.no/website/app/_sanity/queries.ts`, [[1]](diffhunk://#diff-24f88c09aee96e652f27e8b22cbb647096cce702c980f8c136fa015efa308b66R212-R235) [[2]](diffhunk://#diff-24f88c09aee96e652f27e8b22cbb647096cce702c980f8c136fa015efa308b66R268-R269)

### Page and Layout Enhancements:
* Introduced a new layout for "prinsipper" pages (`PrinsippLayout`) and standalone pages (`StandaloneLayout`), ensuring consistent structure and styling. (`aksel.nav.no/website/app/dev/(prinsipper)/prinsipper/layout.tsx`, [[1]](diffhunk://#diff-60d820573896acdd9253d80e069ce9883f4852ce2cc1f026222e39f52cb6f8b7R1-R21); `aksel.nav.no/website/app/dev/(standalone)/side/layout.tsx`, [[2]](diffhunk://#diff-c66ddcd55dceb337418a76fa170a5b37bccbbb043a7424ac6f5f6ea450f862c1R1-R21)
* Implemented new page components for rendering "prinsipper" and standalone pages, including metadata generation and content rendering using `CustomPortableText`. (`aksel.nav.no/website/app/dev/(prinsipper)/prinsipper/[[...prinsipp]]/page.tsx`, [aksel.nav.no/website/app/dev/(prinsipper)/prinsipper/[[...prinsipp]]/page.tsxR1-R80](diffhunk://#diff-cc23185b724d0ced4b1b3a66ee1d9665db6400c06f1d5e33fbeb767d42bbd44eR1-R80); `aksel.nav.no/website/app/dev/(standalone)/side/[slug]/page.tsx`, [aksel.nav.no/website/app/dev/(standalone)/side/[slug]/page.tsxR1-R52](diffhunk://#diff-83a1f81f462b3f3e597565db602fb65890f6f93807cfd6069a60796bf1d0fbedR1-R52))
* Updated layout names for existing sections to better reflect their purpose, such as renaming `DesignsystemLayout` to `GodPraksisLayout` and `ProduktbloggenLayout`. (`aksel.nav.no/website/app/dev/(god-praksis)/god-praksis/layout.tsx`, [[1]](diffhunk://#diff-83c429d5be6b24449cd0a37e74939265e5ba6f05c1487b8c0046f4a6f58d14c0L6-R6); `aksel.nav.no/website/app/dev/produktbloggen/layout.tsx`, [[2]](diffhunk://#diff-c6e8426b1698ebea54237ca69550779f879cc044fade8dbf402f3b28816ce1c3L7-R7)

### Error Handling Improvements:
* Added a new `Error` component for handling 500 errors with detailed messaging and tracking using Umami and a logger. (`aksel.nav.no/website/app/error.tsx`, [aksel.nav.no/website/app/error.tsxR1-R95](diffhunk://#diff-e6ec1e416b9a00c3023f78149c275a7ee39d4fbf9213ed8f70a9aed1ff651712R1-R95))
* Created a `NotFound` component for 404 errors, including a tracking mechanism (`UmamiNotFoundPageLog`) and user-friendly navigation options. (`aksel.nav.no/website/app/not-found.tsx`, [[1]](diffhunk://#diff-65d5966f3fee2454227cbc34ec7b665f6106211f36d9a38c3eee85fecd788cdbR1-R63); `aksel.nav.no/website/app/_ui/umami/Umami.log.tsx`, [[2]](diffhunk://#diff-e4810283bc19d4d61a6905879650f9a7bb538414b1d050d7701093d79d7fc330R1-R16)

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
