### PR TITLE
Fix Storybook warning about addon order

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -51,6 +51,15 @@ export default {
     "../aksel.nav.no/website/pages/templates/**/*.tsx",
   ],
   addons: [
+    {
+      name: "@storybook/addon-essentials",
+      options: {
+        actions: false,
+        controls: {
+          hideNoControlsWarning: true,
+        },
+      },
+    },
     "@storybook/addon-a11y",
     "@storybook/addon-interactions",
     "@storybook/addon-themes",
@@ -59,15 +68,6 @@ export default {
       options: {
         loaderOptions: {
           injectStoryParameters: false,
-        },
-      },
-    },
-    {
-      name: "@storybook/addon-essentials",
-      options: {
-        actions: false,
-        controls: {
-          hideNoControlsWarning: true,
         },
       },
     },


### PR DESCRIPTION
Fixes this warning: `Expected '@storybook/addon-actions' (or '@storybook/addon-essentials') to be listed before '@storybook/addon-interactions' in main Storybook config.`

Also changes the visual order in the UI, but I think it's better to have "Controls" first anyways.

Before:
![image](https://github.com/user-attachments/assets/45f20ae3-f33a-4a38-bab0-ab808280e852)

After:
![image](https://github.com/user-attachments/assets/0f0ef0f9-2e09-43b0-9109-75bbb9916840)
