### PR TITLE
Updated Sanity API-version

### DIFF
--- a/aksel.nav.no/website/sanity/config.ts
+++ b/aksel.nav.no/website/sanity/config.ts
@@ -1,7 +1,7 @@
 import { ClientConfig } from "@sanity/client";
 
 export const SANITY_PROJECT_ID = "hnbe3yhs";
-export const SANITY_API_VERSION = "2024-04-11";
+export const SANITY_API_VERSION = "2025-08-10";
 export let SANITY_DATASET = "production";
 
 if (process.env.LOCAL_DATASET_OVERRIDE === "development") {

--- a/aksel.nav.no/website/sanity/schema/documents/admin/editorialStaff.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/admin/editorialStaff.tsx
@@ -1,6 +1,7 @@
 import { parseInt } from "lodash";
 import Image from "next/image";
 import { SlugValue, defineField, defineType } from "sanity";
+import { SANITY_API_VERSION } from "@/sanity/config";
 import { showForDevsOnly } from "../../../util";
 
 export const EditorialStaff = defineType({
@@ -30,7 +31,7 @@ export const EditorialStaff = defineType({
       type: "slug",
       hidden: showForDevsOnly(),
       initialValue: async (params, context) => {
-        const client = context.getClient({ apiVersion: "2025-06-16" });
+        const client = context.getClient({ apiVersion: SANITY_API_VERSION });
 
         let slugs: SlugValue[] = await client.fetch(
           `*[_type == "editorial_staff"].avatar_id`,


### PR DESCRIPTION
### Description

We were still on an old API-version that used "raw" perspective as the default. This caused some sideeffects where we showed unpublished articles in the global search. Updating the API-version resolved this issue.

<img width="637" height="163" alt="Screenshot 2025-08-12 at 09 11 58" src="https://github.com/user-attachments/assets/ee67c3a6-2661-4225-b073-fa494003c5a3" />


I have checked all use of the API-version and this change to "published perspective" as default should hopefully not break anything. Use of the client internally in sanity/admin tool handles perspective themselves so we don't need to specify that we want draft-documents.

Resolves https://nav-it.slack.com/archives/C04C1G7UWG7/p1754939020094189

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
