### PR TITLE
Form components: Improved a11y when using JSX in description

### DIFF
--- a/.changeset/evil-pugs-draw.md
+++ b/.changeset/evil-pugs-draw.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Form components: Improved a11y when using JSX in description

--- a/@navikt/core/react/src/form/fieldset/useFieldset.ts
+++ b/@navikt/core/react/src/form/fieldset/useFieldset.ts
@@ -1,5 +1,9 @@
 import cl from "clsx";
-import { type FormFieldProps, useFormField } from "../useFormField";
+import {
+  type FormFieldProps,
+  containsReadMore,
+  useFormField,
+} from "../useFormField";
 
 /**
  * Handles props for Fieldset in context with parent Fieldset.
@@ -11,11 +15,10 @@ export const useFieldset = (props: FormFieldProps) => {
     ...formField,
     inputProps: {
       // We don't include errorId here, because it will be included on each radio/checkbox inside.
-      // We check that description is string to avoid adding it if it's a ReadMore.
       "aria-describedby":
         cl(props["aria-describedby"], {
           [formField.inputDescriptionId]:
-            props.description && typeof props.description === "string",
+            props.description && !containsReadMore(props.description),
         }) || undefined,
     },
   };

--- a/@navikt/core/react/src/form/useFormField.ts
+++ b/@navikt/core/react/src/form/useFormField.ts
@@ -1,5 +1,6 @@
 import cl from "clsx";
 import React, { useContext } from "react";
+import { ReadMore } from "../read-more/ReadMore";
 import { useId } from "../util/hooks";
 import { FieldsetContext } from "./fieldset/context";
 
@@ -99,10 +100,9 @@ export const useFormField = (
       id,
       ...ariaInvalid,
       "aria-describedby":
-        // We check that description is string to avoid adding it if it's a ReadMore.
         cl(props["aria-describedby"], {
           [inputDescriptionId]:
-            props.description && typeof props.description === "string",
+            props.description && !containsReadMore(props.description),
           [errorId]: showErrorMsg,
           [fieldset?.errorId ?? ""]: hasError && fieldset?.error,
         }) || undefined,
@@ -111,3 +111,17 @@ export const useFormField = (
     },
   };
 };
+
+export function containsReadMore(children: React.ReactNode) {
+  if (React.isValidElement(children)) {
+    if (children.type === ReadMore) {
+      return true;
+    }
+    if (children.props.children) {
+      return containsReadMore(children.props.children);
+    }
+  } else if (Array.isArray(children)) {
+    return children.some(containsReadMore);
+  }
+  return false;
+}

--- a/@navikt/core/react/src/form/useFormField.ts
+++ b/@navikt/core/react/src/form/useFormField.ts
@@ -112,16 +112,19 @@ export const useFormField = (
   };
 };
 
-export function containsReadMore(children: React.ReactNode) {
+export function containsReadMore(
+  children: React.ReactNode,
+  checkNested = true,
+): boolean {
   if (React.isValidElement(children)) {
     if (children.type === ReadMore) {
       return true;
     }
-    if (children.props.children) {
-      return containsReadMore(children.props.children);
+    if (children.props.children && checkNested) {
+      return containsReadMore(children.props.children, false);
     }
   } else if (Array.isArray(children)) {
-    return children.some(containsReadMore);
+    return children.some((child) => containsReadMore(child, checkNested));
   }
   return false;
 }


### PR DESCRIPTION
### Description

Currently we check that description is a string before we connect it to the input with `aria-describedby`. This was done to support having ReadMore as description without it being announced when focusing the input. However, this means that using any JSX in the description will "disable" the `aria-describedby` connection. This PR fixes this by actually checking for a ReadMore-component in the description.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
