### PR TITLE
Timeline: Refactor parseRows() to make it React 19 ready

### DIFF
--- a/.changeset/open-snails-peel.md
+++ b/.changeset/open-snails-peel.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Timeline: Adjusted type for `onSelectPeriod()` and fixed warning when using refs in React 19

--- a/@navikt/core/react/src/timeline/period/index.tsx
+++ b/@navikt/core/react/src/timeline/period/index.tsx
@@ -33,7 +33,9 @@ export interface TimelinePeriodProps
    * Callback when selecting a period.
    */
   onSelectPeriod?: (
-    e: React.MouseEvent<Element, MouseEvent> | React.KeyboardEvent<Element>,
+    event:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLButtonElement>,
   ) => void;
   /**
    * Content displayed in Popover on click.

--- a/@navikt/core/react/src/timeline/period/index.tsx
+++ b/@navikt/core/react/src/timeline/period/index.tsx
@@ -32,7 +32,9 @@ export interface TimelinePeriodProps
   /**
    * Callback when selecting a period.
    */
-  onSelectPeriod?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  onSelectPeriod?: (
+    e: React.MouseEvent<Element, MouseEvent> | React.KeyboardEvent<Element>,
+  ) => void;
   /**
    * Content displayed in Popover on click.
    */

--- a/@navikt/core/react/src/timeline/period/index.tsx
+++ b/@navikt/core/react/src/timeline/period/index.tsx
@@ -33,9 +33,7 @@ export interface TimelinePeriodProps
    * Callback when selecting a period.
    */
   onSelectPeriod?: (
-    event:
-      | React.MouseEvent<HTMLButtonElement>
-      | React.KeyboardEvent<HTMLButtonElement>,
+    event: React.MouseEvent<Element> | React.KeyboardEvent<Element>,
   ) => void;
   /**
    * Content displayed in Popover on click.

--- a/@navikt/core/react/src/timeline/utils/types.external.ts
+++ b/@navikt/core/react/src/timeline/utils/types.external.ts
@@ -16,18 +16,19 @@ export interface Positioned {
 
 export interface Period {
   id: string;
-  label?: string;
   start: Date;
   endInclusive: Date;
   status?: PeriodStatus;
-  onSelectPeriod?: () => void;
+  onSelectPeriod?: (
+    e: React.MouseEvent<Element, MouseEvent> | React.KeyboardEvent<Element>,
+  ) => void;
   icon?: React.ReactNode;
   children?: React.ReactNode;
   end: Date;
   isActive?: boolean;
   statusLabel?: string;
   restProps?: any;
-  ref?: Element;
+  ref?: React.Ref<HTMLDivElement | HTMLButtonElement>;
 }
 
 export interface PositionedPeriod extends Period, Positioned {

--- a/@navikt/core/react/src/timeline/utils/types.internal.ts
+++ b/@navikt/core/react/src/timeline/utils/types.internal.ts
@@ -21,7 +21,9 @@ export interface Period {
   start: Date;
   endInclusive: Date;
   status?: PeriodStatus;
-  onSelectPeriod?: () => void;
+  onSelectPeriod?: (
+    e: React.MouseEvent<Element, MouseEvent> | React.KeyboardEvent<Element>,
+  ) => void;
   icon?: React.ReactNode;
   children?: React.ReactNode;
   isActive?: boolean;

--- a/@navikt/core/react/src/util/getChildRef.ts
+++ b/@navikt/core/react/src/util/getChildRef.ts
@@ -1,0 +1,6 @@
+export const getChildRef = <T>(
+  children: React.ReactElement<React.RefAttributes<T>>,
+): React.Ref<T> | undefined =>
+  Object.prototype.propertyIsEnumerable.call(children.props, "ref")
+    ? (children.props as any).ref // React 19 (children.ref still works, but gives a warning)
+    : (children as any).ref; // React <19


### PR DESCRIPTION
### Description

Fixed React 19 type errors in `parseRows()`.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
