### PR TITLE
:bug: Use correct supports syntax in CSS when checking for `has` selector

### DIFF
--- a/.changeset/tender-tools-tie.md
+++ b/.changeset/tender-tools-tie.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Combobox: Focus styling did not check for has selector-support correctly.

--- a/.changeset/tender-tools-tie.md
+++ b/.changeset/tender-tools-tie.md
@@ -2,4 +2,4 @@
 "@navikt/ds-css": patch
 ---
 
-Combobox: Focus styling did not check for has selector-support correctly.
+Combobox: Focus styling did not check for `:has` selector-support correctly.

--- a/@navikt/core/css/form/combobox.css
+++ b/@navikt/core/css/form/combobox.css
@@ -180,7 +180,7 @@
   }
 }
 
-@supports not selector(:has) {
+@supports not selector(:has(*)) {
   .navds-combobox--focused .navds-combobox__wrapper-inner {
     box-shadow: var(--a-shadow-focus);
     outline: 3px solid transparent;


### PR DESCRIPTION
### Description

`selector(:has)` is invalid syntax, while `selector(:has(*)` solves it.

Solves https://nav-it.slack.com/archives/C7NE7A8UF/p1754553831227739

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
