### PR TITLE
[Darkside] Base theming components part 4

### DIFF
--- a/@navikt/core/react/src/alert/Alert.tsx
+++ b/@navikt/core/react/src/alert/Alert.tsx
@@ -8,7 +8,7 @@ import {
 } from "@navikt/aksel-icons";
 import { Button } from "../button";
 import { useRenameCSS } from "../theme/Theme";
-import { AkselColors } from "../types";
+import { AkselColor } from "../types";
 import { BodyLong } from "../typography";
 import { useI18n } from "../util/i18n/i18n.hooks";
 
@@ -145,7 +145,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
   },
 );
 
-function variantToRole(variant: AlertProps["variant"]): AkselColors {
+function variantToRole(variant: AlertProps["variant"]): AkselColor {
   switch (variant) {
     case "warning":
       return "warning";

--- a/@navikt/core/react/src/button/Button.tsx
+++ b/@navikt/core/react/src/button/Button.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from "react";
 import { Loader } from "../loader";
 import { useRenameCSS } from "../theme/Theme";
-import { AkselColors } from "../types";
+import { AkselColor } from "../types";
 import { Label } from "../typography";
 import { omit } from "../util";
 import { composeEventHandlers } from "../util/composeEventHandlers";
@@ -132,7 +132,7 @@ export const Button: OverridableComponent<ButtonProps, HTMLButtonElement> =
 
 function variantToColor(
   variant: ButtonProps["variant"],
-): AkselColors | undefined {
+): AkselColor | undefined {
   switch (variant) {
     case "primary-neutral":
     case "secondary-neutral":

--- a/@navikt/core/react/src/chat/Chat.tsx
+++ b/@navikt/core/react/src/chat/Chat.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes, forwardRef } from "react";
 import { useRenameCSS } from "../theme/Theme";
-import { AkselColors } from "../types";
+import { AkselColor } from "../types";
 import { BodyLong, HeadingProps } from "../typography";
 import Bubble from "./Bubble";
 
@@ -143,7 +143,7 @@ export const Chat = forwardRef<HTMLDivElement, ChatProps>(
   },
 ) as ChatComponent;
 
-function variantToColor(variant: ChatProps["variant"]): AkselColors {
+function variantToColor(variant: ChatProps["variant"]): AkselColor {
   switch (variant) {
     case "neutral":
       return "neutral";

--- a/@navikt/core/react/src/chips/Removable.tsx
+++ b/@navikt/core/react/src/chips/Removable.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from "react";
 import { XMarkIcon } from "@navikt/aksel-icons";
 import { useRenameCSS, useThemeInternal } from "../theme/Theme";
-import { AkselColors } from "../types";
+import { AkselColor } from "../types";
 import { composeEventHandlers } from "../util/composeEventHandlers";
 import { useI18n } from "../util/i18n/i18n.hooks";
 
@@ -75,7 +75,7 @@ export const RemovableChips = forwardRef<
 
 function variantToColor(
   variant?: ChipsRemovableProps["variant"],
-): AkselColors | undefined {
+): AkselColor | undefined {
   switch (variant) {
     case "action":
       return "accent";

--- a/@navikt/core/react/src/chips/Toggle.tsx
+++ b/@navikt/core/react/src/chips/Toggle.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from "react";
 import { useRenameCSS, useThemeInternal } from "../theme/Theme";
-import { AkselColors } from "../types";
+import { AkselColor } from "../types";
 import { OverridableComponent } from "../util/types";
 
 export interface ChipsToggleProps
@@ -99,7 +99,7 @@ export const ToggleChips: OverridableComponent<
 
 function variantToColor(
   variant?: ChipsToggleProps["variant"],
-): AkselColors | undefined {
+): AkselColor | undefined {
   switch (variant) {
     case "action":
       return "accent";

--- a/@navikt/core/react/src/layout/box/Box.darkside.tsx
+++ b/@navikt/core/react/src/layout/box/Box.darkside.tsx
@@ -1,10 +1,10 @@
 import React, { forwardRef } from "react";
 import type {
-  AkselBaseBackgroundTokens,
-  AkselBaseBorderTokens,
-  AkselColoredBorderTokens,
-  AkselColoredStaticBackgroundTokens,
-  AkselShadowTokens,
+  AkselColoredBorderToken,
+  AkselColoredStatelessBackgroundToken,
+  AkselRootBackgroundToken,
+  AkselRootBorderToken,
+  AkselShadowToken,
 } from "@navikt/ds-tokens/types";
 import { Slot } from "../../slot/Slot";
 import { useRenameCSS } from "../../theme/Theme";
@@ -28,15 +28,15 @@ export type BoxNewProps = React.HTMLAttributes<HTMLDivElement> & {
    * Accepts a [background/surface color token](https://aksel.nav.no/grunnleggende/styling/design-tokens#afff774dad80).
    * @see {@link StaticDefaultBgKeys} and {@link StaticBgKeys}
    */
-  background?: AkselBaseBackgroundTokens | AkselColoredStaticBackgroundTokens;
+  background?: AkselRootBackgroundToken | AkselColoredStatelessBackgroundToken;
   /**
    * CSS `border-color` property.
    * Accepts a [border color token](https://aksel.nav.no/grunnleggende/styling/design-tokens#adb1767e2f87).
    * @see {@link BorderColorKeys} and {@link BorderColorWithRoleKeys}
    */
   borderColor?:
-    | Exclude<AkselBaseBorderTokens, "focus">
-    | AkselColoredBorderTokens;
+    | Exclude<AkselRootBorderToken, "focus">
+    | AkselColoredBorderToken;
   /**
    * CSS `border-radius` property.
    * Accepts a [radius token](https://aksel.nav.no/grunnleggende/styling/design-tokens#6d79c5605d31)
@@ -62,7 +62,7 @@ export type BoxNewProps = React.HTMLAttributes<HTMLDivElement> & {
    * shadow='small'
    * @see {@link ShadowKeys}
    */
-  shadow?: AkselShadowTokens;
+  shadow?: AkselShadowToken;
 } & PrimitiveProps &
   PrimitiveAsChildProps;
 

--- a/@navikt/core/react/src/layout/box/Box.darkside.tsx
+++ b/@navikt/core/react/src/layout/box/Box.darkside.tsx
@@ -1,10 +1,10 @@
 import React, { forwardRef } from "react";
 import type {
-  BorderColorKeys,
-  BorderColorWithRoleKeys,
-  ShadowKeys,
-  StaticBgKeys,
-  StaticDefaultBgKeys,
+  AkselBaseBackgroundTokens,
+  AkselBaseBorderTokens,
+  AkselColoredBorderTokens,
+  AkselColoredStaticBackgroundTokens,
+  AkselShadowTokens,
 } from "@navikt/ds-tokens/types";
 import { Slot } from "../../slot/Slot";
 import { useRenameCSS } from "../../theme/Theme";
@@ -28,13 +28,15 @@ export type BoxNewProps = React.HTMLAttributes<HTMLDivElement> & {
    * Accepts a [background/surface color token](https://aksel.nav.no/grunnleggende/styling/design-tokens#afff774dad80).
    * @see {@link StaticDefaultBgKeys} and {@link StaticBgKeys}
    */
-  background?: StaticDefaultBgKeys | StaticBgKeys;
+  background?: AkselBaseBackgroundTokens | AkselColoredStaticBackgroundTokens;
   /**
    * CSS `border-color` property.
    * Accepts a [border color token](https://aksel.nav.no/grunnleggende/styling/design-tokens#adb1767e2f87).
    * @see {@link BorderColorKeys} and {@link BorderColorWithRoleKeys}
    */
-  borderColor?: Exclude<BorderColorKeys, "focus"> | BorderColorWithRoleKeys;
+  borderColor?:
+    | Exclude<AkselBaseBorderTokens, "focus">
+    | AkselColoredBorderTokens;
   /**
    * CSS `border-radius` property.
    * Accepts a [radius token](https://aksel.nav.no/grunnleggende/styling/design-tokens#6d79c5605d31)
@@ -60,7 +62,7 @@ export type BoxNewProps = React.HTMLAttributes<HTMLDivElement> & {
    * shadow='small'
    * @see {@link ShadowKeys}
    */
-  shadow?: ShadowKeys;
+  shadow?: AkselShadowTokens;
 } & PrimitiveProps &
   PrimitiveAsChildProps;
 

--- a/@navikt/core/react/src/layout/utilities/css.ts
+++ b/@navikt/core/react/src/layout/utilities/css.ts
@@ -1,8 +1,8 @@
 import type {
-  AkselBorderRadiusTokens,
-  AkselLegacyBorderRadiusTokens,
-  AkselLegacySpacingTokens,
-  AkselSpaceTokens,
+  AkselBorderRadiusToken,
+  AkselLegacyBorderRadiusToken,
+  AkselLegacySpacingToken,
+  AkselSpaceToken,
 } from "@navikt/ds-tokens/types";
 import { ResponsiveProp } from "./types";
 
@@ -34,8 +34,8 @@ export function getResponsiveValue<T = string>(
  * Temporary lookup for mapping legacy spacing tokens to new space tokens.
  */
 const legacySpacingTokenLookup: Record<
-  `--ax-spacing-${AkselLegacySpacingTokens}`,
-  `--ax-${AkselSpaceTokens}`
+  `--ax-spacing-${AkselLegacySpacingToken}`,
+  `--ax-${AkselSpaceToken}`
 > = {
   "--ax-spacing-32": "--ax-space-128",
   "--ax-spacing-24": "--ax-space-96",
@@ -61,8 +61,8 @@ const legacySpacingTokenLookup: Record<
 };
 
 const legacyBorderRadiusNameTokenLookup: Record<
-  `${AkselLegacyBorderRadiusTokens}`,
-  `${AkselBorderRadiusTokens}`
+  `${AkselLegacyBorderRadiusToken}`,
+  `${AkselBorderRadiusToken}`
 > = {
   full: "full",
   xlarge: "12",

--- a/@navikt/core/react/src/layout/utilities/css.ts
+++ b/@navikt/core/react/src/layout/utilities/css.ts
@@ -1,8 +1,8 @@
 import type {
-  BorderRadiusKeys,
-  LegacyBorderRadiusKeys,
-  LegacySpacingKeys,
-  SpaceKeys,
+  AkselBorderRadiusTokens,
+  AkselLegacyBorderRadiusTokens,
+  AkselLegacySpacingTokens,
+  AkselSpaceTokens,
 } from "@navikt/ds-tokens/types";
 import { ResponsiveProp } from "./types";
 
@@ -34,8 +34,8 @@ export function getResponsiveValue<T = string>(
  * Temporary lookup for mapping legacy spacing tokens to new space tokens.
  */
 const legacySpacingTokenLookup: Record<
-  `--ax-spacing-${LegacySpacingKeys}`,
-  `--ax-${SpaceKeys}`
+  `--ax-spacing-${AkselLegacySpacingTokens}`,
+  `--ax-${AkselSpaceTokens}`
 > = {
   "--ax-spacing-32": "--ax-space-128",
   "--ax-spacing-24": "--ax-space-96",
@@ -61,8 +61,8 @@ const legacySpacingTokenLookup: Record<
 };
 
 const legacyBorderRadiusNameTokenLookup: Record<
-  `${LegacyBorderRadiusKeys}`,
-  `${BorderRadiusKeys}`
+  `${AkselLegacyBorderRadiusTokens}`,
+  `${AkselBorderRadiusTokens}`
 > = {
   full: "full",
   xlarge: "12",

--- a/@navikt/core/react/src/layout/utilities/types.ts
+++ b/@navikt/core/react/src/layout/utilities/types.ts
@@ -1,27 +1,29 @@
 import type {
-  BorderRadiusKeys,
-  BreakPointKeys,
-  LegacyBgColorKeys,
-  LegacyBorderColorKeys,
-  LegacyBorderRadiusKeys,
-  LegacyShadowKeys,
-  LegacySpacingKeys,
-  LegacySurfaceColorKeys,
-  SpaceKeys,
+  AkselBorderRadiusTokens,
+  AkselBreakpointTokens,
+  AkselLegacyBackgroundColorTokens,
+  AkselLegacyBorderColorTokens,
+  AkselLegacyBorderRadiusTokens,
+  AkselLegacyShadowTokens,
+  AkselLegacySpacingTokens,
+  AkselLegacySurfaceColorTokens,
+  AkselSpaceTokens,
 } from "@navikt/ds-tokens/types";
 
-export type BackgroundColorToken = LegacyBgColorKeys;
-export type SurfaceColorToken = LegacySurfaceColorKeys;
-export type BorderColorToken = LegacyBorderColorKeys;
-export type ShadowToken = LegacyShadowKeys;
+export type BackgroundColorToken = AkselLegacyBackgroundColorTokens;
+export type SurfaceColorToken = AkselLegacySurfaceColorTokens;
+export type BorderColorToken = AkselLegacyBorderColorTokens;
+export type ShadowToken = AkselLegacyShadowTokens;
 
 export type BreakpointsAlias = Extract<
-  BreakPointKeys,
+  AkselBreakpointTokens,
   "xs" | "sm" | "md" | "lg" | "xl" | "2xl"
 >;
 
-export type SpacingScale = LegacySpacingKeys | SpaceKeys;
-export type BorderRadiusScale = LegacyBorderRadiusKeys | BorderRadiusKeys;
+export type SpacingScale = AkselLegacySpacingTokens | AkselSpaceTokens;
+export type BorderRadiusScale =
+  | AkselLegacyBorderRadiusTokens
+  | AkselBorderRadiusTokens;
 
 export type SpaceDelimitedAttribute<T extends string> =
   | T

--- a/@navikt/core/react/src/layout/utilities/types.ts
+++ b/@navikt/core/react/src/layout/utilities/types.ts
@@ -1,29 +1,29 @@
 import type {
-  AkselBorderRadiusTokens,
-  AkselBreakpointTokens,
-  AkselLegacyBackgroundColorTokens,
-  AkselLegacyBorderColorTokens,
-  AkselLegacyBorderRadiusTokens,
-  AkselLegacyShadowTokens,
-  AkselLegacySpacingTokens,
-  AkselLegacySurfaceColorTokens,
-  AkselSpaceTokens,
+  AkselBorderRadiusToken,
+  AkselBreakpointToken,
+  AkselLegacyBackgroundColorToken,
+  AkselLegacyBorderColorToken,
+  AkselLegacyBorderRadiusToken,
+  AkselLegacyShadowToken,
+  AkselLegacySpacingToken,
+  AkselLegacySurfaceColorToken,
+  AkselSpaceToken,
 } from "@navikt/ds-tokens/types";
 
-export type BackgroundColorToken = AkselLegacyBackgroundColorTokens;
-export type SurfaceColorToken = AkselLegacySurfaceColorTokens;
-export type BorderColorToken = AkselLegacyBorderColorTokens;
-export type ShadowToken = AkselLegacyShadowTokens;
+export type BackgroundColorToken = AkselLegacyBackgroundColorToken;
+export type SurfaceColorToken = AkselLegacySurfaceColorToken;
+export type BorderColorToken = AkselLegacyBorderColorToken;
+export type ShadowToken = AkselLegacyShadowToken;
 
 export type BreakpointsAlias = Extract<
-  AkselBreakpointTokens,
+  AkselBreakpointToken,
   "xs" | "sm" | "md" | "lg" | "xl" | "2xl"
 >;
 
-export type SpacingScale = AkselLegacySpacingTokens | AkselSpaceTokens;
+export type SpacingScale = AkselLegacySpacingToken | AkselSpaceToken;
 export type BorderRadiusScale =
-  | AkselLegacyBorderRadiusTokens
-  | AkselBorderRadiusTokens;
+  | AkselLegacyBorderRadiusToken
+  | AkselBorderRadiusToken;
 
 export type SpaceDelimitedAttribute<T extends string> =
   | T

--- a/@navikt/core/react/src/link/Link.tsx
+++ b/@navikt/core/react/src/link/Link.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from "react";
 import { useRenameCSS, useThemeInternal } from "../theme/Theme";
-import { AkselColors } from "../types";
+import { AkselColor } from "../types";
 import { OverridableComponent } from "../util/types";
 
 export interface LinkProps
@@ -100,7 +100,7 @@ export const Link: OverridableComponent<LinkProps, HTMLAnchorElement> =
 
 function variantToColor(
   variant?: LinkProps["variant"],
-): AkselColors | undefined {
+): AkselColor | undefined {
   switch (variant) {
     case "action":
       return "accent";

--- a/@navikt/core/react/src/loader/Loader.tsx
+++ b/@navikt/core/react/src/loader/Loader.tsx
@@ -1,6 +1,6 @@
 import React, { SVGProps, forwardRef } from "react";
 import { useRenameCSS } from "../theme/Theme";
-import { AkselColors } from "../types";
+import { AkselColor } from "../types";
 import { omit } from "../util";
 import { useId } from "../util/hooks";
 import { useI18n } from "../util/i18n/i18n.hooks";
@@ -37,7 +37,7 @@ export interface LoaderProps extends Omit<SVGProps<SVGSVGElement>, "ref"> {
   /**
    * Overrides loader-color
    */
-  "data-color"?: AkselColors;
+  "data-color"?: AkselColor;
 }
 
 /* Workaround for @types/react v17/v18 feil */
@@ -120,7 +120,7 @@ export const Loader: LoaderType = forwardRef<SVGSVGElement, LoaderProps>(
 
 function variantToColor(
   variant: LoaderProps["variant"],
-): AkselColors | undefined {
+): AkselColor | undefined {
   switch (variant) {
     case "neutral":
       return "neutral";

--- a/@navikt/core/react/src/tag/Tag.tsx
+++ b/@navikt/core/react/src/tag/Tag.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes, forwardRef } from "react";
 import { useRenameCSS } from "../theme/Theme";
-import { AkselColors } from "../types";
+import { AkselColor } from "../types";
 import { BodyShort } from "../typography";
 
 export interface TagProps extends HTMLAttributes<HTMLSpanElement> {
@@ -101,7 +101,7 @@ export const Tag = forwardRef<HTMLSpanElement, TagProps>(
   },
 );
 
-function variantToColor(variant: TagProps["variant"]): AkselColors {
+function variantToColor(variant: TagProps["variant"]): AkselColor {
   switch (variant) {
     case "warning":
     case "warning-filled":

--- a/@navikt/core/react/src/theme/Theme.tsx
+++ b/@navikt/core/react/src/theme/Theme.tsx
@@ -1,7 +1,7 @@
 import cl from "clsx";
 import React, { forwardRef } from "react";
 import { Slot } from "../slot/Slot";
-import { AkselColors } from "../types";
+import { AkselColor } from "../types";
 import { createContext } from "../util/create-context";
 import { AsChildProps } from "../util/types";
 
@@ -51,7 +51,7 @@ type ThemeContext = {
    * @default Inherits parent theme, or "light" if root
    */
   theme?: "light" | "dark";
-  colorRole?: AkselColors;
+  colorRole?: AkselColor;
 };
 
 const [ThemeProvider, useThemeInternal] = createContext<ThemeContext>({
@@ -69,7 +69,7 @@ export type ThemeProps = {
   /**
    * Sets default 'base'-color for application
    */
-  "data-color"?: AkselColors;
+  "data-color"?: AkselColor;
 } & Omit<ThemeContext, "colorRole"> &
   AsChildProps;
 

--- a/@navikt/core/react/src/toggle-group/ToggleGroup.tsx
+++ b/@navikt/core/react/src/toggle-group/ToggleGroup.tsx
@@ -1,7 +1,7 @@
 import cl from "clsx";
 import React, { forwardRef } from "react";
 import { useRenameCSS, useThemeInternal } from "../theme/Theme";
-import { AkselColors } from "../types";
+import { AkselColor } from "../types";
 import { Label } from "../typography";
 import { useId } from "../util";
 import {
@@ -134,7 +134,7 @@ export const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps>(
 
 function variantToColor(
   variant?: ToggleGroupProps["variant"],
-): AkselColors | undefined {
+): AkselColor | undefined {
   switch (variant) {
     case "action":
       return "accent";

--- a/@navikt/core/react/src/types/theme.d.ts
+++ b/@navikt/core/react/src/types/theme.d.ts
@@ -1,15 +1,15 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-import type { AkselColorTokens } from "@navikt/ds-tokens/types";
+import type { AkselColorRole } from "@navikt/ds-tokens/types";
 
 // biome-ignore lint/suspicious/noEmptyInterface: Users can/will augment this interface
 export interface CustomAkselColors {}
 
-export type AkselColors = AkselColorTokens | keyof CustomAkselColors;
+export type AkselColor = AkselColorRole | keyof CustomAkselColors;
 
 declare global {
   namespace React {
     interface HTMLAttributes {
-      "data-color"?: AkselColors | (string & {});
+      "data-color"?: AkselColor | (string & {});
     }
   }
 }

--- a/@navikt/core/react/src/types/theme.d.ts
+++ b/@navikt/core/react/src/types/theme.d.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-import type { GlobalColorRoles } from "@navikt/ds-tokens/types";
+import type { AkselColorTokens } from "@navikt/ds-tokens/types";
 
 // biome-ignore lint/suspicious/noEmptyInterface: Users can/will augment this interface
 export interface CustomAkselColors {}
 
-export type AkselColors = GlobalColorRoles | keyof CustomAkselColors;
+export type AkselColors = AkselColorTokens | keyof CustomAkselColors;
 
 declare global {
   namespace React {

--- a/@navikt/core/tokens/darkside/index.ts
+++ b/@navikt/core/tokens/darkside/index.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import { bundle } from "lightningcss";
 import StyleDictionary from "style-dictionary";
 import { DesignTokens, Filter } from "style-dictionary/types";
-import { ColorRolesList } from "../types";
+import { AkselColors } from "../types";
 import {
   formatCJS,
   formatDOCS,
@@ -140,7 +140,22 @@ async function buildThemedRolesCSS() {
    */
   const rootSelector = `:root, [data-color=accent]`;
 
-  for (const role of ColorRolesList) {
+  /* To avoid having to export this const from the "global" types, we declare it here locally so users dont get internal types */
+  const colors: Record<AkselColors, string> = {
+    neutral: "",
+    accent: "",
+    "brand-beige": "",
+    "brand-blue": "",
+    "brand-magenta": "",
+    info: "",
+    success: "",
+    warning: "",
+    danger: "",
+    "meta-purple": "",
+    "meta-lime": "",
+  };
+
+  for (const role of Object.keys(colors) as AkselColors[]) {
     const config = [
       globalLightTokens,
       semanticRoleConfig[role],

--- a/@navikt/core/tokens/darkside/index.ts
+++ b/@navikt/core/tokens/darkside/index.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import { bundle } from "lightningcss";
 import StyleDictionary from "style-dictionary";
 import { DesignTokens, Filter } from "style-dictionary/types";
-import { AkselColors } from "../types";
+import { AkselColorTokens } from "../types";
 import {
   formatCJS,
   formatDOCS,
@@ -141,7 +141,7 @@ async function buildThemedRolesCSS() {
   const rootSelector = `:root, [data-color=accent]`;
 
   /* To avoid having to export this const from the "global" types, we declare it here locally so users dont get internal types */
-  const colors: Record<AkselColors, string> = {
+  const colors: Record<AkselColorTokens, string> = {
     neutral: "",
     accent: "",
     "brand-beige": "",
@@ -155,7 +155,7 @@ async function buildThemedRolesCSS() {
     "meta-lime": "",
   };
 
-  for (const role of Object.keys(colors) as AkselColors[]) {
+  for (const role of Object.keys(colors) as AkselColorTokens[]) {
     const config = [
       globalLightTokens,
       semanticRoleConfig[role],

--- a/@navikt/core/tokens/darkside/index.ts
+++ b/@navikt/core/tokens/darkside/index.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import { bundle } from "lightningcss";
 import StyleDictionary from "style-dictionary";
 import { DesignTokens, Filter } from "style-dictionary/types";
-import { AkselColorTokens } from "../types";
+import { AkselColorRole } from "../types";
 import {
   formatCJS,
   formatDOCS,
@@ -141,7 +141,7 @@ async function buildThemedRolesCSS() {
   const rootSelector = `:root, [data-color=accent]`;
 
   /* To avoid having to export this const from the "global" types, we declare it here locally so users dont get internal types */
-  const colors: Record<AkselColorTokens, string> = {
+  const colors: Record<AkselColorRole, string> = {
     neutral: "",
     accent: "",
     "brand-beige": "",
@@ -155,7 +155,7 @@ async function buildThemedRolesCSS() {
     "meta-lime": "",
   };
 
-  for (const role of Object.keys(colors) as AkselColorTokens[]) {
+  for (const role of Object.keys(colors) as AkselColorRole[]) {
     const config = [
       globalLightTokens,
       semanticRoleConfig[role],

--- a/@navikt/core/tokens/darkside/tokens.util.ts
+++ b/@navikt/core/tokens/darkside/tokens.util.ts
@@ -1,10 +1,10 @@
 import _ from "lodash";
-import type { GlobalColorRoles, SemanticColorRoles } from "../types";
+import type { AkselColors, SemanticColorRoles } from "../types";
 
 export type GlobalColorEntry = {
   value: string;
   type: "global-color";
-  group: GlobalColorRoles;
+  group: AkselColors;
 };
 
 export type TokenTypes =
@@ -30,7 +30,7 @@ export type FontGroups =
 export type BreakpointGroups = "mobile first" | "desktop first";
 
 export type TokenGroup =
-  | GlobalColorRoles
+  | AkselColors
   | SemanticTokenGroups
   | `${SemanticTokenGroups}.${SemanticColorRoles}`
   | FontGroups

--- a/@navikt/core/tokens/darkside/tokens.util.ts
+++ b/@navikt/core/tokens/darkside/tokens.util.ts
@@ -1,10 +1,10 @@
 import _ from "lodash";
-import type { AkselColorTokens } from "../types";
+import type { AkselColorRole } from "../types";
 
 export type GlobalColorEntry = {
   value: string;
   type: "global-color";
-  group: AkselColorTokens;
+  group: AkselColorRole;
 };
 
 export type TokenTypes =
@@ -30,9 +30,9 @@ export type FontGroups =
 export type BreakpointGroups = "mobile first" | "desktop first";
 
 export type TokenGroup =
-  | AkselColorTokens
+  | AkselColorRole
   | SemanticTokenGroups
-  | `${SemanticTokenGroups}.${AkselColorTokens}`
+  | `${SemanticTokenGroups}.${AkselColorRole}`
   | FontGroups
   | BreakpointGroups;
 

--- a/@navikt/core/tokens/darkside/tokens.util.ts
+++ b/@navikt/core/tokens/darkside/tokens.util.ts
@@ -1,10 +1,10 @@
 import _ from "lodash";
-import type { AkselColors } from "../types";
+import type { AkselColorTokens } from "../types";
 
 export type GlobalColorEntry = {
   value: string;
   type: "global-color";
-  group: AkselColors;
+  group: AkselColorTokens;
 };
 
 export type TokenTypes =
@@ -30,9 +30,9 @@ export type FontGroups =
 export type BreakpointGroups = "mobile first" | "desktop first";
 
 export type TokenGroup =
-  | AkselColors
+  | AkselColorTokens
   | SemanticTokenGroups
-  | `${SemanticTokenGroups}.${AkselColors}`
+  | `${SemanticTokenGroups}.${AkselColorTokens}`
   | FontGroups
   | BreakpointGroups;
 

--- a/@navikt/core/tokens/darkside/tokens.util.ts
+++ b/@navikt/core/tokens/darkside/tokens.util.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import type { AkselColors, SemanticColorRoles } from "../types";
+import type { AkselColors } from "../types";
 
 export type GlobalColorEntry = {
   value: string;
@@ -32,7 +32,7 @@ export type BreakpointGroups = "mobile first" | "desktop first";
 export type TokenGroup =
   | AkselColors
   | SemanticTokenGroups
-  | `${SemanticTokenGroups}.${SemanticColorRoles}`
+  | `${SemanticTokenGroups}.${AkselColors}`
   | FontGroups
   | BreakpointGroups;
 

--- a/@navikt/core/tokens/darkside/tokens/breakpoint.ts
+++ b/@navikt/core/tokens/darkside/tokens/breakpoint.ts
@@ -1,4 +1,4 @@
-import { type AkselBreakpointTokens } from "../../types";
+import { type AkselBreakpointToken } from "../../types";
 import { type StyleDictionaryToken } from "../tokens.util";
 
 export const breakpointTokenConfig = {
@@ -72,7 +72,7 @@ export const breakpointTokenConfig = {
   },
 } satisfies {
   breakpoint: Record<
-    AkselBreakpointTokens,
+    AkselBreakpointToken,
     StyleDictionaryToken<"global-breakpoint">
   >;
 };

--- a/@navikt/core/tokens/darkside/tokens/breakpoint.ts
+++ b/@navikt/core/tokens/darkside/tokens/breakpoint.ts
@@ -1,4 +1,4 @@
-import { type BreakPointKeys } from "../../types";
+import { type AkselBreakpointTokens } from "../../types";
 import { type StyleDictionaryToken } from "../tokens.util";
 
 export const breakpointTokenConfig = {
@@ -71,5 +71,8 @@ export const breakpointTokenConfig = {
     },
   },
 } satisfies {
-  breakpoint: Record<BreakPointKeys, StyleDictionaryToken<"global-breakpoint">>;
+  breakpoint: Record<
+    AkselBreakpointTokens,
+    StyleDictionaryToken<"global-breakpoint">
+  >;
 };

--- a/@navikt/core/tokens/darkside/tokens/colors/colors.types.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/colors.types.ts
@@ -1,4 +1,5 @@
-import { AkselColors, GlobalColorScale } from "../../../types";
+import type { GlobalColorScale } from "../../../internal-types";
+import type { AkselColors } from "../../../types";
 import { GlobalColorEntry } from "../../tokens.util";
 
 export type GlobalConfigWithAlpha = Record<

--- a/@navikt/core/tokens/darkside/tokens/colors/colors.types.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/colors.types.ts
@@ -1,18 +1,18 @@
 import type { GlobalColorScale } from "../../../internal-types";
-import type { AkselColorTokens } from "../../../types";
+import type { AkselColorRole } from "../../../types";
 import { GlobalColorEntry } from "../../tokens.util";
 
 export type GlobalConfigWithAlpha = Record<
-  Extract<AkselColorTokens, "neutral">,
+  Extract<AkselColorRole, "neutral">,
   Record<GlobalColorScale, GlobalColorEntry>
 > &
   Record<
-    Exclude<AkselColorTokens, "neutral">,
+    Exclude<AkselColorRole, "neutral">,
     Record<Exclude<GlobalColorScale, "000">, GlobalColorEntry>
   >;
 
 export type GlobalConfigWithoutAlpha = Record<
-  AkselColorTokens,
+  AkselColorRole,
   Record<
     Exclude<GlobalColorScale, "000" | "100A" | "200A" | "300A" | "400A">,
     GlobalColorEntry

--- a/@navikt/core/tokens/darkside/tokens/colors/colors.types.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/colors.types.ts
@@ -1,18 +1,18 @@
 import type { GlobalColorScale } from "../../../internal-types";
-import type { AkselColors } from "../../../types";
+import type { AkselColorTokens } from "../../../types";
 import { GlobalColorEntry } from "../../tokens.util";
 
 export type GlobalConfigWithAlpha = Record<
-  Extract<AkselColors, "neutral">,
+  Extract<AkselColorTokens, "neutral">,
   Record<GlobalColorScale, GlobalColorEntry>
 > &
   Record<
-    Exclude<AkselColors, "neutral">,
+    Exclude<AkselColorTokens, "neutral">,
     Record<Exclude<GlobalColorScale, "000">, GlobalColorEntry>
   >;
 
 export type GlobalConfigWithoutAlpha = Record<
-  AkselColors,
+  AkselColorTokens,
   Record<
     Exclude<GlobalColorScale, "000" | "100A" | "200A" | "300A" | "400A">,
     GlobalColorEntry

--- a/@navikt/core/tokens/darkside/tokens/colors/colors.types.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/colors.types.ts
@@ -1,17 +1,17 @@
-import { GlobalColorRoles, GlobalColorScale } from "../../../types";
+import { AkselColors, GlobalColorScale } from "../../../types";
 import { GlobalColorEntry } from "../../tokens.util";
 
 export type GlobalConfigWithAlpha = Record<
-  Extract<GlobalColorRoles, "neutral">,
+  Extract<AkselColors, "neutral">,
   Record<GlobalColorScale, GlobalColorEntry>
 > &
   Record<
-    Exclude<GlobalColorRoles, "neutral">,
+    Exclude<AkselColors, "neutral">,
     Record<Exclude<GlobalColorScale, "000">, GlobalColorEntry>
   >;
 
 export type GlobalConfigWithoutAlpha = Record<
-  GlobalColorRoles,
+  AkselColors,
   Record<
     Exclude<GlobalColorScale, "000" | "100A" | "200A" | "300A" | "400A">,
     GlobalColorEntry

--- a/@navikt/core/tokens/darkside/tokens/colors/create-alpha.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/create-alpha.ts
@@ -1,5 +1,6 @@
 import Color from "colorjs.io";
-import { AkselColors, ColorTheme, GlobalColorScale } from "../../../types";
+import type { GlobalColorScale } from "../../../internal-types";
+import { AkselColorThemes, AkselColors } from "../../../types";
 import { GlobalColorEntry } from "../../tokens.util";
 import { GlobalConfigWithoutAlpha } from "./colors.types";
 import { semanticRootTokens } from "./semantic-root.tokens";
@@ -22,7 +23,7 @@ export function globalConfigWithAlphaTokens({
   theme,
 }: {
   config: GlobalConfigWithoutAlpha;
-  theme: ColorTheme;
+  theme: AkselColorThemes;
 }): GlobalConfigWithAlpha {
   const localConfig = structuredClone(globalConfig) as GlobalConfigWithAlpha;
 
@@ -51,7 +52,7 @@ export function globalConfigWithAlphaTokens({
   return localConfig;
 }
 
-function createAlphaColor(targetColor: string, theme: ColorTheme) {
+function createAlphaColor(targetColor: string, theme: AkselColorThemes) {
   const backgroundColor = semanticRootTokens(theme).bg.default.value;
 
   const [r, g, b, a] = getAlphaColor(

--- a/@navikt/core/tokens/darkside/tokens/colors/create-alpha.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/create-alpha.ts
@@ -1,15 +1,15 @@
 import Color from "colorjs.io";
-import { ColorTheme, GlobalColorRoles, GlobalColorScale } from "../../../types";
+import { AkselColors, ColorTheme, GlobalColorScale } from "../../../types";
 import { GlobalColorEntry } from "../../tokens.util";
 import { GlobalConfigWithoutAlpha } from "./colors.types";
 import { semanticRootTokens } from "./semantic-root.tokens";
 
 type GlobalConfigWithAlpha = Record<
-  Extract<GlobalColorRoles, "neutral">,
+  Extract<AkselColors, "neutral">,
   Record<GlobalColorScale, GlobalColorEntry>
 > &
   Record<
-    Exclude<GlobalColorRoles, "neutral">,
+    Exclude<AkselColors, "neutral">,
     Record<Exclude<GlobalColorScale, "000">, GlobalColorEntry>
   >;
 
@@ -27,7 +27,7 @@ export function globalConfigWithAlphaTokens({
   const localConfig = structuredClone(globalConfig) as GlobalConfigWithAlpha;
 
   Object.keys(globalConfig).forEach((key) => {
-    const _key = key as GlobalColorRoles;
+    const _key = key as AkselColors;
     const scopedConfig = localConfig[_key];
 
     scopedConfig["100A"] = {

--- a/@navikt/core/tokens/darkside/tokens/colors/create-alpha.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/create-alpha.ts
@@ -1,16 +1,16 @@
 import Color from "colorjs.io";
 import type { GlobalColorScale } from "../../../internal-types";
-import { AkselColorThemes, AkselColorTokens } from "../../../types";
+import { AkselColor, AkselColorTheme } from "../../../types";
 import { GlobalColorEntry } from "../../tokens.util";
 import { GlobalConfigWithoutAlpha } from "./colors.types";
 import { semanticRootTokens } from "./semantic-root.tokens";
 
 type GlobalConfigWithAlpha = Record<
-  Extract<AkselColorTokens, "neutral">,
+  Extract<AkselColor, "neutral">,
   Record<GlobalColorScale, GlobalColorEntry>
 > &
   Record<
-    Exclude<AkselColorTokens, "neutral">,
+    Exclude<AkselColor, "neutral">,
     Record<Exclude<GlobalColorScale, "000">, GlobalColorEntry>
   >;
 
@@ -23,12 +23,12 @@ export function globalConfigWithAlphaTokens({
   theme,
 }: {
   config: GlobalConfigWithoutAlpha;
-  theme: AkselColorThemes;
+  theme: AkselColorTheme;
 }): GlobalConfigWithAlpha {
   const localConfig = structuredClone(globalConfig) as GlobalConfigWithAlpha;
 
   Object.keys(globalConfig).forEach((key) => {
-    const _key = key as AkselColorTokens;
+    const _key = key as AkselColor;
     const scopedConfig = localConfig[_key];
 
     scopedConfig["100A"] = {
@@ -52,7 +52,7 @@ export function globalConfigWithAlphaTokens({
   return localConfig;
 }
 
-function createAlphaColor(targetColor: string, theme: AkselColorThemes) {
+function createAlphaColor(targetColor: string, theme: AkselColorTheme) {
   const backgroundColor = semanticRootTokens(theme).bg.default.value;
 
   const [r, g, b, a] = getAlphaColor(

--- a/@navikt/core/tokens/darkside/tokens/colors/create-alpha.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/create-alpha.ts
@@ -1,16 +1,16 @@
 import Color from "colorjs.io";
 import type { GlobalColorScale } from "../../../internal-types";
-import { AkselColorThemes, AkselColors } from "../../../types";
+import { AkselColorThemes, AkselColorTokens } from "../../../types";
 import { GlobalColorEntry } from "../../tokens.util";
 import { GlobalConfigWithoutAlpha } from "./colors.types";
 import { semanticRootTokens } from "./semantic-root.tokens";
 
 type GlobalConfigWithAlpha = Record<
-  Extract<AkselColors, "neutral">,
+  Extract<AkselColorTokens, "neutral">,
   Record<GlobalColorScale, GlobalColorEntry>
 > &
   Record<
-    Exclude<AkselColors, "neutral">,
+    Exclude<AkselColorTokens, "neutral">,
     Record<Exclude<GlobalColorScale, "000">, GlobalColorEntry>
   >;
 
@@ -28,7 +28,7 @@ export function globalConfigWithAlphaTokens({
   const localConfig = structuredClone(globalConfig) as GlobalConfigWithAlpha;
 
   Object.keys(globalConfig).forEach((key) => {
-    const _key = key as AkselColors;
+    const _key = key as AkselColorTokens;
     const scopedConfig = localConfig[_key];
 
     scopedConfig["100A"] = {

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { AkselColors } from "../../../types";
+import { AkselColorTokens } from "../../../types";
 import { type StyleDictionaryTokenConfig } from "../../tokens.util";
 import { accentSemanticTokenConfig } from "./semantic-roles/accent.tokens";
 import { brandBeigeSemanticTokenConfig } from "./semantic-roles/brand-beige.tokens";
@@ -13,7 +13,7 @@ import { neutralSemanticTokenConfig } from "./semantic-roles/neutral.tokens";
 import { successSemanticTokenConfig } from "./semantic-roles/success.tokens";
 import { warningSemanticTokenConfig } from "./semantic-roles/warning.tokens";
 
-const semanticRoleConfig: Record<AkselColors, any> = {
+const semanticRoleConfig: Record<AkselColorTokens, any> = {
   neutral: neutralSemanticTokenConfig,
   accent: accentSemanticTokenConfig,
   success: successSemanticTokenConfig,

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { AkselColorTokens } from "../../../types";
+import { AkselColorRole } from "../../../types";
 import { type StyleDictionaryTokenConfig } from "../../tokens.util";
 import { accentSemanticTokenConfig } from "./semantic-roles/accent.tokens";
 import { brandBeigeSemanticTokenConfig } from "./semantic-roles/brand-beige.tokens";
@@ -13,7 +13,7 @@ import { neutralSemanticTokenConfig } from "./semantic-roles/neutral.tokens";
 import { successSemanticTokenConfig } from "./semantic-roles/success.tokens";
 import { warningSemanticTokenConfig } from "./semantic-roles/warning.tokens";
 
-const semanticRoleConfig: Record<AkselColorTokens, any> = {
+const semanticRoleConfig: Record<AkselColorRole, any> = {
   neutral: neutralSemanticTokenConfig,
   accent: accentSemanticTokenConfig,
   success: successSemanticTokenConfig,

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-role.tokens.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { GlobalColorRoles } from "../../../types";
+import { AkselColors } from "../../../types";
 import { type StyleDictionaryTokenConfig } from "../../tokens.util";
 import { accentSemanticTokenConfig } from "./semantic-roles/accent.tokens";
 import { brandBeigeSemanticTokenConfig } from "./semantic-roles/brand-beige.tokens";
@@ -13,7 +13,7 @@ import { neutralSemanticTokenConfig } from "./semantic-roles/neutral.tokens";
 import { successSemanticTokenConfig } from "./semantic-roles/success.tokens";
 import { warningSemanticTokenConfig } from "./semantic-roles/warning.tokens";
 
-const semanticRoleConfig: Record<GlobalColorRoles, any> = {
+const semanticRoleConfig: Record<AkselColors, any> = {
   neutral: neutralSemanticTokenConfig,
   accent: accentSemanticTokenConfig,
   success: successSemanticTokenConfig,

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-root.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-root.tokens.ts
@@ -1,8 +1,8 @@
 import {
+  type AkselBaseBackgroundTokens,
+  type AkselBaseBorderTokens,
+  type AkselBaseTextTokens,
   type AkselColorThemes,
-  type BorderColorKeys,
-  type DefaultTextColorKeys,
-  type StaticDefaultBgKeys,
 } from "../../../types";
 import { type StyleDictionaryToken } from "../../tokens.util";
 
@@ -80,8 +80,8 @@ export function semanticRootTokens(theme: AkselColorThemes) {
       },
     },
   } satisfies {
-    bg: Record<StaticDefaultBgKeys, StyleDictionaryToken<"color">>;
-    border: Record<BorderColorKeys, StyleDictionaryToken<"color">>;
-    text: Record<DefaultTextColorKeys, StyleDictionaryToken<"color">>;
+    bg: Record<AkselBaseBackgroundTokens, StyleDictionaryToken<"color">>;
+    border: Record<AkselBaseBorderTokens, StyleDictionaryToken<"color">>;
+    text: Record<AkselBaseTextTokens, StyleDictionaryToken<"color">>;
   };
 }

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-root.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-root.tokens.ts
@@ -1,6 +1,6 @@
 import {
+  type AkselColorThemes,
   type BorderColorKeys,
-  type ColorTheme,
   type DefaultTextColorKeys,
   type StaticDefaultBgKeys,
 } from "../../../types";
@@ -10,7 +10,7 @@ import { type StyleDictionaryToken } from "../../tokens.util";
  * Static root-layer for semantic tokens.
  * These tokens are the  "root"-layer in the sense that they are the only "unique" tokens in the semantic layer.
  */
-export function semanticRootTokens(theme: ColorTheme) {
+export function semanticRootTokens(theme: AkselColorThemes) {
   return {
     text: {
       logo: {

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-root.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-root.tokens.ts
@@ -1,8 +1,8 @@
 import {
-  type AkselBaseBackgroundTokens,
-  type AkselBaseBorderTokens,
-  type AkselBaseTextTokens,
-  type AkselColorThemes,
+  type AkselColorTheme,
+  type AkselRootBackgroundToken,
+  type AkselRootBorderToken,
+  type AkselRootTextToken,
 } from "../../../types";
 import { type StyleDictionaryToken } from "../../tokens.util";
 
@@ -10,7 +10,7 @@ import { type StyleDictionaryToken } from "../../tokens.util";
  * Static root-layer for semantic tokens.
  * These tokens are the  "root"-layer in the sense that they are the only "unique" tokens in the semantic layer.
  */
-export function semanticRootTokens(theme: AkselColorThemes) {
+export function semanticRootTokens(theme: AkselColorTheme) {
   return {
     text: {
       logo: {
@@ -80,8 +80,8 @@ export function semanticRootTokens(theme: AkselColorThemes) {
       },
     },
   } satisfies {
-    bg: Record<AkselBaseBackgroundTokens, StyleDictionaryToken<"color">>;
-    border: Record<AkselBaseBorderTokens, StyleDictionaryToken<"color">>;
-    text: Record<AkselBaseTextTokens, StyleDictionaryToken<"color">>;
+    bg: Record<AkselRootBackgroundToken, StyleDictionaryToken<"color">>;
+    border: Record<AkselRootBorderToken, StyleDictionaryToken<"color">>;
+    text: Record<AkselRootTextToken, StyleDictionaryToken<"color">>;
   };
 }

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-themed-base.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-themed-base.tokens.ts
@@ -1,4 +1,4 @@
-import type { AkselColors } from "../../../types";
+import type { AkselColorTokens } from "../../../types";
 
 /**
  * This utility sets the semantic "role"-tokens for a given color role on the "base"-layer.
@@ -18,7 +18,7 @@ import type { AkselColors } from "../../../types";
  * }
  * ```
  */
-export function semanticThemedBaseTokens(role: AkselColors) {
+export function semanticThemedBaseTokens(role: AkselColorTokens) {
   return {
     bg: {
       soft: {

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-themed-base.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-themed-base.tokens.ts
@@ -1,4 +1,4 @@
-import { type SemanticColorRoles } from "../../../types";
+import type { AkselColors } from "../../../types";
 
 /**
  * This utility sets the semantic "role"-tokens for a given color role on the "base"-layer.
@@ -18,7 +18,7 @@ import { type SemanticColorRoles } from "../../../types";
  * }
  * ```
  */
-export function semanticThemedBaseTokens(role: SemanticColorRoles) {
+export function semanticThemedBaseTokens(role: AkselColors) {
   return {
     bg: {
       soft: {

--- a/@navikt/core/tokens/darkside/tokens/colors/semantic-themed-base.tokens.ts
+++ b/@navikt/core/tokens/darkside/tokens/colors/semantic-themed-base.tokens.ts
@@ -1,4 +1,4 @@
-import type { AkselColorTokens } from "../../../types";
+import type { AkselColorRole } from "../../../types";
 
 /**
  * This utility sets the semantic "role"-tokens for a given color role on the "base"-layer.
@@ -18,7 +18,7 @@ import type { AkselColorTokens } from "../../../types";
  * }
  * ```
  */
-export function semanticThemedBaseTokens(role: AkselColorTokens) {
+export function semanticThemedBaseTokens(role: AkselColorRole) {
   return {
     bg: {
       soft: {

--- a/@navikt/core/tokens/darkside/tokens/font.ts
+++ b/@navikt/core/tokens/darkside/tokens/font.ts
@@ -3,7 +3,7 @@ import {
   type FontLineHeightKeys,
   type FontSizeKeys,
   type FontWeightKeys,
-} from "../../types";
+} from "../../internal-types";
 import { type StyleDictionaryToken } from "../tokens.util";
 
 const baseFontSize = 16;

--- a/@navikt/core/tokens/darkside/tokens/opacity.ts
+++ b/@navikt/core/tokens/darkside/tokens/opacity.ts
@@ -1,7 +1,7 @@
-import { ColorTheme } from "../../types";
+import { AkselColorThemes } from "../../types";
 import { StyleDictionaryToken } from "../tokens.util";
 
-export function opacityTokenConfig(theme: ColorTheme) {
+export function opacityTokenConfig(theme: AkselColorThemes) {
   return {
     opacity: {
       disabled: {

--- a/@navikt/core/tokens/darkside/tokens/opacity.ts
+++ b/@navikt/core/tokens/darkside/tokens/opacity.ts
@@ -1,7 +1,7 @@
-import { AkselColorThemes } from "../../types";
+import { AkselColorTheme } from "../../types";
 import { StyleDictionaryToken } from "../tokens.util";
 
-export function opacityTokenConfig(theme: AkselColorThemes) {
+export function opacityTokenConfig(theme: AkselColorTheme) {
   return {
     opacity: {
       disabled: {

--- a/@navikt/core/tokens/darkside/tokens/radius.ts
+++ b/@navikt/core/tokens/darkside/tokens/radius.ts
@@ -1,6 +1,6 @@
 import {
-  AkselBorderRadiusTokens,
-  AkselLegacyBorderRadiusTokens,
+  AkselBorderRadiusToken,
+  AkselLegacyBorderRadiusToken,
 } from "../../types";
 import { type StyleDictionaryToken } from "../tokens.util";
 
@@ -67,13 +67,10 @@ export const radiusTokenConfig = {
     },
   },
 } satisfies {
-  radius: Record<
-    AkselBorderRadiusTokens,
-    StyleDictionaryToken<"global-radius">
-  >;
+  radius: Record<AkselBorderRadiusToken, StyleDictionaryToken<"global-radius">>;
   border: {
     radius: Record<
-      AkselLegacyBorderRadiusTokens,
+      AkselLegacyBorderRadiusToken,
       StyleDictionaryToken<"global-radius">
     >;
   };

--- a/@navikt/core/tokens/darkside/tokens/radius.ts
+++ b/@navikt/core/tokens/darkside/tokens/radius.ts
@@ -1,4 +1,7 @@
-import { type BorderRadiusKeys, LegacyBorderRadiusKeys } from "../../types";
+import {
+  AkselBorderRadiusTokens,
+  AkselLegacyBorderRadiusTokens,
+} from "../../types";
 import { type StyleDictionaryToken } from "../tokens.util";
 
 export const radiusTokenConfig = {
@@ -64,10 +67,13 @@ export const radiusTokenConfig = {
     },
   },
 } satisfies {
-  radius: Record<BorderRadiusKeys, StyleDictionaryToken<"global-radius">>;
+  radius: Record<
+    AkselBorderRadiusTokens,
+    StyleDictionaryToken<"global-radius">
+  >;
   border: {
     radius: Record<
-      LegacyBorderRadiusKeys,
+      AkselLegacyBorderRadiusTokens,
       StyleDictionaryToken<"global-radius">
     >;
   };

--- a/@navikt/core/tokens/darkside/tokens/shadow.ts
+++ b/@navikt/core/tokens/darkside/tokens/shadow.ts
@@ -1,7 +1,7 @@
-import { type ColorTheme, ShadowKeys } from "../../types";
-import { type StyleDictionaryToken } from "../tokens.util";
+import type { AkselColorThemes, ShadowKeys } from "../../types";
+import type { StyleDictionaryToken } from "../tokens.util";
 
-export function shadowTokenConfig(theme: ColorTheme) {
+export function shadowTokenConfig(theme: AkselColorThemes) {
   return {
     shadow: {
       dialog: {

--- a/@navikt/core/tokens/darkside/tokens/shadow.ts
+++ b/@navikt/core/tokens/darkside/tokens/shadow.ts
@@ -1,7 +1,7 @@
-import type { AkselColorThemes, AkselShadowTokens } from "../../types";
+import type { AkselColorTheme, AkselShadowToken } from "../../types";
 import type { StyleDictionaryToken } from "../tokens.util";
 
-export function shadowTokenConfig(theme: AkselColorThemes) {
+export function shadowTokenConfig(theme: AkselColorTheme) {
   return {
     shadow: {
       dialog: {
@@ -16,6 +16,6 @@ export function shadowTokenConfig(theme: AkselColorThemes) {
       },
     },
   } satisfies {
-    shadow: Record<AkselShadowTokens, StyleDictionaryToken<"shadow">>;
+    shadow: Record<AkselShadowToken, StyleDictionaryToken<"shadow">>;
   };
 }

--- a/@navikt/core/tokens/darkside/tokens/shadow.ts
+++ b/@navikt/core/tokens/darkside/tokens/shadow.ts
@@ -1,4 +1,4 @@
-import type { AkselColorThemes, ShadowKeys } from "../../types";
+import type { AkselColorThemes, AkselShadowTokens } from "../../types";
 import type { StyleDictionaryToken } from "../tokens.util";
 
 export function shadowTokenConfig(theme: AkselColorThemes) {
@@ -16,6 +16,6 @@ export function shadowTokenConfig(theme: AkselColorThemes) {
       },
     },
   } satisfies {
-    shadow: Record<ShadowKeys, StyleDictionaryToken<"shadow">>;
+    shadow: Record<AkselShadowTokens, StyleDictionaryToken<"shadow">>;
   };
 }

--- a/@navikt/core/tokens/darkside/tokens/space.ts
+++ b/@navikt/core/tokens/darkside/tokens/space.ts
@@ -1,4 +1,4 @@
-import { spaceInPixels } from "../../types";
+import { spaceInPixels } from "../../internal-types";
 import { type StyleDictionaryToken } from "../tokens.util";
 
 function pxToRem(px: number) {

--- a/@navikt/core/tokens/internal-types.ts
+++ b/@navikt/core/tokens/internal-types.ts
@@ -21,4 +21,10 @@ type GlobalColorKeys =
   | `${Extract<AkselColors, "neutral">}-${Extract<GlobalColorScale, "000">}`
   | `${AkselColors}-${Exclude<GlobalColorScale, "000">}`;
 
+const spaceInPixels = [
+  0, 1, 2, 4, 6, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 56, 64, 72, 80, 96,
+  128,
+] as const;
+
+export { spaceInPixels };
 export type { GlobalColorScale, GlobalColorKeys };

--- a/@navikt/core/tokens/internal-types.ts
+++ b/@navikt/core/tokens/internal-types.ts
@@ -1,4 +1,4 @@
-import { AkselColors } from "./types";
+import { AkselColorTokens } from "./types";
 
 type GlobalColorScale =
   | "100"
@@ -18,8 +18,11 @@ type GlobalColorScale =
   | "400A";
 
 type GlobalColorKeys =
-  | `${Extract<AkselColors, "neutral">}-${Extract<GlobalColorScale, "000">}`
-  | `${AkselColors}-${Exclude<GlobalColorScale, "000">}`;
+  | `${Extract<AkselColorTokens, "neutral">}-${Extract<
+      GlobalColorScale,
+      "000"
+    >}`
+  | `${AkselColorTokens}-${Exclude<GlobalColorScale, "000">}`;
 
 const spaceInPixels = [
   0, 1, 2, 4, 6, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 56, 64, 72, 80, 96,

--- a/@navikt/core/tokens/internal-types.ts
+++ b/@navikt/core/tokens/internal-types.ts
@@ -26,5 +26,39 @@ const spaceInPixels = [
   128,
 ] as const;
 
+/* ------------------------------ Font tokens ------------------------------- */
+type FontFamilyKeys = "family";
+
+type FontSizeKeys =
+  | "size-heading-2xlarge"
+  | "size-heading-xlarge"
+  | "size-heading-large"
+  | "size-heading-medium"
+  | "size-heading-small"
+  | "size-heading-xsmall"
+  | "size-xlarge"
+  | "size-large"
+  | "size-medium"
+  | "size-small";
+
+type FontLineHeightKeys =
+  | "line-height-heading-2xlarge"
+  | "line-height-heading-xlarge"
+  | "line-height-heading-large"
+  | "line-height-heading-medium"
+  | "line-height-heading-small"
+  | "line-height-heading-xsmall"
+  | "line-height-xlarge"
+  | "line-height-large"
+  | "line-height-medium";
+
+export type FontWeightKeys = "weight-bold" | "weight-regular";
+
 export { spaceInPixels };
-export type { GlobalColorScale, GlobalColorKeys };
+export type {
+  GlobalColorScale,
+  GlobalColorKeys,
+  FontFamilyKeys,
+  FontSizeKeys,
+  FontLineHeightKeys,
+};

--- a/@navikt/core/tokens/internal-types.ts
+++ b/@navikt/core/tokens/internal-types.ts
@@ -1,0 +1,24 @@
+import { AkselColors } from "./types";
+
+type GlobalColorScale =
+  | "100"
+  | "200"
+  | "300"
+  | "400"
+  | "500"
+  | "600"
+  | "700"
+  | "800"
+  | "900"
+  | "1000"
+  | "000"
+  | "100A"
+  | "200A"
+  | "300A"
+  | "400A";
+
+type GlobalColorKeys =
+  | `${Extract<AkselColors, "neutral">}-${Extract<GlobalColorScale, "000">}`
+  | `${AkselColors}-${Exclude<GlobalColorScale, "000">}`;
+
+export type { GlobalColorScale, GlobalColorKeys };

--- a/@navikt/core/tokens/internal-types.ts
+++ b/@navikt/core/tokens/internal-types.ts
@@ -1,4 +1,4 @@
-import { AkselColorTokens } from "./types";
+import { AkselColorTokens, AkselSpaceTokens } from "./types";
 
 type GlobalColorScale =
   | "100"
@@ -24,10 +24,34 @@ type GlobalColorKeys =
     >}`
   | `${AkselColorTokens}-${Exclude<GlobalColorScale, "000">}`;
 
-const spaceInPixels = [
-  0, 1, 2, 4, 6, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 56, 64, 72, 80, 96,
-  128,
-] as const;
+type ExtractNumber<T> = T extends `space-${infer N extends number}` ? N : never;
+
+const spaceObject: Record<ExtractNumber<AkselSpaceTokens>, any> = {
+  "0": "",
+  "1": "",
+  "2": "",
+  "4": "",
+  "6": "",
+  "8": "",
+  "12": "",
+  "16": "",
+  "20": "",
+  "24": "",
+  "28": "",
+  "32": "",
+  "36": "",
+  "40": "",
+  "44": "",
+  "48": "",
+  "56": "",
+  "64": "",
+  "72": "",
+  "80": "",
+  "96": "",
+  "128": "",
+};
+
+const spaceInPixels = Object.keys(spaceObject).map(Number);
 
 /* ------------------------------ Font tokens ------------------------------- */
 type FontFamilyKeys = "family";

--- a/@navikt/core/tokens/internal-types.ts
+++ b/@navikt/core/tokens/internal-types.ts
@@ -1,4 +1,4 @@
-import { AkselColorTokens, AkselSpaceTokens } from "./types";
+import { AkselColorRole, AkselSpaceToken } from "./types";
 
 type GlobalColorScale =
   | "100"
@@ -18,15 +18,12 @@ type GlobalColorScale =
   | "400A";
 
 type GlobalColorKeys =
-  | `${Extract<AkselColorTokens, "neutral">}-${Extract<
-      GlobalColorScale,
-      "000"
-    >}`
-  | `${AkselColorTokens}-${Exclude<GlobalColorScale, "000">}`;
+  | `${Extract<AkselColorRole, "neutral">}-${Extract<GlobalColorScale, "000">}`
+  | `${AkselColorRole}-${Exclude<GlobalColorScale, "000">}`;
 
 type ExtractNumber<T> = T extends `space-${infer N extends number}` ? N : never;
 
-const spaceObject: Record<ExtractNumber<AkselSpaceTokens>, any> = {
+const spaceObject: Record<ExtractNumber<AkselSpaceToken>, any> = {
   "0": "",
   "1": "",
   "2": "",

--- a/@navikt/core/tokens/package.json
+++ b/@navikt/core/tokens/package.json
@@ -14,6 +14,7 @@
     "/dist",
     "/src",
     "types.ts",
+    "internal-types.ts",
     "docs.json",
     "token_docs.js",
     "!/dist/darkside",

--- a/@navikt/core/tokens/types.ts
+++ b/@navikt/core/tokens/types.ts
@@ -1,14 +1,5 @@
 import { spaceInPixels } from "./internal-types";
 
-export type {
-  AkselColorThemes,
-  AkselColors,
-  AkselMainColors,
-  AkselStatusColors,
-  AkselBrandColors,
-  AkselMetaColors,
-};
-
 /* --------------------------------- Themes --------------------------------- */
 type AkselColorThemes = "light" | "dark";
 
@@ -31,22 +22,31 @@ type AkselColors =
   | AkselBrandColors
   | AkselMetaColors;
 
-/* ----------------------------- Semantic tokens ---------------------------- */
-export type StaticDefaultBgKeys =
+export type {
+  AkselColorThemes,
+  AkselColors,
+  AkselMainColors,
+  AkselStatusColors,
+  AkselBrandColors,
+  AkselMetaColors,
+};
+
+/* --------------------------- Backgrounds tokens --------------------------- */
+type AkselBaseBackgroundTokens =
   | "default"
   | "input"
   | "raised"
   | "sunken"
   | "overlay";
 
-export type StaticBgKeys =
+type AkselColoredStaticBackgroundTokens =
   | `${AkselColors}-soft`
   | `${AkselColors}-softA`
   | `${AkselColors}-moderate`
   | `${AkselColors}-moderateA`
   | `${AkselColors}-strong`;
 
-export type StatefulBgKeys =
+type AkselColoredStatefulBackgroundTokens =
   | `${AkselColors}-moderate-hover`
   | `${AkselColors}-moderate-hoverA`
   | `${AkselColors}-moderate-pressed`
@@ -54,29 +54,51 @@ export type StatefulBgKeys =
   | `${AkselColors}-strong-hover`
   | `${AkselColors}-strong-pressed`;
 
-export type DefaultTextColorKeys = "logo";
+export type {
+  AkselBaseBackgroundTokens,
+  AkselColoredStaticBackgroundTokens,
+  AkselColoredStatefulBackgroundTokens,
+};
 
-export type TextColorKeys =
+/* ------------------------------- Text tokens ------------------------------ */
+type AkselBaseTextTokens = "logo";
+
+type AkselColoredTextTokens =
   | AkselColors
   | `${AkselColors}-subtle`
   | `${AkselColors}-decoration`
   | `${AkselColors}-contrast`;
 
-export type BorderColorKeys = "focus";
+export type { AkselBaseTextTokens, AkselColoredTextTokens };
 
-export type BorderColorWithRoleKeys =
+/* ------------------------------ Border tokens ----------------------------- */
+type AkselBaseBorderTokens = "focus";
+
+type AkselColoredBorderTokens =
   | AkselColors
   | `${AkselColors}-subtle`
   | `${AkselColors}-subtleA`
   | `${AkselColors}-strong`;
 
-export type SpaceKeys = `space-${(typeof spaceInPixels)[number]}`;
+export type { AkselBaseBorderTokens, AkselColoredBorderTokens };
 
-export type ShadowKeys = "dialog";
+/* ------------------------------ Space tokens ------------------------------ */
+type AkselSpaceTokens = `space-${(typeof spaceInPixels)[number]}`;
 
-export type BorderRadiusKeys = "2" | "4" | "8" | "12" | "full";
+export type { AkselSpaceTokens };
 
-export type BreakPointKeys =
+/* ------------------------------ Shadow tokens ----------------------------- */
+type AkselShadowTokens = "dialog";
+
+export type { AkselShadowTokens };
+
+/* ------------------------------ Border Radius tokens --------------------- */
+type AkselBorderRadiusTokens = "2" | "4" | "8" | "12" | "full";
+
+export type { AkselBorderRadiusTokens };
+
+/* ------------------------------ Breakpoints tokens ------------------------ */
+type AkselBreakpointTokens =
   | "xs"
   | "sm"
   | "sm-down"
@@ -89,52 +111,26 @@ export type BreakPointKeys =
   | "2xl"
   | "2xl-down";
 
-/* Typo-tokens */
-export type FontFamilyKeys = "family";
+export type { AkselBreakpointTokens };
 
-export type FontSizeKeys =
-  | "size-heading-2xlarge"
-  | "size-heading-xlarge"
-  | "size-heading-large"
-  | "size-heading-medium"
-  | "size-heading-small"
-  | "size-heading-xsmall"
-  | "size-xlarge"
-  | "size-large"
-  | "size-medium"
-  | "size-small";
-
-export type FontLineHeightKeys =
-  | "line-height-heading-2xlarge"
-  | "line-height-heading-xlarge"
-  | "line-height-heading-large"
-  | "line-height-heading-medium"
-  | "line-height-heading-small"
-  | "line-height-heading-xsmall"
-  | "line-height-xlarge"
-  | "line-height-large"
-  | "line-height-medium";
-
-export type FontWeightKeys = "weight-bold" | "weight-regular";
-
-/* Legacy tokens */
-export type LegacyBorderRadiusKeys =
+/* ------------------------------ Legacy tokens ----------------------------- */
+type AkselLegacyBorderRadiusTokens =
   | "small"
   | "medium"
   | "large"
   | "xlarge"
   | "full";
 
-export type LegacyShadowKeys =
+type AkselLegacyShadowTokens =
   | "xsmall"
   | "small"
   | "medium"
   | "large"
   | "xlarge";
 
-export type LegacyBgColorKeys = "bg-default" | "bg-subtle";
+type AkselLegacyBgColorTokens = "bg-default" | "bg-subtle";
 
-export type LegacySurfaceColorKeys =
+type AkselLegacySurfaceColorTokens =
   | "surface-default"
   | "surface-selected"
   | "surface-subtle"
@@ -171,7 +167,7 @@ export type LegacySurfaceColorKeys =
   | "surface-alt-3-strong"
   | "surface-alt-3";
 
-export type LegacyBorderColorKeys =
+type AkselLegacyBorderColorTokens =
   | "border-default"
   | "border-strong"
   | "border-divider"
@@ -192,7 +188,7 @@ export type LegacyBorderColorKeys =
   | "border-alt-2"
   | "border-alt-3";
 
-export type LegacySpacingKeys =
+type AkselLegacySpacingTokens =
   | "0"
   | "05"
   | "1"
@@ -214,3 +210,12 @@ export type LegacySpacingKeys =
   | "20"
   | "24"
   | "32";
+
+export type {
+  AkselLegacyBorderRadiusTokens,
+  AkselLegacyShadowTokens,
+  AkselLegacyBgColorTokens,
+  AkselLegacySurfaceColorTokens,
+  AkselLegacyBorderColorTokens,
+  AkselLegacySpacingTokens,
+};

--- a/@navikt/core/tokens/types.ts
+++ b/@navikt/core/tokens/types.ts
@@ -4,31 +4,31 @@ import { spaceInPixels } from "./internal-types";
 type AkselColorThemes = "light" | "dark";
 
 /* ------------------------------ Main colors ----------------------------- */
-type AkselMainColors = "neutral" | "accent";
+type AkselMainColorTokens = "neutral" | "accent";
 
 /* ------------------------------ Status colors ----------------------------- */
-type AkselStatusColors = "info" | "success" | "warning" | "danger";
+type AkselStatusColorTokens = "info" | "success" | "warning" | "danger";
 
 /* ------------------------------ Brand colors ------------------------------ */
-type AkselBrandColors = "brand-magenta" | "brand-beige" | "brand-blue";
+type AkselBrandColorTokens = "brand-magenta" | "brand-beige" | "brand-blue";
 
 /* ------------------------------ Meta colors ------------------------------ */
-type AkselMetaColors = "meta-purple" | "meta-lime";
+type AkselMetaColorTokens = "meta-purple" | "meta-lime";
 
 /* ------------------------------- All colors ------------------------------- */
-type AkselColors =
-  | AkselMainColors
-  | AkselStatusColors
-  | AkselBrandColors
-  | AkselMetaColors;
+type AkselColorTokens =
+  | AkselMainColorTokens
+  | AkselStatusColorTokens
+  | AkselBrandColorTokens
+  | AkselMetaColorTokens;
 
 export type {
   AkselColorThemes,
-  AkselColors,
-  AkselMainColors,
-  AkselStatusColors,
-  AkselBrandColors,
-  AkselMetaColors,
+  AkselColorTokens,
+  AkselMainColorTokens,
+  AkselStatusColorTokens,
+  AkselBrandColorTokens,
+  AkselMetaColorTokens,
 };
 
 /* --------------------------- Backgrounds tokens --------------------------- */
@@ -40,19 +40,19 @@ type AkselBaseBackgroundTokens =
   | "overlay";
 
 type AkselColoredStaticBackgroundTokens =
-  | `${AkselColors}-soft`
-  | `${AkselColors}-softA`
-  | `${AkselColors}-moderate`
-  | `${AkselColors}-moderateA`
-  | `${AkselColors}-strong`;
+  | `${AkselColorTokens}-soft`
+  | `${AkselColorTokens}-softA`
+  | `${AkselColorTokens}-moderate`
+  | `${AkselColorTokens}-moderateA`
+  | `${AkselColorTokens}-strong`;
 
 type AkselColoredStatefulBackgroundTokens =
-  | `${AkselColors}-moderate-hover`
-  | `${AkselColors}-moderate-hoverA`
-  | `${AkselColors}-moderate-pressed`
-  | `${AkselColors}-moderate-pressedA`
-  | `${AkselColors}-strong-hover`
-  | `${AkselColors}-strong-pressed`;
+  | `${AkselColorTokens}-moderate-hover`
+  | `${AkselColorTokens}-moderate-hoverA`
+  | `${AkselColorTokens}-moderate-pressed`
+  | `${AkselColorTokens}-moderate-pressedA`
+  | `${AkselColorTokens}-strong-hover`
+  | `${AkselColorTokens}-strong-pressed`;
 
 export type {
   AkselBaseBackgroundTokens,
@@ -64,10 +64,10 @@ export type {
 type AkselBaseTextTokens = "logo";
 
 type AkselColoredTextTokens =
-  | AkselColors
-  | `${AkselColors}-subtle`
-  | `${AkselColors}-decoration`
-  | `${AkselColors}-contrast`;
+  | AkselColorTokens
+  | `${AkselColorTokens}-subtle`
+  | `${AkselColorTokens}-decoration`
+  | `${AkselColorTokens}-contrast`;
 
 export type { AkselBaseTextTokens, AkselColoredTextTokens };
 
@@ -75,10 +75,10 @@ export type { AkselBaseTextTokens, AkselColoredTextTokens };
 type AkselBaseBorderTokens = "focus";
 
 type AkselColoredBorderTokens =
-  | AkselColors
-  | `${AkselColors}-subtle`
-  | `${AkselColors}-subtleA`
-  | `${AkselColors}-strong`;
+  | AkselColorTokens
+  | `${AkselColorTokens}-subtle`
+  | `${AkselColorTokens}-subtleA`
+  | `${AkselColorTokens}-strong`;
 
 export type { AkselBaseBorderTokens, AkselColoredBorderTokens };
 
@@ -128,7 +128,7 @@ type AkselLegacyShadowTokens =
   | "large"
   | "xlarge";
 
-type AkselLegacyBgColorTokens = "bg-default" | "bg-subtle";
+type AkselLegacyBackgroundColorTokens = "bg-default" | "bg-subtle";
 
 type AkselLegacySurfaceColorTokens =
   | "surface-default"
@@ -214,7 +214,7 @@ type AkselLegacySpacingTokens =
 export type {
   AkselLegacyBorderRadiusTokens,
   AkselLegacyShadowTokens,
-  AkselLegacyBgColorTokens,
+  AkselLegacyBackgroundColorTokens,
   AkselLegacySurfaceColorTokens,
   AkselLegacyBorderColorTokens,
   AkselLegacySpacingTokens,

--- a/@navikt/core/tokens/types.ts
+++ b/@navikt/core/tokens/types.ts
@@ -82,7 +82,7 @@ export type { AkselRootBorderToken, AkselColoredBorderToken };
 
 /* ------------------------------ Space tokens ------------------------------ */
 type AkselSpaceToken =
-  | `space-0`
+  | "space-0"
   | "space-1"
   | "space-2"
   | "space-4"

--- a/@navikt/core/tokens/types.ts
+++ b/@navikt/core/tokens/types.ts
@@ -1,87 +1,87 @@
 /* --------------------------------- Themes --------------------------------- */
-type AkselColorThemes = "light" | "dark";
+type AkselColorTheme = "light" | "dark";
 
 /* ------------------------------ Main colors ----------------------------- */
-type AkselMainColorTokens = "neutral" | "accent";
+type AkselMainColorRole = "neutral" | "accent";
 
 /* ------------------------------ Status colors ----------------------------- */
-type AkselStatusColorTokens = "info" | "success" | "warning" | "danger";
+type AkselStatusColorRole = "info" | "success" | "warning" | "danger";
 
 /* ------------------------------ Brand colors ------------------------------ */
-type AkselBrandColorTokens = "brand-magenta" | "brand-beige" | "brand-blue";
+type AkselBrandColorRole = "brand-magenta" | "brand-beige" | "brand-blue";
 
 /* ------------------------------ Meta colors ------------------------------ */
-type AkselMetaColorTokens = "meta-purple" | "meta-lime";
+type AkselMetaColorRole = "meta-purple" | "meta-lime";
 
 /* ------------------------------- All colors ------------------------------- */
-type AkselColorTokens =
-  | AkselMainColorTokens
-  | AkselStatusColorTokens
-  | AkselBrandColorTokens
-  | AkselMetaColorTokens;
+type AkselColorRole =
+  | AkselMainColorRole
+  | AkselStatusColorRole
+  | AkselBrandColorRole
+  | AkselMetaColorRole;
 
 export type {
-  AkselColorThemes,
-  AkselColorTokens,
-  AkselMainColorTokens,
-  AkselStatusColorTokens,
-  AkselBrandColorTokens,
-  AkselMetaColorTokens,
+  AkselColorTheme,
+  AkselColorRole,
+  AkselMainColorRole,
+  AkselStatusColorRole,
+  AkselBrandColorRole,
+  AkselMetaColorRole,
 };
 
 /* --------------------------- Backgrounds tokens --------------------------- */
-type AkselBaseBackgroundTokens =
+type AkselRootBackgroundToken =
   | "default"
   | "input"
   | "raised"
   | "sunken"
   | "overlay";
 
-type AkselColoredStaticBackgroundTokens =
-  | `${AkselColorTokens}-soft`
-  | `${AkselColorTokens}-softA`
-  | `${AkselColorTokens}-moderate`
-  | `${AkselColorTokens}-moderateA`
-  | `${AkselColorTokens}-strong`;
+type AkselColoredStatelessBackgroundToken =
+  | `${AkselColorRole}-soft`
+  | `${AkselColorRole}-softA`
+  | `${AkselColorRole}-moderate`
+  | `${AkselColorRole}-moderateA`
+  | `${AkselColorRole}-strong`;
 
-type AkselColoredStatefulBackgroundTokens =
-  | `${AkselColorTokens}-moderate-hover`
-  | `${AkselColorTokens}-moderate-hoverA`
-  | `${AkselColorTokens}-moderate-pressed`
-  | `${AkselColorTokens}-moderate-pressedA`
-  | `${AkselColorTokens}-strong-hover`
-  | `${AkselColorTokens}-strong-pressed`;
+type AkselColoredStatefulBackgroundToken =
+  | `${AkselColorRole}-moderate-hover`
+  | `${AkselColorRole}-moderate-hoverA`
+  | `${AkselColorRole}-moderate-pressed`
+  | `${AkselColorRole}-moderate-pressedA`
+  | `${AkselColorRole}-strong-hover`
+  | `${AkselColorRole}-strong-pressed`;
 
 export type {
-  AkselBaseBackgroundTokens,
-  AkselColoredStaticBackgroundTokens,
-  AkselColoredStatefulBackgroundTokens,
+  AkselRootBackgroundToken,
+  AkselColoredStatelessBackgroundToken,
+  AkselColoredStatefulBackgroundToken,
 };
 
 /* ------------------------------- Text tokens ------------------------------ */
-type AkselBaseTextTokens = "logo";
+type AkselRootTextToken = "logo";
 
-type AkselColoredTextTokens =
-  | AkselColorTokens
-  | `${AkselColorTokens}-subtle`
-  | `${AkselColorTokens}-decoration`
-  | `${AkselColorTokens}-contrast`;
+type AkselColoredTextToken =
+  | AkselColoredStatefulBackgroundToken
+  | `${AkselColoredStatefulBackgroundToken}-subtle`
+  | `${AkselColoredStatefulBackgroundToken}-decoration`
+  | `${AkselColoredStatefulBackgroundToken}-contrast`;
 
-export type { AkselBaseTextTokens, AkselColoredTextTokens };
+export type { AkselRootTextToken, AkselColoredTextToken };
 
 /* ------------------------------ Border tokens ----------------------------- */
-type AkselBaseBorderTokens = "focus";
+type AkselRootBorderToken = "focus";
 
-type AkselColoredBorderTokens =
-  | AkselColorTokens
-  | `${AkselColorTokens}-subtle`
-  | `${AkselColorTokens}-subtleA`
-  | `${AkselColorTokens}-strong`;
+type AkselColoredBorderToken =
+  | AkselColorRole
+  | `${AkselColorRole}-subtle`
+  | `${AkselColorRole}-subtleA`
+  | `${AkselColorRole}-strong`;
 
-export type { AkselBaseBorderTokens, AkselColoredBorderTokens };
+export type { AkselRootBorderToken, AkselColoredBorderToken };
 
 /* ------------------------------ Space tokens ------------------------------ */
-type AkselSpaceTokens =
+type AkselSpaceToken =
   | `space-0`
   | "space-1"
   | "space-2"
@@ -105,20 +105,20 @@ type AkselSpaceTokens =
   | "space-96"
   | "space-128";
 
-export type { AkselSpaceTokens };
+export type { AkselSpaceToken };
 
 /* ------------------------------ Shadow tokens ----------------------------- */
-type AkselShadowTokens = "dialog";
+type AkselShadowToken = "dialog";
 
-export type { AkselShadowTokens };
+export type { AkselShadowToken };
 
 /* ------------------------------ Border Radius tokens --------------------- */
-type AkselBorderRadiusTokens = "2" | "4" | "8" | "12" | "full";
+type AkselBorderRadiusToken = "2" | "4" | "8" | "12" | "full";
 
-export type { AkselBorderRadiusTokens };
+export type { AkselBorderRadiusToken };
 
 /* ------------------------------ Breakpoints tokens ------------------------ */
-type AkselBreakpointTokens =
+type AkselBreakpointToken =
   | "xs"
   | "sm"
   | "sm-down"
@@ -131,26 +131,26 @@ type AkselBreakpointTokens =
   | "2xl"
   | "2xl-down";
 
-export type { AkselBreakpointTokens };
+export type { AkselBreakpointToken };
 
 /* ------------------------------ Legacy tokens ----------------------------- */
-type AkselLegacyBorderRadiusTokens =
+type AkselLegacyBorderRadiusToken =
   | "small"
   | "medium"
   | "large"
   | "xlarge"
   | "full";
 
-type AkselLegacyShadowTokens =
+type AkselLegacyShadowToken =
   | "xsmall"
   | "small"
   | "medium"
   | "large"
   | "xlarge";
 
-type AkselLegacyBackgroundColorTokens = "bg-default" | "bg-subtle";
+type AkselLegacyBackgroundColorToken = "bg-default" | "bg-subtle";
 
-type AkselLegacySurfaceColorTokens =
+type AkselLegacySurfaceColorToken =
   | "surface-default"
   | "surface-selected"
   | "surface-subtle"
@@ -187,7 +187,7 @@ type AkselLegacySurfaceColorTokens =
   | "surface-alt-3-strong"
   | "surface-alt-3";
 
-type AkselLegacyBorderColorTokens =
+type AkselLegacyBorderColorToken =
   | "border-default"
   | "border-strong"
   | "border-divider"
@@ -208,7 +208,7 @@ type AkselLegacyBorderColorTokens =
   | "border-alt-2"
   | "border-alt-3";
 
-type AkselLegacySpacingTokens =
+type AkselLegacySpacingToken =
   | "0"
   | "05"
   | "1"
@@ -232,10 +232,10 @@ type AkselLegacySpacingTokens =
   | "32";
 
 export type {
-  AkselLegacyBorderRadiusTokens,
-  AkselLegacyShadowTokens,
-  AkselLegacyBackgroundColorTokens,
-  AkselLegacySurfaceColorTokens,
-  AkselLegacyBorderColorTokens,
-  AkselLegacySpacingTokens,
+  AkselLegacyBorderRadiusToken,
+  AkselLegacyShadowToken,
+  AkselLegacyBackgroundColorToken,
+  AkselLegacySurfaceColorToken,
+  AkselLegacyBorderColorToken,
+  AkselLegacySpacingToken,
 };

--- a/@navikt/core/tokens/types.ts
+++ b/@navikt/core/tokens/types.ts
@@ -29,31 +29,7 @@ type AkselColors =
   | AkselBrandColors
   | AkselMetaColors;
 
-export type SemanticColorRoles = AkselColors;
-
-export type GlobalColorScale =
-  | "100"
-  | "200"
-  | "300"
-  | "400"
-  | "500"
-  | "600"
-  | "700"
-  | "800"
-  | "900"
-  | "1000"
-  | "000"
-  | "100A"
-  | "200A"
-  | "300A"
-  | "400A";
-
-export type GlobalColorKeys =
-  | `${Extract<AkselColors, "neutral">}-${Extract<GlobalColorScale, "000">}`
-  | `${AkselColors}-${Exclude<GlobalColorScale, "000">}`;
-
 /* ----------------------------- Semantic tokens ---------------------------- */
-
 export type StaticDefaultBgKeys =
   | "default"
   | "input"
@@ -62,35 +38,35 @@ export type StaticDefaultBgKeys =
   | "overlay";
 
 export type StaticBgKeys =
-  | `${SemanticColorRoles}-soft`
-  | `${SemanticColorRoles}-softA`
-  | `${SemanticColorRoles}-moderate`
-  | `${SemanticColorRoles}-moderateA`
-  | `${SemanticColorRoles}-strong`;
+  | `${AkselColors}-soft`
+  | `${AkselColors}-softA`
+  | `${AkselColors}-moderate`
+  | `${AkselColors}-moderateA`
+  | `${AkselColors}-strong`;
 
 export type StatefulBgKeys =
-  | `${SemanticColorRoles}-moderate-hover`
-  | `${SemanticColorRoles}-moderate-hoverA`
-  | `${SemanticColorRoles}-moderate-pressed`
-  | `${SemanticColorRoles}-moderate-pressedA`
-  | `${SemanticColorRoles}-strong-hover`
-  | `${SemanticColorRoles}-strong-pressed`;
+  | `${AkselColors}-moderate-hover`
+  | `${AkselColors}-moderate-hoverA`
+  | `${AkselColors}-moderate-pressed`
+  | `${AkselColors}-moderate-pressedA`
+  | `${AkselColors}-strong-hover`
+  | `${AkselColors}-strong-pressed`;
 
 export type DefaultTextColorKeys = "logo";
 
 export type TextColorKeys =
-  | SemanticColorRoles
-  | `${SemanticColorRoles}-subtle`
-  | `${SemanticColorRoles}-decoration`
-  | `${SemanticColorRoles}-contrast`;
+  | AkselColors
+  | `${AkselColors}-subtle`
+  | `${AkselColors}-decoration`
+  | `${AkselColors}-contrast`;
 
 export type BorderColorKeys = "focus";
 
 export type BorderColorWithRoleKeys =
-  | SemanticColorRoles
-  | `${SemanticColorRoles}-subtle`
-  | `${SemanticColorRoles}-subtleA`
-  | `${SemanticColorRoles}-strong`;
+  | AkselColors
+  | `${AkselColors}-subtle`
+  | `${AkselColors}-subtleA`
+  | `${AkselColors}-strong`;
 
 export const spaceInPixels = [
   0, 1, 2, 4, 6, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 56, 64, 72, 80, 96,

--- a/@navikt/core/tokens/types.ts
+++ b/@navikt/core/tokens/types.ts
@@ -1,21 +1,35 @@
-export type ColorTheme = "light" | "dark";
+export type {
+  AkselColorThemes,
+  AkselColors,
+  AkselMainColors,
+  AkselStatusColors,
+  AkselBrandColors,
+  AkselMetaColors,
+};
 
-export const ColorRolesList = [
-  "neutral",
-  "accent",
-  "success",
-  "warning",
-  "danger",
-  "info",
-  "brand-magenta",
-  "brand-beige",
-  "brand-blue",
-  "meta-purple",
-  "meta-lime",
-] as const;
+/* --------------------------------- Themes --------------------------------- */
+type AkselColorThemes = "light" | "dark";
 
-export type GlobalColorRoles = (typeof ColorRolesList)[number];
-export type SemanticColorRoles = GlobalColorRoles;
+/* ------------------------------ Main colors ----------------------------- */
+type AkselMainColors = "neutral" | "accent";
+
+/* ------------------------------ Status colors ----------------------------- */
+type AkselStatusColors = "info" | "success" | "warning" | "danger";
+
+/* ------------------------------ Brand colors ------------------------------ */
+type AkselBrandColors = "brand-magenta" | "brand-beige" | "brand-blue";
+
+/* ------------------------------ Meta colors ------------------------------ */
+type AkselMetaColors = "meta-purple" | "meta-lime";
+
+/* ------------------------------- All colors ------------------------------- */
+type AkselColors =
+  | AkselMainColors
+  | AkselStatusColors
+  | AkselBrandColors
+  | AkselMetaColors;
+
+export type SemanticColorRoles = AkselColors;
 
 export type GlobalColorScale =
   | "100"
@@ -35,13 +49,10 @@ export type GlobalColorScale =
   | "400A";
 
 export type GlobalColorKeys =
-  | `${Extract<GlobalColorRoles, "neutral">}-${Extract<
-      GlobalColorScale,
-      "000"
-    >}`
-  | `${GlobalColorRoles}-${Exclude<GlobalColorScale, "000">}`;
+  | `${Extract<AkselColors, "neutral">}-${Extract<GlobalColorScale, "000">}`
+  | `${AkselColors}-${Exclude<GlobalColorScale, "000">}`;
 
-/* Semantic tokens */
+/* ----------------------------- Semantic tokens ---------------------------- */
 
 export type StaticDefaultBgKeys =
   | "default"

--- a/@navikt/core/tokens/types.ts
+++ b/@navikt/core/tokens/types.ts
@@ -1,3 +1,5 @@
+import { spaceInPixels } from "./internal-types";
+
 export type {
   AkselColorThemes,
   AkselColors,
@@ -67,11 +69,6 @@ export type BorderColorWithRoleKeys =
   | `${AkselColors}-subtle`
   | `${AkselColors}-subtleA`
   | `${AkselColors}-strong`;
-
-export const spaceInPixels = [
-  0, 1, 2, 4, 6, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 56, 64, 72, 80, 96,
-  128,
-] as const;
 
 export type SpaceKeys = `space-${(typeof spaceInPixels)[number]}`;
 

--- a/@navikt/core/tokens/types.ts
+++ b/@navikt/core/tokens/types.ts
@@ -1,5 +1,3 @@
-import { spaceInPixels } from "./internal-types";
-
 /* --------------------------------- Themes --------------------------------- */
 type AkselColorThemes = "light" | "dark";
 
@@ -83,7 +81,29 @@ type AkselColoredBorderTokens =
 export type { AkselBaseBorderTokens, AkselColoredBorderTokens };
 
 /* ------------------------------ Space tokens ------------------------------ */
-type AkselSpaceTokens = `space-${(typeof spaceInPixels)[number]}`;
+type AkselSpaceTokens =
+  | `space-0`
+  | "space-1"
+  | "space-2"
+  | "space-4"
+  | "space-6"
+  | "space-8"
+  | "space-12"
+  | "space-16"
+  | "space-20"
+  | "space-24"
+  | "space-28"
+  | "space-32"
+  | "space-36"
+  | "space-40"
+  | "space-44"
+  | "space-48"
+  | "space-56"
+  | "space-64"
+  | "space-72"
+  | "space-80"
+  | "space-96"
+  | "space-128";
 
 export type { AkselSpaceTokens };
 

--- a/aksel.nav.no/website/app/_ui/do-dont/DoDont.tsx
+++ b/aksel.nav.no/website/app/_ui/do-dont/DoDont.tsx
@@ -2,7 +2,7 @@
 import type { Image } from "sanity";
 import { HandKnotIcon, ThumbDownIcon, ThumbUpIcon } from "@navikt/aksel-icons";
 import { BodyShort, Box, HGrid } from "@navikt/ds-react";
-import { AkselColors } from "@navikt/ds-react/types/theme";
+import { AkselColor } from "@navikt/ds-react/types/theme";
 import { Do_dont_block } from "@/app/_sanity/query-types";
 import { ExtractPortableComponentProps } from "@/app/_sanity/types";
 import { urlForImage } from "@/app/_sanity/utils";
@@ -58,7 +58,7 @@ function DoDont(props: ExtractPortableComponentProps<"do_dont">) {
 
 const NotchConfig: Record<
   NonNullable<Do_dont_block["variant"]>,
-  { icon: typeof HandKnotIcon; text: string; role: AkselColors }
+  { icon: typeof HandKnotIcon; text: string; role: AkselColor }
 > = {
   do: {
     icon: ThumbUpIcon,

--- a/aksel.nav.no/website/app/_ui/editor-panel/EditorPanel.tsx
+++ b/aksel.nav.no/website/app/_ui/editor-panel/EditorPanel.tsx
@@ -9,7 +9,7 @@ import {
   ThumbUpIcon,
 } from "@navikt/aksel-icons";
 import { Heading, Spacer } from "@navikt/ds-react";
-import { AkselColors } from "@navikt/ds-react/types/theme";
+import { AkselColor } from "@navikt/ds-react/types/theme";
 import styles from "./EditorPanel.module.css";
 
 type EditorPanelProps = {
@@ -43,7 +43,7 @@ const VariantConfig: Record<
   {
     heading: string;
     icon: JSX.Element;
-    color: AkselColors;
+    color: AkselColor;
   }
 > = {
   tips: {

--- a/aksel.nav.no/website/app/_ui/theming/theme-config.ts
+++ b/aksel.nav.no/website/app/_ui/theming/theme-config.ts
@@ -1,9 +1,9 @@
 import { stegaClean } from "next-sanity";
-import { AkselColors } from "@navikt/ds-react/types/theme";
+import { AkselColor } from "@navikt/ds-react/types/theme";
 import { Komponent_artikkel } from "@/app/_sanity/query-types";
 import { AllArticleDocumentsT } from "@/sanity/config";
 
-const doctypeToColorRole: Record<AllArticleDocumentsT, AkselColors> = {
+const doctypeToColorRole: Record<AllArticleDocumentsT, AkselColor> = {
   ds_artikkel: "brand-blue",
   komponent_artikkel: "brand-blue",
   templates_artikkel: "brand-blue",
@@ -15,7 +15,7 @@ const doctypeToColorRole: Record<AllArticleDocumentsT, AkselColors> = {
 
 type StatusTagT = NonNullable<Komponent_artikkel["status"]>["tag"];
 
-const statusToColorRole: Record<NonNullable<StatusTagT>, AkselColors> = {
+const statusToColorRole: Record<NonNullable<StatusTagT>, AkselColor> = {
   beta: "meta-purple",
   deprecated: "neutral",
   new: "success",

--- a/aksel.nav.no/website/app/aksel-theme.d.ts
+++ b/aksel.nav.no/website/app/aksel-theme.d.ts
@@ -4,10 +4,10 @@ import type {} from "@navikt/core/react/types/theme";
 /**
  * @example
  * ```tsx
- * import type { AkselColors } from "@navikt/ds-react/types/theme";
+ * import type { AkselColor } from "@navikt/ds-react/types/theme";
  *
  * interface MyComponentProps {
- *   color: AkselColors;
+ *   color: AkselColor;
  * }
  *
  * const MyComponent = ({ color }: MyComponentProps) => {

--- a/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/darkside/design-tokens/_ui/config.ts
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/darkside/design-tokens/_ui/config.ts
@@ -1,4 +1,4 @@
-import { AkselColorTokens } from "@navikt/ds-tokens/types";
+import { AkselColorRole } from "@navikt/ds-tokens/types";
 
 export type RoleT<T> = {
   id: T;
@@ -8,7 +8,7 @@ export type RoleT<T> = {
 
 export type RootRoleT = RoleT<"root">;
 
-export type ColorRoleT = RoleT<AkselColorTokens> | RootRoleT;
+export type ColorRoleT = RoleT<AkselColorRole> | RootRoleT;
 
 export type FontRoleT = RoleT<"family" | "line-height" | "size" | "weight">;
 

--- a/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/darkside/design-tokens/_ui/config.ts
+++ b/aksel.nav.no/website/app/dev/(designsystemet)/grunnleggende/darkside/design-tokens/_ui/config.ts
@@ -1,4 +1,4 @@
-import { type SemanticColorRoles } from "@navikt/ds-tokens/types";
+import { AkselColorTokens } from "@navikt/ds-tokens/types";
 
 export type RoleT<T> = {
   id: T;
@@ -8,7 +8,7 @@ export type RoleT<T> = {
 
 export type RootRoleT = RoleT<"root">;
 
-export type ColorRoleT = RoleT<SemanticColorRoles> | RootRoleT;
+export type ColorRoleT = RoleT<AkselColorTokens> | RootRoleT;
 
 export type FontRoleT = RoleT<"family" | "line-height" | "size" | "weight">;
 


### PR DESCRIPTION
### Description

Complete rehaul of exported darkside tokens types for a cleaner API.
- Prefixed with `Aksel` to avoid accidental autocomplete 
- Moved "internal" types to separate file that user cant access.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
