### PR TITLE
Adjust form validation pattern examples

### DIFF
--- a/aksel.nav.no/website/pages/templates/skjemavalidering/demo.tsx
+++ b/aksel.nav.no/website/pages/templates/skjemavalidering/demo.tsx
@@ -101,8 +101,6 @@ const Example = () => {
             error={errors.fødselsnummer}
           />
           <RadioGroup
-            id="transportmiddel"
-            tabIndex={-1}
             legend="Transportmiddel"
             value={values.transportmiddel}
             onChange={(newValue) => {
@@ -111,7 +109,9 @@ const Example = () => {
             }}
             error={errors.transportmiddel}
           >
-            <Radio value="car">Bil</Radio>
+            <Radio value="car" id="transportmiddel">
+              Bil
+            </Radio>
             <Radio value="walking">Gange</Radio>
             <Radio value="public">Kollektivtransport</Radio>
           </RadioGroup>

--- a/aksel.nav.no/website/pages/templates/skjemavalidering/react-hook-form.tsx
+++ b/aksel.nav.no/website/pages/templates/skjemavalidering/react-hook-form.tsx
@@ -77,8 +77,6 @@ const Example = () => {
             })}
           />
           <RadioGroup
-            id="transportmiddel"
-            tabIndex={-1}
             legend="Transportmiddel"
             error={errors.transportmiddel?.message}
             onChange={() => trigger("transportmiddel")}
@@ -87,6 +85,7 @@ const Example = () => {
             {["Bil", "Gange", "Kollektivtransport"].map((value) => (
               <Radio
                 key={value}
+                id={value === "Bil" ? "transportmiddel" : undefined}
                 value={value}
                 {...register("transportmiddel", {
                   required: "Du må velge et transportmiddel.",


### PR DESCRIPTION
Focusing the fieldset didn't work with Jaws. This should work better.