### PR TITLE
:sparkles: Allow for custom buttons in fileupload item.

### DIFF
--- a/.changeset/dull-planets-brush.md
+++ b/.changeset/dull-planets-brush.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": minor
+"@navikt/ds-css": minor
+---
+
+FileUpload: Allow for custom buttons in FileUpload.Item.

--- a/@navikt/core/css/config/_mappings.js
+++ b/@navikt/core/css/config/_mappings.js
@@ -124,7 +124,13 @@ const StyleMappings = {
     {
       component: "FileUpload",
       main: formCss,
-      dependencies: [typoCss, "button.css", "loader.css", "link.css"],
+      dependencies: [
+        typoCss,
+        "button.css",
+        "loader.css",
+        "link.css",
+        primitivesCss,
+      ],
     },
     {
       component: "GuidePanel",

--- a/@navikt/core/css/darkside/form/file-upload.darkside.css
+++ b/@navikt/core/css/darkside/form/file-upload.darkside.css
@@ -197,10 +197,6 @@ li.aksel-file-item {
   overflow-wrap: anywhere;
 }
 
-.aksel-file-item__button {
-  margin-left: auto;
-}
-
 .aksel-file-item__error {
   display: grid;
   transition-property: grid-template-rows, padding-top;

--- a/@navikt/core/css/form/file-upload.css
+++ b/@navikt/core/css/form/file-upload.css
@@ -196,10 +196,6 @@ li.navds-file-item {
   overflow-wrap: anywhere;
 }
 
-.navds-file-item__button {
-  margin-left: auto;
-}
-
 .navds-file-item__error {
   color: var(--a-text-danger);
   display: grid;

--- a/@navikt/core/react/src/form/file-upload/file-upload-item.stories.tsx
+++ b/@navikt/core/react/src/form/file-upload/file-upload-item.stories.tsx
@@ -1,7 +1,10 @@
 import { Meta, StoryFn } from "@storybook/react";
 import React from "react";
+import { MenuElipsisVerticalCircleIcon } from "@navikt/aksel-icons";
 import { FileItem, FileUpload } from ".";
+import { Button } from "../../button";
 import { VStack } from "../../layout/stack";
+import { ActionMenu } from "../../overlays/action-menu";
 
 const meta: Meta<typeof FileUpload.Item> = {
   title: "ds-react/FileUpload/Item",
@@ -116,6 +119,34 @@ export const States: StoryFn = () => {
         }}
       />
     </div>
+  );
+};
+
+export const CustomButton: StoryFn = () => {
+  return (
+    <FileUpload.Item
+      file={{ name: "custom button.png", size: 200000 }}
+      button={
+        <ActionMenu>
+          <ActionMenu.Trigger>
+            <Button
+              variant="tertiary-neutral"
+              icon={<MenuElipsisVerticalCircleIcon aria-hidden />}
+            />
+          </ActionMenu.Trigger>
+          <ActionMenu.Content>
+            <ActionMenu.Group label="Systemer og oppslagsverk">
+              <ActionMenu.Item onSelect={console.info}>
+                Action one
+              </ActionMenu.Item>
+              <ActionMenu.Item onSelect={console.info}>
+                Action two
+              </ActionMenu.Item>
+            </ActionMenu.Group>
+          </ActionMenu.Content>
+        </ActionMenu>
+      }
+    />
   );
 };
 

--- a/@navikt/core/react/src/form/file-upload/parts/item/Item.tsx
+++ b/@navikt/core/react/src/form/file-upload/parts/item/Item.tsx
@@ -1,4 +1,5 @@
 import React, { MouseEvent, forwardRef } from "react";
+import { Spacer } from "../../../../layout/stack";
 import { useRenameCSS } from "../../../../theme/Theme";
 import { BodyShort, ErrorMessage } from "../../../../typography";
 import { OverridableComponent } from "../../../../util";
@@ -51,11 +52,13 @@ export interface FileUploadItemProps
   /**
    * Props for the action button.
    */
-  button?: {
-    action: "delete" | "retry";
-    onClick: (event: MouseEvent<HTMLButtonElement>) => void;
-    id?: string;
-  };
+  button?:
+    | {
+        action: "delete" | "retry";
+        onClick: (event: MouseEvent<HTMLButtonElement>) => void;
+        id?: string;
+      }
+    | React.ReactNode;
   /**
    * i18n-API for customizing texts and labels
    */
@@ -100,6 +103,9 @@ export const Item: OverridableComponent<FileUploadItemProps, HTMLDivElement> =
         return description ?? formatFileSize(file);
       }
 
+      const renderButton = status === "idle" && button;
+      const renderCustomButton = isCustomButton(button);
+
       return (
         <Component
           ref={ref}
@@ -131,8 +137,9 @@ export const Item: OverridableComponent<FileUploadItemProps, HTMLDivElement> =
                 )}
               </div>
             </div>
+            {renderButton && <Spacer />}
 
-            {status === "idle" && button && (
+            {renderButton && !renderCustomButton && (
               <ItemButton
                 {...button}
                 title={translate(
@@ -142,10 +149,17 @@ export const Item: OverridableComponent<FileUploadItemProps, HTMLDivElement> =
                 )}
               />
             )}
+            {renderButton && renderCustomButton && button}
           </div>
         </Component>
       );
     },
   );
+
+function isCustomButton(
+  button: FileUploadItemProps["button"],
+): button is React.ReactNode {
+  return React.isValidElement(button);
+}
 
 export default Item;


### PR DESCRIPTION
### Description

Not the prettiest feature, but resolves the issue while avoiding breaking anything.
- Found no uses for deleted css class, so didn't see the need to add it to deprecation list in stylelint.

Resolves #3680

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
