### PR TITLE
:bug: Removed rem-values on SVG causing errors in Safari

### DIFF
--- a/.changeset/fifty-items-pump.md
+++ b/.changeset/fifty-items-pump.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+Checkbox, List: Updated SVG-usage to avoid using rem-values directly on `width` and `height`-attributes.

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -136,10 +136,10 @@
   transform: translate(0.25rem, -10%);
 }
 
-/* Tailwind sets all svg to block */
 .aksel-checkbox__icon > svg {
-  display: inline;
-  vertical-align: initial;
+  display: block;
+  width: 0.8125rem;
+  height: 0.625rem;
 }
 
 .aksel-checkbox--small > .aksel-checkbox__input:checked + .aksel-checkbox__label::before {

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -138,6 +138,8 @@
 
 .aksel-checkbox__icon > svg {
   display: block;
+
+  /* Safari does not support inline rem-values in SVG */
   width: 0.8125rem;
   height: 0.625rem;
 }

--- a/@navikt/core/css/darkside/list.darkside.css
+++ b/@navikt/core/css/darkside/list.darkside.css
@@ -72,6 +72,7 @@
   padding-left: 0.8rem;
 }
 
+/* Safari does not support inline rem-values in SVG */
 .aksel-list__item-marker--bullet > svg {
   width: 0.375rem;
   height: 0.375rem;

--- a/@navikt/core/css/darkside/list.darkside.css
+++ b/@navikt/core/css/darkside/list.darkside.css
@@ -72,6 +72,11 @@
   padding-left: 0.8rem;
 }
 
+.aksel-list__item-marker--bullet > svg {
+  width: 0.375rem;
+  height: 0.375rem;
+}
+
 .aksel-list__item-marker--icon {
   font-size: 1.5rem;
   justify-content: center;

--- a/@navikt/core/css/form/radio-checkbox.css
+++ b/@navikt/core/css/form/radio-checkbox.css
@@ -141,6 +141,8 @@
 /* Tailwind sets all svg to block */
 .navds-checkbox__icon > svg {
   display: block;
+
+  /* Safari does not support inline rem-values in SVG */
   width: 0.8125rem;
   height: 0.625rem;
 }

--- a/@navikt/core/css/form/radio-checkbox.css
+++ b/@navikt/core/css/form/radio-checkbox.css
@@ -140,8 +140,9 @@
 
 /* Tailwind sets all svg to block */
 .navds-checkbox__icon > svg {
-  display: inline;
-  vertical-align: initial;
+  display: block;
+  width: 0.8125rem;
+  height: 0.625rem;
 }
 
 .navds-checkbox--small > .navds-checkbox__input:checked + .navds-checkbox__label::before {

--- a/@navikt/core/css/list.css
+++ b/@navikt/core/css/list.css
@@ -75,6 +75,7 @@
   color: var(--ac-list-marker-ul-color, var(--ac-list-marker-color, var(--a-icon-default)));
 }
 
+/* Safari does not support inline rem-values in SVG */
 .navds-list__item-marker--bullet > svg {
   width: 0.375rem;
   height: 0.375rem;

--- a/@navikt/core/css/list.css
+++ b/@navikt/core/css/list.css
@@ -75,6 +75,11 @@
   color: var(--ac-list-marker-ul-color, var(--ac-list-marker-color, var(--a-icon-default)));
 }
 
+.navds-list__item-marker--bullet > svg {
+  width: 0.375rem;
+  height: 0.375rem;
+}
+
 .navds-list__item-marker--icon {
   font-size: 1.5rem;
   justify-content: center;

--- a/@navikt/core/react/src/form/checkbox/Checkbox.tsx
+++ b/@navikt/core/react/src/form/checkbox/Checkbox.tsx
@@ -55,8 +55,6 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           <span className={cn("navds-checkbox__icon")}>
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              width="0.8125rem"
-              height="0.625rem"
               viewBox="0 0 13 10"
               fill="none"
               focusable={false}

--- a/@navikt/core/react/src/list/List.Item.tsx
+++ b/@navikt/core/react/src/list/List.Item.tsx
@@ -31,8 +31,6 @@ export const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
               icon
             ) : (
               <svg
-                width="0.375rem"
-                height="0.375rem"
                 viewBox="0 0 6 6"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
### Description

Resolves #4044

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
