### PR TITLE
Radio/Checkbox: :bug: Fix issue where label was not announced by screen readers in Firefox

### DIFF
--- a/.changeset/cyan-loops-chew.md
+++ b/.changeset/cyan-loops-chew.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Radio/Checkbox: :bug: Fix issue where label was not announced by screen readers in Firefox

--- a/@navikt/core/react/src/form/checkbox/Checkbox.tsx
+++ b/@navikt/core/react/src/form/checkbox/Checkbox.tsx
@@ -2,7 +2,6 @@ import React, { forwardRef } from "react";
 import { useRenameCSS } from "../../theme/Theme";
 import { BodyShort } from "../../typography";
 import { omit } from "../../util";
-import { useId } from "../../util/hooks";
 import { ReadOnlyIconWithTitle } from "../ReadOnlyIcon";
 import { CheckboxProps } from "./types";
 import useCheckbox from "./useCheckbox";
@@ -11,9 +10,6 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   (props, ref) => {
     const { cn } = useRenameCSS();
     const { inputProps, hasError, size, readOnly, nested } = useCheckbox(props);
-
-    const labelId = useId();
-    const descriptionId = useId();
 
     return (
       <div
@@ -54,13 +50,6 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
               ref.current = el;
             }
           }}
-          aria-labelledby={cn(
-            labelId,
-            !!props["aria-labelledby"] && props["aria-labelledby"],
-            {
-              [descriptionId]: props.description,
-            },
-          )}
         />
         <label htmlFor={inputProps.id} className={cn("navds-checkbox__label")}>
           <span className={cn("navds-checkbox__icon")}>
@@ -88,10 +77,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           >
             <BodyShort
               as="span"
-              id={labelId}
               size={size}
               className={cn("navds-checkbox__label-text")}
-              aria-hidden
             >
               {!nested && readOnly && <ReadOnlyIconWithTitle />}
               {props.children}
@@ -99,12 +86,10 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             {props.description && (
               <BodyShort
                 as="span"
-                id={descriptionId}
                 size={size}
                 className={cn(
                   "navds-form-field__subdescription navds-checkbox__description",
                 )}
-                aria-hidden
               >
                 {props.description}
               </BodyShort>

--- a/@navikt/core/react/src/form/radio/Radio.tsx
+++ b/@navikt/core/react/src/form/radio/Radio.tsx
@@ -1,18 +1,13 @@
-import cl from "clsx";
 import React, { forwardRef } from "react";
 import { useRenameCSS } from "../../theme/Theme";
 import { BodyShort } from "../../typography";
 import { omit } from "../../util";
-import { useId } from "../../util/hooks";
 import { RadioProps } from "./types";
 import { useRadio } from "./useRadio";
 
 export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
   const { cn } = useRenameCSS();
   const { inputProps, size, hasError, readOnly } = useRadio(props);
-
-  const labelId = useId();
-  const descriptionId = useId();
 
   return (
     <div
@@ -26,30 +21,21 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
       <input
         {...omit(props, ["children", "size", "description", "readOnly"])}
         {...omit(inputProps, ["aria-invalid"])}
-        aria-labelledby={cl(
-          labelId,
-          !!props["aria-labelledby"] && props["aria-labelledby"],
-          {
-            [descriptionId]: props.description,
-          },
-        )}
         className={cn("navds-radio__input")}
         ref={ref}
       />
       <label htmlFor={inputProps.id} className={cn("navds-radio__label")}>
         <span className={cn("navds-radio__content")}>
-          <BodyShort as="span" id={labelId} size={size} aria-hidden>
+          <BodyShort as="span" size={size}>
             {props.children}
           </BodyShort>
           {props.description && (
             <BodyShort
               as="span"
-              id={descriptionId}
               size={size}
               className={cn(
                 "navds-form-field__subdescription navds-radio__description",
               )}
-              aria-hidden
             >
               {props.description}
             </BodyShort>


### PR DESCRIPTION
### Description

Temporary fix for [this](https://nav-it.slack.com/archives/C7NE7A8UF/p1751540903972699) by reverting the changes done in Radio.tsx and Checkbox.tsx in https://github.com/navikt/aksel/pull/2562.

This brings back the issue where the label is repeated when using a screen reader, but I think this is better than no announcement at all in Firefox.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
