### PR TITLE
:tada: Scroll examples into view after being closed from expand-state

### DIFF
--- a/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
+++ b/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
@@ -111,7 +111,6 @@ function CodeBlockEditor(props: {
       /* Scroll to the top of the code block when collapsed */
       queueMicrotask(() => {
         wrapperRef.current?.scrollIntoView({
-          behavior: "smooth",
           block: "center",
         });
       });

--- a/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
+++ b/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
@@ -107,7 +107,7 @@ function CodeBlockEditor(props: {
     codeSnippet.update(value, !expanded.current);
     expanded.toggle();
 
-    if (!expanded.current) {
+    if (expanded.current) {
       /* Scroll to the top of the code block when collapsed */
       queueMicrotask(() => {
         wrapperRef.current?.scrollIntoView({

--- a/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
+++ b/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
@@ -107,8 +107,8 @@ function CodeBlockEditor(props: {
     codeSnippet.update(value, !expanded.current);
     expanded.toggle();
 
-    if (expanded.current) {
-      /* Scroll to the top of the code block when expanded */
+    if (!expanded.current) {
+      /* Scroll to the top of the code block when collapsed */
       queueMicrotask(() => {
         wrapperRef.current?.scrollIntoView({
           behavior: "smooth",

--- a/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
+++ b/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Highlight } from "prism-react-renderer";
-import { useId } from "react";
+import { useId, useRef } from "react";
 import { ChevronDownUpIcon, ChevronUpDownIcon } from "@navikt/aksel-icons";
 import { Button, CopyButton, HStack, Spacer, Tabs } from "@navikt/ds-react";
 import { TabsList, TabsPanel, TabsTab } from "@navikt/ds-react/Tabs";
@@ -92,6 +92,7 @@ function CodeBlockEditor(props: {
   extraCode?: string;
   lang: string;
 }) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const { value, code, extraCode, lang } = props;
   const { expanded, codeSnippet, useTabs, showLineNumbers, wrapCode } =
     useCodeBlock();
@@ -105,10 +106,20 @@ function CodeBlockEditor(props: {
   const handleExpandUpdate = () => {
     codeSnippet.update(value, !expanded.current);
     expanded.toggle();
+
+    if (expanded.current) {
+      /* Scroll to the top of the code block when expanded */
+      queueMicrotask(() => {
+        wrapperRef.current?.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+        });
+      });
+    }
   };
 
   return (
-    <Wrapper value={value}>
+    <Wrapper value={value} ref={wrapperRef}>
       <Highlight
         code={visibleCode}
         language={getLanguage(lang)}


### PR DESCRIPTION
### Description

`queueMicrotask` allows the scroll to happen after its closes, centering based on the closed-state, not the open-state

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
