### PR TITLE
[Umami] Migrate from data-attrb based tracking to onClick

### DIFF
--- a/aksel.nav.no/website/app/_ui/footer/Footer.tsx
+++ b/aksel.nav.no/website/app/_ui/footer/Footer.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { HGrid, Heading } from "@navikt/ds-react";
 import { PageBlock } from "@navikt/ds-react/Page";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { FigmaIcon, GithubIcon, SlackIcon } from "@/assets/Icons";
 import AkselLogo from "@/assets/Logo";
 import styles from "./Footer.module.css";
@@ -95,8 +96,7 @@ function LinkBlock({ heading, links }: LinkBlockPropsT) {
             <Link
               className={styles.footerLink}
               href={link.url}
-              data-umami-event="navigere"
-              data-umami-event-kilde="footer"
+              onClick={() => umamiTrack("navigere", { kilde: "footer" })}
               prefetch={false}
             >
               {link.icon}

--- a/aksel.nav.no/website/app/_ui/footer/Footer.tsx
+++ b/aksel.nav.no/website/app/_ui/footer/Footer.tsx
@@ -96,7 +96,9 @@ function LinkBlock({ heading, links }: LinkBlockPropsT) {
             <Link
               className={styles.footerLink}
               href={link.url}
-              onClick={() => umamiTrack("navigere", { kilde: "footer" })}
+              onClick={() =>
+                umamiTrack("navigere", { kilde: "footer", url: link.url })
+              }
               prefetch={false}
             >
               {link.icon}

--- a/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.hit.tsx
+++ b/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.hit.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import React from "react";
 import { Heading } from "@navikt/ds-react";
 import { doctypeToColorRole } from "@/app/_ui/theming/theme-config";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { urlFor } from "@/sanity/interface";
 import { StatusTag } from "@/web/StatusTag";
 import { SearchHitT, SearchResultPageTypesT } from "./GlobalSearch.config";
@@ -65,8 +66,7 @@ function GlobalSearchLink(props: {
             size="small"
             as={Link}
             href={href}
-            data-umami-event="navigere"
-            data-umami-event-kilde="global sok"
+            onClick={() => umamiTrack("navigere", { kilde: "global sok" })}
             className={styles.searchLink}
             prefetch={false}
           >

--- a/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.hit.tsx
+++ b/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.hit.tsx
@@ -66,7 +66,9 @@ function GlobalSearchLink(props: {
             size="small"
             as={Link}
             href={href}
-            onClick={() => umamiTrack("navigere", { kilde: "global sok" })}
+            onClick={() =>
+              umamiTrack("navigere", { kilde: "global sok", url: href })
+            }
             className={styles.searchLink}
             prefetch={false}
           >

--- a/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.provider.tsx
@@ -73,7 +73,7 @@ function GlobalSearchProvider({ children }: { children: React.ReactNode }) {
           const newResults = await fuseGlobalSearch(query);
           setSearchResults(newResults);
         });
-        umamiTrack("sok");
+        umamiTrack("sok", {});
       }),
     [startTransition],
   );

--- a/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.provider.tsx
@@ -11,6 +11,7 @@ import {
   useTransition,
 } from "react";
 import { debounce } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { fuseGlobalSearch } from "./GlobalSearch.actions";
 
 type ActionReturnT = Awaited<ReturnType<typeof fuseGlobalSearch>>;
@@ -72,7 +73,7 @@ function GlobalSearchProvider({ children }: { children: React.ReactNode }) {
           const newResults = await fuseGlobalSearch(query);
           setSearchResults(newResults);
         });
-        window.umami && umami.track("sok");
+        umamiTrack("sok");
       }),
     [startTransition],
   );

