### PR TITLE
:lipstick: CSS-override for Radio/Checkbox focus mistakenly targeted `ExpandableRow` content

### DIFF
--- a/.changeset/olive-shoes-post.md
+++ b/.changeset/olive-shoes-post.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Table: Focus-outline for `Radio` and `Checkbox` now has correct height while inside an `ExpandableRow`.

--- a/@navikt/core/css/darkside/table.darkside.css
+++ b/@navikt/core/css/darkside/table.darkside.css
@@ -143,8 +143,8 @@
   padding: 0;
 }
 
-.aksel-table .aksel-checkbox__input:focus + .aksel-checkbox__label::after,
-.aksel-table .aksel-radio__input:focus + .aksel-radio__label::after {
+.aksel-table tr:not(.aksel-table__expanded-row) .aksel-checkbox__input:focus + .aksel-checkbox__label::after,
+.aksel-table tr:not(.aksel-table__expanded-row) .aksel-radio__input:focus + .aksel-radio__label::after {
   height: 100%;
 }
 

--- a/@navikt/core/react/src/table/stories/table-2-expandable.stories.tsx
+++ b/@navikt/core/react/src/table/stories/table-2-expandable.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Button } from "../../button";
 import { Checkbox } from "../../form/checkbox";
+import { Radio, RadioGroup } from "../../form/radio";
 import { Link } from "../../link";
 import Table from "../Table";
 
@@ -222,6 +223,11 @@ const data = [
       <>
         Ola Conny Brakkestad sier hei. Her er litt innhold med en{" "}
         <Link href="#">link.</Link>
+        <RadioGroup legend="Velg din aldersgruppe.">
+          <Radio value="10">10-20 år</Radio>
+          <Radio value="20">21-45 år</Radio>
+          <Radio value="40">46-80 år</Radio>
+        </RadioGroup>
       </>
     ),
   },


### PR DESCRIPTION
### Description

Resolves https://nav-it.slack.com/archives/C7NE7A8UF/p1755177974062739

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
