### PR TITLE
[Appdir] Support "top-level"-pages

### DIFF
--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/DesignsystemetPage.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/DesignsystemetPage.tsx
@@ -64,7 +64,7 @@ async function DesignsystemetPageHeader({ data }: DesignsystemetPageT) {
         <CustomPortableText
           value={data?.intro?.body as PortableTextBlock[]}
           typoConfig={{
-            type: "short",
+            type: "long",
             size: "large",
           }}
         />

--- a/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[category]/[page]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[category]/[page]/page.tsx
@@ -1,24 +1,13 @@
 import { Metadata, ResolvingMetadata } from "next";
-import { PortableTextBlock } from "next-sanity";
-import { notFound } from "next/navigation";
 import type { Image } from "sanity";
 import { sanityFetch } from "@/app/_sanity/live";
-import {
-  GRUNNLEGGENDE_BY_SLUG_QUERY,
-  METADATA_BY_SLUG_QUERY,
-  TOC_BY_SLUG_QUERY,
-} from "@/app/_sanity/queries";
+import { METADATA_BY_SLUG_QUERY } from "@/app/_sanity/queries";
 import { urlForOpenGraphImage } from "@/app/_sanity/utils";
-import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
-import { TableOfContents } from "@/app/_ui/toc/TableOfContents";
-import {
-  DesignsystemetPageHeader,
-  DesignsystemetPageLayout,
-} from "@/app/dev/(designsystemet)/_ui/DesignsystemetPage";
 import {
   getStaticParamsSlugs,
   parseDesignsystemSlug,
 } from "@/app/dev/(designsystemet)/slug";
+import { GrunnleggendePage } from "../_ui/GrunnleggendePage";
 
 type Props = {
   params: Promise<{ category: string; page: string }>;
@@ -57,37 +46,5 @@ export async function generateStaticParams() {
 export default async function Page({ params }: Props) {
   const { category, page } = await params;
 
-  const parsedSlug = parseDesignsystemSlug(category, page, "grunnleggende");
-
-  const [{ data: pageData }, { data: toc = [] }] = await Promise.all([
-    sanityFetch({
-      query: GRUNNLEGGENDE_BY_SLUG_QUERY,
-      params: { slug: parsedSlug },
-    }),
-    sanityFetch({
-      query: TOC_BY_SLUG_QUERY,
-      params: { slug: parsedSlug },
-    }),
-  ]);
-
-  if (!pageData?._id) {
-    notFound();
-  }
-
-  return (
-    <DesignsystemetPageLayout layout="with-toc">
-      <DesignsystemetPageHeader data={pageData} />
-      <TableOfContents
-        feedback={{
-          name: pageData.heading,
-          text: "Send innspill",
-        }}
-        toc={toc}
-      />
-      <CustomPortableText
-        value={pageData.content as PortableTextBlock[]}
-        data-block-margin="space-28"
-      />
-    </DesignsystemetPageLayout>
-  );
+  return <GrunnleggendePage slug={`grunnleggende/${category}/${page}`} />;
 }

--- a/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[category]/[page]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[category]/[page]/page.tsx
@@ -1,46 +1,38 @@
-import { Metadata, ResolvingMetadata } from "next";
+import { Metadata } from "next";
 import type { Image } from "sanity";
 import { sanityFetch } from "@/app/_sanity/live";
 import { METADATA_BY_SLUG_QUERY } from "@/app/_sanity/queries";
 import { urlForOpenGraphImage } from "@/app/_sanity/utils";
-import {
-  getStaticParamsSlugs,
-  parseDesignsystemSlug,
-} from "@/app/dev/(designsystemet)/slug";
+import { getStaticParamsSlugs } from "@/app/dev/(designsystemet)/slug";
 import { GrunnleggendePage } from "../_ui/GrunnleggendePage";
 
 type Props = {
   params: Promise<{ category: string; page: string }>;
 };
 
-export async function generateMetadata(
-  { params }: Props,
-  parent: ResolvingMetadata,
-): Promise<Metadata> {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { category, page } = await params;
 
   const { data: pageData } = await sanityFetch({
     query: METADATA_BY_SLUG_QUERY,
-    params: { slug: parseDesignsystemSlug(category, page, "grunnleggende") },
+    params: { slug: `grunnleggende/${category}/${page}` },
     stega: false,
   });
-
-  const ogImages = (await parent).openGraph?.images || [];
-  const pageOgImage = urlForOpenGraphImage(pageData?.seo?.image as Image);
-
-  pageOgImage && ogImages.unshift(pageOgImage);
 
   return {
     title: pageData?.heading,
     description: pageData?.seo?.meta,
     openGraph: {
-      images: ogImages,
+      images: urlForOpenGraphImage(pageData?.seo?.image as Image),
     },
   };
 }
 
 export async function generateStaticParams() {
-  return await getStaticParamsSlugs("ds_artikkel");
+  return await getStaticParamsSlugs({
+    type: "ds_artikkel",
+    onlyTopLevelPages: false,
+  });
 }
 
 export default async function Page({ params }: Props) {

--- a/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[category]/_ui/GrunnleggendePage.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[category]/_ui/GrunnleggendePage.tsx
@@ -1,0 +1,49 @@
+import { PortableTextBlock } from "next-sanity";
+import { notFound } from "next/navigation";
+import { sanityFetch } from "@/app/_sanity/live";
+import {
+  GRUNNLEGGENDE_BY_SLUG_QUERY,
+  TOC_BY_SLUG_QUERY,
+} from "@/app/_sanity/queries";
+import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
+import { TableOfContents } from "@/app/_ui/toc/TableOfContents";
+import {
+  DesignsystemetPageHeader,
+  DesignsystemetPageLayout,
+} from "@/app/dev/(designsystemet)/_ui/DesignsystemetPage";
+
+async function GrunnleggendePage({ slug }: { slug: string }) {
+  const [{ data: pageData }, { data: toc = [] }] = await Promise.all([
+    sanityFetch({
+      query: GRUNNLEGGENDE_BY_SLUG_QUERY,
+      params: { slug },
+    }),
+    sanityFetch({
+      query: TOC_BY_SLUG_QUERY,
+      params: { slug },
+    }),
+  ]);
+
+  if (!pageData?._id) {
+    notFound();
+  }
+
+  return (
+    <DesignsystemetPageLayout layout="with-toc">
+      <DesignsystemetPageHeader data={pageData} />
+      <TableOfContents
+        feedback={{
+          name: pageData.heading,
+          text: "Send innspill",
+        }}
+        toc={toc}
+      />
+      <CustomPortableText
+        value={pageData.content as PortableTextBlock[]}
+        data-block-margin="space-28"
+      />
+    </DesignsystemetPageLayout>
+  );
+}
+
+export { GrunnleggendePage };

--- a/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[category]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[category]/page.tsx
@@ -1,13 +1,15 @@
-import { Metadata, ResolvingMetadata } from "next";
+import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import type { Image } from "sanity";
 import { sanityFetch } from "@/app/_sanity/live";
 import {
   DESIGNSYSTEM_GRUNNLEGGENDE_LANDINGPAGE_QUERY,
   DESIGNSYSTEM_OVERVIEW_BY_CATEGORY_QUERY,
+  METADATA_BY_SLUG_QUERY,
 } from "@/app/_sanity/queries";
 import { urlForOpenGraphImage } from "@/app/_sanity/utils";
 import { DesignsystemetOverviewPage } from "@/app/dev/(designsystemet)/_ui/overview/DesignsystemetOverview";
+import { getStaticParamsSlugs } from "@/app/dev/(designsystemet)/slug";
 import { grunnleggendeKategorier, sanityCategoryLookup } from "@/sanity/config";
 import { GrunnleggendePage } from "./_ui/GrunnleggendePage";
 
@@ -17,21 +19,29 @@ type Props = {
 
 const categoryConfig = sanityCategoryLookup("grunnleggende");
 
-export async function generateMetadata(
-  { params }: Props,
-  parent: ResolvingMetadata,
-): Promise<Metadata> {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { category } = await params;
+
+  if (!grunnleggendeKategorier.find((cat) => cat.value === category)) {
+    const { data: pageData } = await sanityFetch({
+      query: METADATA_BY_SLUG_QUERY,
+      params: { slug: `grunnleggende/${category}` },
+      stega: false,
+    });
+
+    return {
+      title: pageData?.heading,
+      description: pageData?.seo?.meta,
+      openGraph: {
+        images: urlForOpenGraphImage(pageData?.seo?.image as Image),
+      },
+    };
+  }
 
   const { data: page } = await sanityFetch({
     query: DESIGNSYSTEM_GRUNNLEGGENDE_LANDINGPAGE_QUERY,
     stega: false,
   });
-
-  const ogImages = (await parent).openGraph?.images || [];
-  const pageOgImage = urlForOpenGraphImage(page?.seo?.image as Image);
-
-  pageOgImage && ogImages.unshift(pageOgImage);
 
   const currentCategory = categoryConfig.find((cat) => cat.value === category);
 
@@ -39,22 +49,30 @@ export async function generateMetadata(
     title: currentCategory?.title,
     description: page?.seo?.meta,
     openGraph: {
-      images: ogImages,
+      images: urlForOpenGraphImage(page?.seo?.image as Image),
     },
   };
 }
 
 export async function generateStaticParams() {
-  const { data: page } = await sanityFetch({
-    query: DESIGNSYSTEM_GRUNNLEGGENDE_LANDINGPAGE_QUERY,
-    stega: false,
-    perspective: "published",
-  });
+  const [{ data: page }, topLevelPages] = await Promise.all([
+    sanityFetch({
+      query: DESIGNSYSTEM_GRUNNLEGGENDE_LANDINGPAGE_QUERY,
+      stega: false,
+      perspective: "published",
+    }),
+    getStaticParamsSlugs({
+      type: "ds_artikkel",
+      onlyTopLevelPages: true,
+    }),
+  ]);
 
-  return (
-    page?.overview_pages?.map((overviewPage) => ({ category: overviewPage })) ??
-    []
+  const pages = topLevelPages;
+  page?.overview_pages?.forEach((overviewPage) =>
+    pages.push({ category: overviewPage }),
   );
+
+  return pages;
 }
 
 export default async function Page({ params }: Props) {

--- a/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[category]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/[category]/page.tsx
@@ -8,7 +8,8 @@ import {
 } from "@/app/_sanity/queries";
 import { urlForOpenGraphImage } from "@/app/_sanity/utils";
 import { DesignsystemetOverviewPage } from "@/app/dev/(designsystemet)/_ui/overview/DesignsystemetOverview";
-import { sanityCategoryLookup } from "@/sanity/config";
+import { grunnleggendeKategorier, sanityCategoryLookup } from "@/sanity/config";
+import { GrunnleggendePage } from "./_ui/GrunnleggendePage";
 
 type Props = {
   params: Promise<{ category: string }>;
@@ -58,6 +59,14 @@ export async function generateStaticParams() {
 
 export default async function Page({ params }: Props) {
   const { category } = await params;
+
+  /**
+   * Overview-pages can only match the categories in config. If we get a category outside of the config,
+   * we can assume its a "top-level" page, and we should not show the overview page.
+   */
+  if (!grunnleggendeKategorier.find((cat) => cat.value === category)) {
+    return <GrunnleggendePage slug={`grunnleggende/${category}`} />;
+  }
 
   const [{ data: categoryPages }, { data: landingPage }] = await Promise.all([
     sanityFetch({

--- a/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[category]/[page]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[category]/[page]/page.tsx
@@ -1,26 +1,13 @@
 import { Metadata, ResolvingMetadata } from "next";
-import { PortableTextBlock } from "next-sanity";
-import { notFound } from "next/navigation";
 import type { Image } from "sanity";
 import { sanityFetch } from "@/app/_sanity/live";
-import {
-  KOMPONENT_BY_SLUG_QUERY,
-  METADATA_BY_SLUG_QUERY,
-  TOC_BY_SLUG_QUERY,
-} from "@/app/_sanity/queries";
+import { METADATA_BY_SLUG_QUERY } from "@/app/_sanity/queries";
 import { urlForOpenGraphImage } from "@/app/_sanity/utils";
-import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
-import { SystemPanel } from "@/app/_ui/system-panel/SystemPanel";
-import { TableOfContents } from "@/app/_ui/toc/TableOfContents";
-import { DesignsystemetKomponentIntro } from "@/app/dev/(designsystemet)/_ui/Designsystemet.intro";
-import {
-  DesignsystemetPageHeader,
-  DesignsystemetPageLayout,
-} from "@/app/dev/(designsystemet)/_ui/DesignsystemetPage";
 import {
   getStaticParamsSlugs,
   parseDesignsystemSlug,
 } from "@/app/dev/(designsystemet)/slug";
+import { KomponenterPage } from "../_ui/KomponenterPage";
 
 type Props = {
   params: Promise<{ category: string; page: string }>;
@@ -59,43 +46,5 @@ export async function generateStaticParams() {
 export default async function Page({ params }: Props) {
   const { category, page } = await params;
 
-  const parsedSlug = parseDesignsystemSlug(category, page, "komponenter");
-
-  const [{ data: pageData }, { data: toc = [] }] = await Promise.all([
-    sanityFetch({
-      query: KOMPONENT_BY_SLUG_QUERY,
-      params: { slug: parsedSlug },
-    }),
-    sanityFetch({
-      query: TOC_BY_SLUG_QUERY,
-      params: { slug: parsedSlug },
-    }),
-  ]);
-
-  if (!pageData?._id) {
-    notFound();
-  }
-
-  return (
-    <DesignsystemetPageLayout layout="with-toc">
-      <DesignsystemetPageHeader data={pageData} />
-      <TableOfContents
-        feedback={{
-          name: pageData.heading,
-          text: "Send innspill",
-        }}
-        toc={toc}
-      />
-      <div>
-        {["beta", "new"].includes(pageData.status?.tag ?? "") && (
-          <SystemPanel
-            variant={pageData.status?.tag as "beta" | "new"}
-            unsafeBeta={pageData.status?.unsafe}
-          />
-        )}
-        <DesignsystemetKomponentIntro data={pageData} />
-        <CustomPortableText value={pageData.content as PortableTextBlock[]} />
-      </div>
-    </DesignsystemetPageLayout>
-  );
+  return <KomponenterPage slug={`komponenter/${category}/${page}`} />;
 }

--- a/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[category]/[page]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[category]/[page]/page.tsx
@@ -1,46 +1,38 @@
-import { Metadata, ResolvingMetadata } from "next";
+import { Metadata } from "next";
 import type { Image } from "sanity";
 import { sanityFetch } from "@/app/_sanity/live";
 import { METADATA_BY_SLUG_QUERY } from "@/app/_sanity/queries";
 import { urlForOpenGraphImage } from "@/app/_sanity/utils";
-import {
-  getStaticParamsSlugs,
-  parseDesignsystemSlug,
-} from "@/app/dev/(designsystemet)/slug";
+import { getStaticParamsSlugs } from "@/app/dev/(designsystemet)/slug";
 import { KomponenterPage } from "../_ui/KomponenterPage";
 
 type Props = {
   params: Promise<{ category: string; page: string }>;
 };
 
-export async function generateMetadata(
-  { params }: Props,
-  parent: ResolvingMetadata,
-): Promise<Metadata> {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { category, page } = await params;
 
   const { data: pageData } = await sanityFetch({
     query: METADATA_BY_SLUG_QUERY,
-    params: { slug: parseDesignsystemSlug(category, page, "komponenter") },
+    params: { slug: `komponenter/${category}/${page}` },
     stega: false,
   });
-
-  const ogImages = (await parent).openGraph?.images || [];
-  const pageOgImage = urlForOpenGraphImage(pageData?.seo?.image as Image);
-
-  pageOgImage && ogImages.unshift(pageOgImage);
 
   return {
     title: pageData?.heading,
     description: pageData?.seo?.meta,
     openGraph: {
-      images: ogImages,
+      images: urlForOpenGraphImage(pageData?.seo?.image as Image),
     },
   };
 }
 
 export async function generateStaticParams() {
-  return await getStaticParamsSlugs("komponent_artikkel");
+  return await getStaticParamsSlugs({
+    type: "komponent_artikkel",
+    onlyTopLevelPages: false,
+  });
 }
 
 export default async function Page({ params }: Props) {

--- a/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[category]/_ui/KomponenterPage.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[category]/_ui/KomponenterPage.tsx
@@ -1,0 +1,57 @@
+import { PortableTextBlock } from "next-sanity";
+import { notFound } from "next/navigation";
+import { sanityFetch } from "@/app/_sanity/live";
+import {
+  KOMPONENT_BY_SLUG_QUERY,
+  TOC_BY_SLUG_QUERY,
+} from "@/app/_sanity/queries";
+import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
+import { SystemPanel } from "@/app/_ui/system-panel/SystemPanel";
+import { TableOfContents } from "@/app/_ui/toc/TableOfContents";
+import { DesignsystemetKomponentIntro } from "@/app/dev/(designsystemet)/_ui/Designsystemet.intro";
+import {
+  DesignsystemetPageHeader,
+  DesignsystemetPageLayout,
+} from "@/app/dev/(designsystemet)/_ui/DesignsystemetPage";
+
+async function KomponenterPage({ slug }: { slug: string }) {
+  const [{ data: pageData }, { data: toc = [] }] = await Promise.all([
+    sanityFetch({
+      query: KOMPONENT_BY_SLUG_QUERY,
+      params: { slug },
+    }),
+    sanityFetch({
+      query: TOC_BY_SLUG_QUERY,
+      params: { slug },
+    }),
+  ]);
+
+  if (!pageData?._id) {
+    notFound();
+  }
+
+  return (
+    <DesignsystemetPageLayout layout="with-toc">
+      <DesignsystemetPageHeader data={pageData} />
+      <TableOfContents
+        feedback={{
+          name: pageData.heading,
+          text: "Send innspill",
+        }}
+        toc={toc}
+      />
+      <div>
+        {["beta", "new"].includes(pageData.status?.tag ?? "") && (
+          <SystemPanel
+            variant={pageData.status?.tag as "beta" | "new"}
+            unsafeBeta={pageData.status?.unsafe}
+          />
+        )}
+        <DesignsystemetKomponentIntro data={pageData} />
+        <CustomPortableText value={pageData.content as PortableTextBlock[]} />
+      </div>
+    </DesignsystemetPageLayout>
+  );
+}
+
+export { KomponenterPage };

--- a/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[category]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/komponenter/[category]/page.tsx
@@ -8,7 +8,8 @@ import {
 } from "@/app/_sanity/queries";
 import { urlForOpenGraphImage } from "@/app/_sanity/utils";
 import { DesignsystemetOverviewPage } from "@/app/dev/(designsystemet)/_ui/overview/DesignsystemetOverview";
-import { sanityCategoryLookup } from "@/sanity/config";
+import { komponentKategorier, sanityCategoryLookup } from "@/sanity/config";
+import { KomponenterPage } from "./_ui/KomponenterPage";
 
 type Props = {
   params: Promise<{ category: string }>;
@@ -58,6 +59,14 @@ export async function generateStaticParams() {
 
 export default async function Page({ params }: Props) {
   const { category } = await params;
+
+  /**
+   * Overview-pages can only match the categories in config. If we get a category outside of the config,
+   * we can assume its a "top-level" page, and we should not show the overview page.
+   */
+  if (!komponentKategorier.find((cat) => cat.value === category)) {
+    return <KomponenterPage slug={`komponenter/${category}`} />;
+  }
 
   const [{ data: categoryPages }, { data: landingPage }] = await Promise.all([
     sanityFetch({

--- a/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[category]/[page]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[category]/[page]/page.tsx
@@ -1,46 +1,38 @@
-import { Metadata, ResolvingMetadata } from "next";
+import { Metadata } from "next";
 import type { Image } from "sanity";
 import { sanityFetch } from "@/app/_sanity/live";
 import { METADATA_BY_SLUG_QUERY } from "@/app/_sanity/queries";
 import { urlForOpenGraphImage } from "@/app/_sanity/utils";
-import {
-  getStaticParamsSlugs,
-  parseDesignsystemSlug,
-} from "@/app/dev/(designsystemet)/slug";
+import { getStaticParamsSlugs } from "@/app/dev/(designsystemet)/slug";
 import { MonsterMalerPage } from "../_ui/MonsterMalerPage";
 
 type Props = {
   params: Promise<{ category: string; page: string }>;
 };
 
-export async function generateMetadata(
-  { params }: Props,
-  parent: ResolvingMetadata,
-): Promise<Metadata> {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { category, page } = await params;
 
   const { data: pageData } = await sanityFetch({
     query: METADATA_BY_SLUG_QUERY,
-    params: { slug: parseDesignsystemSlug(category, page, "monster-maler") },
+    params: { slug: `monster-maler/${category}/${page}` },
     stega: false,
   });
-
-  const ogImages = (await parent).openGraph?.images || [];
-  const pageOgImage = urlForOpenGraphImage(pageData?.seo?.image as Image);
-
-  pageOgImage && ogImages.unshift(pageOgImage);
 
   return {
     title: pageData?.heading,
     description: pageData?.seo?.meta,
     openGraph: {
-      images: ogImages,
+      images: urlForOpenGraphImage(pageData?.seo?.image as Image),
     },
   };
 }
 
 export async function generateStaticParams() {
-  return await getStaticParamsSlugs("templates_artikkel");
+  return await getStaticParamsSlugs({
+    type: "templates_artikkel",
+    onlyTopLevelPages: false,
+  });
 }
 
 export default async function Page({ params }: Props) {

--- a/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[category]/[page]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[category]/[page]/page.tsx
@@ -1,30 +1,13 @@
 import { Metadata, ResolvingMetadata } from "next";
-import { PortableTextBlock } from "next-sanity";
-import { notFound } from "next/navigation";
 import type { Image } from "sanity";
-import { Heading } from "@navikt/ds-react";
 import { sanityFetch } from "@/app/_sanity/live";
-import {
-  METADATA_BY_SLUG_QUERY,
-  MONSTER_MALER_BY_SLUG_QUERY,
-  TOC_BY_SLUG_QUERY,
-} from "@/app/_sanity/queries";
+import { METADATA_BY_SLUG_QUERY } from "@/app/_sanity/queries";
 import { urlForOpenGraphImage } from "@/app/_sanity/utils";
-import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
-import styles from "@/app/_ui/portable-text/CustomPortableText.module.css";
-import { TableOfContents } from "@/app/_ui/toc/TableOfContents";
-import {
-  WebsiteTable,
-  WebsiteTableRow,
-} from "@/app/_ui/website-table/WebsiteTable";
-import {
-  DesignsystemetPageHeader,
-  DesignsystemetPageLayout,
-} from "@/app/dev/(designsystemet)/_ui/DesignsystemetPage";
 import {
   getStaticParamsSlugs,
   parseDesignsystemSlug,
 } from "@/app/dev/(designsystemet)/slug";
+import { MonsterMalerPage } from "../_ui/MonsterMalerPage";
 
 type Props = {
   params: Promise<{ category: string; page: string }>;
@@ -63,70 +46,5 @@ export async function generateStaticParams() {
 export default async function Page({ params }: Props) {
   const { category, page } = await params;
 
-  const parsedSlug = parseDesignsystemSlug(category, page, "monster-maler");
-
-  const [{ data: pageData }, { data: toc = [] }] = await Promise.all([
-    sanityFetch({
-      query: MONSTER_MALER_BY_SLUG_QUERY,
-      params: { slug: parsedSlug },
-    }),
-    sanityFetch({
-      query: TOC_BY_SLUG_QUERY,
-      params: { slug: parsedSlug },
-    }),
-  ]);
-
-  if (!pageData?._id) {
-    notFound();
-  }
-
-  const metadata = pageData.content?.find((x) => x._type === "kode_eksempler")
-    ?.dir?.metadata;
-
-  return (
-    <DesignsystemetPageLayout layout="with-toc">
-      <DesignsystemetPageHeader data={pageData} />
-      <TableOfContents
-        feedback={{
-          name: pageData.heading,
-          text: "Send innspill",
-        }}
-        toc={toc}
-      />
-      <CustomPortableText
-        value={pageData.content as PortableTextBlock[]}
-        data-block-margin="space-28"
-      />
-      {metadata?.changelog && (
-        <div>
-          <Heading
-            className={styles.headingElement}
-            tabIndex={-1}
-            id="changelog"
-            level="2"
-            size="large"
-            data-level="2"
-          >
-            Endringer
-          </Heading>
-          <WebsiteTable
-            th={[{ text: "Dato" }, { text: "Versjon" }, { text: "Endringer" }]}
-          >
-            {metadata.changelog
-              .sort((a, b) => (a.version ?? 0) - (b.version ?? 0))
-              .map((log) => (
-                <WebsiteTableRow
-                  key={log.version}
-                  tr={[
-                    { text: log.date },
-                    { text: log.version },
-                    { text: log.description },
-                  ]}
-                />
-              ))}
-          </WebsiteTable>
-        </div>
-      )}
-    </DesignsystemetPageLayout>
-  );
+  return <MonsterMalerPage slug={`monster-maler/${category}/${page}`} />;
 }

--- a/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[category]/_ui/MonsterMalerPage.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[category]/_ui/MonsterMalerPage.tsx
@@ -1,0 +1,88 @@
+import { PortableTextBlock } from "next-sanity";
+import { notFound } from "next/navigation";
+import { Heading } from "@navikt/ds-react";
+import { sanityFetch } from "@/app/_sanity/live";
+import {
+  MONSTER_MALER_BY_SLUG_QUERY,
+  TOC_BY_SLUG_QUERY,
+} from "@/app/_sanity/queries";
+import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
+import styles from "@/app/_ui/portable-text/CustomPortableText.module.css";
+import { TableOfContents } from "@/app/_ui/toc/TableOfContents";
+import {
+  WebsiteTable,
+  WebsiteTableRow,
+} from "@/app/_ui/website-table/WebsiteTable";
+import {
+  DesignsystemetPageHeader,
+  DesignsystemetPageLayout,
+} from "@/app/dev/(designsystemet)/_ui/DesignsystemetPage";
+
+async function MonsterMalerPage({ slug }: { slug: string }) {
+  const [{ data: pageData }, { data: toc = [] }] = await Promise.all([
+    sanityFetch({
+      query: MONSTER_MALER_BY_SLUG_QUERY,
+      params: { slug },
+    }),
+    sanityFetch({
+      query: TOC_BY_SLUG_QUERY,
+      params: { slug },
+    }),
+  ]);
+
+  if (!pageData) {
+    notFound();
+  }
+
+  const metadata = pageData.content?.find((x) => x._type === "kode_eksempler")
+    ?.dir?.metadata;
+
+  return (
+    <DesignsystemetPageLayout layout="with-toc">
+      <DesignsystemetPageHeader data={pageData} />
+      <TableOfContents
+        feedback={{
+          name: pageData.heading,
+          text: "Send innspill",
+        }}
+        toc={toc}
+      />
+      <CustomPortableText
+        value={pageData.content as PortableTextBlock[]}
+        data-block-margin="space-28"
+      />
+      {metadata?.changelog && (
+        <div>
+          <Heading
+            className={styles.headingElement}
+            tabIndex={-1}
+            id="changelog"
+            level="2"
+            size="large"
+            data-level="2"
+          >
+            Endringer
+          </Heading>
+          <WebsiteTable
+            th={[{ text: "Dato" }, { text: "Versjon" }, { text: "Endringer" }]}
+          >
+            {metadata.changelog
+              .sort((a, b) => (a.version ?? 0) - (b.version ?? 0))
+              .map((log) => (
+                <WebsiteTableRow
+                  key={log.version}
+                  tr={[
+                    { text: log.date },
+                    { text: log.version },
+                    { text: log.description },
+                  ]}
+                />
+              ))}
+          </WebsiteTable>
+        </div>
+      )}
+    </DesignsystemetPageLayout>
+  );
+}
+
+export { MonsterMalerPage };

--- a/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[category]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[category]/page.tsx
@@ -8,7 +8,8 @@ import {
 } from "@/app/_sanity/queries";
 import { urlForOpenGraphImage } from "@/app/_sanity/utils";
 import { DesignsystemetOverviewPage } from "@/app/dev/(designsystemet)/_ui/overview/DesignsystemetOverview";
-import { sanityCategoryLookup } from "@/sanity/config";
+import { sanityCategoryLookup, templatesKategorier } from "@/sanity/config";
+import { MonsterMalerPage } from "./_ui/MonsterMalerPage";
 
 type Props = {
   params: Promise<{ category: string }>;
@@ -58,6 +59,14 @@ export async function generateStaticParams() {
 
 export default async function Page({ params }: Props) {
   const { category } = await params;
+
+  /**
+   * Overview-pages can only match the categories in config. If we get a category outside of the config,
+   * we can assume its a "top-level" page, and we should not show the overview page.
+   */
+  if (!templatesKategorier.find((cat) => cat.value === category)) {
+    return <MonsterMalerPage slug={`monster-maler/${category}`} />;
+  }
 
   const [{ data: categoryPages }, { data: landingPage }] = await Promise.all([
     sanityFetch({

--- a/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[category]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/monster-maler/[category]/page.tsx
@@ -1,13 +1,15 @@
-import { Metadata, ResolvingMetadata } from "next";
+import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import type { Image } from "sanity";
 import { sanityFetch } from "@/app/_sanity/live";
 import {
   DESIGNSYSTEM_OVERVIEW_BY_CATEGORY_QUERY,
   DESIGNSYSTEM_TEMPLATES_LANDINGPAGE_QUERY,
+  METADATA_BY_SLUG_QUERY,
 } from "@/app/_sanity/queries";
 import { urlForOpenGraphImage } from "@/app/_sanity/utils";
 import { DesignsystemetOverviewPage } from "@/app/dev/(designsystemet)/_ui/overview/DesignsystemetOverview";
+import { getStaticParamsSlugs } from "@/app/dev/(designsystemet)/slug";
 import { sanityCategoryLookup, templatesKategorier } from "@/sanity/config";
 import { MonsterMalerPage } from "./_ui/MonsterMalerPage";
 
@@ -17,21 +19,29 @@ type Props = {
 
 const categoryConfig = sanityCategoryLookup("templates");
 
-export async function generateMetadata(
-  { params }: Props,
-  parent: ResolvingMetadata,
-): Promise<Metadata> {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { category } = await params;
+
+  if (!templatesKategorier.find((cat) => cat.value === category)) {
+    const { data: pageData } = await sanityFetch({
+      query: METADATA_BY_SLUG_QUERY,
+      params: { slug: `monster-maler/${category}` },
+      stega: false,
+    });
+
+    return {
+      title: pageData?.heading,
+      description: pageData?.seo?.meta,
+      openGraph: {
+        images: urlForOpenGraphImage(pageData?.seo?.image as Image),
+      },
+    };
+  }
 
   const { data: page } = await sanityFetch({
     query: DESIGNSYSTEM_TEMPLATES_LANDINGPAGE_QUERY,
     stega: false,
   });
-
-  const ogImages = (await parent).openGraph?.images || [];
-  const pageOgImage = urlForOpenGraphImage(page?.seo?.image as Image);
-
-  pageOgImage && ogImages.unshift(pageOgImage);
 
   const currentCategory = categoryConfig.find((cat) => cat.value === category);
 
@@ -39,22 +49,30 @@ export async function generateMetadata(
     title: currentCategory?.title,
     description: page?.seo?.meta,
     openGraph: {
-      images: ogImages,
+      images: urlForOpenGraphImage(page?.seo?.image as Image),
     },
   };
 }
 
 export async function generateStaticParams() {
-  const { data: page } = await sanityFetch({
-    query: DESIGNSYSTEM_TEMPLATES_LANDINGPAGE_QUERY,
-    stega: false,
-    perspective: "published",
-  });
+  const [{ data: page }, topLevelPages] = await Promise.all([
+    sanityFetch({
+      query: DESIGNSYSTEM_TEMPLATES_LANDINGPAGE_QUERY,
+      stega: false,
+      perspective: "published",
+    }),
+    getStaticParamsSlugs({
+      type: "templates_artikkel",
+      onlyTopLevelPages: true,
+    }),
+  ]);
 
-  return (
-    page?.overview_pages?.map((overviewPage) => ({ category: overviewPage })) ??
-    []
+  const pages = topLevelPages;
+  page?.overview_pages?.forEach((overviewPage) =>
+    pages.push({ category: overviewPage }),
   );
+
+  return pages;
 }
 
 export default async function Page({ params }: Props) {


### PR DESCRIPTION
### Description

This update adds back support for the so-called "top-level" pages. A top level page is an article that is not connected to a spesific "sub-category" like "core", "primitves" or "styling". Since its slug might be `komponenter/article-name`, it overlaps with the paths we have for "overview"-pages and is not handles as an exception before rendering the overview-page.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