--- a/aksel.nav.no/website/app/_ui/header/Header.link.tsx
+++ b/aksel.nav.no/website/app/_ui/header/Header.link.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import styles from "./Header.module.css";
 
 type HeaderLinkProps = {
@@ -36,8 +37,7 @@ function HeaderLink({ name, href }: HeaderLinkProps) {
       prefetch={false}
       data-current={isActive()}
       className={styles.headerLink}
-      data-umami-event="navigere"
-      data-umami-event-kilde="header"
+      onClick={() => umamiTrack("navigere", { kilde: "header" })}
     >
       {name}
     </Link>

--- a/aksel.nav.no/website/app/_ui/header/Header.link.tsx
+++ b/aksel.nav.no/website/app/_ui/header/Header.link.tsx
@@ -37,7 +37,7 @@ function HeaderLink({ name, href }: HeaderLinkProps) {
       prefetch={false}
       data-current={isActive()}
       className={styles.headerLink}
-      onClick={() => umamiTrack("navigere", { kilde: "header" })}
+      onClick={() => umamiTrack("navigere", { kilde: "header", url: href })}
     >
       {name}
     </Link>

--- a/aksel.nav.no/website/app/_ui/header/Header.tsx
+++ b/aksel.nav.no/website/app/_ui/header/Header.tsx
@@ -4,6 +4,7 @@ import { Box, HStack, Hide, Show, Spacer } from "@navikt/ds-react";
 import { GlobalSearch } from "@/app/_ui/global-search/GlobalSearch";
 import { MobileNav } from "@/app/_ui/mobile-nav/MobileNav";
 import { ThemeButton } from "@/app/_ui/theming/Theme.button";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import AkselLogo from "@/assets/Logo";
 import { HeaderLink } from "./Header.link";
 import styles from "./Header.module.css";
@@ -29,8 +30,7 @@ function Header({ variant }: { variant?: "default" | "produktbloggen" }) {
         <Link
           href="/"
           passHref
-          data-umami-event="navigere"
-          data-umami-event-kilde="header"
+          onClick={() => umamiTrack("navigere", { kilde: "header" })}
           className={styles.headerLogoLink}
         >
           <Show above="sm">

--- a/aksel.nav.no/website/app/_ui/header/Header.tsx
+++ b/aksel.nav.no/website/app/_ui/header/Header.tsx
@@ -30,7 +30,7 @@ function Header({ variant }: { variant?: "default" | "produktbloggen" }) {
         <Link
           href="/"
           passHref
-          onClick={() => umamiTrack("navigere", { kilde: "header" })}
+          onClick={() => umamiTrack("navigere", { kilde: "header", url: "/" })}
           className={styles.headerLogoLink}
         >
           <Show above="sm">

--- a/aksel.nav.no/website/app/_ui/relatert-innhold/RelatertInnhold.tsx
+++ b/aksel.nav.no/website/app/_ui/relatert-innhold/RelatertInnhold.tsx
@@ -34,7 +34,10 @@ function RelatertInnhold(
               as={NextLink}
               href={getHref(pageLink)}
               onClick={() =>
-                umamiTrack("navigere", { kilde: "relatert innhold" })
+                umamiTrack("navigere", {
+                  kilde: "relatert innhold",
+                  url: getHref(pageLink),
+                })
               }
               variant="neutral"
             >

--- a/aksel.nav.no/website/app/_ui/relatert-innhold/RelatertInnhold.tsx
+++ b/aksel.nav.no/website/app/_ui/relatert-innhold/RelatertInnhold.tsx
@@ -3,6 +3,7 @@ import { Link } from "@navikt/ds-react";
 import { ExtractPortableComponentProps } from "@/app/_sanity/types";
 import { EditorPanel } from "@/app/_ui/editor-panel/EditorPanel";
 import { WebsiteList, WebsiteListItem } from "@/app/_ui/typography/WebsiteList";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 
 function RelatertInnhold(
   props: ExtractPortableComponentProps<"relatert_innhold">,
@@ -32,8 +33,9 @@ function RelatertInnhold(
             <Link
               as={NextLink}
               href={getHref(pageLink)}
-              data-umami-event="navigere"
-              data-umami-event-kilde="relatert innhold"
+              onClick={() =>
+                umamiTrack("navigere", { kilde: "relatert innhold" })
+              }
               variant="neutral"
             >
               {pageLink.title || "Mangler tittel"}

--- a/aksel.nav.no/website/app/_ui/toc/TableOfContents.tsx
+++ b/aksel.nav.no/website/app/_ui/toc/TableOfContents.tsx
@@ -5,6 +5,7 @@ import NextLink from "next/link";
 import { SparklesIcon } from "@navikt/aksel-icons";
 import { BodyShort, Button, Detail } from "@navikt/ds-react";
 import { TOC_BY_SLUG_QUERYResult } from "@/app/_sanity/query-types";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { removeEmojies } from "@/utils";
 import styles from "./TableOfContents.module.css";
 import { TableOfContentsScroll } from "./TableOfContents.scroll";
@@ -66,13 +67,14 @@ function TableOfContents({
                   id={`toc-${node.id}`}
                   prefetch={false}
                   href={`#${node.id}`}
-                  onClick={() => tocCtx.setActiveId(node.id)}
+                  onClick={() => {
+                    tocCtx.setActiveId(node.id);
+                    umamiTrack("navigere", { kilde: "toc" });
+                  }}
                   className={cl(styles.tocNavListItemLink, {
                     [styles.tocNavListNotch]: active,
                   })}
                   data-current={active}
-                  data-umami-event="navigere"
-                  data-umami-event-kilde="toc"
                 >
                   {removeEmojies(node.title).trim()}
                 </NextLink>
@@ -102,8 +104,7 @@ function TableOfContentsLinks({
           size="small"
           icon={<SparklesIcon aria-hidden />}
           href={`https://github.com/navikt/aksel/issues/new?labels=foresp%C3%B8rsel+%F0%9F%A5%B0%2Ckomponenter+%F0%9F%A7%A9&template=update-component.yml&title=%5BInnspill%5D%20${feedback.name}`}
-          data-umami-event="feedback-designsystem"
-          data-umami-event-kilde="toc"
+          onClick={() => umamiTrack("feedback-designsystem", { kilde: "toc" })}
           target="_blank"
           rel="noreferrer"
         >

--- a/aksel.nav.no/website/app/_ui/toc/TableOfContents.tsx
+++ b/aksel.nav.no/website/app/_ui/toc/TableOfContents.tsx
@@ -69,7 +69,10 @@ function TableOfContents({
                   href={`#${node.id}`}
                   onClick={() => {
                     tocCtx.setActiveId(node.id);
-                    umamiTrack("navigere", { kilde: "toc" });
+                    umamiTrack("navigere", {
+                      kilde: "toc",
+                      url: `#${node.id}`,
+                    });
                   }}
                   className={cl(styles.tocNavListItemLink, {
                     [styles.tocNavListNotch]: active,

--- a/aksel.nav.no/website/app/_ui/typography/WebsiteLink.tsx
+++ b/aksel.nav.no/website/app/_ui/typography/WebsiteLink.tsx
@@ -1,6 +1,7 @@
 import NextLink from "next/link";
 import React from "react";
 import { Link } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 
 type Props = {
   href: string;
@@ -16,14 +17,13 @@ function WebsiteLink({ href, children }: Props) {
       as={NextLink}
       href={href}
       inlineText
-      data-umami-event="navigere"
-      data-umami-kilde="inline lenke"
+      onClick={() =>
+        umamiTrack("navigere", { kilde: "inline lenke", url: href })
+      }
       {...(isOutbound
         ? {
             target: "_blank",
             rel: "noreferrer noopener",
-            /* https://umami.is/docs/track-outbound-links */
-            ["data-umami-event-url"]: href,
           }
         : {})}
     >

--- a/aksel.nav.no/website/app/_ui/umami/Umami.log.tsx
+++ b/aksel.nav.no/website/app/_ui/umami/Umami.log.tsx
@@ -8,7 +8,7 @@ import { umamiTrack } from "@/app/_ui/umami/Umami.track";
  */
 function UmamiNotFoundPageLog() {
   useEffect(() => {
-    umamiTrack("404", { urlBuilder: window.location.pathname });
+    umamiTrack("404", { url: window.location.pathname });
   }, []);
 
   return null;

--- a/aksel.nav.no/website/app/_ui/umami/Umami.log.tsx
+++ b/aksel.nav.no/website/app/_ui/umami/Umami.log.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useEffect } from "react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 
 /**
  * Sometimes we need to track that a spesific page was visited, but since Umami is client-side only, we can't use the `page.tsx` file to track it.
  */
 function UmamiNotFoundPageLog() {
   useEffect(() => {
-    window.umami && umami.track("404", { url: window.location.pathname });
+    umamiTrack("404", { urlBuilder: window.location.pathname });
   }, []);
 
   return null;

--- a/aksel.nav.no/website/app/_ui/umami/Umami.track.ts
+++ b/aksel.nav.no/website/app/_ui/umami/Umami.track.ts
@@ -1,6 +1,13 @@
-function umamiTrack(
-  event: string,
-  data: Record<string, string | undefined> = {},
+type UmamiNavigationProps = {
+  kilde: string;
+  url: string;
+};
+
+type UmamiTrackDefaultProps = Record<string, string | undefined> | undefined;
+
+function umamiTrack<T extends `navigere` | string>(
+  event: T,
+  data: T extends "navigere" ? UmamiNavigationProps : UmamiTrackDefaultProps,
 ): void {
   if (typeof window !== "undefined" && window.umami) {
     window.umami.track(event, data);

--- a/aksel.nav.no/website/app/_ui/umami/Umami.track.ts
+++ b/aksel.nav.no/website/app/_ui/umami/Umami.track.ts
@@ -1,0 +1,7 @@
+function umamiTrack(event: string, data: Record<string, string> = {}): void {
+  if (typeof window !== "undefined" && window.umami) {
+    window.umami.track(event, data);
+  }
+}
+
+export { umamiTrack };

--- a/aksel.nav.no/website/app/_ui/umami/Umami.track.ts
+++ b/aksel.nav.no/website/app/_ui/umami/Umami.track.ts
@@ -1,4 +1,7 @@
-function umamiTrack(event: string, data: Record<string, string> = {}): void {
+function umamiTrack(
+  event: string,
+  data: Record<string, string | undefined> = {},
+): void {
   if (typeof window !== "undefined" && window.umami) {
     window.umami.track(event, data);
   }

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
@@ -65,7 +65,7 @@ function KomponentLinks({ data }: { data: KOMPONENT_BY_SLUG_QUERYResult }) {
           onClick={() =>
             umamiTrack("navigere", {
               kilde: "komponent-header",
-              url: data.figma_link,
+              url: data.figma_link ?? "",
             })
           }
           variant="subtle"
@@ -79,6 +79,7 @@ function KomponentLinks({ data }: { data: KOMPONENT_BY_SLUG_QUERYResult }) {
         onClick={() =>
           umamiTrack("navigere", {
             kilde: "komponent-header",
+            url: "/grunnleggende/kode/endringslogg",
           })
         }
       >

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
@@ -1,6 +1,7 @@
 import { ClockDashedIcon } from "@navikt/aksel-icons";
 import { HStack, Link } from "@navikt/ds-react";
 import { KOMPONENT_BY_SLUG_QUERYResult } from "@/app/_sanity/query-types";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { FigmaIcon, GithubIcon } from "@/assets/Icons";
 
 const GITHUB_CONFIG = {
@@ -45,9 +46,12 @@ function KomponentLinks({ data }: { data: KOMPONENT_BY_SLUG_QUERYResult }) {
           target="_blank"
           rel="noreferrer noopener"
           href={gitConfig.git}
-          data-umami-event="navigere"
-          data-umami-event-url={gitConfig.git}
-          data-umami-event-kilde="komponent-header"
+          onClick={() =>
+            umamiTrack("navigere", {
+              kilde: "komponent-header",
+              url: gitConfig.git,
+            })
+          }
           variant="subtle"
         >
           <GithubIcon /> Github
@@ -58,9 +62,12 @@ function KomponentLinks({ data }: { data: KOMPONENT_BY_SLUG_QUERYResult }) {
           target="_blank"
           rel="noreferrer noopener"
           href={data.figma_link}
-          data-umami-event="navigere"
-          data-umami-event-url={data.figma_link}
-          data-umami-event-kilde="komponent-header"
+          onClick={() =>
+            umamiTrack("navigere", {
+              kilde: "komponent-header",
+              url: data.figma_link,
+            })
+          }
           variant="subtle"
         >
           <FigmaIcon /> Figma
@@ -69,8 +76,11 @@ function KomponentLinks({ data }: { data: KOMPONENT_BY_SLUG_QUERYResult }) {
       <Link
         href="/grunnleggende/kode/endringslogg"
         variant="subtle"
-        data-umami-event="navigere"
-        data-umami-event-kilde="komponent-header"
+        onClick={() =>
+          umamiTrack("navigere", {
+            kilde: "komponent-header",
+          })
+        }
       >
         <ClockDashedIcon fontSize="1.5rem" aria-hidden />
         Endringslogg

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/icon-page/IconPage.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/icon-page/IconPage.tsx
@@ -67,6 +67,7 @@ function IconPage({
                 onClick={() =>
                   umamiTrack("navigere", {
                     kilde: "ikonside",
+                    url: "https://www.figma.com/community/file/1214869602572392330",
                   })
                 }
               >
@@ -86,6 +87,7 @@ function IconPage({
                 onClick={() =>
                   umamiTrack("navigere", {
                     kilde: "ikonside",
+                    url: "/god-praksis/artikler/tilgjengelig-ikonbruk",
                   })
                 }
               >

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/icon-page/IconPage.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/icon-page/IconPage.tsx
@@ -15,6 +15,7 @@ import {
   VStack,
 } from "@navikt/ds-react";
 import { EmptyStateCard } from "@/app/_ui/empty-state/EmptyState";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { DesignsystemetEyebrow } from "@/app/dev/(designsystemet)/_ui/Designsystemet.eyebrow";
 import { FigmaIcon } from "@/assets/Icons";
 import { DesignsystemetPageLayout } from "../DesignsystemetPage";
@@ -63,8 +64,11 @@ function IconPage({
             >
               <Link
                 variant="subtle"
-                data-umami-event="navigere"
-                data-umami-event-kilde="ikonside"
+                onClick={() =>
+                  umamiTrack("navigere", {
+                    kilde: "ikonside",
+                  })
+                }
               >
                 <FigmaIcon /> <span>Figma</span>
               </Link>
@@ -79,8 +83,11 @@ function IconPage({
             >
               <Link
                 variant="subtle"
-                data-umami-event="navigere"
-                data-umami-event-kilde="ikonside"
+                onClick={() =>
+                  umamiTrack("navigere", {
+                    kilde: "ikonside",
+                  })
+                }
               >
                 <BrailleIcon aria-hidden fontSize="1.5rem" />{" "}
                 <span>Tilgjengelighet</span>
@@ -92,10 +99,13 @@ function IconPage({
               variant="subtle"
               href="https://cdn.nav.no/aksel/icons/zip/aksel-icons.zip"
               download="Ikonpakke"
-              data-umami-event="last ned"
-              data-umami-event-tema="ikon"
-              data-umami-event-type="zip"
-              data-umami-event-tittel="ikonpakke"
+              onClick={() =>
+                umamiTrack("last ned", {
+                  tema: "ikon",
+                  type: "zip",
+                  tittel: "ikonpakke",
+                })
+              }
             >
               <DownloadIcon fontSize="1.5rem" aria-hidden /> Last ned ikonpakke
             </Link>

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/sidebar/Sidebar.item.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/sidebar/Sidebar.item.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { BodyShort, Tag } from "@navikt/ds-react";
 import { getStatusTag } from "@/app/_ui/theming/theme-config";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { SidebarPageT } from "@/types";
 import styles from "./Sidebar.module.css";
 
@@ -35,8 +36,11 @@ function DesignsystemSidebarItem(props: {
         })}
         prefetch={false}
         data-current={active}
-        data-umami-event="navigere"
-        data-umami-event-kilde="sidebar"
+        onClick={() =>
+          umamiTrack("navigere", {
+            kilde: "sidebar",
+          })
+        }
       >
         {page.heading}
         {statusTag && (

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/sidebar/Sidebar.item.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/sidebar/Sidebar.item.tsx
@@ -39,6 +39,7 @@ function DesignsystemSidebarItem(props: {
         onClick={() =>
           umamiTrack("navigere", {
             kilde: "sidebar",
+            url: `/dev/${page.slug}`,
           })
         }
       >

--- a/aksel.nav.no/website/app/dev/(designsystemet)/_ui/sidebar/Sidebar.subnav.tsx
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/_ui/sidebar/Sidebar.subnav.tsx
@@ -4,6 +4,7 @@ import cl from "clsx";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { ChevronDownIcon } from "@navikt/aksel-icons";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { SidebarGroupedPagesT } from "@/types";
 import { DesignsystemSidebarItem } from "./Sidebar.item";
 import styles from "./Sidebar.module.css";
@@ -23,14 +24,17 @@ function DesignsystemSidebarSubNav(
   return (
     <li>
       <button
-        onClick={() => setOpen(!open)}
+        onClick={() => {
+          setOpen(!open);
+          umamiTrack("sidebar-subnav", {
+            kategori: title,
+          });
+        }}
         className={cl(styles.navListSubButton, {
           [styles.navListNotch]: isSectionActive && !open,
         })}
         data-state={isSectionActive ? "active" : "inactive"}
         aria-expanded={open}
-        data-umami-event="sidebar-subnav"
-        data-umami-event-kategori={title}
       >
         {title}
         <ChevronDownIcon aria-hidden className={styles.navListSubButtonIcon} />

--- a/aksel.nav.no/website/app/dev/(god-praksis)/_ui/chips-navigation/ChipsNavigation.button.tsx
+++ b/aksel.nav.no/website/app/dev/(god-praksis)/_ui/chips-navigation/ChipsNavigation.button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import styles from "./ChipsNavigation.module.css";
 
 type GpChipNavigationButtonProps = {
@@ -35,6 +36,13 @@ function GodPrakisChipsNavigationButton(props: GpChipNavigationButtonProps) {
     } else {
       params.set(type, title);
     }
+
+    umamiTrack("god-praksis-chip", {
+      kilde: "sidebar",
+      type: props.type,
+      url: pathname ?? undefined,
+    });
+
     push(getHref(), { scroll: false });
   };
 
@@ -45,9 +53,6 @@ function GodPrakisChipsNavigationButton(props: GpChipNavigationButtonProps) {
       data-active={isActive}
       onClick={handleClick}
       aria-pressed={isActive}
-      data-umami-event="god-praksis-chip"
-      data-umami-event-type={props.type}
-      data-umami-event-url={pathname}
       onMouseEnter={() => {
         const href = getHref();
         prefetch(href);

--- a/aksel.nav.no/website/app/dev/(god-praksis)/_ui/feedback/GodPraksisFeedback.parts.tsx
+++ b/aksel.nav.no/website/app/dev/(god-praksis)/_ui/feedback/GodPraksisFeedback.parts.tsx
@@ -13,6 +13,7 @@ import {
   Link,
   Textarea,
 } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { FormState, sendFeedbackAction } from "./actions";
 import { zodFormDataSchema } from "./actions.zod";
 
@@ -86,11 +87,11 @@ function GodPraksisFeedbackForm({
           error: "Noe gikk galt ved innsending, ta kontakt med team Aksel",
         });
 
-        window.umami &&
-          umami.track("skjema validering feilet", {
-            skjemanavn: "slack-feedback",
-            skjemaId: docId,
-          });
+        umamiTrack("skjema validering feilet", {
+          skjemanavn: "slack-feedback",
+          skjemaId: docId,
+        });
+
         return;
       }
 
@@ -114,11 +115,10 @@ function GodPraksisFeedbackForm({
           error: result.error,
         });
 
-        window.umami &&
-          umami.track("skjema validering feilet", {
-            skjemanavn: "slack-feedback",
-            skjemaId: docId,
-          });
+        umamiTrack("skjema validering feilet", {
+          skjemanavn: "slack-feedback",
+          skjemaId: docId,
+        });
         return;
       }
 
@@ -127,11 +127,10 @@ function GodPraksisFeedbackForm({
         error: null,
       });
 
-      window.umami &&
-        umami.track("skjema fullfort", {
-          skjemanavn: "slack-feedback",
-          skjemaId: docId,
-        });
+      umamiTrack("skjema fullfort", {
+        skjemanavn: "slack-feedback",
+        skjemaId: docId,
+      });
     });
   };
 

--- a/aksel.nav.no/website/app/dev/(god-praksis)/god-praksis/artikler/[slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(god-praksis)/god-praksis/artikler/[slug]/page.tsx
@@ -115,28 +115,30 @@ export default async function Page(props: Props) {
           {`Oppdatert ${await dateStr(verifiedDate)}`}
         </BodyShort>
         <HStack gap="space-8" marginBlock="space-16 space-48">
-          {pageData.undertema?.map(({ tema, title }) => (
-            <NextLink
-              key={title}
-              className={styles.pageUndertemaTag}
-              href={`/god-praksis/${tema?.slug}?undertema=${encodeURIComponent(
-                title ?? "",
-              )}`}
-              data-link-card-anchor
-              onClick={() =>
-                umamiTrack("navigere", {
-                  kilde: "god praksis artikkel chips",
-                  url: `/god-praksis/${tema?.slug}?undertema=${encodeURIComponent(
-                    title ?? "",
-                  )}`,
-                })
-              }
-            >
-              <TagFillIcon aria-hidden fontSize="1.25rem" />
-              <span className={styles.pageUndertemaTagText}>{title}</span>
-              <LinkCardArrow />
-            </NextLink>
-          ))}
+          {pageData.undertema?.map(({ tema, title }) => {
+            const href = `/god-praksis/${tema?.slug}?undertema=${encodeURIComponent(
+              title ?? "",
+            )}`;
+
+            return (
+              <NextLink
+                key={title}
+                className={styles.pageUndertemaTag}
+                href={href}
+                data-link-card-anchor
+                onClick={() =>
+                  umamiTrack("navigere", {
+                    kilde: "god praksis artikkel chips",
+                    url: href,
+                  })
+                }
+              >
+                <TagFillIcon aria-hidden fontSize="1.25rem" />
+                <span className={styles.pageUndertemaTagText}>{title}</span>
+                <LinkCardArrow />
+              </NextLink>
+            );
+          })}
         </HStack>
       </div>
       <TableOfContents toc={toc} />

--- a/aksel.nav.no/website/app/dev/(god-praksis)/god-praksis/artikler/[slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(god-praksis)/god-praksis/artikler/[slug]/page.tsx
@@ -126,6 +126,9 @@ export default async function Page(props: Props) {
               onClick={() =>
                 umamiTrack("navigere", {
                   kilde: "god praksis artikkel chips",
+                  url: `/god-praksis/${tema?.slug}?undertema=${encodeURIComponent(
+                    title ?? "",
+                  )}`,
                 })
               }
             >
@@ -173,6 +176,7 @@ export default async function Page(props: Props) {
                         onClick={() =>
                           umamiTrack("navigere", {
                             kilde: "les ogsaa",
+                            url: item.slug?.current ?? "",
                           })
                         }
                       >

--- a/aksel.nav.no/website/app/dev/(god-praksis)/god-praksis/artikler/[slug]/page.tsx
+++ b/aksel.nav.no/website/app/dev/(god-praksis)/god-praksis/artikler/[slug]/page.tsx
@@ -25,6 +25,7 @@ import { EditorPanel } from "@/app/_ui/editor-panel/EditorPanel";
 import { SystemPanel } from "@/app/_ui/system-panel/SystemPanel";
 import { TableOfContents } from "@/app/_ui/toc/TableOfContents";
 import { WebsiteList, WebsiteListItem } from "@/app/_ui/typography/WebsiteList";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { GodPraksisFeedback } from "@/app/dev/(god-praksis)/_ui/feedback/GodPraksisFeedback";
 import { LinkCardArrow } from "@/app/dev/(god-praksis)/_ui/link-card/LinkCard";
 import { abbrName, dateStr } from "@/utils";
@@ -122,8 +123,11 @@ export default async function Page(props: Props) {
                 title ?? "",
               )}`}
               data-link-card-anchor
-              data-umami-event="navigere"
-              data-umami-event-kilde="god praksis artikkel chips"
+              onClick={() =>
+                umamiTrack("navigere", {
+                  kilde: "god praksis artikkel chips",
+                })
+              }
             >
               <TagFillIcon aria-hidden fontSize="1.25rem" />
               <span className={styles.pageUndertemaTagText}>{title}</span>
@@ -166,8 +170,11 @@ export default async function Page(props: Props) {
                       <Link
                         variant="neutral"
                         href={item.slug?.current}
-                        data-umami-event="navigere"
-                        data-umami-event-kilde="les ogsaa"
+                        onClick={() =>
+                          umamiTrack("navigere", {
+                            kilde: "les ogsaa",
+                          })
+                        }
                       >
                         {item.heading}
                       </Link>

--- a/aksel.nav.no/website/app/dev/(god-praksis)/god-praksis/page.tsx
+++ b/aksel.nav.no/website/app/dev/(god-praksis)/god-praksis/page.tsx
@@ -16,6 +16,7 @@ import {
   GOD_PRAKSIS_LANDING_PAGE_SEO_QUERY,
 } from "@/app/_sanity/queries";
 import { urlForOpenGraphImage } from "@/app/_sanity/utils";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { GodPraksisTaxonomyTag } from "@/app/dev/(god-praksis)/_ui/GodPraksisTaxonomyTag";
 import { GodPraksisIntroHero } from "@/app/dev/(god-praksis)/_ui/hero/Hero";
 import {
@@ -116,8 +117,11 @@ export default async function Page() {
                 <Link
                   href={`/god-praksis/${tema.slug}`}
                   as={NextLink}
-                  data-umami-event="navigere"
-                  data-umami-event-kilde="god praksis forside"
+                  onClick={() =>
+                    umamiTrack("navigere", {
+                      kilde: "god praksis forside",
+                    })
+                  }
                   data-link-card-anchor
                   data-color-role="brand-blue"
                 >

--- a/aksel.nav.no/website/app/dev/(god-praksis)/god-praksis/page.tsx
+++ b/aksel.nav.no/website/app/dev/(god-praksis)/god-praksis/page.tsx
@@ -120,6 +120,7 @@ export default async function Page() {
                   onClick={() =>
                     umamiTrack("navigere", {
                       kilde: "god praksis forside",
+                      url: `/god-praksis/${tema.slug}`,
                     })
                   }
                   data-link-card-anchor

--- a/aksel.nav.no/website/app/error.tsx
+++ b/aksel.nav.no/website/app/error.tsx
@@ -5,6 +5,7 @@ import { BodyShort, Box, Heading, Link, VStack } from "@navikt/ds-react";
 import { Page } from "@navikt/ds-react/Page";
 import { logger } from "@navikt/next-logger";
 import { WebsiteList, WebsiteListItem } from "@/app/_ui/typography/WebsiteList";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 
 export default function Error({
   error,
@@ -16,8 +17,7 @@ export default function Error({
   }, [error]);
 
   useEffect(() => {
-    window.umami &&
-      umami.track("client-error", { url: window.location.pathname });
+    umamiTrack("client-error", { url: window.location.pathname });
   }, []);
 
   return (

--- a/aksel.nav.no/website/components/layout/footer/parts/FooterLink.tsx
+++ b/aksel.nav.no/website/components/layout/footer/parts/FooterLink.tsx
@@ -10,6 +10,7 @@ function FooterLink({ children, href }) {
         onClick={() =>
           umamiTrack("navigere", {
             kilde: "footer",
+            url: href,
           })
         }
       >

--- a/aksel.nav.no/website/components/layout/footer/parts/FooterLink.tsx
+++ b/aksel.nav.no/website/components/layout/footer/parts/FooterLink.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 
 function FooterLink({ children, href }) {
   return (
@@ -6,8 +7,11 @@ function FooterLink({ children, href }) {
       <Link
         className="flex w-fit items-center gap-1 text-text-on-inverted underline hover:no-underline focus:bg-blue-200 focus:text-text-default focus:shadow-focus focus:shadow-blue-200"
         href={href}
-        data-umami-event="navigere"
-        data-umami-event-kilde="footer"
+        onClick={() =>
+          umamiTrack("navigere", {
+            kilde: "footer",
+          })
+        }
       >
         {children}
       </Link>

--- a/aksel.nav.no/website/components/layout/god-praksis-page/cards/GpFrontpageCard.tsx
+++ b/aksel.nav.no/website/components/layout/god-praksis-page/cards/GpFrontpageCard.tsx
@@ -38,6 +38,7 @@ const GpFrontpageCard = ({ image, children, href }: GpFrontpageCardProps) => {
         onClick={() =>
           umamiTrack("navigere", {
             kilde: "god praksis forside",
+            url: href,
           })
         }
       >

--- a/aksel.nav.no/website/components/layout/god-praksis-page/cards/GpFrontpageCard.tsx
+++ b/aksel.nav.no/website/components/layout/god-praksis-page/cards/GpFrontpageCard.tsx
@@ -1,6 +1,7 @@
 import { SanityImageSource } from "@sanity/image-url/lib/types/types";
 import Image from "next/legacy/image";
 import NextLink from "next/link";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import ErrorBoundary from "@/error-boundary";
 import { FallbackPictogram } from "@/layout/god-praksis-page/FallbackPictogram";
 import { urlFor } from "@/sanity/interface";
@@ -33,9 +34,12 @@ const GpFrontpageCard = ({ image, children, href }: GpFrontpageCardProps) => {
       <NextLink
         href={href}
         passHref
-        data-umami-event="navigere"
-        data-umami-event-kilde="god praksis forside"
         className="navds-heading--small navds-link navds-heading flex-wrap break-all text-deepblue-700 no-underline hover:underline focus:outline-none"
+        onClick={() =>
+          umamiTrack("navigere", {
+            kilde: "god praksis forside",
+          })
+        }
       >
         {children}
       </NextLink>

--- a/aksel.nav.no/website/components/layout/god-praksis-page/chipnavigation/GpChip.tsx
+++ b/aksel.nav.no/website/components/layout/god-praksis-page/chipnavigation/GpChip.tsx
@@ -1,5 +1,6 @@
 import cl from "clsx";
 import { useRouter } from "next/router";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 
 type GpChipProps = {
   children: React.ReactNode;
@@ -15,7 +16,6 @@ export function GpChip(props: GpChipProps) {
   return (
     <button
       aria-pressed={props.pressed}
-      onClick={props.onClick}
       className={cl(
         "grid min-h-8 place-content-center whitespace-nowrap rounded-full bg-surface-neutral-subtle px-3 py-1 ring-1 ring-inset transition-opacity focus:outline-none focus-visible:shadow-focus-gap aria-pressed:text-text-on-inverted",
         "disabled:bg-surface-neutral-subtle disabled:opacity-40 disabled:ring-border-default",
@@ -26,9 +26,13 @@ export function GpChip(props: GpChipProps) {
             props.type === "undertema",
         },
       )}
-      data-umami-event="god-praksis-chip"
-      data-umami-event-type={props.type}
-      data-umami-event-url={asPath}
+      onClick={() => {
+        props?.onClick?.();
+        umamiTrack("god-praksis-chip", {
+          type: props.type,
+          url: asPath,
+        });
+      }}
       disabled={props.disabled}
     >
       {props.children}

--- a/aksel.nav.no/website/components/layout/god-praksis-page/chipnavigation/GpChip.tsx
+++ b/aksel.nav.no/website/components/layout/god-praksis-page/chipnavigation/GpChip.tsx
@@ -27,7 +27,7 @@ export function GpChip(props: GpChipProps) {
         },
       )}
       onClick={() => {
-        props?.onClick?.();
+        props.onClick?.();
         umamiTrack("god-praksis-chip", {
           type: props.type,
           url: asPath,

--- a/aksel.nav.no/website/components/layout/header/Header.tsx
+++ b/aksel.nav.no/website/components/layout/header/Header.tsx
@@ -41,6 +41,7 @@ const Header = ({
             onClick={() =>
               umamiTrack("navigere", {
                 kilde: "header",
+                url: "/",
               })
             }
             className="mx-4 grid h-11 place-items-center rounded px-2 focus:outline-none focus-visible:shadow-focus sm:mr-6"

--- a/aksel.nav.no/website/components/layout/header/Header.tsx
+++ b/aksel.nav.no/website/components/layout/header/Header.tsx
@@ -2,6 +2,7 @@ import cl from "clsx";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { Box, HStack, Page, Show, Spacer } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import AkselLogo from "@/assets/Logo";
 import { AkselSearchButton } from "@/web/search/parts/SearchButton";
 import { Hamburger } from "./parts/Hamburger";
@@ -37,8 +38,11 @@ const Header = ({
           <Link
             href="/"
             passHref
-            data-umami-event="navigere"
-            data-umami-event-kilde="header"
+            onClick={() =>
+              umamiTrack("navigere", {
+                kilde: "header",
+              })
+            }
             className="mx-4 grid h-11 place-items-center rounded px-2 focus:outline-none focus-visible:shadow-focus sm:mr-6"
           >
             <AkselLogo className="text-deepblue-800" />

--- a/aksel.nav.no/website/components/layout/header/parts/HamburgerLink.tsx
+++ b/aksel.nav.no/website/components/layout/header/parts/HamburgerLink.tsx
@@ -22,6 +22,7 @@ function HamburgerLink({ name, href, onClick }) {
           onClick();
           umamiTrack("navigere", {
             kilde: "hamburger",
+            url: href,
           });
         }}
       >

--- a/aksel.nav.no/website/components/layout/header/parts/HamburgerLink.tsx
+++ b/aksel.nav.no/website/components/layout/header/parts/HamburgerLink.tsx
@@ -1,6 +1,7 @@
 import cl from "clsx";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 
 function HamburgerLink({ name, href, onClick }) {
   const { asPath } = useRouter();
@@ -17,9 +18,12 @@ function HamburgerLink({ name, href, onClick }) {
             "": !asPath.startsWith(href),
           },
         )}
-        onClick={() => onClick()}
-        data-umami-event="navigere"
-        data-umami-event-kilde="hamburger"
+        onClick={() => {
+          onClick();
+          umamiTrack("navigere", {
+            kilde: "hamburger",
+          });
+        }}
       >
         {name}
       </Link>

--- a/aksel.nav.no/website/components/layout/header/parts/HeaderLink.tsx
+++ b/aksel.nav.no/website/components/layout/header/parts/HeaderLink.tsx
@@ -28,6 +28,7 @@ function HeaderLink({ name, href, prefetch = undefined }: HeaderLinkProps) {
         onClick={() =>
           umamiTrack("navigere", {
             kilde: "header",
+            url: href,
           })
         }
       >

--- a/aksel.nav.no/website/components/layout/header/parts/HeaderLink.tsx
+++ b/aksel.nav.no/website/components/layout/header/parts/HeaderLink.tsx
@@ -1,6 +1,7 @@
 import cl from "clsx";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 
 type HeaderLinkProps = {
   name: string;
@@ -24,8 +25,11 @@ function HeaderLink({ name, href, prefetch = undefined }: HeaderLinkProps) {
               !asPath.startsWith(href),
           },
         )}
-        data-umami-event="navigere"
-        data-umami-event-kilde="header"
+        onClick={() =>
+          umamiTrack("navigere", {
+            kilde: "header",
+          })
+        }
       >
         {name}
       </Link>

--- a/aksel.nav.no/website/components/layout/sidebar/Sidebar.tsx
+++ b/aksel.nav.no/website/components/layout/sidebar/Sidebar.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import React, { useContext, useId, useState } from "react";
 import { ChevronDownIcon } from "@navikt/aksel-icons";
 import { BodyShort, Detail } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import {
   DesignsystemSidebarSectionT,
   SidebarGroupedPagesT,
@@ -121,14 +122,17 @@ function SidebarSubNav(props: SidebarGroupedPagesT) {
   return (
     <li>
       <button
-        onClick={() => setOpen(!open)}
         className={cl(styles.navListSubButton, {
           [styles.navListNotch]: isSectionActive && !open,
         })}
         data-state={isSectionActive ? "active" : "inactive"}
         aria-expanded={open}
-        data-umami-event="sidebar-subnav"
-        data-umami-event-kategori={title}
+        onClick={() => {
+          setOpen(!open);
+          umamiTrack("sidebar-subnav", {
+            kategori: title,
+          });
+        }}
       >
         {title}
         <ChevronDownIcon aria-hidden />
@@ -164,8 +168,11 @@ function SidebarItem(props: { page: SidebarPageT; isIndented?: boolean }) {
         })}
         prefetch={false}
         data-current={active}
-        data-umami-event="navigere"
-        data-umami-event-kilde="sidebar"
+        onClick={() =>
+          umamiTrack("navigere", {
+            kilde: "sidebar",
+          })
+        }
       >
         {page.heading}
         <StatusTag size="xsmall" status={page.tag} />

--- a/aksel.nav.no/website/components/layout/sidebar/Sidebar.tsx
+++ b/aksel.nav.no/website/components/layout/sidebar/Sidebar.tsx
@@ -171,6 +171,7 @@ function SidebarItem(props: { page: SidebarPageT; isIndented?: boolean }) {
         onClick={() =>
           umamiTrack("navigere", {
             kilde: "sidebar",
+            url: `/${page.slug}`,
           })
         }
       >

--- a/aksel.nav.no/website/components/sanity-modules/frontpage-blocks/latest-articles/Card.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/frontpage-blocks/latest-articles/Card.tsx
@@ -142,6 +142,7 @@ const Card = ({ article, visible, index }: CardProps) => {
             onClick={() =>
               umamiTrack("navigere", {
                 kilde: "forsidekort",
+                url: `/${article.slug}`,
               })
             }
           >

--- a/aksel.nav.no/website/components/sanity-modules/frontpage-blocks/latest-articles/Card.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/frontpage-blocks/latest-articles/Card.tsx
@@ -2,6 +2,7 @@ import cl from "clsx";
 import NextImage from "next/legacy/image";
 import NextLink from "next/link";
 import { BodyShort, Detail, Heading } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import ErrorBoundary from "@/error-boundary";
 import { useFormatedDate } from "@/hooks/useFormatedDate";
 import { urlFor } from "@/sanity/interface";
@@ -138,8 +139,11 @@ const Card = ({ article, visible, index }: CardProps) => {
             href={`/${article.slug}`}
             passHref
             className="after:absolute after:inset-0 after:z-10 after:rounded-lg focus:outline-none"
-            data-umami-event="navigere"
-            data-umami-event-kilde="forsidekort"
+            onClick={() =>
+              umamiTrack("navigere", {
+                kilde: "forsidekort",
+              })
+            }
           >
             <Heading
               level="3"

--- a/aksel.nav.no/website/components/sanity-modules/frontpage-blocks/latest-articles/Highlight.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/frontpage-blocks/latest-articles/Highlight.tsx
@@ -2,6 +2,7 @@ import cl from "clsx";
 import Image from "next/legacy/image";
 import NextLink from "next/link";
 import { BodyLong, BodyShort, Heading, Link } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { useFormatedDate } from "@/hooks/useFormatedDate";
 import { urlFor } from "@/sanity/interface";
 import { getAuthors, getImage } from "@/utils";
@@ -103,8 +104,11 @@ export const Highlight = ({
         <Heading size="large" level="3">
           <Link
             as={NextLink}
-            data-umami-event="navigere"
-            data-umami-event-kilde="global sok"
+            onClick={() =>
+              umamiTrack("navigere", {
+                kilde: "global sok",
+              })
+            }
             href={`/${article.slug.current}`}
             className="mb-5 mt-2 text-text-default underline hover:no-underline"
           >

--- a/aksel.nav.no/website/components/sanity-modules/frontpage-blocks/latest-articles/Highlight.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/frontpage-blocks/latest-articles/Highlight.tsx
@@ -107,6 +107,7 @@ export const Highlight = ({
             onClick={() =>
               umamiTrack("navigere", {
                 kilde: "global sok",
+                url: `/${article.slug.current}`,
               })
             }
             href={`/${article.slug.current}`}

--- a/aksel.nav.no/website/components/sanity-modules/relatert-innhold/RelatertInnhold.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/relatert-innhold/RelatertInnhold.tsx
@@ -37,6 +37,7 @@ const RelatertInnhold = ({ node }: RelatertInnholdProps) => {
               onClick={() =>
                 umamiTrack("navigere", {
                   kilde: "relatert innhold",
+                  url: getHref(x),
                 })
               }
               className="text-xl font-semibold text-gray-800 dark:text-text-on-inverted"

--- a/aksel.nav.no/website/components/sanity-modules/relatert-innhold/RelatertInnhold.tsx
+++ b/aksel.nav.no/website/components/sanity-modules/relatert-innhold/RelatertInnhold.tsx
@@ -1,6 +1,7 @@
 import NextLink from "next/link";
 import { NewspaperIcon } from "@navikt/aksel-icons";
 import { Heading, Link } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import ErrorBoundary from "@/error-boundary";
 import { RelatertInnholdT } from "@/types";
 
@@ -33,8 +34,11 @@ const RelatertInnhold = ({ node }: RelatertInnholdProps) => {
             <Link
               as={NextLink}
               href={getHref(x)}
-              data-umami-event="navigere"
-              data-umami-event-kilde="relatert innhold"
+              onClick={() =>
+                umamiTrack("navigere", {
+                  kilde: "relatert innhold",
+                })
+              }
               className="text-xl font-semibold text-gray-800 dark:text-text-on-inverted"
             >
               {x.title}

--- a/aksel.nav.no/website/components/website-modules/AkselLink.tsx
+++ b/aksel.nav.no/website/components/website-modules/AkselLink.tsx
@@ -1,6 +1,7 @@
 import NextLink from "next/link";
 import React from "react";
 import { Link } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 
 type Props = {
   href: string;
@@ -15,14 +16,13 @@ const AkselLink = ({ href, children }: Props) => {
       as={NextLink}
       href={href}
       inlineText
-      data-umami-event="navigere"
-      data-umami-kilde="inline lenke"
+      onClick={() =>
+        umamiTrack("navigere", { kilde: "inline lenke", url: href })
+      }
       {...(isOutbound
         ? {
             target: "_blank",
             rel: "noreferrer noopener",
-            /* https://umami.is/docs/track-outbound-links */
-            ["data-umami-event-url"]: href,
           }
         : {})}
     >

--- a/aksel.nav.no/website/components/website-modules/Feedback/Feedback.tsx
+++ b/aksel.nav.no/website/components/website-modules/Feedback/Feedback.tsx
@@ -13,6 +13,7 @@ import {
   Textarea,
   VStack,
 } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { AuthUser, UserStateT } from "@/auth/auth.types";
 import { useAuth } from "@/auth/useAuth";
 import { SlackFeedbackResponse } from "@/slack";
@@ -64,30 +65,28 @@ export const FeedbackForm = ({ user }: { user: AuthUser }) => {
           setAPIError(res.error);
           setState("error");
 
-          window.umami &&
-            umami.track("skjema validering feilet", {
-              skjemanavn: "slack-feedback",
-              skjemaId: sanityDocumentId,
-            });
+          umamiTrack("skjema validering feilet", {
+            skjemanavn: "slack-feedback",
+            skjemaId: sanityDocumentId,
+          });
         } else {
           setFormError(null);
           setState("feedbackSent");
 
-          window.umami &&
-            umami.track("skjema fullfort", {
-              skjemanavn: "slack-feedback",
-              skjemaId: sanityDocumentId,
-            });
+          umamiTrack("skjema fullfort", {
+            skjemanavn: "slack-feedback",
+            skjemaId: sanityDocumentId,
+          });
         }
       })
       .catch(() => {
         setAPIError("unknownError");
         setState("error");
-        window.umami &&
-          umami.track("skjema validering feilet", {
-            skjemanavn: "slack-feedback",
-            skjemaId: sanityDocumentId,
-          });
+
+        umamiTrack("skjema validering feilet", {
+          skjemanavn: "slack-feedback",
+          skjemaId: sanityDocumentId,
+        });
       });
   };
 

--- a/aksel.nav.no/website/components/website-modules/IntroCards.tsx
+++ b/aksel.nav.no/website/components/website-modules/IntroCards.tsx
@@ -33,6 +33,7 @@ export const IntroCards = ({
             onClick={() =>
               umamiTrack("navigere", {
                 kilde: "introkort",
+                url: href,
               })
             }
           >

--- a/aksel.nav.no/website/components/website-modules/IntroCards.tsx
+++ b/aksel.nav.no/website/components/website-modules/IntroCards.tsx
@@ -1,5 +1,6 @@
 import cl from "clsx";
 import Link from "next/link";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 
 export const IntroCards = ({
   links,
@@ -29,8 +30,11 @@ export const IntroCards = ({
               },
             )}
             prefetch={false}
-            data-umami-event="navigere"
-            data-umami-event-kilde="introkort"
+            onClick={() =>
+              umamiTrack("navigere", {
+                kilde: "introkort",
+              })
+            }
           >
             <span className="flex items-center gap-2">
               <Icon

--- a/aksel.nav.no/website/components/website-modules/Umami.tsx
+++ b/aksel.nav.no/website/components/website-modules/Umami.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import getConfig from "next/config";
-
-/* import Script from "next/script"; */
+import Script from "next/script";
 import { useEffect, useState } from "react";
 import { useCookies } from "./CookieProvider";
 
@@ -21,10 +20,7 @@ export const Umami = () => {
     return null;
   }
 
-  /* 30.04.2025: Umami is down currently. Until we handle logging better internally we have disabled it. */
-  return null;
-
-  /* return (
+  return (
     <Script
       defer
       src="https://cdn.nav.no/team-researchops/sporing/sporing.js"
@@ -33,7 +29,7 @@ export const Umami = () => {
       data-tag={umamiTag}
       data-exclude-search="true"
     />
-  ); */
+  );
 };
 
 /**

--- a/aksel.nav.no/website/components/website-modules/icon-page/Sidebar.tsx
+++ b/aksel.nav.no/website/components/website-modules/icon-page/Sidebar.tsx
@@ -5,6 +5,7 @@ import ReactDOMServer from "react-dom/server";
 import * as Icons from "@navikt/aksel-icons";
 import meta from "@navikt/aksel-icons/metadata";
 import { Button, Heading } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import SnippetLazy from "@/cms/code-snippet/SnippetLazy";
 import { useEscapeKeydown } from "@/hooks/useEscapeKeydown";
 import { SuggestionBlock } from "@/web/suggestionblock/SuggestionBlock";
@@ -97,10 +98,13 @@ export const IconSidebar = ({
         variant="primary"
         className="mt-8 w-full"
         as="a"
-        data-umami-event="last ned"
-        data-umami-event-tema="ikon"
-        data-umami-event-type="svg"
-        data-umami-event-tittel={name}
+        onClick={() =>
+          umamiTrack("last ned", {
+            tema: "ikon",
+            type: "svg",
+            tittel: name,
+          })
+        }
         href={blob ? URL.createObjectURL(blob) : "#"}
         download={name}
       >

--- a/aksel.nav.no/website/components/website-modules/icon-page/TitleLinks.tsx
+++ b/aksel.nav.no/website/components/website-modules/icon-page/TitleLinks.tsx
@@ -1,6 +1,7 @@
 import NextLink from "next/link";
 import { BrailleIcon, DownloadIcon, PackageIcon } from "@navikt/aksel-icons";
 import { Link as DsLink } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { FigmaIcon, GithubIcon } from "@/assets/Icons";
 
 const Divider = () => (
@@ -20,8 +21,11 @@ export const TitleLinks = () => (
       >
         <DsLink
           className="text-text-default no-underline hover:underline"
-          data-umami-event="navigere"
-          data-umami-event-kilde="ikonside"
+          onClick={() =>
+            umamiTrack("navigere", {
+              kilde: "ikonside",
+            })
+          }
         >
           <FigmaIcon className="ml-1" /> <span className="">Figma</span>
         </DsLink>
@@ -33,10 +37,13 @@ export const TitleLinks = () => (
         className="text-text-default no-underline hover:underline"
         href="https://cdn.nav.no/aksel/icons/zip/aksel-icons.zip"
         download="Ikonpakke"
-        data-umami-event="last ned"
-        data-umami-event-tema="ikon"
-        data-umami-event-type="zip"
-        data-umami-event-tittel="ikonpakke"
+        onClick={() =>
+          umamiTrack("last ned", {
+            tema: "ikon",
+            type: "zip",
+            tittel: "ikonpakke",
+          })
+        }
       >
         <DownloadIcon className="text-2xl" aria-hidden /> Last ned ikonpakke
       </DsLink>
@@ -50,8 +57,11 @@ export const TitleLinks = () => (
       >
         <DsLink
           className="text-text-default no-underline hover:underline"
-          data-umami-event="navigere"
-          data-umami-event-kilde="ikonside"
+          onClick={() =>
+            umamiTrack("navigere", {
+              kilde: "ikonside",
+            })
+          }
         >
           <PackageIcon className="text-2xl" aria-hidden /> Installer med NPM
         </DsLink>
@@ -66,8 +76,11 @@ export const TitleLinks = () => (
       >
         <DsLink
           className="text-text-default no-underline hover:underline"
-          data-umami-event="navigere"
-          data-umami-event-kilde="ikonside"
+          onClick={() =>
+            umamiTrack("navigere", {
+              kilde: "ikonside",
+            })
+          }
         >
           <GithubIcon className="ml-[3px] h-[18px] w-[18px]" />{" "}
           <span className="ml-1">Bidra</span>
@@ -83,8 +96,11 @@ export const TitleLinks = () => (
       >
         <DsLink
           className="text-text-default no-underline hover:underline"
-          data-umami-event="navigere"
-          data-umami-event-kilde="ikonside"
+          onClick={() =>
+            umamiTrack("navigere", {
+              kilde: "ikonside",
+            })
+          }
         >
           <BrailleIcon aria-hidden className="text-2xl" />{" "}
           <span>Tilgjengelighet</span>

--- a/aksel.nav.no/website/components/website-modules/icon-page/TitleLinks.tsx
+++ b/aksel.nav.no/website/components/website-modules/icon-page/TitleLinks.tsx
@@ -24,6 +24,7 @@ export const TitleLinks = () => (
           onClick={() =>
             umamiTrack("navigere", {
               kilde: "ikonside",
+              url: "https://www.figma.com/community/file/1214869602572392330",
             })
           }
         >
@@ -60,6 +61,7 @@ export const TitleLinks = () => (
           onClick={() =>
             umamiTrack("navigere", {
               kilde: "ikonside",
+              url: "https://www.npmjs.com/package/@navikt/aksel-icons",
             })
           }
         >
@@ -79,6 +81,7 @@ export const TitleLinks = () => (
           onClick={() =>
             umamiTrack("navigere", {
               kilde: "ikonside",
+              url: "https://github.com/navikt/aksel/tree/main/%40navikt/aksel-icons/CONTRIBUTING.md",
             })
           }
         >
@@ -99,6 +102,7 @@ export const TitleLinks = () => (
           onClick={() =>
             umamiTrack("navigere", {
               kilde: "ikonside",
+              url: "/god-praksis/artikler/tilgjengelig-ikonbruk",
             })
           }
         >

--- a/aksel.nav.no/website/components/website-modules/menu/Menu.tsx
+++ b/aksel.nav.no/website/components/website-modules/menu/Menu.tsx
@@ -2,6 +2,7 @@ import cl from "clsx";
 import Link from "next/link";
 import { HTMLAttributes, createContext, useContext } from "react";
 import { BodyShort, Label } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import styles from "./Menu.module.css";
 
 type MenuProps = {
@@ -91,9 +92,12 @@ export function MenuLink({
         as={Link}
         prefetch={false}
         href={href}
-        onClick={() => onClick?.()}
-        data-umami-event="navigere"
-        data-umami-event-kilde={source}
+        onClick={() => {
+          onClick?.();
+          umamiTrack("navigere", {
+            kilde: source,
+          });
+        }}
         className={cl(
           styles.menuListItem,
           "flex py-05 focus:outline-none *:focus-visible:shadow-focus group-first:pt-0 group-last:last:pb-0",

--- a/aksel.nav.no/website/components/website-modules/menu/Menu.tsx
+++ b/aksel.nav.no/website/components/website-modules/menu/Menu.tsx
@@ -96,6 +96,7 @@ export function MenuLink({
           onClick?.();
           umamiTrack("navigere", {
             kilde: source,
+            url: href,
           });
         }}
         className={cl(

--- a/aksel.nav.no/website/components/website-modules/search/hooks/useSearch.ts
+++ b/aksel.nav.no/website/components/website-modules/search/hooks/useSearch.ts
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import useSWRImmutable from "swr/immutable";
 import { debounce } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { SearchResultsT } from "@/types";
 import { createSearchResult, formatResults, fuseSearch } from "../utils";
 
@@ -27,7 +28,8 @@ export const useSearch = () => {
           ...createSearchResult(formatedResults, rawResults),
           query: value,
         });
-        window.umami && umami.track("sok");
+
+        umamiTrack("sok");
       }),
     [data],
   );

--- a/aksel.nav.no/website/components/website-modules/search/hooks/useSearch.ts
+++ b/aksel.nav.no/website/components/website-modules/search/hooks/useSearch.ts
@@ -29,7 +29,7 @@ export const useSearch = () => {
           query: value,
         });
 
-        umamiTrack("sok");
+        umamiTrack("sok", {});
       }),
     [data],
   );

--- a/aksel.nav.no/website/components/website-modules/search/parts/Hit.tsx
+++ b/aksel.nav.no/website/components/website-modules/search/parts/Hit.tsx
@@ -50,6 +50,7 @@ export const Hit = forwardRef<
             onClick={() =>
               umamiTrack("navigere", {
                 kilde: "global sok",
+                url: href,
               })
             }
             className={cl(

--- a/aksel.nav.no/website/components/website-modules/search/parts/Hit.tsx
+++ b/aksel.nav.no/website/components/website-modules/search/parts/Hit.tsx
@@ -3,6 +3,7 @@ import Image from "next/legacy/image";
 import NextLink from "next/link";
 import { forwardRef, useContext } from "react";
 import { Show } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { Tag } from "@/cms/frontpage-blocks/latest-articles/Tag";
 import { urlFor } from "@/sanity/interface";
 import { SearchHitT, searchOptions } from "@/types";
@@ -46,8 +47,11 @@ export const Hit = forwardRef<
         >
           <NextLink
             href={href}
-            data-umami-event="navigere"
-            data-umami-event-kilde="global sok"
+            onClick={() =>
+              umamiTrack("navigere", {
+                kilde: "global sok",
+              })
+            }
             className={cl(
               "group scroll-my-32 break-words text-xl font-semibold underline hover:decoration-[3px] focus:outline-none",
               "after:absolute after:inset-0 after:rounded-lg after:ring-inset focus-visible:after:ring-[3px] focus-visible:after:ring-border-focus",

--- a/aksel.nav.no/website/components/website-modules/toc/parts/UlList.tsx
+++ b/aksel.nav.no/website/components/website-modules/toc/parts/UlList.tsx
@@ -1,6 +1,7 @@
 import cl from "clsx";
 import Link from "next/link";
 import { BodyShort } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { TableOfContentsT } from "@/types";
 import { removeEmojies } from "@/utils";
 import styles from "../TableOfContents.module.css";
@@ -52,13 +53,15 @@ function UlList({
                   as={Link}
                   prefetch={false}
                   href={`#${node.id}`}
-                  onClick={() =>
+                  onClick={() => {
                     nested
                       ? tocProps.setActiveSubId(node.id)
-                      : tocProps.setActiveId(node.id)
-                  }
-                  data-umami-event="navigere"
-                  data-umami-event-kilde="toc"
+                      : tocProps.setActiveId(node.id);
+
+                    umamiTrack("navigere", {
+                      kilde: "toc",
+                    });
+                  }}
                   className={cl(
                     styles.menuListItem,
                     "flex py-05 focus:outline-none *:focus-visible:shadow-focus group-first:pt-0 group-last:last:pb-0",

--- a/aksel.nav.no/website/components/website-modules/toc/parts/UlList.tsx
+++ b/aksel.nav.no/website/components/website-modules/toc/parts/UlList.tsx
@@ -60,6 +60,7 @@ function UlList({
 
                     umamiTrack("navigere", {
                       kilde: "toc",
+                      url: `#${node.id}`,
                     });
                   }}
                   className={cl(

--- a/aksel.nav.no/website/pages/404.tsx
+++ b/aksel.nav.no/website/pages/404.tsx
@@ -9,12 +9,15 @@ import {
   Page,
   VStack,
 } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import Footer from "@/layout/footer/Footer";
 import Header from "@/layout/header/Header";
 
 export default function NotFound() {
   useEffect(() => {
-    window.umami && umami.track("404", { url: window.location.pathname });
+    umamiTrack("404", {
+      url: window.location.pathname,
+    });
   }, []);
 
   return (

--- a/aksel.nav.no/website/pages/500.tsx
+++ b/aksel.nav.no/website/pages/500.tsx
@@ -8,6 +8,7 @@ import {
   Page,
   VStack,
 } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import Footer from "@/layout/footer/Footer";
 import Header from "@/layout/header/Header";
 
@@ -15,7 +16,9 @@ function ErrorPage({ statusCode }) {
   const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
-    window.umami && umami.track(statusCode, { url: window.location.pathname });
+    umamiTrack(statusCode, {
+      url: window.location.pathname,
+    });
     setIsClient(true);
   }, [statusCode]);
 

--- a/aksel.nav.no/website/pages/_error.js
+++ b/aksel.nav.no/website/pages/_error.js
@@ -8,6 +8,7 @@ import {
   Page,
   VStack,
 } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import Footer from "@/layout/footer/Footer";
 import Header from "@/layout/header/Header";
 
@@ -15,8 +16,9 @@ function ErrorPage({ statusCode }) {
   const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
-    // eslint-disable-next-line
-    window.umami && umami.track(statusCode, { url: window.location.pathname });
+    umamiTrack(statusCode, {
+      url: window.location.pathname,
+    });
     setIsClient(true);
   }, [statusCode]);
 

--- a/aksel.nav.no/website/pages/god-praksis/index.tsx
+++ b/aksel.nav.no/website/pages/god-praksis/index.tsx
@@ -202,6 +202,7 @@ const GpPage = (props: PageProps["props"]) => {
                             onClick={() =>
                               umamiTrack("navigere", {
                                 kilde: "god praksis forside",
+                                url: `/god-praksis/${tema.slug}`,
                               })
                             }
                           >

--- a/aksel.nav.no/website/pages/god-praksis/index.tsx
+++ b/aksel.nav.no/website/pages/god-praksis/index.tsx
@@ -12,6 +12,7 @@ import {
   Stack,
   VStack,
 } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import Footer from "@/layout/footer/Footer";
 import { GpCardGrid } from "@/layout/god-praksis-page/ArticleSections";
 import GpArticleCard from "@/layout/god-praksis-page/cards/GpArticleCard";
@@ -198,8 +199,11 @@ const GpPage = (props: PageProps["props"]) => {
                             href={`/god-praksis/${tema.slug}`}
                             as={NextLink}
                             className="group mt-4 w-fit text-deepblue-700"
-                            data-umami-event="navigere"
-                            data-umami-event-kilde="god praksis forside"
+                            onClick={() =>
+                              umamiTrack("navigere", {
+                                kilde: "god praksis forside",
+                              })
+                            }
                           >
                             <h3 className="flex items-center">
                               {`Alt fra ${tema.title} `}

--- a/aksel.nav.no/website/pages/komponenter/[...slug].tsx
+++ b/aksel.nav.no/website/pages/komponenter/[...slug].tsx
@@ -1,5 +1,6 @@
 import { GetStaticPaths } from "next/types";
 import { BodyShort, Detail, Heading } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { ChangelogIcon, FigmaIcon, GithubIcon, YarnIcon } from "@/assets/Icons";
 import ComponentOverview from "@/cms/component-overview/ComponentOverview";
 import IntroSeksjon from "@/cms/intro-seksjon/IntroSeksjon";
@@ -190,8 +191,12 @@ const Page = ({
             rel="noreferrer noopener"
             href={pack.git}
             className="flex items-center gap-1 underline hover:text-text-default hover:no-underline focus:bg-blue-800 focus:text-text-on-inverted focus:no-underline focus:shadow-focus focus:outline-none"
-            data-umami-event="navigere"
-            data-umami-event-url={pack.git}
+            onClick={() =>
+              umamiTrack("navigere", {
+                kilde: "komponent-header",
+                url: pack.git,
+              })
+            }
           >
             <GithubIcon /> Github
           </a>
@@ -200,8 +205,12 @@ const Page = ({
             rel="noreferrer noopener"
             href={`https://yarnpkg.com/package/${pack.title}`}
             className="flex items-center gap-1 underline hover:text-text-default hover:no-underline focus:bg-blue-800 focus:text-text-on-inverted focus:no-underline focus:shadow-focus focus:outline-none"
-            data-umami-event="navigere"
-            data-umami-event-url={`https://yarnpkg.com/package/${pack.title}`}
+            onClick={() =>
+              umamiTrack("navigere", {
+                kilde: "komponent-header",
+                url: `https://yarnpkg.com/package/${pack.title}`,
+              })
+            }
           >
             <YarnIcon />
             Yarn
@@ -215,8 +224,12 @@ const Page = ({
           rel="noreferrer noopener"
           href={page.figma_link}
           className="flex items-center gap-1 underline hover:text-text-default hover:no-underline focus:bg-blue-800 focus:text-text-on-inverted focus:no-underline focus:shadow-focus focus:outline-none"
-          data-umami-event="navigere"
-          data-umami-event-url={page.figma_link}
+          onClick={() =>
+            umamiTrack("navigere", {
+              kilde: "komponent-header",
+              url: page.figma_link,
+            })
+          }
         >
           <FigmaIcon /> Figma
         </a>
@@ -227,8 +240,12 @@ const Page = ({
           rel="noreferrer noopener"
           href={pack.changelog}
           className="flex items-center gap-1 underline hover:text-text-default hover:no-underline focus:bg-blue-800 focus:text-text-on-inverted focus:no-underline focus:shadow-focus focus:outline-none"
-          data-umami-event="navigere"
-          data-umami-event-url={pack.changelog}
+          onClick={() =>
+            umamiTrack("navigere", {
+              kilde: "komponent-header",
+              url: pack.changelog,
+            })
+          }
         >
           <ChangelogIcon />
           Endringslogg

--- a/aksel.nav.no/website/pages/komponenter/[...slug].tsx
+++ b/aksel.nav.no/website/pages/komponenter/[...slug].tsx
@@ -227,7 +227,7 @@ const Page = ({
           onClick={() =>
             umamiTrack("navigere", {
               kilde: "komponent-header",
-              url: page.figma_link,
+              url: page.figma_link ?? "",
             })
           }
         >

--- a/aksel.nav.no/website/pages/komponenter/index.tsx
+++ b/aksel.nav.no/website/pages/komponenter/index.tsx
@@ -2,6 +2,7 @@ import cl from "clsx";
 import { GetStaticProps } from "next/types";
 import { CodeIcon } from "@navikt/aksel-icons";
 import { BodyLong, BodyShort, Heading } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import {
   ChangelogIcon,
   FigmaIcon,
@@ -161,8 +162,12 @@ function Links() {
         rel="noreferrer noopener"
         href="https://github.com/navikt/aksel/tree/main/%40navikt"
         className="flex items-center gap-1 underline hover:text-text-on-inverted hover:no-underline focus:bg-border-focus-on-inverted focus:text-text-default focus:no-underline focus:shadow-[0_0_0_2px_var(--a-border-focus-on-inverted)] focus:outline-none"
-        data-umami-event="navigere"
-        data-umami-event-url="https://github.com/navikt/aksel/tree/main/%40navikt"
+        onClick={() =>
+          umamiTrack("navigere", {
+            kilde: "komponent-header",
+            url: "https://github.com/navikt/aksel/tree/main/%40navikt",
+          })
+        }
       >
         <GithubIcon /> Github
       </a>
@@ -171,8 +176,12 @@ function Links() {
         rel="noreferrer noopener"
         href="https://yarnpkg.com/package/@navikt/ds-react"
         className="flex items-center gap-1 underline hover:text-text-on-inverted hover:no-underline focus:bg-border-focus-on-inverted focus:text-text-default focus:no-underline focus:shadow-[0_0_0_2px_var(--a-border-focus-on-inverted)] focus:outline-none"
-        data-umami-event="navigere"
-        data-umami-event-url="https://yarnpkg.com/package/@navikt/ds-react"
+        onClick={() =>
+          umamiTrack("navigere", {
+            kilde: "komponent-header",
+            url: "https://yarnpkg.com/package/@navikt/ds-react",
+          })
+        }
       >
         <YarnIcon />
         Yarn
@@ -182,8 +191,12 @@ function Links() {
         rel="noreferrer noopener"
         href="/grunnleggende/kode/endringslogg"
         className="flex items-center gap-1 underline hover:text-text-on-inverted hover:no-underline focus:bg-border-focus-on-inverted focus:text-text-default focus:no-underline focus:shadow-[0_0_0_2px_var(--a-border-focus-on-inverted)] focus:outline-none"
-        data-umami-event="navigere"
-        data-umami-event-url="/grunnleggende/kode/endringslogg"
+        onClick={() =>
+          umamiTrack("navigere", {
+            kilde: "komponent-header",
+            url: "/grunnleggende/kode/endringslogg",
+          })
+        }
       >
         <ChangelogIcon />
         Endringslogg
@@ -194,8 +207,12 @@ function Links() {
         rel="noreferrer noopener"
         href="https://www.figma.com/@nav_aksel"
         className="flex items-center gap-1 underline hover:text-text-on-inverted hover:no-underline focus:bg-border-focus-on-inverted focus:text-text-default focus:no-underline focus:shadow-[0_0_0_2px_var(--a-border-focus-on-inverted)] focus:outline-none"
-        data-umami-event="navigere"
-        data-umami-event-url="https://www.figma.com/@nav_aksel"
+        onClick={() =>
+          umamiTrack("navigere", {
+            kilde: "komponent-header",
+            url: "https://www.figma.com/@nav_aksel",
+          })
+        }
       >
         <FigmaIcon /> Figma-community
       </a>
@@ -204,7 +221,12 @@ function Links() {
         rel="noreferrer noopener"
         href="/storybook"
         className="group flex items-center gap-1 underline hover:text-text-on-inverted hover:no-underline focus:bg-border-focus-on-inverted focus:text-text-default focus:no-underline focus:shadow-[0_0_0_2px_var(--a-border-focus-on-inverted)] focus:outline-none"
-        data-umami-event="navigere"
+        onClick={() =>
+          umamiTrack("navigere", {
+            kilde: "komponent-header",
+            url: "/storybook",
+          })
+        }
       >
         <StorybookIcon className="mr-1" /> Storybook
       </a>


### PR DESCRIPTION
### Description

This solves the issue where Links and buttons would have their native actions stopped with `preventDefault`.
As a consequence for this happening, if the fetch-request to the Umami-proxy took X seconds, the user would have to wait X seconds (or until it timed out) for anything to move along. By moving the tracking to onClick, the tracking now only acts as a side-effect when navigating. 

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
