### PR TITLE
Exclude dependencies from changelog generation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.2.0/schema.json",
-  "changelog": [
-    "@svitejs/changesets-changelog-github-compact",
-    { "repo": "navikt/aksel" }
-  ],
+  "changelog": ["./generate-changelog-line.js", { "repo": "navikt/aksel" }],
   "commit": false,
   "fixed": [
     [

--- a/.changeset/generate-changelog-line.js
+++ b/.changeset/generate-changelog-line.js
@@ -1,0 +1,20 @@
+// https://github.com/changesets/changesets/blob/main/docs/modifying-changelog-format.md
+
+const svitejsChangelogFunctions = require("@svitejs/changesets-changelog-github-compact");
+
+const getDependencyReleaseLine = async () => {
+  /*
+  Would normally generate something like this:
+  ```
+    - Updated dependencies []:
+      - @navikt/ds-tokens@7.18.0
+      - @navikt/aksel-icons@7.18.0
+  ```
+  */
+  return "";
+};
+
+module.exports = {
+  getReleaseLine: svitejsChangelogFunctions.default.getReleaseLine,
+  getDependencyReleaseLine,
+};


### PR DESCRIPTION
We have to be sure that we want to do this, since it would probably be hard to add back missing entries later.

Question: Should we remove the existing "Updated dependencies" entries in the changelogs, so that we can remove the code for this in createMainChangelog.ts?