### PR TITLE
:fire: Deprecate headingSize-prop in Accordion

### DIFF
--- a/.changeset/good-sites-dig.md
+++ b/.changeset/good-sites-dig.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Accordion: Mark `headingSize` as deprecated.

--- a/@navikt/core/react/src/accordion/Accordion.tsx
+++ b/@navikt/core/react/src/accordion/Accordion.tsx
@@ -37,6 +37,7 @@ export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: "default" | "neutral";
   /**
    * @default "small"
+   * @deprecated `size`-prop will be the only prop to control the size of the accordion.
    */
   headingSize?: "large" | "medium" | "small" | "xsmall";
   /**

--- a/aksel.nav.no/website/pages/eksempler/accordion/size.tsx
+++ b/aksel.nav.no/website/pages/eksempler/accordion/size.tsx
@@ -7,7 +7,7 @@ const Example = () => {
       <Heading size="small" spacing textColor="subtle">
         size=large
       </Heading>
-      <Accordion size="large" headingSize="large">
+      <Accordion size="large">
         <Accordion.Item>
           <Accordion.Header>Til deg mellom 62 og 67 år</Accordion.Header>
           <Accordion.Content>
@@ -22,7 +22,7 @@ const Example = () => {
       <Heading size="small" spacing textColor="subtle">
         size=medium
       </Heading>
-      <Accordion size="medium" headingSize="medium">
+      <Accordion size="medium">
         <Accordion.Item>
           <Accordion.Header>Til deg mellom 62 og 67 år</Accordion.Header>
           <Accordion.Content>
@@ -37,7 +37,7 @@ const Example = () => {
       <Heading size="small" spacing textColor="subtle">
         size=small
       </Heading>
-      <Accordion size="small" headingSize="small">
+      <Accordion size="small">
         <Accordion.Item>
           <Accordion.Header>Til deg mellom 62 og 67 år</Accordion.Header>
           <Accordion.Content>
@@ -48,20 +48,6 @@ const Example = () => {
         </Accordion.Item>
       </Accordion>
       <br />
-
-      <Heading size="small" spacing textColor="subtle">
-        size=small headingSize=xsmall
-      </Heading>
-      <Accordion size="small" headingSize="xsmall">
-        <Accordion.Item>
-          <Accordion.Header>Til deg mellom 62 og 67 år</Accordion.Header>
-          <Accordion.Content>
-            Hvis du er mellom 62 og 67 år når du søker, må du som hovedregel ha
-            hatt en pensjonsgivende inntekt som tilsvarer x G, året før du fikk
-            nedsatt arbeidsevnen. Nav kan gjøre <Link href="#">unntak</Link>.
-          </Accordion.Content>
-        </Accordion.Item>
-      </Accordion>
     </>
   );
 };


### PR DESCRIPTION
### Description

Unsure why we didn't do this earlier since darkside only supports the `size`-prop and not `headingSize`

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
