### PR TITLE
Bugfix/CopyButton avoid layout shift for multi lined texts

### DIFF
--- a/.changeset/ready-points-say.md
+++ b/.changeset/ready-points-say.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+CopyButton: Fix issue with UI shift when copying with a multi-line button

--- a/@navikt/core/css/copybutton.css
+++ b/@navikt/core/css/copybutton.css
@@ -25,7 +25,8 @@
   border-radius: var(--ac-copybutton-border-radius, var(--a-border-radius-medium));
   padding: var(--__ac-copybutton-padding);
   display: grid;
-  place-content: center;
+  place-content: flex-start;
+  align-content: center;
 }
 
 @media (forced-colors: active) {
@@ -188,6 +189,7 @@
   align-items: center;
   justify-content: center;
   gap: var(--a-spacing-2);
+  text-align: start;
 }
 
 .navds-copybutton--small > .navds-copybutton__content {

--- a/@navikt/core/react/src/copybutton/CopyButton.stories.tsx
+++ b/@navikt/core/react/src/copybutton/CopyButton.stories.tsx
@@ -151,11 +151,19 @@ export const Texts: Story = {
           activeText="Kopierte XYZ"
         />
       </div>
-      <div>
+      <div
+        style={{
+          width: "350px",
+          display: "flex",
+          flexDirection: "column",
+          gap: "1rem",
+          alignItems: "flex-start",
+        }}
+      >
         <CopyButton
           copyText="3.14"
-          text="Kopier en veldig lang tekst som ikke får plass"
-          activeText="Kopierte XYZ"
+          text="Kopier en veldig lang tekst som brekker over flere linjer"
+          activeText="Kopierte teksten uten layout-shift"
           iconPosition="right"
         />
       </div>

--- a/@navikt/core/react/src/copybutton/CopyButton.stories.tsx
+++ b/@navikt/core/react/src/copybutton/CopyButton.stories.tsx
@@ -151,6 +151,14 @@ export const Texts: Story = {
           activeText="Kopierte XYZ"
         />
       </div>
+      <div>
+        <CopyButton
+          copyText="3.14"
+          text="Kopier en veldig lang tekst som ikke får plass"
+          activeText="Kopierte XYZ"
+          iconPosition="right"
+        />
+      </div>
     </div>
   ),
 };

--- a/@navikt/core/react/src/copybutton/CopyButton.tsx
+++ b/@navikt/core/react/src/copybutton/CopyButton.tsx
@@ -175,7 +175,7 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
           size={size}
           style={
             fixedSize
-              ? { height: fixedSize.height, width: fixedSize.width }
+              ? { minHeight: fixedSize.height, minWidth: fixedSize.width }
               : undefined
           }
         >

--- a/@navikt/core/react/src/copybutton/CopyButton.tsx
+++ b/@navikt/core/react/src/copybutton/CopyButton.tsx
@@ -190,7 +190,6 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
         type="button"
         {...rest}
         className={cn(
-          "tull",
           "navds-copybutton",
           className,
           `navds-copybutton--${size}`,

--- a/@navikt/core/react/src/copybutton/CopyButton.tsx
+++ b/@navikt/core/react/src/copybutton/CopyButton.tsx
@@ -11,6 +11,7 @@ import { useRenameCSS, useThemeInternal } from "../theme/Theme";
 import { Label } from "../typography";
 import { composeEventHandlers } from "../util/composeEventHandlers";
 import copy from "../util/copy";
+import { mergeRefs } from "../util/hooks/useMergeRefs";
 import { useI18n } from "../util/i18n/i18n.hooks";
 
 export interface CopyButtonProps
@@ -96,6 +97,11 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
     const [active, setActive] = useState(false);
     const timeoutRef = useRef<number>();
     const translate = useI18n("CopyButton");
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const mergedRef = mergeRefs([buttonRef, ref]);
+    const [fixedSize, setFixedSize] = useState<
+      { width: number; height: number } | undefined
+    >(undefined);
 
     const { cn } = useRenameCSS();
 
@@ -105,6 +111,15 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
       return () => {
         timeoutRef.current && clearTimeout(timeoutRef.current);
       };
+    }, []);
+
+    useEffect(() => {
+      if (buttonRef?.current) {
+        setFixedSize({
+          height: buttonRef?.current.offsetHeight,
+          width: buttonRef?.current.offsetWidth,
+        });
+      }
     }, []);
 
     const handleClick = () => {
@@ -148,7 +163,7 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
     if (themeContext) {
       return (
         <Button
-          ref={ref}
+          ref={mergedRef}
           type="button"
           className={cn("navds-copybutton", className)}
           {...rest}
@@ -158,6 +173,11 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
           icon={copyIcon}
           data-active={active}
           size={size}
+          style={
+            fixedSize
+              ? { height: fixedSize.height, width: fixedSize.width }
+              : undefined
+          }
         >
           {text ? (active ? activeString : text) : null}
         </Button>
@@ -166,10 +186,11 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
 
     return (
       <button
-        ref={ref}
+        ref={mergedRef}
         type="button"
         {...rest}
         className={cn(
+          "tull",
           "navds-copybutton",
           className,
           `navds-copybutton--${size}`,
@@ -181,6 +202,11 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
           },
         )}
         onClick={composeEventHandlers(onClick, handleClick)}
+        style={
+          fixedSize
+            ? { minHeight: fixedSize.height, minWidth: fixedSize.width }
+            : undefined
+        }
       >
         <span className={cn("navds-copybutton__content")}>
           {iconPosition === "left" && copyIcon}


### PR DESCRIPTION
### Description

On the new token page, we have a CopyButton for copying the tokens. In some cases, the text wraps over two lines.
However, when copying,  the active text is single-line, causing the UI to "jump". This PR fixes that by adding a minHeight and minWidth after first render.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [X] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [X] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
