### PR TITLE
Darkside: Adjust visually-hidden typography css

### DIFF
--- a/.changeset/early-dolls-walk.md
+++ b/.changeset/early-dolls-walk.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Darkside: Adjust visually-hidden typography css

--- a/@navikt/core/css/darkside/typography.darkside.css
+++ b/@navikt/core/css/darkside/typography.darkside.css
@@ -251,7 +251,6 @@
   margin: -1px !important;
   overflow: hidden !important;
   padding: 0 !important;
-  top: 0 !important;
   position: absolute !important;
   white-space: nowrap !important;
   width: 1px !important;

--- a/@navikt/core/css/darkside/typography.darkside.css
+++ b/@navikt/core/css/darkside/typography.darkside.css
@@ -247,6 +247,7 @@
 .aksel-typo--visually-hidden {
   border: 0 !important;
   clip: rect(0, 0, 0, 0) !important;
+  clip-path: inset(50%) !important;
   height: 1px !important;
   margin: -1px !important;
   overflow: hidden !important;


### PR DESCRIPTION
### Description

When using `visuallyHidden` the element is moved to the top of the closest positioned ancestor because of `top: 0`. You would think it didn't matter where the element ends up since it's not visible anyways, but when testing with various screen readers I experience that the screen reader often "scrolls into view" the item that is currently in the screen reader's "focus". This even applies to "visually hidden" elements. If the element is far away from the original position, this can be disorienting and confusing. (Not sure how many people this affects though, since you would have to have some vision but still use a screen reader.)

To mitigate this at least a bit, I suggest removing `top: 0`. This seems to move the element to the top of the immediate parent instead. This will sometimes not make any difference, but sometimes it will. We don't set `top: 0` on the `.sr-only` class, and I can't see any reason we would need it here but not there.

Let me know if you know of any downsides of this.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
