### PR TITLE
[aksel.nav.no] Adjust EditorPanel width, fix example scrolling, adjust examples

### DIFF
--- a/aksel.nav.no/website/app/_ui/editor-panel/EditorPanel.tsx
+++ b/aksel.nav.no/website/app/_ui/editor-panel/EditorPanel.tsx
@@ -98,6 +98,7 @@ function EditorPanel(props: EditorPanelProps) {
       data-block-margin="space-28"
       className={styles.editorPanel}
       data-color={config.color}
+      data-text-prose
     >
       <EditorPanelHeader
         variant={variant}
@@ -105,9 +106,7 @@ function EditorPanel(props: EditorPanelProps) {
         headingTag={headingTag}
         actionComponent={actionComponent}
       />
-      <div data-text-prose className={styles.editorPanelContent}>
-        {children}
-      </div>
+      <div className={styles.editorPanelContent}>{children}</div>
     </div>
   );
 }

--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
@@ -109,12 +109,12 @@ function KodeEksemplerProvider(props: {
 
     prevSearchParam.current = param;
 
-    setTimeout(() => {
+    queueMicrotask(() => {
       iframeRef.current?.scrollIntoView({
         behavior: "smooth",
         block: "nearest",
       });
-    }, 1);
+    });
 
     iframeRef.current?.focus({ preventScroll: true });
   }, [dir?.filer, dir?.title, searchParams]);

--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
@@ -113,8 +113,23 @@ function KodeEksemplerProvider(props: {
       behavior: "smooth",
       block: "nearest",
     });
+    console.warn("HH scrolling nearest");
+
     iframeRef.current?.focus({ preventScroll: true });
   }, [dir?.filer, dir?.title, searchParams]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Only run on first render
+  useEffect(() => {
+    //const param = searchParams?.get("demo");
+    if (!searchParams?.get("demo")) {
+      return;
+    }
+    console.warn("HH SCROLLING CENTER");
+    iframeRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+    });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <KodeEksemplerContext.Provider

--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
@@ -109,27 +109,16 @@ function KodeEksemplerProvider(props: {
 
     prevSearchParam.current = param;
 
-    iframeRef.current?.scrollIntoView({
-      behavior: "smooth",
-      block: "nearest",
-    });
-    console.warn("HH scrolling nearest");
+    setTimeout(() => {
+      console.warn("HH scrolling nearest");
+      iframeRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+      });
+    }, 1);
 
     iframeRef.current?.focus({ preventScroll: true });
   }, [dir?.filer, dir?.title, searchParams]);
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Only run on first render
-  useEffect(() => {
-    //const param = searchParams?.get("demo");
-    if (!searchParams?.get("demo")) {
-      return;
-    }
-    console.warn("HH SCROLLING CENTER");
-    iframeRef.current?.scrollIntoView({
-      behavior: "smooth",
-      block: "center",
-    });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <KodeEksemplerContext.Provider

--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
@@ -110,7 +110,6 @@ function KodeEksemplerProvider(props: {
     prevSearchParam.current = param;
 
     setTimeout(() => {
-      console.warn("HH scrolling nearest");
       iframeRef.current?.scrollIntoView({
         behavior: "smooth",
         block: "nearest",

--- a/aksel.nav.no/website/pages/eksempler/errorsummary/heading-tag.tsx
+++ b/aksel.nav.no/website/pages/eksempler/errorsummary/heading-tag.tsx
@@ -27,4 +27,5 @@ export const Demo = {
 
 export const args = {
   index: 2,
+  desc: "Ved behov kan overskriftsnivået endres med `headingTag`-propen.",
 };

--- a/aksel.nav.no/website/pages/eksempler/helptext/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/helptext/demo.tsx
@@ -4,7 +4,7 @@ import { withDsExample } from "@/web/examples/withDsExample";
 const Example = () => {
   return (
     <HelpText title="Hvor kommer dette fra?">
-      Informasjonen er hentet fra X sin statistikk fra 2021
+      Informasjonen er hentet fra Nav sin statistikk fra 2021
     </HelpText>
   );
 };


### PR DESCRIPTION
- Set width of EditorPanel (why is it called that?) to same as text (as agreed in doc meeting).
- Fix issue where browser did not scroll far enough when clicking on a link to an example.
- Adjust some examples on ErrorSummary and HelpText.