### PR TITLE
ToggleGroup: Improved SR experience by using `aria-labelledby` instead of `aria-describedby` for label

### DIFF
--- a/.changeset/deep-breads-chew.md
+++ b/.changeset/deep-breads-chew.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-ToggleGroup: Improved a11y
+ToggleGroup: Improved screen reader experience by using `aria-labelledby` instead of `aria-describedby` for the label

--- a/.changeset/deep-breads-chew.md
+++ b/.changeset/deep-breads-chew.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+ToggleGroup: Improved a11y

--- a/@navikt/core/react/src/toggle-group/ToggleGroup.stories.tsx
+++ b/@navikt/core/react/src/toggle-group/ToggleGroup.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/react";
+import { Meta, StoryFn } from "@storybook/react";
 import React, { useState } from "react";
 import {
   EnvelopeClosedIcon,
@@ -7,23 +7,13 @@ import {
   SparklesIcon,
 } from "@navikt/aksel-icons";
 import { VStack } from "../layout/stack";
+import { renderStoriesForChromatic } from "../util/renderStoriesForChromatic";
 import ToggleGroup from "./ToggleGroup";
+import { ToggleGroupProps } from "./ToggleGroup.types";
 
 const meta: Meta<typeof ToggleGroup> = {
   title: "ds-react/ToggleGroup",
   component: ToggleGroup,
-  argTypes: {
-    size: {
-      options: ["medium", "small"],
-      control: {
-        type: "radio",
-      },
-    },
-    variant: {
-      options: ["action", "neutral"],
-      control: { type: "radio" },
-    },
-  },
   parameters: {
     chromatic: { disable: true },
   },
@@ -64,7 +54,12 @@ const Items = (icon?: boolean, both?: boolean) => {
   );
 };
 
-export const Default = (props) => {
+interface Props extends Pick<ToggleGroupProps, "size" | "variant"> {
+  icon: boolean;
+  text: boolean;
+  label: boolean;
+}
+export const Default: StoryFn<Props> = (props) => {
   const [activeValue, setActiveValue] = useState("ulest");
   return (
     <ToggleGroup
@@ -81,11 +76,30 @@ export const Default = (props) => {
     </ToggleGroup>
   );
 };
-
+Default.argTypes = {
+  size: {
+    options: ["medium", "small"],
+    control: {
+      type: "radio",
+    },
+  },
+  variant: {
+    options: ["action", "neutral"],
+    control: { type: "radio" },
+  },
+};
 Default.args = {
   icon: true,
   text: true,
   label: false,
+};
+
+export const Label = () => {
+  return (
+    <ToggleGroup label="Innboks" value="ulest" onChange={() => {}}>
+      {Items()}
+    </ToggleGroup>
+  );
 };
 
 export const Compositions = () => {
@@ -146,6 +160,14 @@ export const Small = () => {
       <ToggleGroup size="small" value={activeValue} onChange={setActiveValue}>
         {Items(true)}
       </ToggleGroup>
+      <ToggleGroup
+        size="small"
+        fill
+        value={activeValue}
+        onChange={setActiveValue}
+      >
+        {Items(true)}
+      </ToggleGroup>
     </VStack>
   );
 };
@@ -175,58 +197,10 @@ export const ColorRoles = () => {
   );
 };
 
-export const Chromatic = {
-  render: () => (
-    <VStack gap="6">
-      <div>
-        <h2>Text</h2>
-        <ToggleGroup value="ulest" onChange={console.log}>
-          {Items()}
-        </ToggleGroup>
-      </div>
-      <div>
-        <h2>Icon</h2>
-        <ToggleGroup value="ulest" onChange={console.log}>
-          {Items(true)}
-        </ToggleGroup>
-      </div>
-      <div>
-        <h2>Text + icon</h2>
-        <ToggleGroup value="ulest" onChange={console.log}>
-          {Items(true, true)}
-        </ToggleGroup>
-      </div>
-      <div style={{ minWidth: 600 }}>
-        <h2>Fill</h2>
-        <ToggleGroup value="ulest" onChange={console.log} fill>
-          {Items(true, true)}
-        </ToggleGroup>
-      </div>
-      <div>
-        <h2>Small</h2>
-        <ToggleGroup value="ulest" onChange={console.log} size="small">
-          {Items(true, true)}
-        </ToggleGroup>
-      </div>
-      <div>
-        <h2>Small + fill</h2>
-        <ToggleGroup value="ulest" onChange={console.log} size="small" fill>
-          {Items(true, true)}
-        </ToggleGroup>
-      </div>
-      <div>
-        <h2>Neutral</h2>
-        <ToggleGroup value="ulest" onChange={console.log} variant="neutral">
-          {Items(true, true)}
-        </ToggleGroup>
-      </div>
-      <div>
-        <h2>ColorRoles</h2>
-        <ColorRoles />
-      </div>
-    </VStack>
-  ),
-  parameters: {
-    chromatic: { disable: false },
-  },
-};
+export const Chromatic = renderStoriesForChromatic({
+  Label,
+  Compositions,
+  Variants,
+  Small,
+  ColorRoles,
+});

--- a/@navikt/core/react/src/toggle-group/ToggleGroup.tsx
+++ b/@navikt/core/react/src/toggle-group/ToggleGroup.tsx
@@ -48,7 +48,7 @@ export const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps>(
       label,
       value,
       defaultValue,
-      "aria-describedby": userDescribedby,
+      "aria-labelledby": userLabelledby,
       variant,
       fill = false,
       "data-color": color,
@@ -103,6 +103,7 @@ export const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps>(
           >
             {label && (
               <Label
+                as="div"
                 size={size}
                 className={cn("navds-toggle-group__label")}
                 id={labelId}
@@ -118,8 +119,8 @@ export const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps>(
                 `navds-toggle-group--${size}`,
                 { [`navds-toggle-group--${localVariant}`]: localVariant },
               )}
-              aria-describedby={
-                cl(userDescribedby, !!label && labelId) || undefined
+              aria-labelledby={
+                cl(userLabelledby, !!label && labelId) || undefined
               }
               role="radiogroup"
             >

--- a/@navikt/core/react/src/toggle-group/ToggleGroup.tsx
+++ b/@navikt/core/react/src/toggle-group/ToggleGroup.tsx
@@ -1,4 +1,3 @@
-import cl from "clsx";
 import React, { forwardRef } from "react";
 import { useRenameCSS, useThemeInternal } from "../theme/Theme";
 import { AkselColor } from "../types";
@@ -48,7 +47,6 @@ export const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps>(
       label,
       value,
       defaultValue,
-      "aria-labelledby": userLabelledby,
       variant,
       fill = false,
       "data-color": color,
@@ -112,6 +110,7 @@ export const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps>(
               </Label>
             )}
             <div
+              aria-labelledby={label ? labelId : undefined}
               {...rest}
               ref={ref}
               className={cn(
@@ -119,9 +118,6 @@ export const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps>(
                 `navds-toggle-group--${size}`,
                 { [`navds-toggle-group--${localVariant}`]: localVariant },
               )}
-              aria-labelledby={
-                cl(userLabelledby, !!label && labelId) || undefined
-              }
               role="radiogroup"
             >
               {children}

--- a/aksel.nav.no/website/pages/eksempler/togglegroup/group-label.tsx
+++ b/aksel.nav.no/website/pages/eksempler/togglegroup/group-label.tsx
@@ -3,7 +3,7 @@ import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
   return (
-    <ToggleGroup defaultValue="lest" onChange={console.info} label="Inbox">
+    <ToggleGroup defaultValue="lest" onChange={console.info} label="Innboks">
       <ToggleGroup.Item value="ulest" label="Ulest" />
       <ToggleGroup.Item value="lest" label="Lest" />
       <ToggleGroup.Item value="sendt" label="Sendt" />


### PR DESCRIPTION
### Description

- Change `aria-describedby` to `aria-labelledby` as discussed in doc meeting.
- Changed `<label>` to `<div>`, since the former is only allowed for form elements.
- Changed "Inbox" to "Innboks" in code example for consistent language.

### Component Checklist 📝

- [ ] JSDoc
- [x] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
