### PR TITLE
[Komponenter] Switch size small synced with radio and checkbox.

### DIFF
--- a/.changeset/flat-numbers-kiss.md
+++ b/.changeset/flat-numbers-kiss.md
@@ -1,5 +1,5 @@
 ---
-"@navikt/aksel-stylelint": minor
+"@navikt/aksel-stylelint": patch
 ---
 
 Switch: Removed 'navds-switch\_\_checkmark' css class.

--- a/.changeset/flat-numbers-kiss.md
+++ b/.changeset/flat-numbers-kiss.md
@@ -1,0 +1,5 @@
+---
+"@navikt/aksel-stylelint": minor
+---
+
+Switch: Removed 'navds-switch\_\_checkmark' css class.

--- a/.changeset/hip-walls-itch.md
+++ b/.changeset/hip-walls-itch.md
@@ -1,6 +1,6 @@
 ---
-"@navikt/ds-react": minor
-"@navikt/ds-css": minor
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
 ---
 
 Switch: Size='small' are now visually comparable to radio and checkbox in the same size.

--- a/.changeset/hip-walls-itch.md
+++ b/.changeset/hip-walls-itch.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": minor
+"@navikt/ds-css": minor
+---
+
+Switch: Size='small' are now visually comparable to radio and checkbox in the same size.

--- a/@navikt/aksel-stylelint/src/deprecations.ts
+++ b/@navikt/aksel-stylelint/src/deprecations.ts
@@ -76,4 +76,8 @@ export const deprecations: DeprecatedList = [
     classes: ["navds-combobox__button-clear"],
     message: "Removed in v7.8.0",
   },
+  {
+    classes: ["navds-switch__checkmark"],
+    message: "Removed in v7.24.0 ",
+  },
 ];

--- a/@navikt/aksel-stylelint/src/deprecations.ts
+++ b/@navikt/aksel-stylelint/src/deprecations.ts
@@ -78,6 +78,6 @@ export const deprecations: DeprecatedList = [
   },
   {
     classes: ["navds-switch__checkmark"],
-    message: "Removed in v7.24.0 ",
+    message: "Removed in v7.24.0",
   },
 ];

--- a/@navikt/core/css/darkside/form/switch.darkside.css
+++ b/@navikt/core/css/darkside/form/switch.darkside.css
@@ -20,6 +20,7 @@
 
   .aksel-switch--small > & {
     height: 2rem;
+    width: 2.5rem;
     top: 0;
   }
 }
@@ -32,19 +33,21 @@
 
 .aksel-switch__content {
   --__axc-switch-block-padding: 0.75rem;
+  --__axc-switch-inline-padding: 3.25rem;
 
   position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--ax-space-2);
-  padding: var(--__axc-switch-block-padding) 0 var(--__axc-switch-block-padding) 3.25rem;
+  padding: var(--__axc-switch-block-padding) 0 var(--__axc-switch-block-padding) var(--__axc-switch-inline-padding);
 
   .aksel-switch--right & {
-    padding: var(--__axc-switch-block-padding) 3.25rem var(--__axc-switch-block-padding) 0;
+    padding: var(--__axc-switch-block-padding) var(--__axc-switch-inline-padding) var(--__axc-switch-block-padding) 0;
   }
 
   .aksel-switch--small & {
     --__axc-switch-block-padding: 0.375rem;
+    --__axc-switch-inline-padding: 2.75rem;
   }
 
   &.aksel-switch--with-description {
@@ -87,7 +90,9 @@
   transition-timing-function: ease;
 
   .aksel-switch--small > & {
-    top: var(--ax-space-4);
+    top: var(--ax-space-6);
+    width: 2.25rem;
+    height: 1.25rem;
   }
 
   .aksel-switch__input:checked ~ & {
@@ -135,6 +140,11 @@
   left: 0.0625rem;
   top: 0.0625rem;
 
+  .aksel-switch--small & {
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+
   .aksel-switch__input:checked ~ .aksel-switch__track > & {
     background-color: var(--ax-bg-raised);
     transform: translateX(1.25rem);
@@ -145,16 +155,13 @@
     top: 0;
   }
 
-  .aksel-switch__input:checked ~ .aksel-switch__track > & > .aksel-switch__checkmark {
-    visibility: visible;
-    opacity: 1;
+  .aksel-switch--small > .aksel-switch__input:checked ~ .aksel-switch__track > & {
+    transform: translateX(1rem);
+    width: 1rem;
+    height: 1rem;
+    left: 0;
+    top: 0;
   }
-}
-
-.aksel-switch__checkmark {
-  visibility: hidden;
-  opacity: 0;
-  transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -164,6 +171,10 @@
 
   .aksel-switch__input:checked:hover:not(:disabled) ~ .aksel-switch__track > .aksel-switch__thumb {
     transform: translateX(1.1rem);
+  }
+
+  .aksel-switch--small > .aksel-switch__input:checked:hover:not(:disabled) ~ .aksel-switch__track > .aksel-switch__thumb {
+    transform: translateX(0.875rem);
   }
 }
 
@@ -226,6 +237,10 @@
 
     & > .aksel-switch__input:checked:hover ~ .aksel-switch__track > .aksel-switch__thumb {
       transform: translateX(1.25rem);
+    }
+
+    &.aksel-switch--small > .aksel-switch__input:checked:hover ~ .aksel-switch__track > .aksel-switch__thumb {
+      transform: translateX(1rem);
     }
   }
 }

--- a/@navikt/core/css/form/switch.css
+++ b/@navikt/core/css/form/switch.css
@@ -159,14 +159,6 @@
   top: 0;
 }
 
