### PR TITLE
:sparkles: Now auto-scrolls to examples when navigated to.

### DIFF
--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.iframe.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.iframe.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { stegaClean } from "next-sanity";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { BoxNew, HStack, Skeleton, VStack } from "@navikt/ds-react";
 import { ExtractPortableComponentProps } from "@/app/_sanity/types";
 import { CodeBlock } from "@/app/_ui/code-block/CodeBlock";
@@ -19,8 +19,6 @@ function KodeEksemplerIFrame(props: {
 }) {
   const { dir } = props;
 
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-
   const [frameState, setFrameState] = useState(300);
 
   const {
@@ -28,6 +26,7 @@ function KodeEksemplerIFrame(props: {
     showCode,
     compact,
     resizerRef,
+    iframeRef,
   } = useKodeEksempler();
 
   const handleExampleLoad = () => {

--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
@@ -81,7 +81,20 @@ function KodeEksemplerProvider(props: {
 
     const id = nameToId(dir?.title ?? "", exampleName);
     router.push(pathname + "?" + createQueryString(id), { scroll: false });
+    iframeRef.current?.focus({ preventScroll: true });
   };
+
+  useEffect(() => {
+    if (!searchParams?.get("demo")) {
+      return;
+    }
+
+    iframeRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+    });
+    iframeRef.current?.focus({ preventScroll: true });
+  }, [searchParams]);
 
   useEffect(() => {
     const param = searchParams?.get("demo");
@@ -98,16 +111,6 @@ function KodeEksemplerProvider(props: {
       setActiveExample(foundMatch);
     }
   }, [dir?.filer, dir?.title, searchParams]);
-
-  useEffect(() => {
-    if (activeExample) {
-      iframeRef.current?.scrollIntoView({
-        behavior: "smooth",
-        block: "nearest",
-      });
-      iframeRef.current?.focus({ preventScroll: true });
-    }
-  }, [activeExample]);
 
   return (
     <KodeEksemplerContext.Provider

--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
@@ -45,6 +45,7 @@ function KodeEksemplerProvider(props: {
   const searchParams = useSearchParams();
 
   const resizerRef = useRef<HTMLDivElement>(null);
+  const prevActiveExampleRef = useRef<FileT | null>(null);
 
   const [activeExample, setActiveExample] = useState<FileT | null>(
     dir?.filer?.[0] ?? null,
@@ -96,6 +97,19 @@ function KodeEksemplerProvider(props: {
       setActiveExample(foundMatch);
     }
   }, [dir?.filer, dir?.title, searchParams]);
+
+  useEffect(() => {
+    if (
+      activeExample &&
+      prevActiveExampleRef.current?.navn !== activeExample.navn
+    ) {
+      resizerRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+      });
+    }
+    prevActiveExampleRef.current = activeExample;
+  }, [activeExample]);
 
   return (
     <KodeEksemplerContext.Provider

--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
@@ -27,8 +27,8 @@ type KodeEksemplerContextT = {
   showCode: boolean;
   toggleShowCode: () => void;
   compact: boolean;
-  resizerRef?: React.RefObject<HTMLDivElement>;
-  iframeRef?: React.RefObject<HTMLDivElement>;
+  resizerRef: React.RefObject<HTMLDivElement>;
+  iframeRef: React.RefObject<HTMLIFrameElement>;
 };
 
 const KodeEksemplerContext = createContext<KodeEksemplerContextT | null>(null);

--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
@@ -28,6 +28,7 @@ type KodeEksemplerContextT = {
   toggleShowCode: () => void;
   compact: boolean;
   resizerRef?: React.RefObject<HTMLDivElement>;
+  iframeRef?: React.RefObject<HTMLDivElement>;
 };
 
 const KodeEksemplerContext = createContext<KodeEksemplerContextT | null>(null);
@@ -45,7 +46,7 @@ function KodeEksemplerProvider(props: {
   const searchParams = useSearchParams();
 
   const resizerRef = useRef<HTMLDivElement>(null);
-  const prevActiveExampleRef = useRef<FileT | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const [activeExample, setActiveExample] = useState<FileT | null>(
     dir?.filer?.[0] ?? null,
@@ -99,16 +100,13 @@ function KodeEksemplerProvider(props: {
   }, [dir?.filer, dir?.title, searchParams]);
 
   useEffect(() => {
-    if (
-      activeExample &&
-      prevActiveExampleRef.current?.navn !== activeExample.navn
-    ) {
-      resizerRef.current?.scrollIntoView({
+    if (activeExample) {
+      iframeRef.current?.scrollIntoView({
         behavior: "smooth",
         block: "nearest",
       });
+      iframeRef.current?.focus({ preventScroll: true });
     }
-    prevActiveExampleRef.current = activeExample;
   }, [activeExample]);
 
   return (
@@ -124,6 +122,7 @@ function KodeEksemplerProvider(props: {
         toggleShowCode: () => setShowCode((prev) => !prev),
         compact,
         resizerRef,
+        iframeRef,
       }}
     >
       {children}


### PR DESCRIPTION
### Description

This allows us to directly link to examples and for it to scroll into view

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
