### PR TITLE
[Eslint] Added check for use of React 18 and 19 features in packages

### DIFF
--- a/@navikt/aksel-icons/.svgrrc.js
+++ b/@navikt/aksel-icons/.svgrrc.js
@@ -5,6 +5,7 @@ module.exports = {
   ref: true,
   icon: true,
   titleProp: true,
+  jsxRuntime: "automatic",
   svgProps: {
     focusable: false,
     role: "img",

--- a/@navikt/aksel-icons/config/template.js
+++ b/@navikt/aksel-icons/config/template.js
@@ -1,5 +1,13 @@
 const template = (variables, { tpl }) => {
-  const imports = variables.imports;
+  /*
+   * Remove any react imports SVGR added
+   * This allows us to de-duplicate the react import.
+   */
+  const imports = variables.imports.filter(
+    (imp) =>
+      !(imp.type === "ImportDeclaration" && imp.source.value === "react"),
+  );
+
   imports.push({
     type: "ImportDeclaration",
     specifiers: [
@@ -26,6 +34,7 @@ const template = (variables, { tpl }) => {
 
   return tpl`
 "use client";
+import React, { forwardRef, type Ref, type SVGProps } from "react";
 ${imports};
 
 ${variables.interfaces};

--- a/@navikt/aksel-icons/figma-plugin/src/ui/vite-env.d.ts
+++ b/@navikt/aksel-icons/figma-plugin/src/ui/vite-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 declare module "*.svg?component" {
-  import * as React from "react";
+  import React from "react";
 
   const ReactComponent: React.FunctionComponent<
     React.ComponentProps<"svg"> & { title?: string }

--- a/@navikt/core/react/src/date/datepicker/DatePicker.stories.tsx
+++ b/@navikt/core/react/src/date/datepicker/DatePicker.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { isSameDay } from "date-fns";
-import React, { useId, useState } from "react";
+import React, { useState } from "react";
 import { Button } from "../../button";
 import { HGrid } from "../../layout/grid";
 import Modal from "../../modal/Modal";
 import { BodyLong } from "../../typography";
+import { useId } from "../../util";
 import DatePicker, { DatePickerProps } from "./DatePicker";
 import { useDatepicker } from "./hooks/useDatepicker";
 import { useRangeDatepicker } from "./hooks/useRangeDatepicker";

--- a/@navikt/core/react/src/date/monthpicker/monthpicker.stories.tsx
+++ b/@navikt/core/react/src/date/monthpicker/monthpicker.stories.tsx
@@ -1,8 +1,9 @@
 import { Meta, StoryFn, StoryObj } from "@storybook/react";
 import { expect, userEvent, within } from "@storybook/test";
 import { setYear } from "date-fns";
-import React, { useId, useState } from "react";
+import React, { useState } from "react";
 import { Button } from "../../button";
+import { useId } from "../../util";
 import { DateInputProps } from "../Date.Input";
 import MonthPicker from "./MonthPicker";
 import { MonthPickerProps } from "./MonthPicker.types";

--- a/@navikt/core/react/src/form/combobox/__tests__/combobox.test.tsx
+++ b/@navikt/core/react/src/form/combobox/__tests__/combobox.test.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable testing-library/no-unnecessary-act -- https://kentcdodds.com/blog/fix-the-not-wrapped-in-act-warning */
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React, { useId } from "react";
+import React from "react";
 import { describe, expect, test, vi } from "vitest";
+import { useId } from "../../../util";
 import nb from "../../../util/i18n/locales/nb";
 import { ComboboxProps, UNSAFE_Combobox } from "../index";
 

--- a/@navikt/core/react/src/overlays/floating-menu/parts/FocusScope.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/parts/FocusScope.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { forwardRef, useEffect, useState } from "react";
+import React, { forwardRef, useEffect, useState } from "react";
 import { Slot } from "../../../slot/Slot";
 import { useCallbackRef, useMergeRefs } from "../../../util/hooks";
 

--- a/@navikt/core/react/src/overlays/floating/Floating.stories.tsx
+++ b/@navikt/core/react/src/overlays/floating/Floating.stories.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useState } from "react";
+import React, { useState } from "react";
 import { Portal } from "../../portal";
 import { Floating } from "./Floating";
 

--- a/@navikt/core/react/src/slot/Slot.tsx
+++ b/@navikt/core/react/src/slot/Slot.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { mergeRefs } from "../util/hooks/useMergeRefs";
 import { mergeProps } from "./merge-props";
 

--- a/@navikt/core/react/src/timeline/timeline.stories.tsx
+++ b/@navikt/core/react/src/timeline/timeline.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryFn } from "@storybook/react";
-import * as React from "react";
-import { useState } from "react";
+import React, { useState } from "react";
 import {
   CheckmarkCircleFillIcon,
   ExclamationmarkTriangleFillIcon,

--- a/@navikt/core/react/src/util/hooks/descendants/descendant.stories.tsx
+++ b/@navikt/core/react/src/util/hooks/descendants/descendant.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import { HStack } from "../../../layout/stack";
 import { createDescendantContext } from "./useDescendant";
 

--- a/@navikt/core/react/src/util/i18n/locales/nb.ts
+++ b/@navikt/core/react/src/util/i18n/locales/nb.ts
@@ -7,138 +7,216 @@ interface TranslationMap {
 export default {
   global: {
     dateLocale: nb,
+    /** @default "Vis mer" */
     showMore: "Vis mer",
+    /** @default "Vis mindre" */
     showLess: "Vis mindre",
+    /** @default "Skrivebeskyttet" */
     readOnly: "Skrivebeskyttet",
+    /** @default "Lukk" */
     close: "Lukk",
   },
 
   Alert: {
+    /** @default "Lukk varsel" */
     closeAlert: "Lukk varsel",
+    /** @default "Lukk melding" */
     closeMessage: "Lukk melding",
+    /** @default "Feil" */
     error: "Feil",
+    /** @default "Informasjon" */
     info: "Informasjon",
+    /** @default "Suksess" */
     success: "Suksess",
+    /** @default "Advarsel" */
     warning: "Advarsel",
   },
   Chips: {
     Removable: {
-      /** Will be appended to the accessible name for the button. */
+      /** Will be appended to the accessible name for the button.
+       * @default "slett" */
       labelSuffix: "slett",
     },
   },
   Combobox: {
-    /** The input value will be appended to the end of this text, e.g. `Legg til "input value"`. */
+    /** The input value will be appended to the end of this text, e.g. `Legg til "input value"`.
+     * @default "Legg til" */
     addOption: "Legg til",
-    /** Loader title */
+    /** Loader title
+     * @default "Søker…" */
     loading: "Søker…",
+    /** @default "{selected} av maks {limit} er valgt." */
     maxSelected: "{selected} av maks {limit} er valgt.",
   },
   CopyButton: {
+    /** @default "Kopier" */
     title: "Kopier",
+    /** @default "Kopiert!" */
     activeText: "Kopiert!",
   },
   DatePicker: {
+    /** @default "Velg dato" */
     chooseDate: "Velg dato",
+    /** @default "Velg datoer" */
     chooseDates: "Velg datoer",
+    /** @default "Velg start- og sluttdato" */
     chooseDateRange: "Velg start- og sluttdato",
+    /** @default "Velg måned" */
     chooseMonth: "Velg måned",
+    /** @default "Uke" */
     week: "Uke",
+    /** @default "Uke {week}" */
     weekNumber: "Uke {week}",
+    /** @default "Velg uke {week}" */
     selectWeekNumber: "Velg uke {week}",
+    /** @default "Måned" */
     month: "Måned",
+    /** @default "Gå til neste måned" */
     goToNextMonth: "Gå til neste måned",
+    /** @default "Gå til forrige måned" */
     goToPreviousMonth: "Gå til forrige måned",
+    /** @default "År" */
     year: "År",
+    /** @default "Gå til neste år" */
     goToNextYear: "Gå til neste år",
+    /** @default "Gå til forrige år" */
     goToPreviousYear: "Gå til forrige år",
+    /** @default "Åpne datovelger" */
     openDatePicker: "Åpne datovelger",
+    /** @default "Åpne månedsvelger" */
     openMonthPicker: "Åpne månedsvelger",
+    /** @default "Lukk datovelger" */
     closeDatePicker: "Lukk datovelger",
+    /** @default "Lukk månedsvelger" */
     closeMonthPicker: "Lukk månedsvelger",
   },
   ErrorSummary: {
+    /** @default "Du må rette disse feilene før du kan fortsette:" */
     heading: "Du må rette disse feilene før du kan fortsette:",
   },
   FileUpload: {
     dropzone: {
+      /** @default "Velg fil" */
       button: "Velg fil",
+      /** @default "Velg filer" */
       buttonMultiple: "Velg filer",
+      /** @default "Dra og slipp filen her" */
       dragAndDrop: "Dra og slipp filen her",
+      /** @default "Dra og slipp filer her" */
       dragAndDropMultiple: "Dra og slipp filer her",
+      /** @default "Slipp" */
       drop: "Slipp",
+      /** @default "eller" */
       or: "eller",
+      /** @default "Filopplasting er deaktivert" */
       disabled: "Filopplasting er deaktivert",
+      /** @default "Du kan ikke laste opp flere filer" */
       disabledFilelimit: "Du kan ikke laste opp flere filer",
     },
     item: {
+      /** @default "Prøv å laste opp filen på nytt" */
       retryButtonTitle: "Prøv å laste opp filen på nytt",
+      /** @default "Slett filen" */
       deleteButtonTitle: "Slett filen",
+      /** @default "Laster opp…" */
       uploading: "Laster opp…",
+      /** @default "Laster ned…" */
       downloading: "Laster ned…",
     },
   },
   FormProgress: {
+    /** @default "Steg {activeStep} av {totalSteps}" */
     step: "Steg {activeStep} av {totalSteps}",
+    /** @default "Vis alle steg" */
     showAllSteps: "Vis alle steg",
+    /** @default "Skjul alle steg" */
     hideAllSteps: "Skjul alle steg",
   },
   FormSummary: {
+    /** @default "Endre svar" */
     editAnswer: "Endre svar",
   },
   GuidePanel: {
+    /** @default "Illustrasjon av veileder" */
     illustrationLabel: "Illustrasjon av veileder",
   },
   HelpText: {
+    /** @default "Mer informasjon" */
     title: "Mer informasjon",
   },
   Loader: {
+    /** @default "Venter…" */
     title: "Venter…",
   },
   Pagination: {
+    /** @default "Forrige" */
     previous: "Forrige",
+    /** @default "Neste" */
     next: "Neste",
   },
   Process: {
+    /** @default "Aktiv" */
     active: "Aktiv",
   },
   ProgressBar: {
+    /** @default "{current} av {max}" */
     progress: "{current} av {max}",
+    /** @default "Fremdrift kan ikke beregnes, antatt tid er {seconds} sekunder." */
     progressUnknown:
       "Fremdrift kan ikke beregnes, antatt tid er {seconds} sekunder.",
   },
   Search: {
+    /** @default "Tøm feltet" */
     clear: "Tøm feltet",
+    /** @default "Søk" */
     search: "Søk",
   },
   Textarea: {
-    /** Screen readers only */
+    /** Screen readers only
+     * @default "Tekstområde med plass til {maxLength} tegn." */
     maxLength: "Tekstområde med plass til {maxLength} tegn.",
+    /** @default "{chars} tegn for mye" */
     charsTooMany: "{chars} tegn for mye",
+    /** @default "{chars} tegn igjen" */
     charsLeft: "{chars} tegn igjen",
   },
   Timeline: {
+    /** @default "dd.MM.yyyy" */
     dateFormat: "dd.MM.yyyy",
+    /** @default "dd.MM" */
     dayFormat: "dd.MM",
+    /** @default "MMM yy" */
     monthFormat: "MMM yy",
+    /** @default "yyyy" */
     yearFormat: "yyyy",
     Row: {
+      /** @default "Ingen perioder" */
       noPeriods: "Ingen perioder",
+      /** @default "{start} til {end}" */
       period: "{start} til {end}",
     },
     Period: {
+      /** @default "Suksess" */
       success: "Suksess",
+      /** @default "Advarsel" */
       warning: "Advarsel",
+      /** @default "Fare" */
       danger: "Fare",
+      /** @default "Info" */
       info: "Info",
+      /** @default "Nøytral" */
       neutral: "Nøytral",
+      /** @default "{status} fra {start} til {end}" */
       period: "{status} fra {start} til {end}",
     },
     Pin: {
+      /** @default "Pin: {date}" */
       pin: "Pin: {date}",
     },
     Zoom: {
+      /** @default "Zoom tidslinjen {start} til {end}" */
       zoom: "Zoom tidslinjen {start} til {end}",
+      /** @default "Tilbakestill tidsperspektiv" */
       reset: "Tilbakestill tidsperspektiv",
     },
   },

--- a/@navikt/core/react/src/util/i18n/locales/nb.ts
+++ b/@navikt/core/react/src/util/i18n/locales/nb.ts
@@ -7,216 +7,138 @@ interface TranslationMap {
 export default {
   global: {
     dateLocale: nb,
-    /** @default "Vis mer" */
     showMore: "Vis mer",
-    /** @default "Vis mindre" */
     showLess: "Vis mindre",
-    /** @default "Skrivebeskyttet" */
     readOnly: "Skrivebeskyttet",
-    /** @default "Lukk" */
     close: "Lukk",
   },
 
   Alert: {
-    /** @default "Lukk varsel" */
     closeAlert: "Lukk varsel",
-    /** @default "Lukk melding" */
     closeMessage: "Lukk melding",
-    /** @default "Feil" */
     error: "Feil",
-    /** @default "Informasjon" */
     info: "Informasjon",
-    /** @default "Suksess" */
     success: "Suksess",
-    /** @default "Advarsel" */
     warning: "Advarsel",
   },
   Chips: {
     Removable: {
-      /** Will be appended to the accessible name for the button.
-       * @default "slett" */
+      /** Will be appended to the accessible name for the button. */
       labelSuffix: "slett",
     },
   },
   Combobox: {
-    /** The input value will be appended to the end of this text, e.g. `Legg til "input value"`.
-     * @default "Legg til" */
+    /** The input value will be appended to the end of this text, e.g. `Legg til "input value"`. */
     addOption: "Legg til",
-    /** Loader title
-     * @default "Søker…" */
+    /** Loader title */
     loading: "Søker…",
-    /** @default "{selected} av maks {limit} er valgt." */
     maxSelected: "{selected} av maks {limit} er valgt.",
   },
   CopyButton: {
-    /** @default "Kopier" */
     title: "Kopier",
-    /** @default "Kopiert!" */
     activeText: "Kopiert!",
   },
   DatePicker: {
-    /** @default "Velg dato" */
     chooseDate: "Velg dato",
-    /** @default "Velg datoer" */
     chooseDates: "Velg datoer",
-    /** @default "Velg start- og sluttdato" */
     chooseDateRange: "Velg start- og sluttdato",
-    /** @default "Velg måned" */
     chooseMonth: "Velg måned",
-    /** @default "Uke" */
     week: "Uke",
-    /** @default "Uke {week}" */
     weekNumber: "Uke {week}",
-    /** @default "Velg uke {week}" */
     selectWeekNumber: "Velg uke {week}",
-    /** @default "Måned" */
     month: "Måned",
-    /** @default "Gå til neste måned" */
     goToNextMonth: "Gå til neste måned",
-    /** @default "Gå til forrige måned" */
     goToPreviousMonth: "Gå til forrige måned",
-    /** @default "År" */
     year: "År",
-    /** @default "Gå til neste år" */
     goToNextYear: "Gå til neste år",
-    /** @default "Gå til forrige år" */
     goToPreviousYear: "Gå til forrige år",
-    /** @default "Åpne datovelger" */
     openDatePicker: "Åpne datovelger",
-    /** @default "Åpne månedsvelger" */
     openMonthPicker: "Åpne månedsvelger",
-    /** @default "Lukk datovelger" */
     closeDatePicker: "Lukk datovelger",
-    /** @default "Lukk månedsvelger" */
     closeMonthPicker: "Lukk månedsvelger",
   },
   ErrorSummary: {
-    /** @default "Du må rette disse feilene før du kan fortsette:" */
     heading: "Du må rette disse feilene før du kan fortsette:",
   },
   FileUpload: {
     dropzone: {
-      /** @default "Velg fil" */
       button: "Velg fil",
-      /** @default "Velg filer" */
       buttonMultiple: "Velg filer",
-      /** @default "Dra og slipp filen her" */
       dragAndDrop: "Dra og slipp filen her",
-      /** @default "Dra og slipp filer her" */
       dragAndDropMultiple: "Dra og slipp filer her",
-      /** @default "Slipp" */
       drop: "Slipp",
-      /** @default "eller" */
       or: "eller",
-      /** @default "Filopplasting er deaktivert" */
       disabled: "Filopplasting er deaktivert",
-      /** @default "Du kan ikke laste opp flere filer" */
       disabledFilelimit: "Du kan ikke laste opp flere filer",
     },
     item: {
-      /** @default "Prøv å laste opp filen på nytt" */
       retryButtonTitle: "Prøv å laste opp filen på nytt",
-      /** @default "Slett filen" */
       deleteButtonTitle: "Slett filen",
-      /** @default "Laster opp…" */
       uploading: "Laster opp…",
-      /** @default "Laster ned…" */
       downloading: "Laster ned…",
     },
   },
   FormProgress: {
-    /** @default "Steg {activeStep} av {totalSteps}" */
     step: "Steg {activeStep} av {totalSteps}",
-    /** @default "Vis alle steg" */
     showAllSteps: "Vis alle steg",
-    /** @default "Skjul alle steg" */
     hideAllSteps: "Skjul alle steg",
   },
   FormSummary: {
-    /** @default "Endre svar" */
     editAnswer: "Endre svar",
   },
   GuidePanel: {
-    /** @default "Illustrasjon av veileder" */
     illustrationLabel: "Illustrasjon av veileder",
   },
   HelpText: {
-    /** @default "Mer informasjon" */
     title: "Mer informasjon",
   },
   Loader: {
-    /** @default "Venter…" */
     title: "Venter…",
   },
   Pagination: {
-    /** @default "Forrige" */
     previous: "Forrige",
-    /** @default "Neste" */
     next: "Neste",
   },
   Process: {
-    /** @default "Aktiv" */
     active: "Aktiv",
   },
   ProgressBar: {
-    /** @default "{current} av {max}" */
     progress: "{current} av {max}",
-    /** @default "Fremdrift kan ikke beregnes, antatt tid er {seconds} sekunder." */
     progressUnknown:
       "Fremdrift kan ikke beregnes, antatt tid er {seconds} sekunder.",
   },
   Search: {
-    /** @default "Tøm feltet" */
     clear: "Tøm feltet",
-    /** @default "Søk" */
     search: "Søk",
   },
   Textarea: {
-    /** Screen readers only
-     * @default "Tekstområde med plass til {maxLength} tegn." */
+    /** Screen readers only */
     maxLength: "Tekstområde med plass til {maxLength} tegn.",
-    /** @default "{chars} tegn for mye" */
     charsTooMany: "{chars} tegn for mye",
-    /** @default "{chars} tegn igjen" */
     charsLeft: "{chars} tegn igjen",
   },
   Timeline: {
-    /** @default "dd.MM.yyyy" */
     dateFormat: "dd.MM.yyyy",
-    /** @default "dd.MM" */
     dayFormat: "dd.MM",
-    /** @default "MMM yy" */
     monthFormat: "MMM yy",
-    /** @default "yyyy" */
     yearFormat: "yyyy",
     Row: {
-      /** @default "Ingen perioder" */
       noPeriods: "Ingen perioder",
-      /** @default "{start} til {end}" */
       period: "{start} til {end}",
     },
     Period: {
-      /** @default "Suksess" */
       success: "Suksess",
-      /** @default "Advarsel" */
       warning: "Advarsel",
-      /** @default "Fare" */
       danger: "Fare",
-      /** @default "Info" */
       info: "Info",
-      /** @default "Nøytral" */
       neutral: "Nøytral",
-      /** @default "{status} fra {start} til {end}" */
       period: "{status} fra {start} til {end}",
     },
     Pin: {
-      /** @default "Pin: {date}" */
       pin: "Pin: {date}",
     },
     Zoom: {
-      /** @default "Zoom tidslinjen {start} til {end}" */
       zoom: "Zoom tidslinjen {start} til {end}",
-      /** @default "Tilbakestill tidsperspektiv" */
       reset: "Tilbakestill tidsperspektiv",
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -178,4 +178,103 @@ module.exports = tseslint.config([
       "react/react-in-jsx-scope": "off",
     },
   },
+  {
+    files: ["@navikt/**"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "react",
+              importNames: [
+                // React 18
+                "useId",
+                "useInsertionEffect",
+                "useSyncExternalStore",
+                "useDeferredValue",
+                "useTransition",
+                "startTransition",
+                // React 19
+                "useOptimistic",
+                "useActionState",
+                "use",
+                "cache",
+                "useEffectEvent",
+              ],
+              message:
+                "We currently only support React-features accesible in React 17. To add new features, we will need to update peerDependencies (breaking change).",
+            },
+            // react-dom 18+
+            {
+              name: "react-dom/client",
+              importNames: ["createRoot", "hydrateRoot"],
+              message: "React 18+ API not allowed (targeting React 17).",
+            },
+          ],
+        },
+      ],
+
+      "no-restricted-properties": [
+        "error",
+        // React 18
+        {
+          object: "React",
+          property: "useId",
+          message: "React 18+ API not allowed (targeting React 17).",
+        },
+        {
+          object: "React",
+          property: "useInsertionEffect",
+          message: "React 18+ API not allowed (targeting React 17).",
+        },
+        {
+          object: "React",
+          property: "useSyncExternalStore",
+          message: "React 18+ API not allowed (targeting React 17).",
+        },
+        {
+          object: "React",
+          property: "useDeferredValue",
+          message: "React 18+ API not allowed (targeting React 17).",
+        },
+        {
+          object: "React",
+          property: "useTransition",
+          message: "React 18+ API not allowed (targeting React 17).",
+        },
+        {
+          object: "React",
+          property: "startTransition",
+          message: "React 18+ API not allowed (targeting React 17).",
+        },
+        // React 19
+        {
+          object: "React",
+          property: "useOptimistic",
+          message: "React 19+ API not allowed (targeting React 17).",
+        },
+        {
+          object: "React",
+          property: "useActionState",
+          message: "React 19+ API not allowed (targeting React 17).",
+        },
+        {
+          object: "React",
+          property: "use",
+          message: "React 19+ API not allowed (targeting React 17).",
+        },
+        {
+          object: "React",
+          property: "cache",
+          message: "React 19+ API not allowed (targeting React 17).",
+        },
+        {
+          object: "React",
+          property: "useEffectEvent",
+          message: "React 19+ API not allowed (targeting React 17).",
+        },
+      ],
+    },
+  },
 ]);


### PR DESCRIPTION
### Description

This allows us to update the monorepo to React-19, while being somewhat safe from mistakenly using newer features from React 19 and 18.
- `Import * as React` does not pass the current test, so needed to update the imports for some components
- All icons used above import. Updated template to use the new import. I don't really see a need for a Changeset here.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
