### PR TITLE
:memo: Deprecate ConfirmationPanel

### DIFF
--- a/.changeset/chatty-things-yawn.md
+++ b/.changeset/chatty-things-yawn.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+ConfirmationPanel: Now tagges as deprecated. [See documentation](https://aksel.nav.no/komponenter/legacy/confirmationpanel#99622218e7f0) for more information.

--- a/.changeset/chatty-things-yawn.md
+++ b/.changeset/chatty-things-yawn.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-ConfirmationPanel: Now tagges as deprecated. [See documentation](https://aksel.nav.no/komponenter/legacy/confirmationpanel#99622218e7f0) for more information.
+ConfirmationPanel: Now tagged as deprecated. [See documentation](https://aksel.nav.no/komponenter/legacy/confirmationpanel#99622218e7f0) for more information.

--- a/@navikt/core/react/src/form/confirmation-panel/ConfirmationPanel.tsx
+++ b/@navikt/core/react/src/form/confirmation-panel/ConfirmationPanel.tsx
@@ -31,6 +31,7 @@ export interface ConfirmationPanelProps
 
 /**
  * A component that displays a confirmation checkbox with a label.
+ * @deprecated Use `Checkbox` instead. See [new pattern documentation](https://aksel.nav.no/monster-maler/soknadsdialog/introside-for-soknadsdialoger#8346a8cb849b) for more information.
  *
  * @see [📝 Documentation](https://aksel.nav.no/komponenter/core/confirmationpanel)
  * @see 🏷️ {@link ConfirmationPanelProps}


### PR DESCRIPTION
### Description

https://github.com/navikt/team-aksel/issues/707

https://aksel.nav.no/komponenter/legacy/confirmationpanel#99622218e7f0

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
