### PR TITLE
increase padding under certain width to avoid overlapping

### DIFF
--- a/aksel.nav.no/website/components/website-modules/examples/examples.module.css
+++ b/aksel.nav.no/website/components/website-modules/examples/examples.module.css
@@ -40,3 +40,9 @@
 .containerFullscreen {
   padding: 0;
 }
+
+@media (max-width: 820px) {
+  .container {
+    padding-block: 3rem;
+  }
+}


### PR DESCRIPTION
The examples had some overlapping elements (especially visible on mobile & tablet widths)
<img width="422" height="166" alt="image" src="https://github.com/user-attachments/assets/f2b23ba9-97a0-44ed-9cfa-2d85859de6dc" />

This change increases the padding for the example container under a certain width:
<img width="505" height="247" alt="image" src="https://github.com/user-attachments/assets/26b4e7cf-0836-4e80-9d7e-724d404549b2" />
