### PR TITLE
:tada: Added roboto-flex support in storybook for testing

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -109,4 +109,10 @@ export default {
           : [TsconfigPathsPlugin(tsConfigPathsPluginOpts)],
     } satisfies InlineConfig);
   },
+  /* Lets us preview Roboto-flex font in storybook. */
+  previewHead: (head) => `
+  ${head}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wght@8..144,100..1000&display=swap" rel="stylesheet">`,
 } satisfies StorybookConfig;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,6 @@
 import { withThemeByClassName } from "@storybook/addon-themes";
 import { Preview } from "@storybook/react";
-import React, { useLayoutEffect } from "react";
+import React, { useEffect, useLayoutEffect } from "react";
 // @ts-expect-error - Temporary
 import darksideCss from "../@navikt/core/css/darkside/index.css?inline";
 // @ts-expect-error - Temporary
@@ -52,6 +52,21 @@ const LanguageDecorator = ({ children, language }) => {
   return children;
 };
 
+const TypoDecorator = ({ children, font }) => {
+  useEffect(() => {
+    let fontVariable: string | null = null;
+
+    if (font === "robotoflex") {
+      fontVariable = `"Roboto Flex", sans-serif`;
+    }
+
+    document.body.style.setProperty("--ax-font-family", fontVariable);
+    document.body.style.setProperty("--a-font-family", fontVariable);
+  }, [font]);
+
+  return children;
+};
+
 export default {
   parameters: {
     options: {
@@ -99,13 +114,29 @@ export default {
         dynamicTitle: true,
       },
     },
+    font: {
+      toolbar: {
+        icon: "edit",
+        items: [
+          { value: "sourcesans", title: "Source sans 3" },
+          { value: "robotoflex", title: "Roboto flex" },
+        ],
+        dynamicTitle: true,
+      },
+    },
   },
 
   initialGlobals: {
     mode: "default",
+    font: "sourcesans",
   },
 
   decorators: [
+    (StoryFn, context) => (
+      <TypoDecorator font={context.globals.font}>
+        <StoryFn />
+      </TypoDecorator>
+    ),
     (StoryFn, context) => (
       <ModeDecorator mode={context.globals.mode} theme={context.globals.theme}>
         <StoryFn />


### PR DESCRIPTION
### Description

This allows the designers to browse the components and test with an alternative font. Also works for the template-examples, so its possible to test on compositions 🎉 

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
