### PR TITLE
:bug: `onToggle` prop overlaps with new Popover API

### DIFF
--- a/.changeset/shy-games-sit.md
+++ b/.changeset/shy-games-sit.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+ExpansionCard: Omit `onToggle` from extending `HTMLAttributes<HTMLDivElement>` to avoid overlapping with popover api.

--- a/@navikt/core/react/src/expansion-card/ExpansionCard.tsx
+++ b/@navikt/core/react/src/expansion-card/ExpansionCard.tsx
@@ -48,7 +48,7 @@ interface ExpansionCardComponent
 }
 
 interface ExpansionCardCommonProps
-  extends React.HTMLAttributes<HTMLDivElement> {
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "onToggle"> {
   children: React.ReactNode;
   /**
    * Callback for when Card is toggled open/closed


### PR DESCRIPTION
### Description

https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event
https://nav-it.slack.com/archives/C7NE7A8UF/p1746451266236419

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
