### PR TITLE
:bug: Add correct className for border-radius when using Box

### DIFF
--- a/.changeset/shaggy-wings-study.md
+++ b/.changeset/shaggy-wings-study.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-Box: Fixed bug where darkside-css did not properly show border-radius.
+Box: Fixed bug where darkside-css did not properly apply border-radius.

--- a/.changeset/shaggy-wings-study.md
+++ b/.changeset/shaggy-wings-study.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Box: Fixed bug where darkside-css did not properly show border-radius.

--- a/@navikt/core/react/src/layout/box/Box.tsx
+++ b/@navikt/core/react/src/layout/box/Box.tsx
@@ -173,7 +173,8 @@ export const BoxComponent: OverridableComponent<BoxProps, HTMLDivElement> =
               "navds-box-bg": background,
               "navds-box-border-color": borderColor,
               "navds-box-border-width": borderWidth,
-              "navds-box-border-radius": borderRadius,
+              "navds-box-border-radius": borderRadius && !themeContext,
+              "navds-box-radius": borderRadius && themeContext,
               "navds-box-shadow": shadow,
             })}
           >


### PR DESCRIPTION
### Description

Resolves https://nav-it.slack.com/archives/C04C1G7UWG7/p1755506801297489

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
