### PR TITLE
:bug: Fixed regressions causing Weeknumber to have no styling in darkside

### DIFF
--- a/.changeset/gold-knives-teach.md
+++ b/.changeset/gold-knives-teach.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Datepicker: Fix regression causing clickable weeknumber to have no applied styles in Darkside.

--- a/@navikt/core/react/src/date/datepicker/parts/DatePicker.WeekNumber.tsx
+++ b/@navikt/core/react/src/date/datepicker/parts/DatePicker.WeekNumber.tsx
@@ -76,7 +76,9 @@ const DatePickerWeekNumber = ({
             );
           }}
           icon={
-            <span className="navds-date__weeknumber-number">{weekNumber}</span>
+            <span className={cn("navds-date__weeknumber-number")}>
+              {weekNumber}
+            </span>
           }
         />
       </td>


### PR DESCRIPTION
### Description

This was introduced when we added the `aksel`-prefix to darkside CSS

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
