### PR TITLE
[CI] Set cache-dependency-path to "yarn.lock"

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,7 @@ runs:
       with:
         node-version: lts/*
         cache: yarn
-        cache-dependency-path: "**/yarn.lock"
+        cache-dependency-path: "yarn.lock"
 
     - name: Install dependencies
       run: yarn --immutable

--- a/.github/workflows/backup-sanity.yml
+++ b/.github/workflows/backup-sanity.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: lts/*
           cache: yarn
-          cache-dependency-path: "**/yarn.lock"
+          cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
         run: cd aksel.nav.no/website && yarn

--- a/.github/workflows/figma-config.yml
+++ b/.github/workflows/figma-config.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: lts/*
           cache: yarn
-          cache-dependency-path: "**/yarn.lock"
+          cache-dependency-path: "yarn.lock"
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: lts/*
           cache: yarn
-          cache-dependency-path: "**/yarn.lock"
+          cache-dependency-path: "yarn.lock"
 
       - uses: denoland/setup-deno@v2
         with:


### PR DESCRIPTION
An attempt to fix the error `Could not get yarn cache folder path (...)` that happens sporadically.

Example: https://github.com/navikt/aksel/actions/runs/17645506014/job/50142373908
