### PR TITLE
:bug: Using Theme component to set color to dark did not work when root node did not set light/dark

### DIFF
--- a/.changeset/true-nails-follow.md
+++ b/.changeset/true-nails-follow.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-tokens": minor
+"@navikt/ds-react": minor
+---
+
+Darkside: Using 'Theme' to set current color-theme now works when root-node does not set light or dark class.

--- a/@navikt/core/react/src/theme/Theme.tsx
+++ b/@navikt/core/react/src/theme/Theme.tsx
@@ -100,7 +100,7 @@ const Theme = forwardRef<HTMLDivElement, ThemeProps>(
             ref={ref}
             className={cl("aksel-theme", className, theme)}
             data-background={hasBackground}
-            data-color={color}
+            data-color={color ?? ""}
           >
             {children}
           </SlotElement>

--- a/@navikt/core/tokens/darkside/index.ts
+++ b/@navikt/core/tokens/darkside/index.ts
@@ -138,7 +138,7 @@ async function buildThemedRolesCSS() {
   /**
    * We set 'accent' as the default color palette.
    */
-  const rootSelector = `:root, [data-color=accent]`;
+  const rootSelector = `:root, [data-color=accent], [data-color=""]`;
 
   /* To avoid having to export this const from the "global" types, we declare it here locally so users dont get internal types */
   const colors: Record<AkselColorRole, string> = {


### PR DESCRIPTION
### Description

By setting `data-color` to empty string + updating token-config, when Theme-component is used, it will make sure to correctly update cascade.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
