### PR TITLE
[website] Fix changelog link in component links to ref new changelog

### DIFF
--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
@@ -76,12 +76,12 @@ function KomponentLinks({ data }: { data: KOMPONENT_BY_SLUG_QUERYResult }) {
         </Link>
       )}
       <Link
-        href="/grunnleggende/kode/endringslogg"
+        href="/grunnleggende/endringslogg"
         variant="subtle"
         onClick={() =>
           umamiTrack("navigere", {
             kilde: "komponent-header",
-            url: "/grunnleggende/kode/endringslogg",
+            url: "/grunnleggende/endringslogg",
           })
         }
       >


### PR DESCRIPTION
### Description

Every component page has a set of links to the GitHub repo, the changelog and sometimes a Figma-link. This PR updates the changelog link to reference the new location of the "Endringslogg" at `/grunnleggende/endringslogg` (rather than at `/grunnleggende/kode/endringslogg`).

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
