### PR TITLE
:bug: JsCodeshift ignored given filepaths when extensions were given

### DIFF
--- a/.changeset/calm-cameras-wave.md
+++ b/.changeset/calm-cameras-wave.md
@@ -1,0 +1,5 @@
+---
+"@navikt/aksel": patch
+---
+
+CLI: Codemods now respect filepath globs instead of ignoring some based on file-extension.

--- a/@navikt/aksel/src/codemod/run-codeshift.ts
+++ b/@navikt/aksel/src/codemod/run-codeshift.ts
@@ -39,7 +39,6 @@ export async function runCodeshift(
     await jscodeshift.run(codemodPath, filepaths, {
       babel: true,
       ignorePattern: ignoreNodeModules,
-      extensions: "tsx,ts,jsx,js",
       parser: "tsx",
       verbose: 2,
       runInBand: true,

--- a/@navikt/aksel/src/darkside/run-tooling.ts
+++ b/@navikt/aksel/src/darkside/run-tooling.ts
@@ -205,7 +205,6 @@ async function runCodeshift(
   await jscodeshift.run(codemodPath, filepaths, {
     babel: true,
     ignorePattern: GLOB_IGNORE_PATTERNS,
-    extensions: "tsx,ts,jsx,js",
     parser: "tsx",
     verbose: 2,
     runInBand: true,


### PR DESCRIPTION
### Description

This lead to migrations to all files not js,ts,tsx,jsx to be ignored.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
