### PR TITLE
Radio/Checkbox: Improve screen reader experience by moving description out of label

### DIFF
--- a/.changeset/fresh-groups-stand.md
+++ b/.changeset/fresh-groups-stand.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+Darkside: Improved screen reader experience in Radio and Checkbox by moving description out of label

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -2,9 +2,6 @@
 .aksel-radio {
   --__axc-radio-checkbox-marker-size: 1.5rem;
   --__axc-radio-checkbox-marker-target: 2.75rem; /* We want the click area to be a bit larger than the visible radio/checkbox */
-  --__axc-radio-checkbox-marker-padding: calc(
-    (var(--__axc-radio-checkbox-marker-target) - var(--__axc-radio-checkbox-marker-size)) / 2
-  );
 
   position: relative;
   width: fit-content;
@@ -51,6 +48,14 @@
   grid-column-start: 2;
 }
 
+/* Spacing between marker and text */
+.aksel-checkbox__label,
+.aksel-radio__label,
+.aksel-checkbox__description,
+.aksel-radio__description {
+  padding-left: var(--ax-space-8);
+}
+
 /* Checkbox has a wrapper around input and checkmark svg (consider creating the checkmark with css in the future) */
 .aksel-checkbox__input-wrapper {
   position: relative;
@@ -64,18 +69,12 @@
   appearance: none;
   cursor: pointer;
   outline: none;
-  box-sizing: content-box;
   width: var(--__axc-radio-checkbox-marker-size);
   height: var(--__axc-radio-checkbox-marker-size);
-  padding: var(--__axc-radio-checkbox-marker-padding);
-  margin: calc(-1 * var(--__axc-radio-checkbox-marker-padding));
-}
-
-/* Spacing between marker and label */
-.aksel-checkbox:not(.aksel-checkbox--hidelabel) .aksel-checkbox__input,
-.aksel-radio__input {
-  margin-right: 0;
-  padding-right: var(--ax-space-8);
+  background-color: var(--ax-bg-input);
+  border: 2px solid var(--ax-border-neutral);
+  border-radius: var(--ax-radius-4);
+  position: relative;
 }
 
 /* Visible marker */
@@ -83,15 +82,11 @@
 .aksel-radio__input::before {
   content: "";
   position: absolute;
-  border-radius: var(--ax-radius-4);
-  background-color: var(--ax-bg-input);
-  width: var(--__axc-radio-checkbox-marker-size);
-  height: var(--__axc-radio-checkbox-marker-size);
-  border: 2px solid var(--ax-border-neutral);
+  inset: calc(-1 * (var(--__axc-radio-checkbox-marker-target) - var(--__axc-radio-checkbox-marker-size)) / 2);
 }
 
 /* Radio marker should be round */
-.aksel-radio__input::before {
+.aksel-radio__input {
   border-radius: var(--ax-radius-full);
 }
 
@@ -113,13 +108,13 @@
 }
 
 /* Checkbox marker colors in checked/indeterminate state */
