### PR TITLE
[endringslogg] :art: hoist state up to searchForm, useEffect on handleSearch

### DIFF
--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/FilterChips.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/FilterChips.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { Dispatch, SetStateAction } from "react";
 import { VStack } from "@navikt/ds-react";
 import FilterGroup from "./FilterGroup";
 
 interface Props {
   years: string[];
   categories: string[];
-  categorySelectedState: [string, Dispatch<SetStateAction<string>>];
-  yearSelectedState: [string, Dispatch<SetStateAction<string>>];
+  categorySelectedState: [string, (newValue: string) => void];
+  yearSelectedState: [string, (newValue: string) => void];
 }
 
 export default function FilterChips({

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/FilterGroup.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/FilterGroup.tsx
@@ -1,6 +1,5 @@
 // import { usePathname, useRouter, useSearchParams } from "next/navigation";
 // import { startTransition, useOptimistic } from "react";
-import { Dispatch, SetStateAction } from "react";
 import { Chips, Label, VStack } from "@navikt/ds-react";
 import { capitalizeText } from "@/ui-utils/format-text";
 
@@ -12,7 +11,7 @@ export default function FilterGroup({
 }: {
   // type: "category" | "period";
   options: string[];
-  selectedState: [string, Dispatch<SetStateAction<string>>];
+  selectedState: [string, (newState: string) => void];
   label: string;
 }) {
   // const { push, prefetch } = useRouter();

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { Dispatch, SetStateAction, useEffect, useRef } from "react";
 import {
   BodyLong,
@@ -18,14 +18,14 @@ export default function SearchField({
   semverSearchState,
   categorySelectedState,
   yearSelectedState,
+  searchInputState,
 }: {
   semverSearchState: [boolean, Dispatch<SetStateAction<boolean>>]; // no ReturnType<typeof useState<boolean>>; ?
   categorySelectedState: [string, Dispatch<SetStateAction<string>>];
   yearSelectedState: [string, Dispatch<SetStateAction<string>>];
+  searchInputState: [string, Dispatch<SetStateAction<string>>];
 }) {
   const searchParams = useSearchParams();
-  const pathname = usePathname();
-  const { replace } = useRouter();
   const searchRef = useRef<HTMLInputElement>(null);
 
   const semverRef = useRef<HTMLInputElement>(null);
@@ -34,6 +34,8 @@ export default function SearchField({
   const [categorySelected, setCategorySelected] = categorySelectedState;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [yearSelected, setYearSelected] = yearSelectedState;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [searchInput, setSearchInput] = searchInputState;
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -41,36 +43,7 @@ export default function SearchField({
     const input = form.elements.namedItem(
       "fritekst",
     ) as HTMLInputElement | null;
-    handleSearch(input?.value ?? "");
-  }
-
-  function handleSearch(query: string) {
-    const params = new URLSearchParams(searchParams?.toString());
-    if (query) {
-      params.set("fritekst", query);
-    } else {
-      params.delete("fritekst");
-    }
-
-    if (semverSearch) {
-      params.set("semver", "true");
-    } else {
-      params.delete("semver");
-    }
-
-    if (yearSelected) {
-      params.set("periode", yearSelected);
-    } else {
-      params.delete("periode");
-    }
-
-    if (categorySelected) {
-      params.set("kategori", categorySelected);
-    } else {
-      params.delete("kategori");
-    }
-
-    replace(`${pathname}${params.toString() ? `?${params.toString()}` : ""}`);
+    setSearchInput(input?.value ?? "");
   }
 
   useEffect(() => {
@@ -92,8 +65,15 @@ export default function SearchField({
             variant="secondary"
             htmlSize="20"
             autoComplete="off"
-            // onClear={() => handleSearch("")} // TODO: do we want smarter behaviour?
-            // onChange={(v) => v === "" && handleSearch("")} // TODO: do we want smarter behaviour?
+            onClear={() => {
+              setSearchInput("");
+            }}
+            // onChange={() => {
+            // TODO: feels a bit jank? (backspace + start typing -> sudden refresh)
+            // if (v === "") {
+            //   setSearchInput("");
+            // }
+            //  }}
             data-color="neutral"
             className={styles.searchField}
           />
@@ -102,6 +82,7 @@ export default function SearchField({
               ref={semverRef}
               value="semver"
               onClick={() => {
+                setSearchInput("");
                 setSemverSearch(!semverSearch);
               }}
               defaultChecked={!!searchParams?.get("semver")}

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
@@ -18,16 +18,18 @@ export default function SearchField({
   semverSearchState,
   searchInputState,
   onSearch,
+  onSemverToggle,
 }: {
   semverSearchState: [boolean, Dispatch<SetStateAction<boolean>>];
   searchInputState: [string, Dispatch<SetStateAction<string>>];
   onSearch: CallableFunction;
+  onSemverToggle: CallableFunction;
 }) {
   const searchParams = useSearchParams();
   const searchRef = useRef<HTMLInputElement>(null);
   const semverRef = useRef<HTMLInputElement>(null);
 
-  const [semverSearch, setSemverSearch] = semverSearchState;
+  const [semverSearch] = semverSearchState;
   const [searchInput, setSearchInput] = searchInputState;
 
   // Only get initial value from URL params
@@ -75,7 +77,7 @@ export default function SearchField({
               value="semver"
               onClick={() => {
                 setSearchInput("");
-                setSemverSearch(!semverSearch);
+                onSemverToggle();
               }}
               defaultChecked={!!searchParams?.get("semver")}
               checked={semverSearch}

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
@@ -16,41 +16,36 @@ import styles from "./SearchField.module.css";
 
 export default function SearchField({
   semverSearchState,
-  categorySelectedState,
-  yearSelectedState,
   searchInputState,
+  onSearch,
 }: {
-  semverSearchState: [boolean, Dispatch<SetStateAction<boolean>>]; // no ReturnType<typeof useState<boolean>>; ?
-  categorySelectedState: [string, Dispatch<SetStateAction<string>>];
-  yearSelectedState: [string, Dispatch<SetStateAction<string>>];
+  semverSearchState: [boolean, Dispatch<SetStateAction<boolean>>];
   searchInputState: [string, Dispatch<SetStateAction<string>>];
+  onSearch: CallableFunction;
 }) {
   const searchParams = useSearchParams();
   const searchRef = useRef<HTMLInputElement>(null);
-
   const semverRef = useRef<HTMLInputElement>(null);
+
   const [semverSearch, setSemverSearch] = semverSearchState;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [categorySelected, setCategorySelected] = categorySelectedState;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [yearSelected, setYearSelected] = yearSelectedState;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [searchInput, setSearchInput] = searchInputState;
+
+  // Only get initial value from URL params
+  const fritekstParam = searchParams?.get("fritekst") || "";
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const form = event.currentTarget;
-    const input = form.elements.namedItem(
-      "fritekst",
-    ) as HTMLInputElement | null;
-    setSearchInput(input?.value ?? "");
+    onSearch();
   }
 
+  // Only sync URL to input on initial load/page refresh
   useEffect(() => {
-    if (searchRef.current) {
-      searchRef.current.value = searchParams?.get("fritekst") || "";
+    if (searchRef.current && !searchInput && fritekstParam) {
+      searchRef.current.value = fritekstParam;
+      setSearchInput(fritekstParam);
     }
-  }, [searchParams]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <form role="search" onSubmit={handleSubmit}>
@@ -59,21 +54,18 @@ export default function SearchField({
           <Search
             ref={searchRef}
             label="Søk i endringsloggen"
-            defaultValue={searchParams?.get("fritekst") || ""}
+            value={searchInput}
             name="fritekst"
             hideLabel
             variant="secondary"
             htmlSize="20"
             autoComplete="off"
+            onChange={(value) => {
+              setSearchInput(value);
+            }}
             onClear={() => {
               setSearchInput("");
             }}
-            // onChange={() => {
-            // TODO: feels a bit jank? (backspace + start typing -> sudden refresh)
-            // if (v === "") {
-            //   setSearchInput("");
-            // }
-            //  }}
             data-color="neutral"
             className={styles.searchField}
           />

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
-import { Dispatch, SetStateAction, useEffect, useRef } from "react";
+import { Dispatch, SetStateAction } from "react";
 import {
   BodyLong,
   Checkbox,
@@ -15,46 +14,28 @@ import { Code } from "@/app/_ui/typography/Code";
 import styles from "./SearchField.module.css";
 
 export default function SearchField({
-  semverSearchState,
+  semverSearch,
   searchInputState,
   onSearch,
   onSemverToggle,
 }: {
-  semverSearchState: [boolean, Dispatch<SetStateAction<boolean>>];
+  semverSearch: boolean;
   searchInputState: [string, Dispatch<SetStateAction<string>>];
   onSearch: CallableFunction;
   onSemverToggle: CallableFunction;
 }) {
-  const searchParams = useSearchParams();
-  const searchRef = useRef<HTMLInputElement>(null);
-  const semverRef = useRef<HTMLInputElement>(null);
-
-  const [semverSearch] = semverSearchState;
   const [searchInput, setSearchInput] = searchInputState;
-
-  // Only get initial value from URL params
-  const fritekstParam = searchParams?.get("fritekst") || "";
 
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     onSearch();
   }
 
-  // Only sync URL to input on initial load/page refresh
-  useEffect(() => {
-    if (searchRef.current && !searchInput && fritekstParam) {
-      searchRef.current.value = fritekstParam;
-      setSearchInput(fritekstParam);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   return (
     <form role="search" onSubmit={handleSubmit}>
       <VStack gap="space-12">
         <HStack align="center" gap="space-24">
           <Search
-            ref={searchRef}
             label="Søk i endringsloggen"
             value={searchInput}
             name="fritekst"
@@ -62,24 +43,16 @@ export default function SearchField({
             variant="secondary"
             htmlSize="20"
             autoComplete="off"
-            onChange={(value) => {
-              setSearchInput(value);
-            }}
-            onClear={() => {
-              setSearchInput("");
-            }}
+            onChange={setSearchInput}
             data-color="neutral"
             className={styles.searchField}
           />
           <HStack align="center" gap="space-4">
             <Checkbox
-              ref={semverRef}
               value="semver"
               onClick={() => {
-                setSearchInput("");
                 onSemverToggle();
               }}
-              defaultChecked={!!searchParams?.get("semver")}
               checked={semverSearch}
             >
               Semver-søk

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchForm.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchForm.tsx
@@ -29,44 +29,60 @@ export const SearchForm = ({
 
   const searchParams = useSearchParams();
 
-  const handleSearch = useCallback(() => {
-    const params_url = new URLSearchParams(searchParams?.toString());
-    if (searchInput) {
-      params_url.set("fritekst", searchInput);
-    } else {
-      params_url.delete("fritekst");
-    }
+  const updateUrlParams = useCallback(
+    (includeSearchInput: boolean = false) => {
+      const params_url = new URLSearchParams(searchParams?.toString());
 
-    if (semverSearch) {
-      params_url.set("semver", "true");
-    } else {
-      params_url.delete("semver");
-    }
+      // Handle search input based on flag
+      if (includeSearchInput) {
+        if (searchInput) {
+          params_url.set("fritekst", searchInput);
+        } else {
+          params_url.delete("fritekst");
+        }
+      }
+      // If not including search input, preserve existing fritekst param
+      // (it's already in the URLSearchParams from toString())
 
-    if (yearSelected) {
-      params_url.set("periode", yearSelected);
-    } else {
-      params_url.delete("periode");
-    }
+      // Always update filter params
+      if (semverSearch) {
+        params_url.set("semver", "true");
+      } else {
+        params_url.delete("semver");
+      }
 
-    if (categorySelected) {
-      params_url.set("kategori", categorySelected);
-    } else {
-      params_url.delete("kategori");
-    }
+      if (yearSelected) {
+        params_url.set("periode", yearSelected);
+      } else {
+        params_url.delete("periode");
+      }
 
-    replace(
-      `${pathname}${params_url.toString() ? `?${params_url.toString()}` : ""}`,
-    );
-  }, [
-    replace,
-    pathname,
-    searchInput,
-    semverSearch,
-    yearSelected,
-    categorySelected,
-    searchParams,
-  ]);
+      if (categorySelected) {
+        params_url.set("kategori", categorySelected);
+      } else {
+        params_url.delete("kategori");
+      }
+
+      replace(
+        `${pathname}${
+          params_url.toString() ? `?${params_url.toString()}` : ""
+        }`,
+      );
+    },
+    [
+      replace,
+      pathname,
+      searchInput,
+      semverSearch,
+      yearSelected,
+      categorySelected,
+      searchParams,
+    ],
+  );
+
+  const handleTextSearch = useCallback(() => {
+    updateUrlParams(true);
+  }, [updateUrlParams]);
 
   const { years, categories } = params;
 
@@ -74,9 +90,10 @@ export const SearchForm = ({
     setSemverSearch(!!searchParams?.get("semver") || false);
   }, [searchParams, setSemverSearch]);
 
+  // Update URL when filters change (but not search input)
   useEffect(() => {
-    handleSearch();
-  }, [handleSearch, searchInput, semverSearch, categorySelected, yearSelected]);
+    updateUrlParams(false);
+  }, [updateUrlParams, semverSearch, categorySelected, yearSelected]);
 
   return (
     <VStack gap="space-24" paddingBlock="space-12 space-0">
@@ -85,6 +102,7 @@ export const SearchForm = ({
         yearSelectedState={yearSelectedState}
         categorySelectedState={categorySelectedState}
         searchInputState={searchInputState}
+        onSearch={handleTextSearch}
       />
       {!semverSearch && (
         <FilterChips

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchForm.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchForm.tsx
@@ -1,7 +1,17 @@
 "use client";
 
+// TODO: I feel we should probably replace SearchForm and SearchField logic with
+// a third party form library, since this has grown sufficiently complex.
+// I think that would cut down on this complexity, if you're reading this
+// in the future, and parsing this is hard, it's probably time for a complete
+// overhaul of this form.
+// The form has:
+// - dependent form fields (state depends on other form fields)
+// - live updating form fields (but only for a subset of the form elements) triggering:
+//    - url sync of all form state (also those that don't trigger a sync)
+//    - form submission
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { VStack } from "@navikt/ds-react";
 import FilterChips from "./FilterChips";
 import SearchField from "./SearchField";
@@ -26,23 +36,27 @@ export const SearchForm = ({
 
   const pathname = usePathname();
   const { replace } = useRouter();
-
   const searchParams = useSearchParams();
 
+  // Use a ref to track if we're handling a semver toggle to prevent race conditions
+  const isSemverToggling = useRef(false);
+
   const updateUrlParams = useCallback(
-    (includeSearchInput: boolean = false) => {
+    (options: { includeSearchInput?: boolean; clearSearch?: boolean } = {}) => {
+      const { includeSearchInput = false, clearSearch = false } = options;
       const params_url = new URLSearchParams(searchParams?.toString());
 
-      // Handle search input based on flag
-      if (includeSearchInput) {
+      // Handle search input based on flags
+      if (clearSearch) {
+        params_url.delete("fritekst");
+      } else if (includeSearchInput) {
         if (searchInput) {
           params_url.set("fritekst", searchInput);
         } else {
           params_url.delete("fritekst");
         }
       }
-      // If not including search input, preserve existing fritekst param
-      // (it's already in the URLSearchParams from toString())
+      // If not including search input and not clearing, preserve existing fritekst param
 
       // Always update filter params
       if (semverSearch) {
@@ -81,28 +95,81 @@ export const SearchForm = ({
   );
 
   const handleTextSearch = useCallback(() => {
-    updateUrlParams(true);
+    updateUrlParams({ includeSearchInput: true });
   }, [updateUrlParams]);
+
+  const handleSemverToggle = useCallback(() => {
+    isSemverToggling.current = true;
+    setSemverSearch((prev) => {
+      const newState = !prev;
+
+      // Update URL immediately with the new state
+      const params_url = new URLSearchParams(searchParams?.toString());
+      params_url.delete("fritekst"); // Always clear search when toggling semver
+
+      if (newState) {
+        params_url.set("semver", "true");
+      } else {
+        params_url.delete("semver");
+      }
+
+      if (yearSelected) {
+        params_url.set("periode", yearSelected);
+      } else {
+        params_url.delete("periode");
+      }
+
+      if (categorySelected) {
+        params_url.set("kategori", categorySelected);
+      } else {
+        params_url.delete("kategori");
+      }
+
+      replace(
+        `${pathname}${
+          params_url.toString() ? `?${params_url.toString()}` : ""
+        }`,
+      );
+
+      // Reset flag after a short delay
+      setTimeout(() => {
+        isSemverToggling.current = false;
+      }, 0);
+
+      return newState;
+    });
+  }, [
+    setSemverSearch,
+    searchParams,
+    yearSelected,
+    categorySelected,
+    pathname,
+    replace,
+  ]);
 
   const { years, categories } = params;
 
+  // Sync semver state from URL only if we're not in the middle of toggling
   useEffect(() => {
-    setSemverSearch(!!searchParams?.get("semver") || false);
+    if (!isSemverToggling.current) {
+      setSemverSearch(!!searchParams?.get("semver"));
+    }
   }, [searchParams, setSemverSearch]);
 
-  // Update URL when filters change (but not search input)
+  // Update URL when filters change (but not search input or semver)
   useEffect(() => {
-    updateUrlParams(false);
-  }, [updateUrlParams, semverSearch, categorySelected, yearSelected]);
+    if (!isSemverToggling.current) {
+      updateUrlParams();
+    }
+  }, [updateUrlParams, categorySelected, yearSelected]);
 
   return (
     <VStack gap="space-24" paddingBlock="space-12 space-0">
       <SearchField
         semverSearchState={semverState}
-        yearSelectedState={yearSelectedState}
-        categorySelectedState={categorySelectedState}
         searchInputState={searchInputState}
         onSearch={handleTextSearch}
+        onSemverToggle={handleSemverToggle}
       />
       {!semverSearch && (
         <FilterChips


### PR DESCRIPTION
This variant works, but needs:
- ~~clear search text on semver checkbox toggle (you are searching for different things, keeping it makes no sense)~~

nice to have:
- optimize it more... bring back `prefetch()` for the chip toggles
- ~~refactor? could probably go full context inside SearchForm now, instead of passing down props~~ I think complete rewrite using a third-party form library 💭 

solves https://github.com/navikt/team-aksel/issues/855