### PR TITLE
:tada: Auto-generate github-releases based on changeset release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -23,7 +23,8 @@
   "ignore": [
     "aksel.nav.no",
     "aksel-icons-figma-plugin",
-    "eslint-plugin-aksel-local"
+    "eslint-plugin-aksel-local",
+    "scripts"
   ],
 
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -105,7 +105,7 @@ module.exports = tseslint.config([
   },
 
   {
-    files: ["**/*.stories.ts?(x)"],
+    files: ["**/*.stories.ts?(x)", "scripts/*.ts"],
     rules: {
       "no-console": "off",
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:css": "yarn stylelint '@navikt/**/*.css'",
     "changeset": "changeset",
     "create-version": "changeset version && yarn changelog && yarn",
-    "release": "yarn boot && yarn docgen && changeset publish",
+    "release": "yarn boot && yarn docgen && changeset publish && yarn script:git-release",
     "biome:lint": "yarn biome lint ."
   },
   "workspaces": [
@@ -31,7 +31,8 @@
     "@navikt/aksel-stylelint",
     "@navikt/aksel",
     "aksel.nav.no",
-    "scripts/eslint"
+    "scripts/eslint",
+    "scripts"
   ],
   "prettier": {
     "plugins": [

--- a/scripts/git-release.ts
+++ b/scripts/git-release.ts
@@ -15,7 +15,7 @@ async function main() {
   const releaseLines = newestEntry[0].trim().split("\n");
 
   const version = releaseLines[0];
-  // Remove the version line and the separator (usually an empty line) before the actual release notes.
+  // Remove the version line and the empty line before the actual release notes.
   releaseLines.splice(0, 2);
   const releaseNotes = releaseLines.join("\n").trim();
 

--- a/scripts/git-release.ts
+++ b/scripts/git-release.ts
@@ -15,6 +15,7 @@ async function main() {
   const releaseLines = newestEntry[0].trim().split("\n");
 
   const version = releaseLines[0];
+  // Remove the version line and the separator (usually an empty line) before the actual release notes.
   releaseLines.splice(0, 2);
   const releaseNotes = releaseLines.join("\n").trim();
 

--- a/scripts/git-release.ts
+++ b/scripts/git-release.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { spawnSync } from "child_process";
 import fs from "fs";
 import simpleGit from "simple-git";
 
@@ -30,10 +30,23 @@ async function main() {
   }
 
   try {
-    execSync(
-      `gh release create ${tagName} --title "v${version}" --notes "${releaseNotes}"`,
+    const result = spawnSync(
+      "gh",
+      [
+        "release",
+        "create",
+        tagName,
+        "--title",
+        `v${version}`,
+        "--notes",
+        releaseNotes,
+      ],
       { stdio: "inherit" },
     );
+
+    if (result.error) {
+      throw result.error;
+    }
   } catch (error) {
     console.error("Error creating GitHub release:", error);
   }

--- a/scripts/git-release.ts
+++ b/scripts/git-release.ts
@@ -1,0 +1,51 @@
+import { execSync } from "child_process";
+import fs from "fs";
+import simpleGit from "simple-git";
+
+const git = simpleGit();
+
+main();
+
+async function main() {
+  const changelogFile = fs.readFileSync("../CHANGELOG.md", "utf-8");
+
+  const newestEntry = changelogFile.split("\n## ");
+  newestEntry.shift(); // Remove the first item, it's the main heading.
+
+  const releaseLines = newestEntry[0].trim().split("\n");
+
+  const version = releaseLines[0];
+  releaseLines.splice(0, 2);
+  const releaseNotes = releaseLines.join("\n").trim();
+
+  console.log(`Creating release for version: ${version}`);
+
+  const tagName = `release-v${version}`;
+
+  /* Release will fail if tag is duplicated */
+  const tagExists = await gitTagExists(tagName);
+
+  if (tagExists) {
+    console.log(`Tag ${tagName} already exists. Skipping release creation.`);
+    return;
+  }
+
+  try {
+    execSync(
+      `gh release create ${tagName} --title "v${version}" --notes "${releaseNotes}"`,
+      { stdio: "inherit" },
+    );
+  } catch (error) {
+    console.error("Error creating GitHub release:", error);
+  }
+}
+
+async function gitTagExists(tag: string): Promise<boolean> {
+  try {
+    const output = await git.listRemote(["--tags", "origin", tag]);
+    return output.includes(tag);
+  } catch (error) {
+    console.error("Error checking for tag:", error);
+    return false; // Assume tag doesn't exist on error
+  }
+}

--- a/scripts/git-release.ts
+++ b/scripts/git-release.ts
@@ -9,10 +9,8 @@ main();
 async function main() {
   const changelogFile = fs.readFileSync("../CHANGELOG.md", "utf-8");
 
-  const newestEntry = changelogFile.split("\n## ");
-  newestEntry.shift(); // Remove the first item, it's the main heading.
-
-  const releaseLines = newestEntry[0].trim().split("\n");
+  const newestEntry = changelogFile.split("\n## ")[1]; // The first item is the main heading.
+  const releaseLines = newestEntry.trim().split("\n");
 
   const version = releaseLines[0];
   // Remove the version line and the empty line before the actual release notes.

--- a/scripts/git-release.ts
+++ b/scripts/git-release.ts
@@ -19,7 +19,7 @@ async function main() {
 
   console.log(`Creating release for version: ${version}`);
 
-  const tagName = `release-v${version}`;
+  const tagName = `v${version}`;
 
   /* Release will fail if tag is duplicated */
   const tagExists = await gitTagExists(tagName);

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "scripts",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Aksel repo scripts",
+  "scripts": {
+    "script:git-release": "tsx ./git-release"
+  },
+  "devDependencies": {
+    "simple-git": "^3.28.0",
+    "tsx": "^4.19.1"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3902,6 +3902,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@kwsites/file-exists@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@kwsites/file-exists@npm:1.1.1"
+  dependencies:
+    debug: "npm:^4.1.1"
+  checksum: 10/4ff945de7293285133aeae759caddc71e73c4a44a12fac710fdd4f574cce2671a3f89d8165fdb03d383cfc97f3f96f677d8de3c95133da3d0e12a123a23109fe
+  languageName: node
+  linkType: hard
+
+"@kwsites/promise-deferred@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@kwsites/promise-deferred@npm:1.1.1"
+  checksum: 10/07455477a0123d9a38afb503739eeff2c5424afa8d3dbdcc7f9502f13604488a4b1d9742fc7288832a52a6422cf1e1c0a1d51f69a39052f14d27c9a0420b6629
+  languageName: node
+  linkType: hard
+
 "@leichtgewicht/ip-codec@npm:^2.0.1":
   version: 2.0.5
   resolution: "@leichtgewicht/ip-codec@npm:2.0.5"
@@ -22531,6 +22547,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"scripts@workspace:scripts":
+  version: 0.0.0-use.local
+  resolution: "scripts@workspace:scripts"
+  dependencies:
+    simple-git: "npm:^3.28.0"
+    tsx: "npm:^4.19.1"
+  languageName: unknown
+  linkType: soft
+
 "scroll-into-view-if-needed@npm:^3.0.3, scroll-into-view-if-needed@npm:^3.1.0":
   version: 3.1.0
   resolution: "scroll-into-view-if-needed@npm:3.1.0"
@@ -23031,6 +23056,17 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f
+  languageName: node
+  linkType: hard
+
+"simple-git@npm:^3.28.0":
+  version: 3.28.0
+  resolution: "simple-git@npm:3.28.0"
+  dependencies:
+    "@kwsites/file-exists": "npm:^1.1.1"
+    "@kwsites/promise-deferred": "npm:^1.1.1"
+    debug: "npm:^4.4.0"
+  checksum: 10/2582e6c1c50db8aa0b7d07ed0f0f86eb4ea647e6b33d1596cf44e509c7b658372da9db1dcbea626e7d71e30e8d826a84410bbc73c5d1066f2526724a31836f81
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Gets the latest version and release-notes from changelog, then uses `gh` to create a github-release. If the release already exists, we skip releasing again.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
