### PR TITLE
Darkside: Fix arrow in Tooltip

### DIFF
--- a/.changeset/yummy-forks-run.md
+++ b/.changeset/yummy-forks-run.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Darkside: Fix arrow in Tooltip

--- a/@navikt/core/css/darkside/tooltip.darkside.css
+++ b/@navikt/core/css/darkside/tooltip.darkside.css
@@ -18,7 +18,7 @@
   }
 }
 
-.navds-tooltip__arrow {
+.aksel-tooltip__arrow {
   height: 0.5rem;
   width: 0.5rem;
   z-index: -1;


### PR DESCRIPTION
### Description

The arrow was missing b.c. of wrong classname in the CSS file.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
