### PR TITLE
:lipstick: Accent is now set as default base color theme

### DIFF
--- a/.changeset/plenty-areas-lick.md
+++ b/.changeset/plenty-areas-lick.md
@@ -2,4 +2,4 @@
 "@navikt/ds-tokens": minor
 ---
 
-Darkside: Accent is not set as default 'base' color theme.
+Darkside: Set accent as default base color theme.

--- a/.changeset/plenty-areas-lick.md
+++ b/.changeset/plenty-areas-lick.md
@@ -2,4 +2,4 @@
 "@navikt/ds-tokens": minor
 ---
 
-Darkside: Set accent as default base color theme.
+Darkside: Set accent color-role as the default color palette.

--- a/.changeset/plenty-areas-lick.md
+++ b/.changeset/plenty-areas-lick.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-tokens": minor
+---
+
+Darkside: Accent is not set as default 'base' color theme.

--- a/@navikt/core/tokens/darkside/index.ts
+++ b/@navikt/core/tokens/darkside/index.ts
@@ -146,7 +146,10 @@ async function buildThemedRolesCSS() {
       /* mergeConfigs is strictly typed, so we use any until we potentially update types */
       tokens: tokensWithPrefix(mergeConfigs(config as any)),
       filename: `role-${role}.css`,
-      selector: `[data-color-role=${role}]`,
+      selector:
+        role === "accent"
+          ? `:root, [data-color-role=${role}]`
+          : `[data-color-role=${role}]`,
       filter: async (token) => token.type === "themed-role",
     });
   }

--- a/@navikt/core/tokens/darkside/index.ts
+++ b/@navikt/core/tokens/darkside/index.ts
@@ -135,6 +135,11 @@ async function main() {
  * ```
  */
 async function buildThemedRolesCSS() {
+  /**
+   * We set 'accent' as the default base-theme.
+   */
+  const rootSelector = `:root, [data-color-role=accent]`;
+
   for (const role of ColorRolesList) {
     const config = [
       globalLightTokens,
@@ -146,10 +151,7 @@ async function buildThemedRolesCSS() {
       /* mergeConfigs is strictly typed, so we use any until we potentially update types */
       tokens: tokensWithPrefix(mergeConfigs(config as any)),
       filename: `role-${role}.css`,
-      selector:
-        role === "accent"
-          ? `:root, [data-color-role=${role}]`
-          : `[data-color-role=${role}]`,
+      selector: role === "accent" ? rootSelector : `[data-color-role=${role}]`,
       filter: async (token) => token.type === "themed-role",
     });
   }

--- a/@navikt/core/tokens/darkside/index.ts
+++ b/@navikt/core/tokens/darkside/index.ts
@@ -136,7 +136,7 @@ async function main() {
  */
 async function buildThemedRolesCSS() {
   /**
-   * We set 'accent' as the default base-theme.
+   * We set 'accent' as the default color palette.
    */
   const rootSelector = `:root, [data-color-role=accent]`;
 


### PR DESCRIPTION
### Description

This makes sure one does not end up with unstyled 'based theming' tokens used, and allows for updating all relevant components on the basis that a 'default' color exist.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
