### PR TITLE
Improved clean script

### DIFF
--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -52,7 +52,7 @@ console.group("Cleaning up node_modules. This may take a while...");
 
 const nodeModulesFolders = FastGlob.sync("**/node_modules", {
   onlyDirectories: true,
-  ignore: ["**/node_modules/**/node_modules"],
+  ignore: ["**/node_modules/**/node_modules"], // Ignore nested node_modules
 });
 
 for (const folder of nodeModulesFolders) {


### PR DESCRIPTION
Exchanged unlink/rmdir with rm. Results in less code, but I think it's faster too.

The current logic for finding node_modules folders did not work well on Windows. It just ran for a very long time, then crashed. The changes in this PR works much better. I guess it can't handle the amount of nested node_modules folders 😅

Also added a small "quality of life" hack for Windows that warns if there are other node processes running. I often experience that deleting node_modules fails b.c. some files are in use.