### PR TITLE
make "hopp til innhold" disappear when not focused

### DIFF
--- a/aksel.nav.no/website/app/_ui/header/Header.module.css
+++ b/aksel.nav.no/website/app/_ui/header/Header.module.css
@@ -91,11 +91,12 @@
   color: var(--ax-text-info-contrast);
   text-decoration: none;
 
-  /* We move it further away to avoid it showing when scroll "overshoots" */
-  transform: translateY(-300%);
+  /* We move it further away and (just in case scale it to 0) 
+  to avoid it showing when scroll "overshoots" */
+  transform: translateY(-300%) scale(0);
 
   &:focus-within {
-    transform: translateY(0);
+    transform: translateY(0) scale(1);
     outline: none;
   }
 }


### PR DESCRIPTION
arguable we don't need the translate "out of the way" if we make it scale to 0, but who knows... maybe it renders oddly on half pixels on certain zoom levels / browser combos? 🙈 