### PR TITLE
Styling fixes on Radio and Checkbox

### DIFF
--- a/.changeset/gentle-brooms-tickle.md
+++ b/.changeset/gentle-brooms-tickle.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Darkside: Styling fixes on Radio and Checkbox

--- a/.changeset/gentle-brooms-tickle.md
+++ b/.changeset/gentle-brooms-tickle.md
@@ -2,4 +2,4 @@
 "@navikt/ds-css": patch
 ---
 
-Darkside: Styling fixes on Radio and Checkbox
+Darkside: Fix styling for small readOnly checked Radio

--- a/.changeset/ten-women-design.md
+++ b/.changeset/ten-women-design.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Checkbox: Fix styling for indeterminate state with description

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -97,7 +97,7 @@
   border-radius: 1px;
   position: absolute;
   transform: translate(var(--ax-space-6), -50%);
-  top: var(--ax-space-24);
+  top: 50%;
   pointer-events: none;
 }
 

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -97,12 +97,13 @@
   border-radius: 1px;
   position: absolute;
   transform: translate(var(--ax-space-6), -50%);
-  top: 50%;
+  top: var(--ax-space-24);
   pointer-events: none;
 }
 
 .aksel-checkbox--small .aksel-checkbox__input:indeterminate + .aksel-checkbox__label > .aksel-checkbox__icon-indeterminate {
   transform: translate(var(--ax-space-4), -50%);
+  top: var(--ax-space-16);
   height: 0.1875rem;
 }
 
@@ -215,6 +216,12 @@
   box-shadow:
     inset 0 0 0 2px var(--ax-border-neutral-subtle),
     inset 0 0 0 8px var(--ax-bg-neutral-moderate);
+}
+
+.aksel-radio--small.aksel-radio--readonly > .aksel-radio__input:checked + .aksel-radio__label::before {
+  box-shadow:
+    inset 0 0 0 2px var(--ax-border-neutral-subtle),
+    inset 0 0 0 7px var(--ax-bg-neutral-moderate);
 }
 
 .aksel-checkbox--readonly > .aksel-checkbox__input:indeterminate + .aksel-checkbox__label > .aksel-checkbox__icon-indeterminate {

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -97,7 +97,7 @@
   border-radius: 1px;
   position: absolute;
   transform: translate(var(--ax-space-6), -50%);
-  top: 50%;
+  top: var(--ax-space-24);
   pointer-events: none;
 }
 

--- a/@navikt/core/css/darkside/table.darkside.css
+++ b/@navikt/core/css/darkside/table.darkside.css
@@ -143,6 +143,18 @@
   padding: 0;
 }
 
+.aksel-table tr:not(.aksel-table__expanded-row) .aksel-checkbox__label > .aksel-checkbox__icon-indeterminate {
+  top: var(--ax-space-12);
+}
+
+.aksel-table
+  tr:not(.aksel-table__expanded-row)
+  .aksel-checkbox--small
+  .aksel-checkbox__label
+  > .aksel-checkbox__icon-indeterminate {
+  top: 0.6rem;
+}
+
 .aksel-table tr:not(.aksel-table__expanded-row) .aksel-checkbox__input:focus + .aksel-checkbox__label::after {
   height: 100%;
 }

--- a/@navikt/core/css/form/radio-checkbox.css
+++ b/@navikt/core/css/form/radio-checkbox.css
@@ -95,7 +95,7 @@
 .navds-checkbox__input:indeterminate + .navds-checkbox__label::after {
   content: "";
   position: absolute;
-  top: 50%;
+  top: var(--a-spacing-6);
   transform: translate(var(--a-spacing-1-alt), -50%);
   background-color: var(--ac-radio-checkbox-bg, var(--a-surface-default));
   width: 0.75rem;
@@ -106,6 +106,7 @@
 
 .navds-checkbox--small .navds-checkbox__input:indeterminate + .navds-checkbox__label::after {
   transform: translate(0.25rem, -50%);
+  top: var(--a-spacing-4);
 }
 
 .navds-checkbox__input:where(:checked, :indeterminate) + .navds-checkbox__label::before {

--- a/@navikt/core/css/table.css
+++ b/@navikt/core/css/table.css
@@ -141,6 +141,18 @@
   padding: 0;
 }
 
+.navds-table :not(.navds-checkboxes) > .navds-checkbox .navds-checkbox__input:indeterminate + .navds-checkbox__label::after {
+  top: var(--a-spacing-3);
+}
+
+.navds-table
+  :not(.navds-checkboxes)
+  > .navds-checkbox--small
+  .navds-checkbox__input:indeterminate
+  + .navds-checkbox__label::after {
+  top: 0.6rem;
+}
+
 .navds-table__header-cell[aria-sort] {
   padding: 0;
 }

--- a/@navikt/core/react/src/form/checkbox/checkbox.stories.tsx
+++ b/@navikt/core/react/src/form/checkbox/checkbox.stories.tsx
@@ -192,6 +192,9 @@ export const Indeterminate = () => {
           Child 2
         </Checkbox>
       </div>
+      <Checkbox indeterminate description="With description">
+        Indeterminate medium
+      </Checkbox>
       <Checkbox indeterminate size="small" description="With description">
         Indeterminate small
       </Checkbox>

--- a/@navikt/core/react/src/form/checkbox/checkbox.stories.tsx
+++ b/@navikt/core/react/src/form/checkbox/checkbox.stories.tsx
@@ -192,6 +192,9 @@ export const Indeterminate = () => {
           Child 2
         </Checkbox>
       </div>
+      <Checkbox indeterminate size="small" description="With description">
+        Indeterminate small
+      </Checkbox>
     </>
   );
 };

--- a/@navikt/core/react/src/form/radio/radio.stories.tsx
+++ b/@navikt/core/react/src/form/radio/radio.stories.tsx
@@ -183,11 +183,7 @@ export const TestInsideAccordion = () => (
 
 export const Readonly = () => (
   <div className="colgap">
-    <RadioGroup
-      legend="Hvilken frukt liker du?"
-      defaultValue={["banan"]}
-      readOnly
-    >
+    <RadioGroup legend="Hvilken frukt liker du?" defaultValue="banan" readOnly>
       <Radio value="banan">Banan</Radio>
       <Radio value="eple">Eple</Radio>
       <Radio value="druer">Druer</Radio>
@@ -197,6 +193,7 @@ export const Readonly = () => (
       error="feilmelding"
       defaultValue="eple"
       readOnly
+      size="small"
     >
       <Radio value="eple">Eple</Radio>
       <Radio value="banan">Banan</Radio>
@@ -206,13 +203,11 @@ export const Readonly = () => (
 
 export const Disabled = () => (
   <div className="colgap">
-    <RadioGroup
-      legend="Hvilken frukt liker du?"
-      defaultValue={["banan"]}
-      disabled
-    >
+    <RadioGroup legend="Hvilken frukt liker du?" defaultValue="banan" disabled>
       <Radio value="banan">Banan</Radio>
-      <Radio value="eple">Eple</Radio>
+      <Radio value="eple" description="Rød, grønn eller gul.">
+        Eple
+      </Radio>
       <Radio value="druer">Druer</Radio>
     </RadioGroup>
     <RadioGroup


### PR DESCRIPTION
### Description

- Radio darkside: Fix "dot" size on small + checked + readOnly state.
- Checkbox: Fix "icon" position on indeterminate state with description.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [x] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
