### PR TITLE
:bug: Reverted regression that lead to 'aria-controls' being ignored

### DIFF
--- a/.changeset/cold-trams-send.md
+++ b/.changeset/cold-trams-send.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Timeline: Reverted regression that lead to 'aria-controls' being ignored when passed to Pin or Period.

--- a/@navikt/core/react/src/timeline/Pin.tsx
+++ b/@navikt/core/react/src/timeline/Pin.tsx
@@ -11,7 +11,6 @@ import {
   useFocus,
   useHover,
   useInteractions,
-  useRole,
 } from "@floating-ui/react";
 import { format } from "date-fns";
 import React, { forwardRef, useRef, useState } from "react";
@@ -79,7 +78,6 @@ export const Pin = forwardRef<HTMLButtonElement, TimelinePinProps>(
     });
     const focus = useFocus(context);
     const dismiss = useDismiss(context);
-    const role = useRole(context, { role: "dialog" });
 
     const { getFloatingProps, getReferenceProps } = useInteractions([
       hover,
@@ -112,6 +110,7 @@ export const Pin = forwardRef<HTMLButtonElement, TimelinePinProps>(
             })}
             type="button"
             aria-expanded={children ? open : undefined}
+            aria-haspopup={children ? "true" : "false"}
             {...getReferenceProps({
               onKeyDown: (e) => {
                 rest?.onKeyDown?.(e as React.KeyboardEvent<HTMLButtonElement>);

--- a/@navikt/core/react/src/timeline/Pin.tsx
+++ b/@navikt/core/react/src/timeline/Pin.tsx
@@ -83,7 +83,6 @@ export const Pin = forwardRef<HTMLButtonElement, TimelinePinProps>(
       hover,
       focus,
       dismiss,
-      role,
     ]);
 
     const mergedRef = useMergeRefs(refs.setReference, ref);
@@ -134,6 +133,7 @@ export const Pin = forwardRef<HTMLButtonElement, TimelinePinProps>(
               className={cn("navds-timeline__popover")}
               data-placement={placement}
               ref={refs.setFloating}
+              role="dialog"
               {...getFloatingProps()}
               style={floatingStyles}
             >

--- a/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
@@ -167,6 +167,7 @@ const ClickablePeriod = React.memo(
               className={cn("navds-timeline__popover")}
               data-placement={placement}
               ref={refs.setFloating}
+              role="dialog"
               {...getFloatingProps()}
               style={floatingStyles}
             >

--- a/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
@@ -11,7 +11,6 @@ import {
   useFocus,
   useHover,
   useInteractions,
-  useRole,
 } from "@floating-ui/react";
 import React, { useRef, useState } from "react";
 import { useRenameCSS, useThemeInternal } from "../../theme/Theme";
@@ -91,13 +90,11 @@ const ClickablePeriod = React.memo(
     });
     const focus = useFocus(context);
     const dismiss = useDismiss(context);
-    const role = useRole(context, { role: "dialog" });
 
     const { getFloatingProps, getReferenceProps } = useInteractions([
       hover,
       focus,
       dismiss,
-      role,
     ]);
 
     const mergedRef = useMergeRefs(refs.setReference, periodRef);
@@ -129,6 +126,7 @@ const ClickablePeriod = React.memo(
           )}
           aria-expanded={children ? open : undefined}
           aria-current={isActive || undefined}
+          aria-haspopup={children ? "true" : "false"}
           {...getReferenceProps({
             onFocus: () => {
               initiate(index);


### PR DESCRIPTION
### Description

This was caused by the `useRole`-hook being updated a few weeks ago. Since we mostly skip using most of the features from the hook itself, we can manually add role and haspopup.

https://github.com/floating-ui/floating-ui/blob/master/packages/react/src/hooks/useRole.ts

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
