### PR TITLE
:bug: Outline-tag had light on light text-color in forced-color mode

### DIFF
--- a/.changeset/icy-bats-tap.md
+++ b/.changeset/icy-bats-tap.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Darkside: Outline Tag in high-contrast mode had wrong text-color.

--- a/@navikt/core/css/darkside/tag.darkside.css
+++ b/@navikt/core/css/darkside/tag.darkside.css
@@ -23,10 +23,6 @@
     box-shadow: inset 0 0 0 1px var(--ax-border-default);
     background: var(--ax-bg-moderate);
     color: var(--ax-text-default);
-
-    @media (forced-colors: active) {
-      color: canvastext;
-    }
   }
 
   &[data-variant="moderate"] {


### PR DESCRIPTION
### Description

<!-- PR description/motivation, summary of changes, links to issue/slack discussion etc. -->

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