-.aksel-checkbox__input:where(:checked, :indeterminate)::before {
+.aksel-checkbox__input:where(:checked, :indeterminate) {
   background-color: var(--ax-bg-strong-pressed);
   border-color: var(--ax-bg-strong-pressed);
 }
 
 /* Checkbox marker colors in checked/indeterminate + hover state (unless disabled) */
-.aksel-checkbox__input:where(:checked, :indeterminate):not(:disabled):hover::before {
+.aksel-checkbox__input:where(:checked, :indeterminate):not(:disabled):hover {
   border-color: var(--ax-bg-strong-hover);
   background-color: var(--ax-bg-strong-hover);
 }
@@ -146,26 +141,26 @@
 }
 
 /* Radio marker colors in checked state */
-.aksel-radio__input:checked::before {
+.aksel-radio__input:checked {
   background-color: var(--ax-bg-input);
   border: 8px solid var(--ax-bg-strong-pressed);
 }
 
 /* Small Radio dot size in checked state */
-.aksel-radio--small > .aksel-radio__input:checked::before {
+.aksel-radio--small > .aksel-radio__input:checked {
   border-width: 7px;
 }
 
 /* Marker colors in unchecked hover state (unless disabled) */
-.aksel-checkbox__input:hover:not(:disabled, :checked, :indeterminate)::before,
-.aksel-radio__input:hover:not(:disabled, :checked)::before {
+.aksel-checkbox__input:hover:not(:disabled, :checked, :indeterminate),
+.aksel-radio__input:hover:not(:disabled, :checked) {
   border-color: var(--ax-border-strong);
   background-color: var(--ax-bg-moderate-hoverA);
 }
 
 /* Marker colors in unchecked error state (unless disabled) */
-.aksel-checkbox--error .aksel-checkbox__input:not(:disabled, :checked, :indeterminate)::before,
-.aksel-radio--error > .aksel-radio__input:not(:disabled, :checked)::before {
+.aksel-checkbox--error .aksel-checkbox__input:not(:disabled, :checked, :indeterminate),
+.aksel-radio--error > .aksel-radio__input:not(:disabled, :checked) {
   border-color: var(--ax-border-danger-strong);
 }
 
@@ -188,8 +183,8 @@
 }
 
 /* Marker colors in readonly state (`:not(:disabled)` is just to get same specificity as (hence override) hover colors) */
-.aksel-checkbox--readonly .aksel-checkbox__input:not(:disabled)::before,
-.aksel-radio--readonly > .aksel-radio__input:not(:disabled)::before {
+.aksel-checkbox--readonly .aksel-checkbox__input:not(:disabled),
+.aksel-radio--readonly > .aksel-radio__input:not(:disabled) {
   background-color: var(--ax-bg-neutral-moderate);
   border-color: var(--ax-border-neutral-subtle);
 }
@@ -212,7 +207,7 @@
 }
 
 /* Radio marker colors in readonly + checked state */
-.aksel-radio--readonly > .aksel-radio__input:checked::before {
+.aksel-radio--readonly > .aksel-radio__input:checked {
   background-color: var(--ax-bg-neutral-strong);
   border-width: 0;
   box-shadow:
@@ -221,7 +216,7 @@
 }
 
 /* Small Radio dot size in readonly + checked state */
-.aksel-radio--small.aksel-radio--readonly > .aksel-radio__input:checked::before {
+.aksel-radio--small.aksel-radio--readonly > .aksel-radio__input:checked {
   box-shadow:
     inset 0 0 0 2px var(--ax-border-neutral-subtle),
     inset 0 0 0 7px var(--ax-bg-neutral-moderate);
@@ -241,8 +236,8 @@
   }
 
   /* Marker border color on hover (unless readonly/disabled) */
-  .aksel-checkbox:not(.aksel-checkbox--readonly) .aksel-checkbox__input:hover:not(:disabled)::before,
-  .aksel-radio:not(.aksel-radio--readonly) > .aksel-radio__input:hover:not(:disabled)::before {
+  .aksel-checkbox:not(.aksel-checkbox--readonly) .aksel-checkbox__input:hover:not(:disabled),
+  .aksel-radio:not(.aksel-radio--readonly) > .aksel-radio__input:hover:not(:disabled) {
     border-color: highlight;
   }
 
@@ -252,12 +247,12 @@
   }
 
   /* Radio dot size in readonly + checked state */
-  .aksel-radio--readonly > .aksel-radio__input:checked::before {
+  .aksel-radio--readonly > .aksel-radio__input:checked {
     border-width: 8px;
   }
 
   /* Small Radio dot size in readonly + checked state */
-  .aksel-radio--small.aksel-radio--readonly > .aksel-radio__input:checked::before {
+  .aksel-radio--small.aksel-radio--readonly > .aksel-radio__input:checked {
     border-width: 7px;
   }
 
@@ -268,8 +263,8 @@
   }
 
   /* Marker colors in disabled state */
-  .aksel-checkbox--disabled .aksel-checkbox__input::before,
-  .aksel-radio--disabled .aksel-radio__input::before {
+  .aksel-checkbox--disabled .aksel-checkbox__input,
+  .aksel-radio--disabled .aksel-radio__input {
     border-color: graytext;
     background-color: field;
   }

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -1,176 +1,161 @@
 .aksel-checkbox,
 .aksel-radio {
+  --__axc-radio-checkbox-marker-size: 1.5rem;
+  --__axc-radio-checkbox-marker-target: 2.75rem;
+  --__axc-radio-checkbox-marker-padding: calc(
+    (var(--__axc-radio-checkbox-marker-target) - var(--__axc-radio-checkbox-marker-size)) / 2
+  );
+
   position: relative;
   width: fit-content;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--ax-space-2) 0;
+  padding: var(--ax-space-12) 0; /* We need spacing even bellow the least element to allocate space for the clickable area */
+
+  /* Focus outline */
+  &:focus-within::after {
+    content: "";
+    position: absolute;
+    inset: var(--ax-space-12) 0;
+    pointer-events: none;
+    border-radius: var(--ax-radius-4);
+    outline: 3px solid var(--ax-border-focus);
+    outline-offset: 3px;
+  }
+}
+
+.aksel-checkbox--small,
+.aksel-radio--small {
+  --__axc-radio-checkbox-marker-size: 1.25rem;
+  --__axc-radio-checkbox-marker-target: 2rem;
+
+  padding: var(--ax-space-6) 0;
+
+  /* Focus outline */
+  &:focus-within::after {
+    inset: var(--ax-space-6) 0;
+  }
 }
 
 .aksel-checkbox__input,
 .aksel-radio__input {
-  position: absolute;
-  width: 3rem;
-  height: 3rem;
-  top: 0;
-  left: -0.75rem;
-  z-index: 1;
-  opacity: 0;
+  -webkit-appearance: none; /* Safari <= 15.3 */
+  appearance: none;
   cursor: pointer;
+  outline: none;
+  box-sizing: content-box;
+  width: var(--__axc-radio-checkbox-marker-size);
+  height: var(--__axc-radio-checkbox-marker-size);
+  padding: var(--__axc-radio-checkbox-marker-padding);
+  margin: calc(-1 * var(--__axc-radio-checkbox-marker-padding));
+}
+
+.aksel-checkbox:not(.aksel-checkbox--hidelabel) .aksel-checkbox__input,
+.aksel-radio__input {
+  margin-right: 0;
+  padding-right: var(--ax-space-8);
+}
+
+.aksel-checkbox__input::before,
+.aksel-radio__input::before {
+  content: "";
+  position: absolute;
+  border-radius: var(--ax-radius-4);
+  background-color: var(--ax-bg-input);
+  width: var(--__axc-radio-checkbox-marker-size);
+  height: var(--__axc-radio-checkbox-marker-size);
+  border: 2px solid var(--ax-border-neutral);
+}
+
+.aksel-radio__input::before {
+  border-radius: var(--ax-radius-full);
 }
 
 .aksel-checkbox__label,
 .aksel-radio__label {
-  padding: var(--ax-space-12) 0;
   cursor: pointer;
+}
+
+.aksel-checkbox__description,
+.aksel-radio__description {
+  grid-column-start: 2;
+}
+
+.aksel-checkbox__input-wrapper {
+  position: relative;
+  height: var(--__axc-radio-checkbox-marker-size);
+}
+
+.aksel-checkbox__input:indeterminate {
   display: flex;
-  gap: var(--ax-space-8);
-
-  --__axc-radio-checkbox-readonly-bg: var(--ax-bg-neutral-moderate);
-  --__axc-radio-checkbox-readonly-border: var(--ax-border-neutral-subtle);
+  align-items: center;
+  justify-content: center;
 }
 
-.aksel-checkbox__label::before,
-.aksel-radio__label::before {
+.aksel-checkbox__input:indeterminate::after {
   content: "";
-  border-radius: var(--ax-radius-4);
-  background-color: var(--ax-bg-input);
-  flex-shrink: 0;
-  width: 1.5rem;
-  height: 1.5rem;
-  border: 2px solid var(--ax-border-neutral);
-}
-
-.aksel-radio__label::before {
-  border-radius: var(--ax-radius-full);
-}
-
-.aksel-checkbox__content,
-.aksel-radio__content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.125rem;
-}
-
-.aksel-checkbox--small > .aksel-checkbox__input,
-.aksel-radio--small > .aksel-radio__input {
-  width: 2rem;
-  height: 2rem;
-  top: 0;
-  left: -0.375rem;
-}
-
-.aksel-checkbox--small > .aksel-checkbox__label,
-.aksel-radio--small > .aksel-radio__label {
-  padding: var(--ax-space-6) 0;
-}
-
-.aksel-checkbox--small > .aksel-checkbox__label::before,
-.aksel-radio--small > .aksel-radio__label::before {
-  width: 1.25rem;
-  height: 1.25rem;
-}
-
-.aksel-checkbox__input:focus + .aksel-checkbox__label::after,
-.aksel-radio__input:focus + .aksel-radio__label::after {
-  content: "";
-  position: absolute;
-  width: 100%;
-  height: calc(100% - var(--ax-space-24));
-  border-radius: var(--ax-radius-4);
-  outline: 3px solid var(--ax-border-focus);
-  outline-offset: 3px;
-  pointer-events: none;
-}
-
-.aksel-checkbox--small > .aksel-checkbox__input:focus + .aksel-checkbox__label::after,
-.aksel-radio--small > .aksel-radio__input:focus + .aksel-radio__label::after {
-  height: calc(100% - var(--ax-space-12));
-}
-
-.aksel-checkbox__icon-indeterminate {
-  display: none;
-}
-
-.aksel-checkbox__input:indeterminate + .aksel-checkbox__label > .aksel-checkbox__icon-indeterminate {
-  display: block;
   width: 0.75rem;
   height: 0.25rem;
   background-color: var(--ax-bg-default);
   border-radius: 1px;
   position: absolute;
-  transform: translate(var(--ax-space-6), -50%);
-  top: var(--ax-space-24);
-  pointer-events: none;
 }
 
-.aksel-checkbox--small .aksel-checkbox__input:indeterminate + .aksel-checkbox__label > .aksel-checkbox__icon-indeterminate {
-  transform: translate(var(--ax-space-4), -50%);
-  top: var(--ax-space-16);
-  height: 0.1875rem;
-}
-
-.aksel-checkbox__input:where(:checked, :indeterminate) + .aksel-checkbox__label::before {
+.aksel-checkbox__input:where(:checked, :indeterminate)::before {
   background-color: var(--ax-bg-strong-pressed);
   border-color: var(--ax-bg-strong-pressed);
 }
 
-.aksel-checkbox__input:where(:checked, :indeterminate):not(:disabled):hover + .aksel-checkbox__label::before {
+.aksel-checkbox__input:where(:checked, :indeterminate):not(:disabled):hover::before {
   border-color: var(--ax-bg-strong-hover);
   background-color: var(--ax-bg-strong-hover);
 }
 
-.aksel-checkbox__input:where(:not(:checked)) + .aksel-checkbox__label > .aksel-checkbox__icon {
+.aksel-checkbox__input:where(:not(:checked)) + .aksel-checkbox__icon {
   display: none;
 }
 
-.aksel-checkbox__input:checked + .aksel-checkbox__label > .aksel-checkbox__icon {
+.aksel-checkbox__input:checked::before {
+  color: var(--ax-bg-default);
+}
+
+.aksel-checkbox__input:checked + .aksel-checkbox__icon {
   color: var(--ax-bg-default);
   position: absolute;
-  height: 1.5rem;
-  transform: translate(var(--ax-space-6));
   pointer-events: none;
-
-  /* Fixed edcase where when using in shadow-dom, svg will not center */
-  display: flex;
-  align-items: center;
+  height: var(--__axc-radio-checkbox-marker-size);
+  top: 0;
+  left: var(--ax-space-6);
 }
 
-.aksel-checkbox--small .aksel-checkbox__input:checked + .aksel-checkbox__label > .aksel-checkbox__icon {
-  transform: translate(0.25rem, -10%);
+.aksel-checkbox--small .aksel-checkbox__input:checked + .aksel-checkbox__icon {
+  left: var(--ax-space-4);
 }
 
-.aksel-checkbox__icon > svg {
-  display: block;
-
+.aksel-checkbox__icon {
   /* Safari does not support inline rem-values in SVG */
   width: 0.8125rem;
-  height: 0.625rem;
 }
 
-.aksel-checkbox--small > .aksel-checkbox__input:checked + .aksel-checkbox__label::before {
-  background-position: 0.25rem center;
-}
-
-.aksel-radio__input:checked + .aksel-radio__label::before {
+.aksel-radio__input:checked::before {
   background-color: var(--ax-bg-input);
   border: 8px solid var(--ax-bg-strong-pressed);
 }
 
-.aksel-radio--small > .aksel-radio__input:checked + .aksel-radio__label::before {
-  border-width: 6px;
+.aksel-radio--small > .aksel-radio__input:checked::before {
+  border-width: 7px;
 }
 
-.aksel-checkbox__input:hover:not(:disabled, :checked, :indeterminate) + .aksel-checkbox__label::before,
-.aksel-radio__input:hover:not(:disabled, :checked) + .aksel-radio__label::before {
+.aksel-checkbox__input:hover:not(:disabled, :checked, :indeterminate)::before,
+.aksel-radio__input:hover:not(:disabled, :checked)::before {
   border-color: var(--ax-border-strong);
   background-color: var(--ax-bg-moderate-hoverA);
 }
 
-.aksel-checkbox--error > .aksel-checkbox__input:not(:disabled, :checked, :indeterminate) + .aksel-checkbox__label::before,
-.aksel-radio--error > .aksel-radio__input:not(:disabled, :checked) + .aksel-radio__label::before {
+.aksel-checkbox--error .aksel-checkbox__input:not(:disabled, :checked, :indeterminate)::before,
+.aksel-radio--error > .aksel-radio__input:not(:disabled, :checked)::before {
   border-color: var(--ax-border-danger-strong);
-}
-
-.aksel-radio--error > .aksel-radio__input:checked + .aksel-radio__label::before {
-  border-color: var(--ax-bg-danger-strong-pressed);
 }
 
 .aksel-checkbox--disabled,
@@ -178,41 +163,31 @@
   opacity: var(--ax-opacity-disabled);
 }
 
-.aksel-checkbox--disabled > .aksel-checkbox__input,
-.aksel-checkbox--disabled > .aksel-checkbox__label,
-.aksel-radio--disabled > .aksel-radio__input,
-.aksel-radio--disabled > .aksel-radio__label {
+.aksel-checkbox--disabled :where(.aksel-checkbox__input, .aksel-checkbox__label),
+.aksel-radio--disabled > :where(.aksel-radio__input, .aksel-radio__label) {
   cursor: not-allowed;
 }
 
-/* Readonly */
-.aksel-checkbox--readonly > :where(.aksel-checkbox__input, .aksel-checkbox__label),
+.aksel-checkbox--readonly :where(.aksel-checkbox__input, .aksel-checkbox__label),
 .aksel-radio--readonly > :where(.aksel-radio__input, .aksel-radio__label) {
   cursor: default;
 }
 
-.aksel-checkbox--readonly .aksel-checkbox__label-text {
-  display: inline-flex;
+.aksel-checkbox--readonly .aksel-checkbox__label {
+  display: inline-flex; /* Needed to center the lock icon on standalone checkbox */
 }
 
-.aksel-checkbox--readonly > .aksel-checkbox__input:not(:disabled) + .aksel-checkbox__label::before,
-.aksel-checkbox--readonly > .aksel-checkbox__input:hover .aksel-checkbox__label::before,
-.aksel-radio--readonly > .aksel-radio__input:not(:disabled, :checked) + .aksel-radio__label::before,
-.aksel-radio--readonly > .aksel-radio__input:hover:not(:checked, :focus) + .aksel-radio__label::before {
-  background-color: var(--__axc-radio-checkbox-readonly-bg);
-  border-color: var(--__axc-radio-checkbox-readonly-border);
+.aksel-checkbox--readonly .aksel-checkbox__input:not(:disabled)::before,
+.aksel-radio--readonly > .aksel-radio__input:not(:disabled, :checked)::before {
+  background-color: var(--ax-bg-neutral-moderate);
+  border-color: var(--ax-border-neutral-subtle);
 }
 
-.aksel-checkbox--readonly > .aksel-checkbox__input:where(:checked, :indeterminate) + .aksel-checkbox__label::before {
-  border-color: var(--__axc-radio-checkbox-readonly-border);
-  background-color: var(--__axc-radio-checkbox-readonly-bg);
-}
-
-.aksel-checkbox--readonly > .aksel-checkbox__input:checked + .aksel-checkbox__label > .aksel-checkbox__icon {
+.aksel-checkbox--readonly .aksel-checkbox__input:checked + .aksel-checkbox__icon {
   color: var(--ax-text-neutral-subtle);
 }
 
-.aksel-radio--readonly > .aksel-radio__input:checked + .aksel-radio__label::before {
+.aksel-radio--readonly > .aksel-radio__input:checked::before {
   background-color: var(--ax-bg-neutral-strong);
   border-width: 0;
   box-shadow:
@@ -220,75 +195,61 @@
     inset 0 0 0 8px var(--ax-bg-neutral-moderate);
 }
 
-.aksel-radio--small.aksel-radio--readonly > .aksel-radio__input:checked + .aksel-radio__label::before {
+.aksel-radio--small.aksel-radio--readonly > .aksel-radio__input:checked::before {
   box-shadow:
     inset 0 0 0 2px var(--ax-border-neutral-subtle),
     inset 0 0 0 7px var(--ax-bg-neutral-moderate);
 }
 
-.aksel-checkbox--readonly > .aksel-checkbox__input:indeterminate + .aksel-checkbox__label > .aksel-checkbox__icon-indeterminate {
+.aksel-checkbox--readonly .aksel-checkbox__input:indeterminate::after {
   background-color: var(--ax-text-neutral-subtle);
 }
 
 @media (forced-colors: active) {
-  .aksel-checkbox,
-  .aksel-radio {
-    --__axc-radio-checkbox-high-contrast-bg: field;
-    --__axc-radio-checkbox-high-contrast-text: fieldtext;
-    --__axc-radio-checkbox-high-contrast-highlight: highlight;
-
-    /* TODO: Consider adding this to global scope */
-    --ax-border-focus: Highlight;
+  :is(.aksel-checkbox, .aksel-checkbox--readonly) .aksel-checkbox__input:indeterminate::after {
+    background-color: fieldtext;
   }
 
-  .aksel-checkbox__label::before,
-  .aksel-radio__label::before {
-    border: 1px solid var(--__axc-radio-checkbox-high-contrast-text);
-    background-color: var(--__axc-radio-checkbox-high-contrast-bg);
-  }
-
-  .aksel-checkbox__input:checked + .aksel-checkbox__label > .aksel-checkbox__icon {
-    color: var(--__axc-radio-checkbox-high-contrast-text);
-  }
-
-  .aksel-checkbox__input:indeterminate + .aksel-checkbox__label > .aksel-checkbox__icon-indeterminate {
-    background-color: var(--__axc-radio-checkbox-high-contrast-text);
-  }
-
-  .aksel-radio__input:checked + .aksel-radio__label::before {
-    border: 6px solid var(--__axc-radio-checkbox-high-contrast-text);
-  }
-
-  :not(.aksel-checkbox--readonly) > .aksel-checkbox__input:hover:not(:disabled) + .aksel-checkbox__label,
+  .aksel-checkbox:not(.aksel-checkbox--readonly):has(.aksel-checkbox__input:hover:not(:disabled)) > .aksel-checkbox__label,
   :not(.aksel-radio--readonly) > .aksel-radio__input:hover:not(:disabled) + .aksel-radio__label {
     color: highlight;
   }
 
-  .aksel-checkbox--readonly > .aksel-checkbox__input:checked + .aksel-checkbox__label::before {
-    border: 1px solid var(--__axc-radio-checkbox-high-contrast-text);
-    background-color: var(--__axc-radio-checkbox-high-contrast-bg);
+  .aksel-checkbox__input:hover::before,
+  .aksel-radio__input:hover::before {
+    border-color: highlight;
   }
 
-  .aksel-checkbox--readonly
-    > .aksel-checkbox__input:indeterminate
-    + .aksel-checkbox__label
-    > .aksel-checkbox__icon-indeterminate {
-    background-color: var(--__axc-radio-checkbox-high-contrast-text);
+  .aksel-checkbox--readonly .aksel-checkbox__input:checked + .aksel-checkbox__icon {
+    color: var(--ax-bg-default);
   }
 
-  .aksel-radio--readonly > .aksel-radio__input:checked + .aksel-radio__label::before {
-    border-width: 6px;
+  .aksel-radio--readonly > .aksel-radio__input:checked::before {
+    border-width: 8px;
   }
 
   .aksel-checkbox--disabled,
   .aksel-radio--disabled {
     opacity: 1;
-
-    --__axc-radio-checkbox-high-contrast-bg: field;
-    --__axc-radio-checkbox-high-contrast-text: graytext;
   }
 
-  :is(.aksel-checkbox--disabled, .aksel-radio--disabled) :is(.aksel-checkbox__label, .aksel-radio__label) {
+  .aksel-checkbox--disabled .aksel-checkbox__input::before,
+  .aksel-radio--disabled .aksel-radio__input::before {
+    border-color: graytext;
+    background-color: field;
+  }
+
+  .aksel-checkbox--disabled .aksel-checkbox__input:indeterminate::after {
+    background-color: graytext;
+  }
+
+  .aksel-checkbox--disabled
+    :is(.aksel-checkbox__label, .aksel-checkbox__description, .aksel-checkbox__input:checked + .aksel-checkbox__icon),
+  .aksel-radio--disabled :is(.aksel-radio__label, .aksel-radio__description) {
     color: graytext;
   }
 }
+
+/*
+TODO: Vurder background-color: SelectedItem på selected checkbox
+*/

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -1,7 +1,7 @@
 .aksel-checkbox,
 .aksel-radio {
   --__axc-radio-checkbox-marker-size: 1.5rem;
-  --__axc-radio-checkbox-marker-target: 2.75rem;
+  --__axc-radio-checkbox-marker-target: 2.75rem; /* We want the click area to be a bit larger than the visible radio/checkbox */
   --__axc-radio-checkbox-marker-padding: calc(
     (var(--__axc-radio-checkbox-marker-target) - var(--__axc-radio-checkbox-marker-size)) / 2
   );
@@ -11,7 +11,7 @@
   display: grid;
   grid-template-columns: auto 1fr;
   gap: var(--ax-space-2) 0;
-  padding: var(--ax-space-12) 0; /* We need spacing even bellow the least element to allocate space for the clickable area */
+  padding: var(--ax-space-12) 0; /* We need spacing even bellow the last element to allocate space for the clickable area */
 
   /* Focus outline */
   &:focus-within::after {
@@ -25,6 +25,7 @@
   }
 }
 
+/* Small */
 .aksel-checkbox--small,
 .aksel-radio--small {
   --__axc-radio-checkbox-marker-size: 1.25rem;
@@ -38,6 +39,25 @@
   }
 }
 
+/* Label */
+.aksel-checkbox__label,
+.aksel-radio__label {
+  cursor: pointer;
+}
+
+/* Description */
+.aksel-checkbox__description,
+.aksel-radio__description {
+  grid-column-start: 2;
+}
+
+/* Checkbox has a wrapper around input and checkmark svg (consider creating the checkmark with css in the future) */
+.aksel-checkbox__input-wrapper {
+  position: relative;
+  height: var(--__axc-radio-checkbox-marker-size);
+}
+
+/* The input acts as a container for the marker (since the click area should be larger than the visible marker) */
 .aksel-checkbox__input,
 .aksel-radio__input {
   -webkit-appearance: none; /* Safari <= 15.3 */
@@ -51,12 +71,14 @@
   margin: calc(-1 * var(--__axc-radio-checkbox-marker-padding));
 }
 
+/* Spacing between marker and label */
 .aksel-checkbox:not(.aksel-checkbox--hidelabel) .aksel-checkbox__input,
 .aksel-radio__input {
   margin-right: 0;
   padding-right: var(--ax-space-8);
 }
 
+/* Visible marker */
 .aksel-checkbox__input::before,
 .aksel-radio__input::before {
   content: "";
@@ -68,31 +90,19 @@
   border: 2px solid var(--ax-border-neutral);
 }
 
+/* Radio marker should be round */
 .aksel-radio__input::before {
   border-radius: var(--ax-radius-full);
 }
 
-.aksel-checkbox__label,
-.aksel-radio__label {
-  cursor: pointer;
-}
-
-.aksel-checkbox__description,
-.aksel-radio__description {
-  grid-column-start: 2;
-}
-
-.aksel-checkbox__input-wrapper {
-  position: relative;
-  height: var(--__axc-radio-checkbox-marker-size);
-}
-
+/* Checkbox indeterminate: Center the icon */
 .aksel-checkbox__input:indeterminate {
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
+/* Checkbox indeterminate icon */
 .aksel-checkbox__input:indeterminate::after {
   content: "";
   width: 0.75rem;
@@ -102,91 +112,106 @@
   position: absolute;
 }
 
+/* Checkbox marker colors in checked/indeterminate state */
 .aksel-checkbox__input:where(:checked, :indeterminate)::before {
   background-color: var(--ax-bg-strong-pressed);
   border-color: var(--ax-bg-strong-pressed);
 }
 
+/* Checkbox marker colors in checked/indeterminate + hover state (unless disabled) */
 .aksel-checkbox__input:where(:checked, :indeterminate):not(:disabled):hover::before {
   border-color: var(--ax-bg-strong-hover);
   background-color: var(--ax-bg-strong-hover);
 }
 
+/* Checkbox checkmark: Hide when unchecked */
 .aksel-checkbox__input:where(:not(:checked)) + .aksel-checkbox__icon {
   display: none;
 }
 
-.aksel-checkbox__input:checked::before {
+/* Checkbox checkmark */
+.aksel-checkbox__icon {
   color: var(--ax-bg-default);
-}
-
-.aksel-checkbox__input:checked + .aksel-checkbox__icon {
-  color: var(--ax-bg-default);
-  position: absolute;
   pointer-events: none;
+  width: 0.8125rem; /* Safari does not support inline rem-values in SVG */
   height: var(--__axc-radio-checkbox-marker-size);
+  position: absolute;
   top: 0;
   left: var(--ax-space-6);
 }
 
+/* Small Checkbox checkmark position */
 .aksel-checkbox--small .aksel-checkbox__input:checked + .aksel-checkbox__icon {
   left: var(--ax-space-4);
 }
 
-.aksel-checkbox__icon {
-  /* Safari does not support inline rem-values in SVG */
-  width: 0.8125rem;
-}
-
+/* Radio marker colors in checked state */
 .aksel-radio__input:checked::before {
   background-color: var(--ax-bg-input);
   border: 8px solid var(--ax-bg-strong-pressed);
 }
 
+/* Small Radio dot size in checked state */
 .aksel-radio--small > .aksel-radio__input:checked::before {
   border-width: 7px;
 }
 
+/* Marker colors in unchecked hover state (unless disabled) */
 .aksel-checkbox__input:hover:not(:disabled, :checked, :indeterminate)::before,
 .aksel-radio__input:hover:not(:disabled, :checked)::before {
   border-color: var(--ax-border-strong);
   background-color: var(--ax-bg-moderate-hoverA);
 }
 
+/* Marker colors in unchecked error state (unless disabled) */
 .aksel-checkbox--error .aksel-checkbox__input:not(:disabled, :checked, :indeterminate)::before,
 .aksel-radio--error > .aksel-radio__input:not(:disabled, :checked)::before {
   border-color: var(--ax-border-danger-strong);
 }
 
+/* Opacity in disabled state */
 .aksel-checkbox--disabled,
 .aksel-radio--disabled {
   opacity: var(--ax-opacity-disabled);
 }
 
+/* Cursor in disabled state on otherwise clickable elements */
 .aksel-checkbox--disabled :where(.aksel-checkbox__input, .aksel-checkbox__label),
 .aksel-radio--disabled > :where(.aksel-radio__input, .aksel-radio__label) {
   cursor: not-allowed;
 }
 
+/* Cursor in readonly state on otherwise clickable elements */
 .aksel-checkbox--readonly :where(.aksel-checkbox__input, .aksel-checkbox__label),
 .aksel-radio--readonly > :where(.aksel-radio__input, .aksel-radio__label) {
   cursor: default;
 }
 
-.aksel-checkbox--readonly .aksel-checkbox__label {
-  display: inline-flex; /* Needed to center the lock icon on standalone checkbox */
-}
-
+/* Marker colors in readonly state (`:not(:disabled)` is just to get same specificity as (hence override) hover colors) */
 .aksel-checkbox--readonly .aksel-checkbox__input:not(:disabled)::before,
-.aksel-radio--readonly > .aksel-radio__input:not(:disabled, :checked)::before {
+.aksel-radio--readonly > .aksel-radio__input:not(:disabled)::before {
   background-color: var(--ax-bg-neutral-moderate);
   border-color: var(--ax-border-neutral-subtle);
 }
 
-.aksel-checkbox--readonly .aksel-checkbox__input:checked + .aksel-checkbox__icon {
-  color: var(--ax-text-neutral-subtle);
+.aksel-checkbox--readonly {
+  /* Needed to center the lock icon on standalone checkbox */
+  .aksel-checkbox__label {
+    display: inline-flex;
+  }
+
+  /* Checkbox checkmark color in readonly + checked state */
+  .aksel-checkbox__input:checked + .aksel-checkbox__icon {
+    color: var(--ax-text-neutral-subtle);
+  }
+
+  /* Checkbox indeterminate icon color in readonly + indeterminate state */
+  .aksel-checkbox__input:indeterminate::after {
+    background-color: var(--ax-text-neutral-subtle);
+  }
 }
 
+/* Radio marker colors in readonly + checked state */
 .aksel-radio--readonly > .aksel-radio__input:checked::before {
   background-color: var(--ax-bg-neutral-strong);
   border-width: 0;
@@ -195,61 +220,69 @@
     inset 0 0 0 8px var(--ax-bg-neutral-moderate);
 }
 
+/* Small Radio dot size in readonly + checked state */
 .aksel-radio--small.aksel-radio--readonly > .aksel-radio__input:checked::before {
   box-shadow:
     inset 0 0 0 2px var(--ax-border-neutral-subtle),
     inset 0 0 0 7px var(--ax-bg-neutral-moderate);
 }
 
-.aksel-checkbox--readonly .aksel-checkbox__input:indeterminate::after {
-  background-color: var(--ax-text-neutral-subtle);
-}
-
+/* High contrast mode */
 @media (forced-colors: active) {
+  /* Checkbox indeterminate icon color */
   :is(.aksel-checkbox, .aksel-checkbox--readonly) .aksel-checkbox__input:indeterminate::after {
     background-color: fieldtext;
   }
 
+  /* Label color on hover (unless readonly/disabled) */
   .aksel-checkbox:not(.aksel-checkbox--readonly):has(.aksel-checkbox__input:hover:not(:disabled)) > .aksel-checkbox__label,
-  :not(.aksel-radio--readonly) > .aksel-radio__input:hover:not(:disabled) + .aksel-radio__label {
+  .aksel-radio:not(.aksel-radio--readonly) > .aksel-radio__input:hover:not(:disabled) + .aksel-radio__label {
     color: highlight;
   }
 
-  .aksel-checkbox__input:hover::before,
-  .aksel-radio__input:hover::before {
+  /* Marker border color on hover (unless readonly/disabled) */
+  .aksel-checkbox:not(.aksel-checkbox--readonly) .aksel-checkbox__input:hover:not(:disabled)::before,
+  .aksel-radio:not(.aksel-radio--readonly) > .aksel-radio__input:hover:not(:disabled)::before {
     border-color: highlight;
   }
 
+  /* Checkbox checkmark color in readonly + checked state */
   .aksel-checkbox--readonly .aksel-checkbox__input:checked + .aksel-checkbox__icon {
     color: var(--ax-bg-default);
   }
 
+  /* Radio dot size in readonly + checked state */
   .aksel-radio--readonly > .aksel-radio__input:checked::before {
     border-width: 8px;
   }
 
+  /* Small Radio dot size in readonly + checked state */
+  .aksel-radio--small.aksel-radio--readonly > .aksel-radio__input:checked::before {
+    border-width: 7px;
+  }
+
+  /* Turn off disabled state transparency */
   .aksel-checkbox--disabled,
   .aksel-radio--disabled {
     opacity: 1;
   }
 
+  /* Marker colors in disabled state */
   .aksel-checkbox--disabled .aksel-checkbox__input::before,
   .aksel-radio--disabled .aksel-radio__input::before {
     border-color: graytext;
     background-color: field;
   }
 
+  /* Checkbox indeterminate icon color in disabled state */
   .aksel-checkbox--disabled .aksel-checkbox__input:indeterminate::after {
     background-color: graytext;
   }
 
+  /* Text/icon color in disabled state */
   .aksel-checkbox--disabled
     :is(.aksel-checkbox__label, .aksel-checkbox__description, .aksel-checkbox__input:checked + .aksel-checkbox__icon),
   .aksel-radio--disabled :is(.aksel-radio__label, .aksel-radio__description) {
     color: graytext;
   }
 }
-
-/*
-TODO: Vurder background-color: SelectedItem på selected checkbox
-*/

--- a/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
+++ b/@navikt/core/css/darkside/form/radio-checkbox.darkside.css
@@ -65,6 +65,8 @@
 /* The input acts as a container for the marker (since the click area should be larger than the visible marker) */
 .aksel-checkbox__input,
 .aksel-radio__input {
+  --__axc-radio-checkbox-marker-border: 2px;
+
   -webkit-appearance: none; /* Safari <= 15.3 */
   appearance: none;
   cursor: pointer;
@@ -72,7 +74,7 @@
   width: var(--__axc-radio-checkbox-marker-size);
   height: var(--__axc-radio-checkbox-marker-size);
   background-color: var(--ax-bg-input);
-  border: 2px solid var(--ax-border-neutral);
+  border: var(--__axc-radio-checkbox-marker-border) solid var(--ax-border-neutral);
   border-radius: var(--ax-radius-4);
   position: relative;
 }
@@ -82,7 +84,10 @@
 .aksel-radio__input::before {
   content: "";
   position: absolute;
-  inset: calc(-1 * (var(--__axc-radio-checkbox-marker-target) - var(--__axc-radio-checkbox-marker-size)) / 2);
+  inset: calc(
+    -1 * (var(--__axc-radio-checkbox-marker-border) +
+          (var(--__axc-radio-checkbox-marker-target) - var(--__axc-radio-checkbox-marker-size)) / 2)
+  );
 }
 
 /* Radio marker should be round */
@@ -142,13 +147,15 @@
 
 /* Radio marker colors in checked state */
 .aksel-radio__input:checked {
+  --__axc-radio-checkbox-marker-border: 8px;
+
+  border-color: var(--ax-bg-strong-pressed);
   background-color: var(--ax-bg-input);
-  border: 8px solid var(--ax-bg-strong-pressed);
 }
 
 /* Small Radio dot size in checked state */
 .aksel-radio--small > .aksel-radio__input:checked {
-  border-width: 7px;
+  --__axc-radio-checkbox-marker-border: 7px;
 }
 
 /* Marker colors in unchecked hover state (unless disabled) */
@@ -208,8 +215,9 @@
 
 /* Radio marker colors in readonly + checked state */
 .aksel-radio--readonly > .aksel-radio__input:checked {
+  --__axc-radio-checkbox-marker-border: 0px; /* Needs unit for calc() to work */
+
   background-color: var(--ax-bg-neutral-strong);
-  border-width: 0;
   box-shadow:
     inset 0 0 0 2px var(--ax-border-neutral-subtle),
     inset 0 0 0 8px var(--ax-bg-neutral-moderate);
@@ -248,12 +256,12 @@
 
   /* Radio dot size in readonly + checked state */
   .aksel-radio--readonly > .aksel-radio__input:checked {
-    border-width: 8px;
+    --__axc-radio-checkbox-marker-border: 8px;
   }
 
   /* Small Radio dot size in readonly + checked state */
   .aksel-radio--small.aksel-radio--readonly > .aksel-radio__input:checked {
-    border-width: 7px;
+    --__axc-radio-checkbox-marker-border: 7px;
   }
 
   /* Turn off disabled state transparency */

--- a/@navikt/core/css/darkside/table.darkside.css
+++ b/@navikt/core/css/darkside/table.darkside.css
@@ -131,32 +131,12 @@
 }
 
 /* TODO: Look to handle "inline"-checkbox better than custom CSS-overrides in the future. */
-.aksel-table tr:not(.aksel-table__expanded-row) .aksel-checkbox__input {
-  top: -0.75rem;
-}
-
-.aksel-table tr:not(.aksel-table__expanded-row) .aksel-checkbox--small .aksel-checkbox__input {
-  top: -0.375rem;
-}
-
-.aksel-table tr:not(.aksel-table__expanded-row) .aksel-checkbox__label {
+.aksel-table tr:not(.aksel-table__expanded-row) .aksel-checkbox {
   padding: 0;
 }
 
-.aksel-table tr:not(.aksel-table__expanded-row) .aksel-checkbox__label > .aksel-checkbox__icon-indeterminate {
-  top: var(--ax-space-12);
-}
-
-.aksel-table
-  tr:not(.aksel-table__expanded-row)
-  .aksel-checkbox--small
-  .aksel-checkbox__label
-  > .aksel-checkbox__icon-indeterminate {
-  top: 0.6rem;
-}
-
-.aksel-table tr:not(.aksel-table__expanded-row) .aksel-checkbox__input:focus + .aksel-checkbox__label::after {
-  height: 100%;
+.aksel-table tr:not(.aksel-table__expanded-row) .aksel-checkbox:focus-within::after {
+  inset: 0;
 }
 
 .aksel-table__header-cell[aria-sort] {

--- a/@navikt/core/react/src/form/checkbox/Checkbox.tsx
+++ b/@navikt/core/react/src/form/checkbox/Checkbox.tsx
@@ -25,7 +25,6 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
               "navds-checkbox--error": hasError,
               "navds-checkbox--disabled": inputProps.disabled,
               "navds-checkbox--readonly": readOnly,
-              "navds-checkbox--hidelabel": props.hideLabel,
             },
           )}
           data-color={hasError ? "danger" : props["data-color"]}

--- a/@navikt/core/react/src/form/checkbox/Checkbox.tsx
+++ b/@navikt/core/react/src/form/checkbox/Checkbox.tsx
@@ -1,7 +1,8 @@
+import cl from "clsx";
 import React, { forwardRef } from "react";
-import { useRenameCSS } from "../../theme/Theme";
+import { useRenameCSS, useThemeInternal } from "../../theme/Theme";
 import { BodyShort } from "../../typography";
-import { omit } from "../../util";
+import { omit, useId } from "../../util";
 import { ReadOnlyIconWithTitle } from "../ReadOnlyIcon";
 import { CheckboxProps } from "./types";
 import useCheckbox from "./useCheckbox";
@@ -10,6 +11,95 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   (props, ref) => {
     const { cn } = useRenameCSS();
     const { inputProps, hasError, size, readOnly, nested } = useCheckbox(props);
+    const descriptionId = useId();
+    const themeContext = useThemeInternal(false);
+
+    if (themeContext) {
+      return (
+        <div
+          className={cn(
+            props.className,
+            "navds-checkbox",
+            `navds-checkbox--${size}`,
+            {
+              "navds-checkbox--error": hasError,
+              "navds-checkbox--disabled": inputProps.disabled,
+              "navds-checkbox--readonly": readOnly,
+              "navds-checkbox--hidelabel": props.hideLabel,
+            },
+          )}
+          data-color={hasError ? "danger" : props["data-color"]}
+        >
+          <div className={cn("navds-checkbox__input-wrapper")}>
+            <input
+              {...omit(props, [
+                "children",
+                "size",
+                "error",
+                "description",
+                "hideLabel",
+                "indeterminate",
+                "errorId",
+                "readOnly",
+              ])}
+              {...omit(inputProps, ["aria-invalid", "aria-describedby"])}
+              aria-describedby={cl(inputProps["aria-describedby"], {
+                [descriptionId]: props.description,
+              })}
+              type="checkbox"
+              className={cn("navds-checkbox__input")}
+              ref={(el) => {
+                if (el) {
+                  el.indeterminate = props.indeterminate ?? false;
+                }
+
+                if (typeof ref === "function") {
+                  ref(el);
+                } else if (ref != null) {
+                  ref.current = el;
+                }
+              }}
+            />
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 13 10"
+              fill="none"
+              focusable={false}
+              role="img"
+              aria-hidden
+              className={cn("navds-checkbox__icon")}
+            >
+              <path
+                d="M4.03524 6.41478L10.4752 0.404669C11.0792 -0.160351 12.029 -0.130672 12.5955 0.47478C13.162 1.08027 13.1296 2.03007 12.5245 2.59621L5.02111 9.59934C4.74099 9.85904 4.37559 10 4.00025 10C3.60651 10 3.22717 9.84621 2.93914 9.56111L0.439143 7.06111C-0.146381 6.47558 -0.146381 5.52542 0.439143 4.93989C1.02467 4.35437 1.97483 4.35437 2.56036 4.93989L4.03524 6.41478Z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+          <BodyShort
+            as="label"
+            htmlFor={inputProps.id}
+            size={size}
+            className={cn("navds-checkbox__label", {
+              "navds-sr-only": props.hideLabel,
+            })}
+          >
+            {!nested && readOnly && <ReadOnlyIconWithTitle />}
+            {props.children}
+          </BodyShort>
+          {props.description && (
+            <BodyShort
+              id={descriptionId}
+              size={size}
+              className={cn(
+                "navds-form-field__subdescription navds-checkbox__description",
+              )}
+            >
+              {props.description}
+            </BodyShort>
+          )}
+        </div>
+      );
+    }
 
     return (
       <div

--- a/@navikt/core/react/src/form/checkbox/useCheckbox.ts
+++ b/@navikt/core/react/src/form/checkbox/useCheckbox.ts
@@ -40,19 +40,19 @@ const useCheckbox = (props: CheckboxProps) => {
       defaultChecked: checkboxGroup?.defaultValue
         ? checkboxGroup.defaultValue.includes(props.value)
         : props.defaultChecked,
-      onChange: (e) => {
+      onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
         if (readOnly) {
           return;
         }
-        props.onChange?.(e);
+        props.onChange?.(event);
         checkboxGroup?.toggleValue(props.value);
       },
-      onClick: (e) => {
+      onClick: (event: React.MouseEvent<HTMLInputElement>) => {
         if (readOnly) {
-          e.preventDefault();
+          event.preventDefault();
           return;
         }
-        props?.onClick?.(e);
+        props?.onClick?.(event);
       },
     },
   };

--- a/@navikt/core/react/src/form/radio/Radio.tsx
+++ b/@navikt/core/react/src/form/radio/Radio.tsx
@@ -1,13 +1,58 @@
+import cl from "clsx";
 import React, { forwardRef } from "react";
-import { useRenameCSS } from "../../theme/Theme";
+import { useRenameCSS, useThemeInternal } from "../../theme/Theme";
 import { BodyShort } from "../../typography";
-import { omit } from "../../util";
+import { omit, useId } from "../../util";
 import { RadioProps } from "./types";
 import { useRadio } from "./useRadio";
 
 export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
   const { cn } = useRenameCSS();
   const { inputProps, size, hasError, readOnly } = useRadio(props);
+  const descriptionId = useId();
+  const themeContext = useThemeInternal(false);
+
+  if (themeContext) {
+    return (
+      <div
+        className={cn(props.className, "navds-radio", `navds-radio--${size}`, {
+          "navds-radio--error": hasError,
+          "navds-radio--disabled": inputProps.disabled,
+          "navds-radio--readonly": readOnly,
+        })}
+        data-color={hasError ? "danger" : props["data-color"]}
+      >
+        <input
+          {...omit(props, ["children", "size", "description", "readOnly"])}
+          {...omit(inputProps, ["aria-invalid", "aria-describedby"])}
+          aria-describedby={cl(inputProps["aria-describedby"], {
+            [descriptionId]: props.description,
+          })}
+          className={cn("navds-radio__input")}
+          ref={ref}
+        />
+        <BodyShort
+          as="label"
+          htmlFor={inputProps.id}
+          className={cn("navds-radio__label")}
+          size={size}
+        >
+          {props.children}
+        </BodyShort>
+        {props.description && (
+          <BodyShort
+            id={descriptionId}
+            size={size}
+            className={cn(
+              "navds-form-field__subdescription navds-radio__description",
+            )}
+          >
+            {props.description}
+          </BodyShort>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div

--- a/@navikt/core/react/src/form/radio/useRadio.ts
+++ b/@navikt/core/react/src/form/radio/useRadio.ts
@@ -37,19 +37,19 @@ export const useRadio = (props: RadioProps) => {
         radioGroup?.value === undefined
           ? undefined
           : radioGroup?.value === props.value,
-      onChange: (e) => {
+      onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
         if (readOnly) {
           return;
         }
-        props.onChange?.(e);
+        props.onChange?.(event);
         radioGroup?.onChange?.(props.value);
       },
-      onClick: (e) => {
+      onClick: (event: React.MouseEvent<HTMLInputElement>) => {
         if (readOnly) {
-          e.preventDefault();
+          event.preventDefault();
           return;
         }
-        props?.onClick?.(e);
+        props?.onClick?.(event);
       },
       required: radioGroup?.required,
       type: "radio",


### PR DESCRIPTION
I think the marker coloring in checked state in forced-colors mode could be better, but we could look into that later. (We might want to use `background-color: SelectedItem` or maybe even `appearance: auto`)

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