-.navds-switch__input:checked ~ .navds-switch__track .navds-switch__checkmark {
-  visibility: visible;
-}
-
-.navds-switch__checkmark {
-  visibility: hidden;
-}
-
 @media (hover: hover) and (pointer: fine) {
   .navds-switch__input:hover ~ .navds-switch__track > .navds-switch__thumb {
     transform: translateX(0.125rem);

--- a/@navikt/core/css/form/switch.css
+++ b/@navikt/core/css/form/switch.css
@@ -26,6 +26,7 @@
 
 .navds-switch--small > .navds-switch__input {
   height: 2rem;
+  width: 2.5rem;
   top: 0;
 }
 
@@ -47,11 +48,11 @@
 }
 
 .navds-switch--small > .navds-switch__label-wrapper > .navds-switch__content {
-  padding: calc(var(--a-spacing-2) - var(--a-spacing-05)) 0 calc(var(--a-spacing-2) - var(--a-spacing-05)) 3.25rem;
+  padding: calc(var(--a-spacing-2) - var(--a-spacing-05)) 0 calc(var(--a-spacing-2) - var(--a-spacing-05)) 2.75rem;
 }
 
 .navds-switch--right.navds-switch--small > .navds-switch__label-wrapper > .navds-switch__content {
-  padding: calc(var(--a-spacing-2) - var(--a-spacing-05)) 3.25rem calc(var(--a-spacing-2) - var(--a-spacing-05)) 0;
+  padding: calc(var(--a-spacing-2) - var(--a-spacing-05)) 2.75rem calc(var(--a-spacing-2) - var(--a-spacing-05)) 0;
 }
 
 .navds-switch--with-description,
@@ -84,7 +85,9 @@
 }
 
 .navds-switch--small > .navds-switch__track {
-  top: var(--a-spacing-1);
+  top: var(--a-spacing-1-alt);
+  width: 2.25rem;
+  height: 1.25rem;
 }
 
 .navds-switch--right > .navds-switch__input,
@@ -149,12 +152,25 @@
   justify-content: center;
 }
 
+.navds-switch--small .navds-switch__thumb {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
 .navds-switch__input:checked ~ .navds-switch__track > .navds-switch__thumb {
   transform: translateX(1.25rem);
   color: var(--ac-switch-thumb-icon-checked, var(--a-icon-action-selected));
   background-color: var(--a-surface-default);
   width: 1.25rem;
   height: 1.25rem;
+  left: 0;
+  top: 0;
+}
+
+.navds-switch--small > .navds-switch__input:checked ~ .navds-switch__track > .navds-switch__thumb {
+  transform: translateX(1rem);
+  width: 1rem;
+  height: 1rem;
   left: 0;
   top: 0;
 }
@@ -167,6 +183,10 @@
   .navds-switch__input:checked:hover ~ .navds-switch__track > .navds-switch__thumb {
     transform: translateX(1.125rem);
   }
+
+  .navds-switch--small > .navds-switch__input:checked:hover ~ .navds-switch__track > .navds-switch__thumb {
+    transform: translateX(0.875rem);
+  }
 }
 
 .navds-switch__input:disabled:hover ~ .navds-switch__track > .navds-switch__thumb {
@@ -175,6 +195,10 @@
 
 .navds-switch__input:checked:disabled:hover ~ .navds-switch__track > .navds-switch__thumb {
   transform: translateX(1.25rem);
+}
+
+.navds-switch--small > .navds-switch__input:checked:disabled:hover ~ .navds-switch__track > .navds-switch__thumb {
+  transform: translateX(1rem);
 }
 
 /* Disabled */

--- a/@navikt/core/react/src/form/switch/Switch.tsx
+++ b/@navikt/core/react/src/form/switch/Switch.tsx
@@ -117,32 +117,7 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
         />
         <span className={cn("navds-switch__track")}>
           <span className={cn("navds-switch__thumb")}>
-            {loading ? (
-              <Loader
-                size="xsmall"
-                aria-live="polite"
-                variant={checked ? "interaction" : "inverted"}
-              />
-            ) : (
-              <svg
-                width="12"
-                height="10"
-                viewBox="0 0 12 10"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                focusable={false}
-                role="img"
-                aria-hidden
-                className={cn("navds-switch__checkmark")}
-              >
-                <path
-                  fillRule="evenodd"
-                  clipRule="evenodd"
-                  d="M11.2674 0.647802C11.8762 1.20971 11.9141 2.1587 11.3522 2.76743L5.35221 9.26743C5.07531 9.56739 4.68813 9.74155 4.27998 9.74971C3.87184 9.75787 3.478 9.59933 3.18934 9.31067L0.68934 6.81067C0.103553 6.22488 0.103553 5.27513 0.68934 4.68935C1.27513 4.10356 2.22487 4.10356 2.81066 4.68935L4.20673 6.08541L9.14779 0.732587C9.7097 0.123856 10.6587 0.0858967 11.2674 0.647802Z"
-                  fill="currentColor"
-                />
-              </svg>
-            )}
+            <SwitchIcon size={size} checked={checked} loading={loading} />
           </span>
         </span>
         <label
@@ -180,5 +155,71 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
     );
   },
 );
