### PR TITLE
[Aksel.nav.no] Design-token toc moved between filter and content

### DIFF
--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/darkside/design-tokens/_ui/TokensPage.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/darkside/design-tokens/_ui/TokensPage.tsx
@@ -2,12 +2,11 @@
 
 import { useSearchParams } from "next/navigation";
 import React from "react";
-import { BodyShort, Link, VStack } from "@navikt/ds-react";
+import { BodyShort, Box, Link, VStack } from "@navikt/ds-react";
 import { EmptyStateCard } from "@/app/_ui/empty-state/EmptyState";
 import TokenCategory from "./TokenCategory";
 import { TOKEN_CATEGORIES } from "./config";
 import { searchTokens } from "./toolbar/SearchField.utils";
-import Toolbar from "./toolbar/Toolbar";
 
 const TokensPage = () => {
   const searchParams = useSearchParams();
@@ -16,8 +15,7 @@ const TokensPage = () => {
     filteredTokens.some((token) => token.category === id),
   );
   return (
-    <VStack gap="space-8">
-      <Toolbar />
+    <Box marginBlock="space-40 0">
       {filteredTokens.length === 0 && (
         <EmptyStateCard
           actionComponent={
@@ -58,7 +56,7 @@ const TokensPage = () => {
           );
         })}
       </VStack>
-    </VStack>
+    </Box>
   );
 };
 

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/darkside/design-tokens/_ui/toolbar/Toolbar.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/darkside/design-tokens/_ui/toolbar/Toolbar.tsx
@@ -4,13 +4,7 @@ import TokenFormatSelector from "./TokenFormatSelector";
 
 const Toolbar = () => {
   return (
-    <HStack
-      as="nav"
-      align="center"
-      justify="space-between"
-      marginBlock="space-0 space-16"
-      gap="space-16"
-    >
+    <HStack as="nav" align="center" justify="space-between" gap="space-16">
       <SearchField />
       <TokenFormatSelector />
     </HStack>

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/darkside/design-tokens/page.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/darkside/design-tokens/page.tsx
@@ -8,7 +8,7 @@ import TokenTableOfContents from "./_ui/TokenTableOfContents";
 import TokensPage from "./_ui/TokensPage";
 import Toolbar from "./_ui/toolbar/Toolbar";
 
-/* Since page relies on searchparams for general navigation, we avoid Suspense by foce-dynamic */
+/* Since page relies on searchparams for general navigation, we avoid Suspense by force-dynamic */
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/darkside/design-tokens/page.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/darkside/design-tokens/page.tsx
@@ -6,6 +6,7 @@ import { DesignsystemetEyebrow } from "../../../_ui/Designsystemet.eyebrow";
 import { DesignsystemetPageLayout } from "../../../_ui/DesignsystemetPage";
 import TokenTableOfContents from "./_ui/TokenTableOfContents";
 import TokensPage from "./_ui/TokensPage";
+import Toolbar from "./_ui/toolbar/Toolbar";
 
 /* Since page relies on searchparams for general navigation, we avoid Suspense by foce-dynamic */
 export const dynamic = "force-dynamic";
@@ -20,44 +21,43 @@ export const metadata: Metadata = {
 const Page = async () => {
   return (
     <DesignsystemetPageLayout layout="with-toc">
-      <VStack gap="space-40">
-        <VStack gap="space-24">
-          <VStack>
-            <DesignsystemetEyebrow type="ds_artikkel" />
-            <Heading level="1" size="xlarge" data-aksel-heading-color>
-              Tokenoversikt
-            </Heading>
-            <BodyLong size="large">
-              Tokens er alle farger, avstander, typografi, osv. som vi bruker i
-              komponenter og layout.
-            </BodyLong>
-          </VStack>
-          <VStack gap="space-16">
-            <HStack gap="space-16" align="center">
-              <Link href="https://github.com/navikt/aksel" variant="neutral">
-                <GithubIcon aria-hidden />
-                GitHub
-              </Link>
-              <Link
-                href="https://www.figma.com/community/file/1214869602572392330"
-                variant="neutral"
-              >
-                <FigmaIcon aria-hidden />
-                Figma-community
-              </Link>
-              <Link
-                href="https://aksel.nav.no/grunnleggende/kode/endringslogg"
-                variant="neutral"
-              >
-                <ClockDashedIcon aria-hidden />
-                Endringslogg
-              </Link>
-            </HStack>
-          </VStack>
+      <VStack gap="space-8">
+        <VStack marginBlock="0 space-16">
+          <DesignsystemetEyebrow type="ds_artikkel" />
+          <Heading level="1" size="xlarge" data-aksel-heading-color>
+            Tokenoversikt
+          </Heading>
+          <BodyLong size="large">
+            Tokens er alle farger, avstander, typografi, osv. som vi bruker i
+            komponenter og layout.
+          </BodyLong>
         </VStack>
-        <TokensPage />
+        <VStack gap="space-16" marginBlock="0 space-16">
+          <HStack gap="space-16" align="center">
+            <Link href="https://github.com/navikt/aksel" variant="neutral">
+              <GithubIcon aria-hidden />
+              GitHub
+            </Link>
+            <Link
+              href="https://www.figma.com/community/file/1214869602572392330"
+              variant="neutral"
+            >
+              <FigmaIcon aria-hidden />
+              Figma-community
+            </Link>
+            <Link
+              href="https://aksel.nav.no/grunnleggende/kode/endringslogg"
+              variant="neutral"
+            >
+              <ClockDashedIcon aria-hidden />
+              Endringslogg
+            </Link>
+          </HStack>
+        </VStack>
+        <Toolbar />
       </VStack>
       <TokenTableOfContents />
+      <TokensPage />
     </DesignsystemetPageLayout>
   );
 };


### PR DESCRIPTION
### Description

Resolves https://github.com/navikt/team-aksel/issues/843

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
