### PR TITLE
[website] Fix image overflow issue in DoDont

### DIFF
--- a/aksel.nav.no/website/app/_ui/do-dont/DoDont.module.css
+++ b/aksel.nav.no/website/app/_ui/do-dont/DoDont.module.css
@@ -2,6 +2,7 @@
   border: 1px solid var(--ax-border-default);
   border-radius: var(--ax-border-radius-xlarge);
   height: fit-content;
+  overflow: hidden;
 }
 
 .doDontNotch {


### PR DESCRIPTION
Before (notice bottom corners):
<img width="318" height="272" alt="image" src="https://github.com/user-attachments/assets/c6333a1c-9ccc-4391-889c-e2eeb016348c" />

After:
<img width="311" height="267" alt="image" src="https://github.com/user-attachments/assets/f9fbcfff-fcb8-4991-acf0-78b00540dd7c" />

http://localhost:3000/komponenter/core/list