### PR TITLE
Dependabot: Ignore examples directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ registries:
 updates:
   - package-ecosystem: npm
     directory: /
+    exclude-paths:
+      - "examples/**"
     schedule:
       interval: weekly
     registries:


### PR DESCRIPTION
I only find it annoying to be notified about updates in the examples dir since it's not used in production. What do you think about ignoring it?

https://github.blog/changelog/2025-08-26-dependabot-can-now-exclude-automatic-pull-requests-for-manifests-in-selected-subdirectories/

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#exclude-paths-