### PR TITLE
:sparkles: Allow disabling new themeswitch and Theme in examples

### DIFF
--- a/aksel.nav.no/website/components/website-modules/examples/withDsExample.theme.tsx
+++ b/aksel.nav.no/website/components/website-modules/examples/withDsExample.theme.tsx
@@ -24,7 +24,11 @@ function ExampleTheming({ children }: { children: React.ReactNode }) {
   );
 }
 
-function ExampleThemingSwitch() {
+function ExampleThemingSwitch({
+  legacyOnly = false,
+}: {
+  legacyOnly?: boolean;
+}) {
   const { theme, setTheme } = useTheme();
   const { query, isReady } = useRouter();
   const currentStylesheetRef = useRef<HTMLLinkElement | null>(null);
@@ -62,7 +66,7 @@ function ExampleThemingSwitch() {
   );
 
   useEffect(() => {
-    if (!shouldShow || !theme) {
+    if (!shouldShow || !theme || legacyOnly) {
       resetThemeLink();
       return;
     }
@@ -73,9 +77,9 @@ function ExampleThemingSwitch() {
     return () => {
       resetThemeLink();
     };
-  }, [createThemeLink, resetThemeLink, shouldShow, theme]);
+  }, [createThemeLink, legacyOnly, resetThemeLink, shouldShow, theme]);
 
-  if (!shouldShow) {
+  if (!shouldShow || legacyOnly) {
     return null;
   }
 

--- a/aksel.nav.no/website/components/website-modules/examples/withDsExample.tsx
+++ b/aksel.nav.no/website/components/website-modules/examples/withDsExample.tsx
@@ -30,7 +30,7 @@ type withDsT = {
 
 export const withDsExample = (
   Component: ComponentType,
-  { variant, background, showBreakpoints, legacyOnly = true }: withDsT = {},
+  { variant, background, showBreakpoints, legacyOnly = false }: withDsT = {},
 ) => {
   const DsHOC = (props: any) => {
     const [width, setWidth] = useState<number>();

--- a/aksel.nav.no/website/components/website-modules/examples/withDsExample.tsx
+++ b/aksel.nav.no/website/components/website-modules/examples/withDsExample.tsx
@@ -22,11 +22,15 @@ type withDsT = {
   variant?: "full" | "static" | "static-full" | "fullscreen";
   background?: "inverted" | "subtle";
   showBreakpoints?: boolean;
+  /**
+   * Hides theme switch and makes sure to not use `AkselTheme` wrapper.
+   */
+  legacyOnly?: boolean;
 };
 
 export const withDsExample = (
   Component: ComponentType,
-  { variant, background, showBreakpoints }: withDsT = {},
+  { variant, background, showBreakpoints, legacyOnly = true }: withDsT = {},
 ) => {
   const DsHOC = (props: any) => {
     const [width, setWidth] = useState<number>();
@@ -91,7 +95,7 @@ export const withDsExample = (
 
     let Wrapper: string | ((props: any) => JSX.Element) = "div";
 
-    if (theme === "light" || theme === "dark") {
+    if ((theme === "light" || theme === "dark") && !legacyOnly) {
       Wrapper = (_props: any) => (
         <AkselTheme {..._props} hasBackground={false} />
       );
@@ -108,7 +112,7 @@ export const withDsExample = (
         })}
         style={{ background: getBg(background) }}
       >
-        <ExampleThemingSwitch />
+        {!legacyOnly && <ExampleThemingSwitch />}
         {showBreakpoints && <BreakpointText />}
         <div
           id="ds-example"

--- a/aksel.nav.no/website/components/website-modules/examples/withDsExample.tsx
+++ b/aksel.nav.no/website/components/website-modules/examples/withDsExample.tsx
@@ -23,7 +23,7 @@ type withDsT = {
   background?: "inverted" | "subtle";
   showBreakpoints?: boolean;
   /**
-   * Hides theme switch and makes sure to not use `AkselTheme` wrapper.
+   * Hides theme switch, makes sure to not use `AkselTheme` wrapper and forces light-mode.
    */
   legacyOnly?: boolean;
 };
@@ -104,6 +104,8 @@ export const withDsExample = (
     return (
       <Wrapper
         className={cl(styles.container, {
+          /* Overrides global theme when showing legacy-examples */
+          light: legacyOnly,
           [styles.containerDefault]: !variant,
           [styles.containerStatic]: variant === "static",
           [styles.containerFull]: variant === "full",
@@ -112,7 +114,7 @@ export const withDsExample = (
         })}
         style={{ background: getBg(background) }}
       >
-        {!legacyOnly && <ExampleThemingSwitch />}
+        <ExampleThemingSwitch legacyOnly={legacyOnly} />
         {showBreakpoints && <BreakpointText />}
         <div
           id="ds-example"

--- a/aksel.nav.no/website/pages/eksempler/copybutton/used-in-info.tsx
+++ b/aksel.nav.no/website/pages/eksempler/copybutton/used-in-info.tsx
@@ -28,6 +28,7 @@ export default withDsExample(Example);
 /* Storybook story */
 export const Demo = {
   render: Example,
+  legacyOnly: true,
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/eksempler/h-grid/align.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-grid/align.tsx
@@ -38,6 +38,7 @@ const Placeholder = ({ height = "2rem", children = "" }) => (
 export default withDsExample(Example, {
   variant: "full",
   showBreakpoints: true,
+  legacyOnly: true,
 });
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/h-grid/columns-variants.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-grid/columns-variants.tsx
@@ -23,6 +23,7 @@ const Placeholder = () => <Box background="surface-alt-3" height="15rem" />;
 export default withDsExample(Example, {
   variant: "full",
   showBreakpoints: true,
+  legacyOnly: true,
 });
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/h-grid/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-grid/demo.tsx
@@ -19,6 +19,7 @@ const Placeholder = () => <Box background="surface-alt-3" height="15rem" />;
 export default withDsExample(Example, {
   variant: "full",
   showBreakpoints: true,
+  legacyOnly: true,
 });
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/h-grid/responsive-columns.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-grid/responsive-columns.tsx
@@ -20,6 +20,7 @@ const Placeholder = () => <Box background="surface-alt-3" height="15rem" />;
 export default withDsExample(Example, {
   variant: "full",
   showBreakpoints: true,
+  legacyOnly: true,
 });
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/h-grid/responsive-gap.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-grid/responsive-gap.tsx
@@ -20,6 +20,7 @@ const Placeholder = () => <Box background="surface-alt-3" height="15rem" />;
 export default withDsExample(Example, {
   variant: "full",
   showBreakpoints: true,
+  legacyOnly: true,
 });
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/h-stack/align.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-stack/align.tsx
@@ -63,7 +63,10 @@ const Placeholder = ({
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example, { showBreakpoints: true });
+export default withDsExample(Example, {
+  showBreakpoints: true,
+  legacyOnly: true,
+});
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/h-stack/justify.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-stack/justify.tsx
@@ -60,7 +60,10 @@ const Placeholder = ({ text }: { text?: string }) => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example, { showBreakpoints: true });
+export default withDsExample(Example, {
+  showBreakpoints: true,
+  legacyOnly: true,
+});
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/h-stack/responsive-direction.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-stack/responsive-direction.tsx
@@ -29,6 +29,7 @@ const Placeholder = ({ height = "3rem" }: { height?: string }) => (
 export default withDsExample(Example, {
   showBreakpoints: true,
   variant: "full",
+  legacyOnly: true,
 });
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/h-stack/spacer.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-stack/spacer.tsx
@@ -26,6 +26,7 @@ const Placeholder = () => (
 export default withDsExample(Example, {
   variant: "full",
   showBreakpoints: true,
+  legacyOnly: true,
 });
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/h-stack/wrap.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-stack/wrap.tsx
@@ -37,7 +37,10 @@ const Example = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example, { showBreakpoints: true });
+export default withDsExample(Example, {
+  showBreakpoints: true,
+  legacyOnly: true,
+});
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/as-child.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/as-child.tsx
@@ -24,7 +24,7 @@ function DemoWrapper({ children }: { children: React.ReactNode }) {
 }
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { legacyOnly: true });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/demo.tsx
@@ -24,7 +24,7 @@ function DemoWrapper({ children }: { children: React.ReactNode }) {
 }
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { legacyOnly: true });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/directions.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/directions.tsx
@@ -47,7 +47,7 @@ function DemoWrapper({ children }: { children: React.ReactNode }) {
 }
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { legacyOnly: true });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/full.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/full.tsx
@@ -28,7 +28,7 @@ const Example = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { legacyOnly: true });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/optical-alignment.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/optical-alignment.tsx
@@ -35,7 +35,7 @@ const Example = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { legacyOnly: true });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/reflective-padding.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/reflective-padding.tsx
@@ -30,7 +30,7 @@ function DemoWrapper({ children }: { children: React.ReactNode }) {
 }
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { legacyOnly: true });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/responsive.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/responsive.tsx
@@ -33,6 +33,7 @@ function DemoWrapper({ children }: { children: React.ReactNode }) {
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
 export default withDsExample(Example, {
   showBreakpoints: true,
+  legacyOnly: true,
 });
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/background.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/background.tsx
@@ -18,7 +18,9 @@ const Example = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, {
+  legacyOnly: true,
+});
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/border-color.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/border-color.tsx
@@ -33,7 +33,9 @@ const Example = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, {
+  legacyOnly: true,
+});
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/border-radius.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/border-radius.tsx
@@ -38,6 +38,7 @@ const Example = () => {
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
 export default withDsExample(Example, {
   showBreakpoints: true,
+  legacyOnly: true,
 });
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/border-width.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/border-width.tsx
@@ -15,7 +15,9 @@ const Example = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, {
+  legacyOnly: true,
+});
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/header.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/header.tsx
@@ -104,6 +104,7 @@ function Pictogram() {
 export default withDsExample(Example, {
   showBreakpoints: true,
   variant: "full",
+  legacyOnly: true,
 });
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/padding-block.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/padding-block.tsx
@@ -26,6 +26,7 @@ const Example = () => {
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
 export default withDsExample(Example, {
   showBreakpoints: true,
+  legacyOnly: true,
 });
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/padding-inline.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/padding-inline.tsx
@@ -26,6 +26,7 @@ const Example = () => {
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
 export default withDsExample(Example, {
   showBreakpoints: true,
+  legacyOnly: true,
 });
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/padding.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/padding.tsx
@@ -26,6 +26,7 @@ export default withDsExample(Example, {
 /* Storybook story */
 export const Demo = {
   render: Example,
+  legacyOnly: true,
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/panel.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/panel.tsx
@@ -30,6 +30,7 @@ const Example = () => {
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
 export default withDsExample(Example, {
   background: "subtle",
+  legacyOnly: true,
 });
 
 /* Storybook story */

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/shadow.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/shadow.tsx
@@ -46,6 +46,7 @@ export default withDsExample(Example);
 /* Storybook story */
 export const Demo = {
   render: Example,
+  legacyOnly: true,
 };
 
 export const args = {

--- a/aksel.nav.no/website/pages/eksempler/skeleton/card.tsx
+++ b/aksel.nav.no/website/pages/eksempler/skeleton/card.tsx
@@ -14,7 +14,7 @@ const Example = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example);
+export default withDsExample(Example, { legacyOnly: true });
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/v-stack/align.tsx
+++ b/aksel.nav.no/website/pages/eksempler/v-stack/align.tsx
@@ -65,7 +65,10 @@ const Placeholder = ({
 );
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example, { showBreakpoints: true });
+export default withDsExample(Example, {
+  showBreakpoints: true,
+  legacyOnly: true,
+});
 
 /* Storybook story */
 export const Demo = {

--- a/aksel.nav.no/website/pages/eksempler/v-stack/justify.tsx
+++ b/aksel.nav.no/website/pages/eksempler/v-stack/justify.tsx
@@ -65,7 +65,10 @@ const Divider = () => {
 };
 
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
-export default withDsExample(Example, { showBreakpoints: true });
+export default withDsExample(Example, {
+  showBreakpoints: true,
+  legacyOnly: true,
+});
 
 /* Storybook story */
 export const Demo = {


### PR DESCRIPTION
### Description

While not causing any errors to occur, some stories could switch between themes while not actually changing anything. The flag `legacyOnly` makes sure to remove the theme-switch and not render the "Theme"-wrapper for specific examples.

TODO: 
- [x] Fix bug where if you change theme in different examples, then visit "disabled" story, the theme would remain. 

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
