### PR TITLE
:lipstick: ErrorSummary heading is now size 'xsmall' on smaller sizes

### DIFF
--- a/.changeset/grumpy-melons-grab.md
+++ b/.changeset/grumpy-melons-grab.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+ErrorSummary: Heading is now 'xsmall' with size='small'".

--- a/.changeset/grumpy-melons-grab.md
+++ b/.changeset/grumpy-melons-grab.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-ErrorSummary: Heading is now 'xsmall' with size='small'".
+ErrorSummary: Heading size is now 'xsmall' for non-medium sizes and remains 'small' when size='medium'.

--- a/@navikt/core/react/src/form/error-summary/ErrorSummary.tsx
+++ b/@navikt/core/react/src/form/error-summary/ErrorSummary.tsx
@@ -105,7 +105,7 @@ export const ErrorSummary = forwardRef<HTMLDivElement, ErrorSummaryProps>(
         <Heading
           className={cn("navds-error-summary__heading")}
           as={headingTag}
-          size="small"
+          size={size === "medium" ? "small" : "xsmall"}
           ref={headingRef}
           tabIndex={-1}
         >


### PR DESCRIPTION
### Description

https://www.figma.com/design/QlKvEaiyqGTnXcWsD8NvCp?node-id=2897-27463#1258321902

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
