### PR TITLE
:tada: Left-align images for left-aligned page-layouts

### DIFF
--- a/aksel.nav.no/website/app/(routes)/(produktbloggen)/produktbloggen/[slug]/page.tsx
+++ b/aksel.nav.no/website/app/(routes)/(produktbloggen)/produktbloggen/[slug]/page.tsx
@@ -153,7 +153,7 @@ export default async function Page({ params }: Props) {
         </div>
       </div>
 
-      <div className={styles.customBlockWrapper}>
+      <div className={styles.customBlockWrapper} data-page-layout="centered">
         <CustomPortableText
           data-wrapper-prose
           value={(pageData?.content ?? []) as PortableTextBlock[]}

--- a/aksel.nav.no/website/app/_ui/bilde/Bilde.module.css
+++ b/aksel.nav.no/website/app/_ui/bilde/Bilde.module.css
@@ -1,36 +1,8 @@
-.doDontNotch {
-  padding: var(--ax-space-12) var(--ax-space-16);
-  color: var(--ax-text-default);
-  background-color: var(--ax-bg-moderate);
-  border: 1px solid var(--ax-border-subtleA);
-  border-bottom: 0;
-  border-radius: var(--ax-border-radius-xlarge) var(--ax-border-radius-xlarge) 0 0;
-  display: flex;
-  gap: var(--ax-space-6);
-}
-
-.doDontDescription {
-  padding: var(--ax-space-12) var(--ax-space-16);
-  color: var(--ax-text-neutral);
-  background-color: var(--ax-bg-neutral-moderate);
-  border: 1px solid var(--ax-border-neutral-subtleA);
-  border-top: 0;
-  border-radius: 0 0 var(--ax-border-radius-xlarge) var(--ax-border-radius-xlarge);
-}
-
-.doDontImage {
-  position: relative;
-  border-inline: 1px solid var(--ax-border-neutral-subtleA);
-  background-color: var(--ax-bg-default);
-}
-
 .bildeFigure {
-  margin-inline: auto;
   border-radius: var(--ax-border-radius-large);
 }
 
 .bildeImage {
-  margin-inline: auto;
   padding: 0;
   border-radius: var(--ax-border-radius-large);
   background-color: var(--bilde-background, var(--ax-bg-neutral-softA));
@@ -42,4 +14,12 @@
   &[data-image-size="small"] {
     max-width: min(100%, 600px);
   }
+}
+
+[data-page-layout="centered"] .bildeImage {
+  margin-inline: auto;
+}
+
+[data-page-layout="centered"] .bildeCaption {
+  text-align: center;
 }

--- a/aksel.nav.no/website/app/_ui/bilde/Bilde.tsx
+++ b/aksel.nav.no/website/app/_ui/bilde/Bilde.tsx
@@ -28,7 +28,11 @@ function Bilde(props: ExtractPortableComponentProps<"bilde">) {
     `rgba(${background.rgb?.r},${background.rgb?.g},${background.rgb?.b},${background.rgb?.a})`;
 
   return (
-    <figure data-block-margin="space-28" className={styles.bildeFigure}>
+    <figure
+      data-block-margin="space-28"
+      className={styles.bildeFigure}
+      data-text-prose
+    >
       <img
         data-image-border={border}
         className={`light ${styles.bildeImage}`}
@@ -41,15 +45,12 @@ function Bilde(props: ExtractPortableComponentProps<"bilde">) {
       {caption && (
         <HGrid
           as="figcaption"
-          marginBlock="space-12 0"
+          marginBlock="space-8 0"
           marginInline="space-12"
           gap="space-4"
+          className={styles.bildeCaption}
         >
-          <BodyLong
-            as="span"
-            size="small"
-            align={kilde?.har_kilde ? "start" : "center"}
-          >
+          <BodyLong as="span" size="small">
             {caption}
           </BodyLong>
           {kilde?.har_kilde && (

--- a/aksel.nav.no/website/app/_ui/bilde/Bilde.tsx
+++ b/aksel.nav.no/website/app/_ui/bilde/Bilde.tsx
@@ -28,11 +28,7 @@ function Bilde(props: ExtractPortableComponentProps<"bilde">) {
     `rgba(${background.rgb?.r},${background.rgb?.g},${background.rgb?.b},${background.rgb?.a})`;
 
   return (
-    <figure
-      data-block-margin="space-28"
-      className={styles.bildeFigure}
-      data-text-prose
-    >
+    <figure data-block-margin="space-28" className={styles.bildeFigure}>
       <img
         data-image-border={border}
         className={`light ${styles.bildeImage}`}

--- a/aksel.nav.no/website/app/theme.d.ts
+++ b/aksel.nav.no/website/app/theme.d.ts
@@ -47,5 +47,10 @@ declare module "react" {
      * Adds line-clamping to the text.
      */
     "data-clamp-text"?: "4-lines";
+    /**
+     * Some components may need changes based on the page-type.
+     * This is used to apply specific styles based on the page type.
+     */
+    "data-page-layout"?: "centered" | "left-aligned";
   }
 }


### PR DESCRIPTION
### Description

Solves https://nav-it.slack.com/archives/G7NE6ESLX/p1754636100243549

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
