### PR TITLE
[ExpansionCard] Content defaults to app-color from Theme.

### DIFF
--- a/.changeset/eight-games-stop.md
+++ b/.changeset/eight-games-stop.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+ExpansionCard: Content now defaults to app-color defined in `Theme`, fixing a regression causing all content to be colored `neutral`.

--- a/.changeset/eight-games-stop.md
+++ b/.changeset/eight-games-stop.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-ExpansionCard: Content now defaults to app-color defined in `Theme`, fixing a regression causing all content to be colored `neutral`.
+Darkside: ExpansionCardContent now defaults to app-color defined in `Theme`, fixing a regression causing all content to be colored `neutral`.

--- a/@navikt/core/react/src/accordion/AccordionContent.tsx
+++ b/@navikt/core/react/src/accordion/AccordionContent.tsx
@@ -41,7 +41,7 @@ const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps>(
           !context.open || undefined
         } /* Added to fix bug with Radio component, where label text inside a span sometimes is ignored by screen readers after hiding/displaying the RadioGroup inside an Accordion */
       >
-        {themeContext ? (
+        {themeContext?.isDarkside ? (
           <div className={cn("navds-accordion__content-inner")}>{children}</div>
         ) : (
           children

--- a/@navikt/core/react/src/accordion/AccordionHeader.tsx
+++ b/@navikt/core/react/src/accordion/AccordionHeader.tsx
@@ -31,7 +31,7 @@ const AccordionHeader = forwardRef<HTMLButtonElement, AccordionHeaderProps>(
 
     let headingSize = accordionContext?.headingSize ?? "small";
 
-    if (themeContext) {
+    if (themeContext?.isDarkside) {
       /* Fallback to "medium" Accordion-size if any other sizes are used */
       headingSize = accordionContext?.size === "small" ? "xsmall" : "small";
     }

--- a/@navikt/core/react/src/chips/Removable.tsx
+++ b/@navikt/core/react/src/chips/Removable.tsx
@@ -42,7 +42,7 @@ export const RemovableChips = forwardRef<
 
     let localVariant: ChipsRemovableProps["variant"] | undefined;
 
-    if (themeContext) {
+    if (themeContext?.isDarkside) {
       localVariant = variant;
     } else {
       localVariant = variant ?? "action";

--- a/@navikt/core/react/src/chips/Toggle.tsx
+++ b/@navikt/core/react/src/chips/Toggle.tsx
@@ -43,7 +43,7 @@ export const ToggleChips: OverridableComponent<
     const themeContext = useThemeInternal(false);
     let localVariant: ChipsToggleProps["variant"] | undefined;
 
-    if (themeContext) {
+    if (themeContext?.isDarkside) {
       localVariant = variant;
     } else {
       localVariant = variant ?? "action";

--- a/@navikt/core/react/src/copybutton/CopyButton.tsx
+++ b/@navikt/core/react/src/copybutton/CopyButton.tsx
@@ -122,14 +122,16 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
     const activeString = activeText || translate("activeText");
 
     const copyIcon = (
-      <LegacyIconWrapper useLegacy={!themeContext}>
+      <LegacyIconWrapper useLegacy={!themeContext?.isDarkside}>
         {active
           ? activeIcon ?? (
               <CheckmarkIcon
                 aria-hidden={!!text}
                 title={text ? undefined : activeString}
                 className={
-                  themeContext ? cn("navds-copybutton__icon") : undefined
+                  themeContext?.isDarkside
+                    ? cn("navds-copybutton__icon")
+                    : undefined
                 }
               />
             )
@@ -138,14 +140,16 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
                 aria-hidden={!!text}
                 title={text ? undefined : title || translate("title")}
                 className={
-                  themeContext ? cn("navds-copybutton__icon") : undefined
+                  themeContext?.isDarkside
+                    ? cn("navds-copybutton__icon")
+                    : undefined
                 }
               />
             )}
       </LegacyIconWrapper>
     );
 
-    if (themeContext) {
+    if (themeContext?.isDarkside) {
       return (
         <Button
           ref={ref}

--- a/@navikt/core/react/src/expansion-card/ExpansionCard.stories.tsx
+++ b/@navikt/core/react/src/expansion-card/ExpansionCard.stories.tsx
@@ -41,7 +41,7 @@ const Content = () => (
       lunsjpauser, trimaktiviteter og lignende i arbeidstiden.
     </BodyLong>
     <Link href="#">LENKE</Link>
-    <Checkbox>Label</Checkbox>
+    <Checkbox checked>Label</Checkbox>
     <BodyLong spacing>
       Som hovedregel er du som arbeidstaker ikke yrkesskadedekket på veien til
       og fra arbeid eller første og siste oppdragssted. Du er heller ikke

--- a/@navikt/core/react/src/expansion-card/ExpansionCard.stories.tsx
+++ b/@navikt/core/react/src/expansion-card/ExpansionCard.stories.tsx
@@ -2,7 +2,9 @@ import { Meta, StoryFn, StoryObj } from "@storybook/react";
 import React, { useState } from "react";
 import { PlantIcon } from "@navikt/aksel-icons";
 import { ExpansionCard, ExpansionCardProps } from ".";
+import { Checkbox } from "../form/checkbox";
 import { VStack } from "../layout/stack";
+import { Link } from "../link";
 import { BodyLong } from "../typography";
 
 const meta: Meta<typeof ExpansionCard> = {
@@ -38,6 +40,8 @@ const Content = () => (
       På ditt faste arbeidssted vil du ha yrkesskadedekning også i hvilepauser,
       lunsjpauser, trimaktiviteter og lignende i arbeidstiden.
     </BodyLong>
+    <Link href="#">LENKE</Link>
+    <Checkbox>Label</Checkbox>
     <BodyLong spacing>
       Som hovedregel er du som arbeidstaker ikke yrkesskadedekket på veien til
       og fra arbeid eller første og siste oppdragssted. Du er heller ikke

--- a/@navikt/core/react/src/expansion-card/ExpansionCardContent.tsx
+++ b/@navikt/core/react/src/expansion-card/ExpansionCardContent.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useContext } from "react";
-import { useRenameCSS } from "../theme/Theme";
+import { useRenameCSS, useThemeInternal } from "../theme/Theme";
 import { BodyLong } from "../typography";
 import { ExpansionCardContext } from "./context";
 
@@ -14,6 +14,7 @@ const ExpansionCardContent = forwardRef<
 >(({ children, className, ...rest }, ref) => {
   const { cn } = useRenameCSS();
   const panelContext = useContext(ExpansionCardContext);
+  const themeContext = useThemeInternal(false);
 
   if (panelContext === null) {
     console.error(
@@ -24,6 +25,7 @@ const ExpansionCardContent = forwardRef<
 
   return (
     <BodyLong
+      data-color={themeContext?.color}
       {...rest}
       ref={ref}
       as="div"

--- a/@navikt/core/react/src/form/search/Search.tsx
+++ b/@navikt/core/react/src/form/search/Search.tsx
@@ -271,7 +271,7 @@ function ClearButton({
   const themeContext = useThemeInternal(false);
   const translate = useI18n("Search");
 
-  return themeContext ? (
+  return themeContext?.isDarkside ? (
     <Button
       className={cn("navds-search__button-clear")}
       variant="tertiary"

--- a/@navikt/core/react/src/guide-panel/GuidePanel.tsx
+++ b/@navikt/core/react/src/guide-panel/GuidePanel.tsx
@@ -64,14 +64,14 @@ export const GuidePanel = forwardRef<HTMLDivElement, GuidePanelProps>(
       >
         <div className={cn("navds-guide")}>
           {illustration ??
-            (themeContext ? (
+            (themeContext?.isDarkside ? (
               <DarksideGudiepanelIllustration />
             ) : (
               <DefaultIllustration />
             ))}
         </div>
         <div className={cn("navds-guide-panel__content")}>
-          {themeContext && (
+          {themeContext?.isDarkside && (
             <svg
               viewBox="0 0 33 22"
               width="33"
@@ -96,7 +96,7 @@ export const GuidePanel = forwardRef<HTMLDivElement, GuidePanelProps>(
               />
             </svg>
           )}
-          {themeContext ? (
+          {themeContext?.isDarkside ? (
             <div className={cn("navds-guide-panel__content-inner")}>
               {children}
             </div>

--- a/@navikt/core/react/src/help-text/HelpText.tsx
+++ b/@navikt/core/react/src/help-text/HelpText.tsx
@@ -81,8 +81,8 @@ export const HelpText = forwardRef<HTMLButtonElement, HelpTextProps>(
           anchorEl={buttonRef.current}
           placement={placement}
           strategy={strategy}
-          offset={themeContext ? 8 : 12}
-          arrow={!themeContext}
+          offset={themeContext?.isDarkside ? 8 : 12}
+          arrow={!themeContext?.isDarkside}
         >
           <Popover.Content className={cn("navds-body-short")}>
             {children}

--- a/@navikt/core/react/src/internal-header/InternalHeader.tsx
+++ b/@navikt/core/react/src/internal-header/InternalHeader.tsx
@@ -84,7 +84,7 @@ export const InternalHeader = forwardRef(({ className, ...rest }, ref) => {
   /*
    * Component is always in "dark" mode, so we manually override global theme.
    */
-  if (themeContext) {
+  if (themeContext?.isDarkside) {
     return (
       <Theme theme="dark" asChild hasBackground={false}>
         <header

--- a/@navikt/core/react/src/layout/base/BasePrimitive.tsx
+++ b/@navikt/core/react/src/layout/base/BasePrimitive.tsx
@@ -253,7 +253,7 @@ export const BasePrimitive = ({
 }: BasePrimitiveProps) => {
   const themeContext = useThemeInternal(false);
   const { cn } = useRenameCSS();
-  const prefix = themeContext ? "ax" : "a";
+  const prefix = themeContext?.isDarkside ? "ax" : "a";
 
   const style: React.CSSProperties = {
     /* Padding */

--- a/@navikt/core/react/src/layout/bleed/Bleed.tsx
+++ b/@navikt/core/react/src/layout/bleed/Bleed.tsx
@@ -82,7 +82,7 @@ export const Bleed = forwardRef<HTMLDivElement, BleedProps>(
   ) => {
     const themeContext = useThemeInternal(false);
     const { cn } = useRenameCSS();
-    const prefix = themeContext ? "ax" : "a";
+    const prefix = themeContext?.isDarkside ? "ax" : "a";
 
     let style: React.CSSProperties = {
       ..._style,

--- a/@navikt/core/react/src/layout/box/Box.tsx
+++ b/@navikt/core/react/src/layout/box/Box.tsx
@@ -113,7 +113,7 @@ export const BoxComponent: OverridableComponent<BoxProps, HTMLDivElement> =
 
       if (
         process.env.NODE_ENV !== "production" &&
-        themeContext &&
+        themeContext?.isDarkside &&
         (background || borderColor || shadow)
       ) {
         let errorText = ``;
@@ -131,7 +131,7 @@ export const BoxComponent: OverridableComponent<BoxProps, HTMLDivElement> =
         );
       }
 
-      const prefix = themeContext ? "ax" : "a";
+      const prefix = themeContext?.isDarkside ? "ax" : "a";
 
       const style: React.CSSProperties = {
         ..._style,
@@ -173,8 +173,9 @@ export const BoxComponent: OverridableComponent<BoxProps, HTMLDivElement> =
               "navds-box-bg": background,
               "navds-box-border-color": borderColor,
               "navds-box-border-width": borderWidth,
-              "navds-box-border-radius": borderRadius && !themeContext,
-              "navds-box-radius": borderRadius && themeContext,
+              "navds-box-border-radius":
+                borderRadius && !themeContext?.isDarkside,
+              "navds-box-radius": borderRadius && themeContext?.isDarkside,
               "navds-box-shadow": shadow,
             })}
           >

--- a/@navikt/core/react/src/layout/grid/HGrid.tsx
+++ b/@navikt/core/react/src/layout/grid/HGrid.tsx
@@ -78,7 +78,7 @@ export const HGrid: OverridableComponent<HGridProps, HTMLDivElement> =
       ref,
     ) => {
       const themeContext = useThemeInternal(false);
-      const prefix = themeContext ? "ax" : "a";
+      const prefix = themeContext?.isDarkside ? "ax" : "a";
       const { cn } = useRenameCSS();
 
       const styles: React.CSSProperties = {

--- a/@navikt/core/react/src/layout/page/Page.tsx
+++ b/@navikt/core/react/src/layout/page/Page.tsx
@@ -56,7 +56,11 @@ export const PageComponent: OverridableComponent<PageProps, HTMLElement> =
       const themeContext = useThemeInternal(false);
       const { cn } = useRenameCSS();
 
-      if (process.env.NODE_ENV !== "production" && themeContext && background) {
+      if (
+        process.env.NODE_ENV !== "production" &&
+        themeContext?.isDarkside &&
+        background
+      ) {
         console.warn(
           `Prop \`background\` is deprecated and cannot be used with theme-support. Instead wrap component with \`<Box asChild background>\``,
         );

--- a/@navikt/core/react/src/layout/stack/Stack.tsx
+++ b/@navikt/core/react/src/layout/stack/Stack.tsx
@@ -84,7 +84,7 @@ export const Stack: OverridableComponent<StackProps, HTMLDivElement> =
       ref,
     ) => {
       const themeContext = useThemeInternal(false);
-      const prefix = themeContext ? "ax" : "a";
+      const prefix = themeContext?.isDarkside ? "ax" : "a";
       const { cn } = useRenameCSS();
 
       const style: React.CSSProperties = {

--- a/@navikt/core/react/src/link/Link.tsx
+++ b/@navikt/core/react/src/link/Link.tsx
@@ -72,7 +72,7 @@ export const Link: OverridableComponent<LinkProps, HTMLAnchorElement> =
        */
       let localVariant: LinkProps["variant"];
 
-      if (themeContext) {
+      if (themeContext?.isDarkside) {
         localVariant = variant;
       } else {
         localVariant = variant ?? "action";

--- a/@navikt/core/react/src/list/List.tsx
+++ b/@navikt/core/react/src/list/List.tsx
@@ -63,7 +63,7 @@ export const List = forwardRef<HTMLDivElement, ListProps>(
 
     const listSize = size ?? contextSize;
 
-    if (themeContext) {
+    if (themeContext?.isDarkside) {
       if (
         process.env.NODE_ENV !== "production" &&
         (title || description || headingTag)

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -802,7 +802,7 @@ export const ActionMenuRadioItem = forwardRef<
                   fill="var(--ax-bg-default, var(--a-surface-default))"
                 />
               </g>
-              {themeContext ? (
+              {themeContext?.isDarkside ? (
                 <g className={cn("navds-action-menu__indicator-icon--checked")}>
                   <rect
                     width="24"

--- a/@navikt/core/react/src/pagination/PaginationItem.tsx
+++ b/@navikt/core/react/src/pagination/PaginationItem.tsx
@@ -46,7 +46,7 @@ export const Item: PaginationItemType = forwardRef(
     return (
       <Button
         as={Component}
-        variant={themeContext ? "tertiary-neutral" : "tertiary"}
+        variant={themeContext?.isDarkside ? "tertiary-neutral" : "tertiary"}
         data-color={color}
         aria-current={selected}
         data-pressed={selected}

--- a/@navikt/core/react/src/popover/Popover.tsx
+++ b/@navikt/core/react/src/popover/Popover.tsx
@@ -138,7 +138,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       placement,
       open,
       middleware: [
-        flOffset(offset ?? (themeContext ? 8 : arrow ? 16 : 4)),
+        flOffset(offset ?? (themeContext?.isDarkside ? 8 : arrow ? 16 : 4)),
         chosenFlip &&
           flip({ padding: 5, fallbackPlacements: ["bottom", "top"] }),
         shift({ padding: 12 }),
@@ -191,7 +191,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         >
           {children}
           {/* Hide arrow in new design, prop will be removed in breaking change update */}
-          {arrow && !themeContext && (
+          {arrow && !themeContext?.isDarkside && (
             <div
               ref={(node) => {
                 arrowRef.current = node;

--- a/@navikt/core/react/src/portal/Portal.tsx
+++ b/@navikt/core/react/src/portal/Portal.tsx
@@ -26,7 +26,7 @@ export const Portal = forwardRef<HTMLDivElement, PortalProps>(
      * Portal can be mounted outside of theme-classNames.
      * If a theme is present, we want to make sure that theme cascades to portaled element.
      */
-    if (themeContext) {
+    if (themeContext?.isDarkside) {
       return root
         ? ReactDOM.createPortal(
             <Theme

--- a/@navikt/core/react/src/theme/Theme.tsx
+++ b/@navikt/core/react/src/theme/Theme.tsx
@@ -45,6 +45,8 @@ const RenameCSS = ({ children }: { children: React.ReactNode }) => {
 /* -------------------------------------------------------------------------- */
 /*                               Theme provider                               */
 /* -------------------------------------------------------------------------- */
+const DEFAULT_COLOR: AkselColor = "accent";
+
 type ThemeContext = {
   /**
    * Color theme
@@ -52,12 +54,21 @@ type ThemeContext = {
    */
   theme?: "light" | "dark";
   color?: AkselColor;
+  /**
+   * Indicates if Theme-component is used or not.
+   * @default false
+   */
+  isDarkside: boolean;
 };
 
 const [ThemeProvider, useThemeInternal] = createContext<ThemeContext>({
   hookName: "useTheme",
   name: "ThemeProvider",
   providerName: "ThemeProvider",
+  defaultValue: {
+    color: DEFAULT_COLOR,
+    isDarkside: false,
+  },
 });
 
 export type ThemeProps = {
@@ -70,7 +81,7 @@ export type ThemeProps = {
    * Sets default 'base'-color for application
    */
   "data-color"?: AkselColor;
-} & Omit<ThemeContext, "color"> &
+} & Omit<ThemeContext, "color" | "isDarkside"> &
   AsChildProps;
 
 const Theme = forwardRef<HTMLDivElement, ThemeProps>(
@@ -86,7 +97,7 @@ const Theme = forwardRef<HTMLDivElement, ThemeProps>(
       "data-color": color = context?.color,
     } = props;
 
-    const isRoot = context === undefined;
+    const isRoot = !context?.isDarkside;
 
     const hasBackground =
       hasBackgroundProp ?? (isRoot && props.theme !== undefined);
@@ -94,7 +105,7 @@ const Theme = forwardRef<HTMLDivElement, ThemeProps>(
     const SlotElement = asChild ? Slot : "div";
 
     return (
-      <ThemeProvider theme={theme} color={color}>
+      <ThemeProvider theme={theme} color={color} isDarkside={true}>
         <RenameCSS>
           <SlotElement
             ref={ref}

--- a/@navikt/core/react/src/timeline/Pin.tsx
+++ b/@navikt/core/react/src/timeline/Pin.tsx
@@ -49,7 +49,7 @@ export const Pin = forwardRef<HTMLButtonElement, TimelinePinProps>(
     const translate = useI18n("Timeline");
 
     const themeContext = useThemeInternal(false);
-    const showArrow = !themeContext;
+    const showArrow = !themeContext?.isDarkside;
 
     const {
       context,

--- a/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
@@ -61,7 +61,7 @@ const ClickablePeriod = React.memo(
     const translate = useI18n("Timeline");
 
     const themeContext = useThemeInternal(false);
-    const showArrow = !themeContext;
+    const showArrow = !themeContext?.isDarkside;
 
     const {
       context,

--- a/@navikt/core/react/src/toggle-group/ToggleGroup.tsx
+++ b/@navikt/core/react/src/toggle-group/ToggleGroup.tsx
@@ -84,7 +84,7 @@ export const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps>(
 
     let localVariant: ToggleGroupProps["variant"] | undefined;
 
-    if (themeContext) {
+    if (themeContext?.isDarkside) {
       localVariant = variant;
     } else {
       localVariant = variant ?? "action";


### PR DESCRIPTION
### Description

Resolves https://nav-it.slack.com/archives/C7NE7A8UF/p1757067055690649

Theme-component now defaults to `accent`-color trough context. Because of this, we now have to use a new flag `isDarkside` from the context to know if we want the new or old system within each component.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
