### PR TITLE
[Komponenter] Scroll margin forms

### DIFF
--- a/.changeset/bumpy-singers-ask.md
+++ b/.changeset/bumpy-singers-ask.md
@@ -3,4 +3,4 @@
 "@navikt/ds-css": patch
 ---
 
-Forms: Added build-in scroll-margin to TextField, Textarea and Select.
+Forms: Added built-in scroll-margin to TextField, Textarea and Select.

--- a/.changeset/bumpy-singers-ask.md
+++ b/.changeset/bumpy-singers-ask.md
@@ -1,5 +1,4 @@
 ---
-"@navikt/ds-react": patch
 "@navikt/ds-css": patch
 ---
 

--- a/.changeset/bumpy-singers-ask.md
+++ b/.changeset/bumpy-singers-ask.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+Forms: Added build-in scroll-margin to TextField, Textarea and Select.

--- a/@navikt/core/css/darkside/form/select.darkside.css
+++ b/@navikt/core/css/darkside/form/select.darkside.css
@@ -11,6 +11,7 @@
   position: relative;
   padding: var(--ax-space-8);
   padding-right: var(--ax-space-40);
+  scroll-margin-block-start: 4rem;
 
   &:hover {
     border-color: var(--ax-border-strong);

--- a/@navikt/core/css/darkside/form/text-field.darkside.css
+++ b/@navikt/core/css/darkside/form/text-field.darkside.css
@@ -7,6 +7,7 @@
   min-height: 3rem;
   width: 100%;
   color: var(--ax-text-neutral);
+  scroll-margin-block-start: 4rem;
 
   &:hover {
     border-color: var(--ax-border-strong);

--- a/@navikt/core/css/darkside/form/textarea.darkside.css
+++ b/@navikt/core/css/darkside/form/textarea.darkside.css
@@ -10,6 +10,7 @@
   width: 100%;
   display: block;
   color: var(--ax-text-neutral);
+  scroll-margin-block-start: 4rem;
 
   &::placeholder {
     color: var(--ax-text-neutral-subtle);

--- a/@navikt/core/css/form/select.css
+++ b/@navikt/core/css/form/select.css
@@ -11,6 +11,7 @@
   position: relative;
   padding: 0.5rem;
   padding-right: 2rem;
+  scroll-margin-block-start: 4rem;
 }
 
 @media (forced-colors: active) {

--- a/@navikt/core/css/form/text-field.css
+++ b/@navikt/core/css/form/text-field.css
@@ -25,6 +25,7 @@
   min-height: 3rem;
   width: 100%;
   color: var(--ac-textfield-text, var(--__ac-textfield-text, var(--a-text-default)));
+  scroll-margin-block-start: 4rem;
 }
 
 .navds-text-field__input[size] {

--- a/@navikt/core/css/form/textarea.css
+++ b/@navikt/core/css/form/textarea.css
@@ -32,6 +32,7 @@
   width: 100%;
   display: block;
   color: var(--ac-textarea-text, var(--__ac-textarea-text, var(--a-text-default)));
+  scroll-margin-block-start: 4rem;
 }
 
 .navds-textarea__input::placeholder {

--- a/@navikt/core/react/src/form/textfield/TextField.stories.tsx
+++ b/@navikt/core/react/src/form/textfield/TextField.stories.tsx
@@ -110,6 +110,20 @@ export const Readonly = () => {
   );
 };
 
+export const ScrollMargin = () => {
+  return (
+    <div style={{ minHeight: "200vh" }}>
+      <TextField
+        label="Bosted"
+        description="Skriv bosted i Norge"
+        value="Oslo"
+        id="smargin-test"
+      />
+      <a href="#smargin-test">Test scroll-margin</a>
+    </div>
+  );
+};
+
 export const ColorRole = () => {
   return (
     <div className="colgap" data-color="brand-magenta">


### PR DESCRIPTION
### Description

Did not add it to checkboxes and radio. Since the are vertically stacked, addings scroll-margin would only work for the first element.

Resolves https://github.com/orgs/navikt/projects/49/views/18?query=is%3Aopen+sort%3Aupdated-desc&pane=issue&itemId=103696924&issue=navikt%7Caksel%7C3698

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
