### PR TITLE
:tada: Allow data-color-role to override Tag variant prop.

### DIFF
--- a/.changeset/dirty-plants-speak.md
+++ b/.changeset/dirty-plants-speak.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Darkside: Let data-color-role override variable defined in Tag-component.

--- a/.changeset/dirty-plants-speak.md
+++ b/.changeset/dirty-plants-speak.md
@@ -1,5 +1,6 @@
 ---
 "@navikt/ds-css": patch
+"@navikt/ds-react": patch
 ---
 
-Darkside: Let data-color-role override variable defined in Tag-component.
+Darkside: Let data-color-role override variant defined in Tag-component.

--- a/@navikt/core/css/darkside/tag.darkside.css
+++ b/@navikt/core/css/darkside/tag.darkside.css
@@ -3,7 +3,6 @@
   --__axc-tag-icon-margin: -2px;
   --__axc-tag-border: ;
   --__axc-tag-bg: ;
-  --__axc-tag-bg-strong: ;
   --__axc-tag-text: ;
   --__axc-tag-text-strong: ;
 
@@ -21,23 +20,28 @@
   }
 
   &[data-variant="outline"] {
-    box-shadow: inset 0 0 0 1px var(--ax-border-default, var(--__axc-tag-border));
-    background: var(--ax-bg-moderateA, var(--__axc-tag-bg));
-    color: var(--ax-text-default, var(--__axc-tag-text));
+    box-shadow: inset 0 0 0 1px var(--ax-border-default);
+    background: var(--ax-bg-moderateA);
+    color: var(--ax-text-default);
+
+    @media (forced-colors: active) {
+      color: canvastext;
+    }
   }
 
   &[data-variant="moderate"] {
-    background: var(--ax-bg-moderateA, var(--__axc-tag-bg));
-    color: var(--ax-text-default, var(--__axc-tag-text));
+    background: var(--ax-bg-moderateA);
+    color: var(--ax-text-default);
 
     @media (forced-colors: active) {
-      box-shadow: inset 0 0 0 1px var(--__axc-tag-bg-strong);
+      box-shadow: inset 0 0 0 1px var(--ax-bg-strong);
+      color: canvastext;
     }
   }
 
   &[data-variant="strong"] {
-    background: var(--ax-bg-strong, var(--__axc-tag-bg-strong));
-    color: var(--ax-text-contrast, var(--__axc-tag-text-strong));
+    background: var(--ax-bg-strong);
+    color: var(--ax-text-contrast);
 
     @media (forced-colors: active) {
       color: canvas;

--- a/@navikt/core/css/darkside/tag.darkside.css
+++ b/@navikt/core/css/darkside/tag.darkside.css
@@ -102,19 +102,19 @@
 }
 
 .aksel-tag--outline {
-  box-shadow: inset 0 0 0 1px var(--__axc-tag-border);
-  background: var(--__axc-tag-bg);
-  color: var(--__axc-tag-text);
+  box-shadow: inset 0 0 0 1px var(--ax-border-default, var(--__axc-tag-border));
+  background: var(--ax-bg-moderateA, var(--__axc-tag-bg));
+  color: var(--ax-text-default, var(--__axc-tag-text));
 }
 
 .aksel-tag--moderate {
-  background: var(--__axc-tag-bg);
-  color: var(--__axc-tag-text);
+  background: var(--ax-bg-moderateA, var(--__axc-tag-bg));
+  color: var(--ax-text-default, var(--__axc-tag-text));
 }
 
 .aksel-tag--strong {
-  background: var(--__axc-tag-bg-strong);
-  color: var(--__axc-tag-text-strong);
+  background: var(--ax-bg-strong, var(--__axc-tag-bg-strong));
+  color: var(--ax-text-contrast, var(--__axc-tag-text-strong));
 }
 
 @media (forced-colors: active) {

--- a/@navikt/core/css/darkside/tag.darkside.css
+++ b/@navikt/core/css/darkside/tag.darkside.css
@@ -19,65 +19,35 @@
   &:has(.aksel-tag__icon--left) {
     gap: var(--ax-space-2);
   }
-}
 
-.aksel-tag--info,
-.aksel-tag--alt3 {
-  --__axc-tag-border: var(--ax-border-info);
-  --__axc-tag-bg: var(--ax-bg-info-moderateA);
-  --__axc-tag-bg-strong: var(--ax-bg-info-strong);
-  --__axc-tag-text: var(--ax-text-info);
-  --__axc-tag-text-strong: var(--ax-text-info-contrast);
-}
+  &[data-variant="outline"] {
+    box-shadow: inset 0 0 0 1px var(--ax-border-default, var(--__axc-tag-border));
+    background: var(--ax-bg-moderateA, var(--__axc-tag-bg));
+    color: var(--ax-text-default, var(--__axc-tag-text));
+  }
 
-.aksel-tag--success {
-  --__axc-tag-border: var(--ax-border-success);
-  --__axc-tag-bg: var(--ax-bg-success-moderateA);
-  --__axc-tag-bg-strong: var(--ax-bg-success-strong);
-  --__axc-tag-text: var(--ax-text-success);
-  --__axc-tag-text-strong: var(--ax-text-success-contrast);
-}
+  &[data-variant="moderate"] {
+    background: var(--ax-bg-moderateA, var(--__axc-tag-bg));
+    color: var(--ax-text-default, var(--__axc-tag-text));
 
-.aksel-tag--warning {
-  --__axc-tag-border: var(--ax-border-warning);
-  --__axc-tag-bg: var(--ax-bg-warning-moderateA);
-  --__axc-tag-bg-strong: var(--ax-bg-warning-strong);
-  --__axc-tag-text: var(--ax-text-warning);
-  --__axc-tag-text-strong: var(--ax-text-warning-contrast);
-}
+    @media (forced-colors: active) {
+      box-shadow: inset 0 0 0 1px var(--__axc-tag-bg-strong);
+    }
+  }
 
-.aksel-tag--error {
-  --__axc-tag-border: var(--ax-border-danger);
-  --__axc-tag-bg: var(--ax-bg-danger-moderateA);
-  --__axc-tag-bg-strong: var(--ax-bg-danger-strong);
-  --__axc-tag-text: var(--ax-text-danger);
-  --__axc-tag-text-strong: var(--ax-text-danger-contrast);
-}
+  &[data-variant="strong"] {
+    background: var(--ax-bg-strong, var(--__axc-tag-bg-strong));
+    color: var(--ax-text-contrast, var(--__axc-tag-text-strong));
 
-.aksel-tag--neutral {
-  --__axc-tag-border: var(--ax-border-neutral);
-  --__axc-tag-bg: var(--ax-bg-neutral-moderateA);
-  --__axc-tag-bg-strong: var(--ax-bg-neutral-strong);
-  --__axc-tag-text: var(--ax-text-neutral);
-  --__axc-tag-text-strong: var(--ax-text-neutral-contrast);
-}
+    @media (forced-colors: active) {
+      color: canvas;
+    }
+  }
 
-.aksel-tag--meta-purple,
-.aksel-tag--alt1 {
-  --__axc-tag-border: var(--ax-border-meta-purple);
-  --__axc-tag-bg: var(--ax-bg-meta-purple-moderateA);
-  --__axc-tag-bg-strong: var(--ax-bg-meta-purple-strong);
-  --__axc-tag-text: var(--ax-text-meta-purple);
-  --__axc-tag-text-strong: var(--ax-text-meta-purple-contrast);
-}
-
-.aksel-tag--meta-lime,
-.aksel-tag--alt2 {
-  --__axc-tag-border: var(--ax-border-meta-lime);
-  --__axc-tag-bg: var(--ax-bg-meta-lime-moderateA);
-  --__axc-tag-bg-strong: var(--ax-bg-meta-lime-strong);
-  --__axc-tag-text: var(--ax-text-meta-lime);
-  --__axc-tag-text-strong: var(--ax-text-meta-lime-contrast);
+  @media (forced-colors: active) {
+    forced-color-adjust: none;
+    color: canvastext;
+  }
 }
 
 .aksel-tag--small {
@@ -99,35 +69,4 @@
   font-size: var(--__axc-tag-icon-size);
   margin-inline-start: var(--__axc-tag-icon-margin);
   display: flex;
-}
-
-.aksel-tag--outline {
-  box-shadow: inset 0 0 0 1px var(--ax-border-default, var(--__axc-tag-border));
-  background: var(--ax-bg-moderateA, var(--__axc-tag-bg));
-  color: var(--ax-text-default, var(--__axc-tag-text));
-}
-
-.aksel-tag--moderate {
-  background: var(--ax-bg-moderateA, var(--__axc-tag-bg));
-  color: var(--ax-text-default, var(--__axc-tag-text));
-}
-
-.aksel-tag--strong {
-  background: var(--ax-bg-strong, var(--__axc-tag-bg-strong));
-  color: var(--ax-text-contrast, var(--__axc-tag-text-strong));
-}
-
-@media (forced-colors: active) {
-  .aksel-tag {
-    forced-color-adjust: none;
-    color: canvastext;
-  }
-
-  .aksel-tag--moderate {
-    box-shadow: inset 0 0 0 1px var(--__axc-tag-bg-strong);
-  }
-
-  .aksel-tag--strong {
-    color: canvas;
-  }
 }

--- a/@navikt/core/react/src/tag/Tag.tsx
+++ b/@navikt/core/react/src/tag/Tag.tsx
@@ -1,4 +1,5 @@
 import React, { HTMLAttributes, forwardRef } from "react";
+import { GlobalColorRoles } from "@navikt/ds-tokens/types";
 import { useRenameCSS } from "../theme/Theme";
 import { BodyShort } from "../typography";
 
@@ -70,6 +71,7 @@ export const Tag = forwardRef<HTMLSpanElement, TagProps>(
 
     return (
       <BodyShort
+        data-color-role={variantToRole(variant)}
         {...rest}
         ref={ref}
         as="span"
@@ -89,5 +91,43 @@ export const Tag = forwardRef<HTMLSpanElement, TagProps>(
     );
   },
 );
+
+function variantToRole(variant: TagProps["variant"]): GlobalColorRoles {
+  switch (variant) {
+    case "warning":
+    case "warning-filled":
+    case "warning-moderate":
+      return "warning";
+    case "error":
+    case "error-filled":
+    case "error-moderate":
+      return "danger";
+    case "info":
+    case "info-filled":
+    case "info-moderate":
+    case "alt3":
+    case "alt3-filled":
+    case "alt3-moderate":
+      return "info";
+    case "success":
+    case "success-filled":
+    case "success-moderate":
+      return "success";
+    case "neutral":
+    case "neutral-filled":
+    case "neutral-moderate":
+      return "neutral";
+    case "alt1":
+    case "alt1-filled":
+    case "alt1-moderate":
+      return "meta-purple";
+    case "alt2":
+    case "alt2-filled":
+    case "alt2-moderate":
+      return "meta-lime";
+    default:
+      return "neutral";
+  }
+}
 
 export default Tag;

--- a/@navikt/core/react/src/tag/Tag.tsx
+++ b/@navikt/core/react/src/tag/Tag.tsx
@@ -67,11 +67,11 @@ export const Tag = forwardRef<HTMLSpanElement, TagProps>(
     const { cn } = useRenameCSS();
     const filledVariant = variant?.endsWith("-filled") && "strong";
     const moderateVariant = variant?.endsWith("-moderate") && "moderate";
-    const color = variant?.replace("-filled", "").replace("-moderate", "");
 
     return (
       <BodyShort
         data-color-role={variantToRole(variant)}
+        data-variant={filledVariant || moderateVariant || "outline"}
         {...rest}
         ref={ref}
         as="span"
@@ -81,8 +81,6 @@ export const Tag = forwardRef<HTMLSpanElement, TagProps>(
           className,
           `navds-tag--${variant}`,
           `navds-tag--${size}`,
-          `navds-tag--${filledVariant || moderateVariant || "outline"}`,
-          `navds-tag--${color}`,
         )}
       >
         {icon && <span className={cn("navds-tag__icon--left")}>{icon}</span>}

--- a/@navikt/core/react/src/tag/tag.stories.tsx
+++ b/@navikt/core/react/src/tag/tag.stories.tsx
@@ -113,6 +113,18 @@ export const Variants: StoryFn<Story> = () => {
   );
 };
 
+export const VariantsWithAccentRoleOverride: StoryFn<Story> = () => {
+  return (
+    <div className="rowgap rowgap-wrap">
+      {variants.map((variant) => (
+        <div key={variant} data-color-role="accent">
+          <Tag variant={variant}>{variant}</Tag>
+        </div>
+      ))}
+    </div>
+  );
+};
+
 export const WithIcons: StoryFn<Story> = () => {
   return (
     <HStack gap="2" align="start">

--- a/@navikt/core/react/src/tag/tag.stories.tsx
+++ b/@navikt/core/react/src/tag/tag.stories.tsx
@@ -117,9 +117,9 @@ export const VariantsWithAccentRoleOverride: StoryFn<Story> = () => {
   return (
     <div className="rowgap rowgap-wrap">
       {variants.map((variant) => (
-        <div key={variant} data-color-role="accent">
-          <Tag variant={variant}>{variant}</Tag>
-        </div>
+        <Tag key={variant} variant={variant} data-color-role="accent">
+          {variant}
+        </Tag>
       ))}
     </div>
   );


### PR DESCRIPTION
### Description

This demonstrates the result if data-color-role is defined
![Screenshot 2025-05-15 at 20 06 28](https://github.com/user-attachments/assets/bfea5f6c-a77a-44e8-a532-4897d3a9b444)

https://github.com/navikt/team-aksel/issues/693?issue=navikt%7Cteam-aksel%7C738


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