+
+const SwitchIcon = ({
+  size,
+  checked,
+  loading,
+}: {
+  size: SwitchProps["size"];
+  checked: SwitchProps["checked"];
+  loading: SwitchProps["loading"];
+}) => {
+  if (loading) {
+    return (
+      <Loader
+        size="xsmall"
+        aria-live="polite"
+        variant={checked ? "interaction" : "inverted"}
+      />
+    );
+  }
+
+  if (!checked) {
+    return null;
+  }
+
+  if (size === "small") {
+    return (
+      <svg
+        width="11"
+        height="8"
+        viewBox="0 0 11 8"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        focusable={false}
+        role="img"
+        aria-hidden
+      >
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M9.62013 0.530226C10.1194 0.952686 10.1817 1.6999 9.7592 2.19917L5.4171 7.33075C5.20318 7.58356 4.89318 7.73525 4.5623 7.74901C4.23142 7.76277 3.90989 7.63735 3.67572 7.40318L1.3073 5.03476C0.844833 4.5723 0.844833 3.8225 1.3073 3.36003C1.76976 2.89757 2.51956 2.89757 2.98202 3.36003L4.4404 4.81841L7.95118 0.669304C8.37364 0.170033 9.12085 0.107765 9.62013 0.530226Z"
+          fill="currentColor"
+        />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      width="12"
+      height="10"
+      viewBox="0 0 12 10"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      focusable={false}
+      role="img"
+      aria-hidden
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M11.2674 0.647802C11.8762 1.20971 11.9141 2.1587 11.3522 2.76743L5.35221 9.26743C5.07531 9.56739 4.68813 9.74155 4.27998 9.74971C3.87184 9.75787 3.478 9.59933 3.18934 9.31067L0.68934 6.81067C0.103553 6.22488 0.103553 5.27513 0.68934 4.68935C1.27513 4.10356 2.22487 4.10356 2.81066 4.68935L4.20673 6.08541L9.14779 0.732587C9.7097 0.123856 10.6587 0.0858967 11.2674 0.647802Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+};
 
 export default Switch;

--- a/@navikt/core/react/src/form/switch/Switch.tsx
+++ b/@navikt/core/react/src/form/switch/Switch.tsx
@@ -166,14 +166,14 @@ const SwitchIcon = ({
   loading: SwitchProps["loading"];
 }) => {
   if (loading) {
-    let baseSize = 1;
+    let baseSize = 16;
 
     if (size === "small") {
-      baseSize = 0.75;
+      baseSize = 12;
     }
 
     if (checked) {
-      baseSize -= 0.0625;
+      baseSize += 2;
     }
 
     return (
@@ -181,8 +181,8 @@ const SwitchIcon = ({
         size="small"
         aria-live="polite"
         variant={checked ? "interaction" : "inverted"}
-        width={`${baseSize}rem`}
-        height={`${baseSize}rem`}
+        width={`${baseSize / 16}rem`}
+        height={`${baseSize / 16}rem`}
       />
     );
   }

--- a/@navikt/core/react/src/form/switch/Switch.tsx
+++ b/@navikt/core/react/src/form/switch/Switch.tsx
@@ -166,11 +166,23 @@ const SwitchIcon = ({
   loading: SwitchProps["loading"];
 }) => {
   if (loading) {
+    let baseSize = 1;
+
+    if (size === "small") {
+      baseSize = 0.75;
+    }
+
+    if (checked) {
+      baseSize -= 0.0625;
+    }
+
     return (
       <Loader
-        size="xsmall"
+        size="small"
         aria-live="polite"
         variant={checked ? "interaction" : "inverted"}
+        width={`${baseSize}rem`}
+        height={`${baseSize}rem`}
       />
     );
   }


### PR DESCRIPTION
### Description

Update `<Switch size="small" />` to match height with radio and checkbox of same size.
- Refactored icon/loader handling for readability, and dynamic loader-size based on checked-state.

Resolves #3696
Resolves https://github.com/orgs/navikt/projects/49/views/18?query=is%3Aopen+sort%3Aupdated-desc&pane=issue&itemId=110454878&issue=navikt%7Cteam-aksel%7C824

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [x] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
