### PR TITLE
:sparkles: Add 'onRowClick' callback-prop to allow for selecting rows on row-click

### DIFF
--- a/.changeset/calm-rabbits-film.md
+++ b/.changeset/calm-rabbits-film.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+Table: Add 'onRowSelect' callback-prop to allow for selecting rows by clicking the row itself.

--- a/.changeset/calm-rabbits-film.md
+++ b/.changeset/calm-rabbits-film.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": minor
 ---
 
-Table: Add 'onRowSelect' callback-prop to allow for selecting rows by clicking the row itself.
+Table: Add 'onRowClick' callback-prop to allow for selecting rows by clicking the row itself.

--- a/@navikt/core/css/darkside/table.darkside.css
+++ b/@navikt/core/css/darkside/table.darkside.css
@@ -40,6 +40,10 @@
   &:has(+ .aksel-table__row--selected) :is(.aksel-table__header-cell, .aksel-table__data-cell) {
     border-color: var(--ax-border-default);
   }
+
+  &[data-interactive="true"]:hover {
+    cursor: pointer;
+  }
 }
 
 .aksel-table__row--selected {

--- a/@navikt/core/css/table.css
+++ b/@navikt/core/css/table.css
@@ -29,6 +29,10 @@
   display: table-row;
 }
 
+.navds-table__row[data-interactive="true"]:hover {
+  cursor: pointer;
+}
+
 .navds-table__body .navds-table__row--shade-on-hover:hover {
   background-color: var(--ac-table-row-hover, var(--a-bg-subtle));
 }

--- a/@navikt/core/react/src/table/ExpandableRow.tsx
+++ b/@navikt/core/react/src/table/ExpandableRow.tsx
@@ -8,6 +8,7 @@ import { useI18n } from "../util/i18n/i18n.hooks";
 import AnimateHeight from "./AnimateHeight";
 import DataCell from "./DataCell";
 import Row, { RowProps } from "./Row";
+import { isElementInteractiveTarget } from "./Table.utils";
 
 export interface ExpandableRowProps
   extends Omit<RowProps, "content" | "onRowClick"> {
@@ -97,7 +98,7 @@ export const ExpandableRow: ExpandableRowType = forwardRef(
     const handleRowClick = (event: React.MouseEvent<HTMLTableRowElement>) => {
       expandOnRowClick &&
         !expansionDisabled &&
-        !isInteractiveTarget(event.target as HTMLElement) &&
+        !isElementInteractiveTarget(event.target as HTMLElement) &&
         expansionHandler(event);
     };
 
@@ -167,20 +168,5 @@ export const ExpandableRow: ExpandableRowType = forwardRef(
     );
   },
 );
-
-function isInteractiveTarget(elm: HTMLElement) {
-  if (elm.nodeName === "TD" || elm.nodeName === "TH" || !elm.parentElement) {
-    return false;
-  }
-  if (
-    ["BUTTON", "DETAILS", "LABEL", "SELECT", "TEXTAREA", "INPUT", "A"].includes(
-      elm.nodeName,
-    )
-  ) {
-    return true;
-  }
-
-  return isInteractiveTarget(elm.parentElement);
-}
 
 export default ExpandableRow;

--- a/@navikt/core/react/src/table/ExpandableRow.tsx
+++ b/@navikt/core/react/src/table/ExpandableRow.tsx
@@ -9,7 +9,8 @@ import AnimateHeight from "./AnimateHeight";
 import DataCell from "./DataCell";
 import Row, { RowProps } from "./Row";
 
-export interface ExpandableRowProps extends Omit<RowProps, "content"> {
+export interface ExpandableRowProps
+  extends Omit<RowProps, "content" | "onRowClick"> {
   /**
    * Content of the expanded row
    */

--- a/@navikt/core/react/src/table/Row.tsx
+++ b/@navikt/core/react/src/table/Row.tsx
@@ -58,6 +58,7 @@ export const Row: RowType = forwardRef(
           "navds-table__row--shade-on-hover": shadeOnHover,
         })}
         onClick={composeEventHandlers(onClick, handleRowClick)}
+        data-interactive={!!onRowClick}
       />
     );
   },

--- a/@navikt/core/react/src/table/Row.tsx
+++ b/@navikt/core/react/src/table/Row.tsx
@@ -15,9 +15,10 @@ export interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
    */
   shadeOnHover?: boolean;
   /**
-   * Click handler for row.
+   * Click handler for row. This differs from onClick by not being called
+   * when clicking on interactive elements within the row (buttons, links, inputs etc).
    */
-  onRowSelect?: (event: React.MouseEvent<HTMLTableRowElement>) => void;
+  onRowClick?: (event: React.MouseEvent<HTMLTableRowElement>) => void;
 }
 
 export type RowType = React.ForwardRefExoticComponent<
@@ -31,7 +32,7 @@ export const Row: RowType = forwardRef(
       selected = false,
       shadeOnHover = true,
       onClick,
-      onRowSelect,
+      onRowClick,
       ...rest
     },
     ref,
@@ -39,13 +40,13 @@ export const Row: RowType = forwardRef(
     const { cn } = useRenameCSS();
 
     const handleRowClick = (event: React.MouseEvent<HTMLTableRowElement>) => {
-      if (!onRowSelect) {
+      if (!onRowClick) {
         return;
       }
       if (isElementInteractiveTarget(event.target as HTMLElement)) {
         return;
       }
-      onRowSelect(event);
+      onRowClick(event);
     };
 
     return (

--- a/@navikt/core/react/src/table/Row.tsx
+++ b/@navikt/core/react/src/table/Row.tsx
@@ -45,7 +45,6 @@ export const Row: RowType = forwardRef(
       if (isElementInteractiveTarget(event.target as HTMLElement)) {
         return;
       }
-      event.stopPropagation();
       onRowSelect(event);
     };
 

--- a/@navikt/core/react/src/table/Row.tsx
+++ b/@navikt/core/react/src/table/Row.tsx
@@ -17,6 +17,8 @@ export interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   /**
    * Click handler for row. This differs from onClick by not being called
    * when clicking on interactive elements within the row (buttons, links, inputs etc).
+   *
+   * **Warning:** This will not be accessible by keyboard! Provide an alternative way to select the row, e.g. a checkbox or a button.
    */
   onRowClick?: (event: React.MouseEvent<HTMLTableRowElement>) => void;
 }

--- a/@navikt/core/react/src/table/Row.tsx
+++ b/@navikt/core/react/src/table/Row.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from "react";
 import { useRenameCSS } from "../theme/Theme";
 import { composeEventHandlers } from "../util/composeEventHandlers";
+import { isElementInteractiveTarget } from "./Table.utils";
 
 export interface RowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   /**
@@ -41,7 +42,7 @@ export const Row: RowType = forwardRef(
       if (!onRowSelect) {
         return;
       }
-      if (isInteractiveTarget(event.target as HTMLElement)) {
+      if (isElementInteractiveTarget(event.target as HTMLElement)) {
         return;
       }
       event.stopPropagation();
@@ -61,20 +62,5 @@ export const Row: RowType = forwardRef(
     );
   },
 );
-
-function isInteractiveTarget(elm: HTMLElement) {
-  if (elm.nodeName === "TD" || elm.nodeName === "TH" || !elm.parentElement) {
-    return false;
-  }
-  if (
-    ["BUTTON", "DETAILS", "LABEL", "SELECT", "TEXTAREA", "INPUT", "A"].includes(
-      elm.nodeName,
-    )
-  ) {
-    return true;
-  }
-
-  return isInteractiveTarget(elm.parentElement);
-}
 
 export default Row;

--- a/@navikt/core/react/src/table/Table.utils.ts
+++ b/@navikt/core/react/src/table/Table.utils.ts
@@ -1,0 +1,65 @@
+const INTERACTIVE_TAGS = new Set([
+  "BUTTON",
+  "A",
+  "INPUT",
+  "SELECT",
+  "TEXTAREA",
+  "DETAILS",
+  "SUMMARY",
+  "LABEL",
+]);
+
+const INTERACTIVE_ROLES = new Set([
+  "button",
+  "link",
+  "checkbox",
+  "radio",
+  "switch",
+  "menuitem",
+  "option",
+  "tab",
+  "textbox",
+  "combobox",
+  "spinbutton",
+  "slider",
+]);
+
+/**
+ * Walks up from the event target until TR/TH (row / header) or root.
+ * Returns true if any ancestor is inherently interactive, explicitly focusable,
+ * or has an interactive ARIA role.
+ * Used to decide whether a row click should be treated as a row selection
+ * or ignored because the user interacted with an embedded control.
+ */
+function isElementInteractiveTarget(element: HTMLElement | null) {
+  for (
+    let node: HTMLElement | null = element;
+    node && node.nodeName !== "TR" && node.nodeName !== "TH";
+    node = node.parentElement
+  ) {
+    const tag = node.nodeName;
+
+    /* Native interactive tag */
+    if (INTERACTIVE_TAGS.has(tag)) {
+      return true;
+    }
+
+    /* Explicit interactive role */
+    const role = node.getAttribute("role");
+    if (role && INTERACTIVE_ROLES.has(role)) {
+      return true;
+    }
+
+    /* Focusable via tabindex (exclude -1) */
+    if (node.hasAttribute("tabindex")) {
+      const ti = node.getAttribute("tabindex");
+      if (ti !== "-1") {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+export { isElementInteractiveTarget };

--- a/@navikt/core/react/src/table/stories/table-1.stories.tsx
+++ b/@navikt/core/react/src/table/stories/table-1.stories.tsx
@@ -267,10 +267,6 @@ export const Chromatic = {
         <h3>Selection small</h3>
         <SelectionSmall />
       </div>
-      <div>
-        <h3>Selection interactive row</h3>
-        <SelectionInteractiveRow />
-      </div>
       <h2>Expandable</h2>
       <div>
         <h3>Large</h3>

--- a/@navikt/core/react/src/table/stories/table-1.stories.tsx
+++ b/@navikt/core/react/src/table/stories/table-1.stories.tsx
@@ -98,7 +98,13 @@ export const SizeSmall = () => <TableComponent size="small" />;
 
 export const Buttons = () => <TableComponent size="small" button />;
 
-const SelectionTable = ({ size = "medium" }: { size?: "small" | "medium" }) => {
+const SelectionTable = ({
+  size = "medium",
+  onRowSelect = false,
+}: {
+  size?: "small" | "medium";
+  onRowSelect?: boolean;
+}) => {
   const useToggleList = (initialState) => {
     const [list, setList] = useState(initialState);
 
@@ -113,7 +119,7 @@ const SelectionTable = ({ size = "medium" }: { size?: "small" | "medium" }) => {
     ];
   };
 
-  const [selectedRows, toggleSelectedRow] = useToggleList([]);
+  const [selectedRows, toggleSelectedRow] = useToggleList(["2"]);
 
   return (
     <Table size={size} zebraStripes>
@@ -122,8 +128,18 @@ const SelectionTable = ({ size = "medium" }: { size?: "small" | "medium" }) => {
           <Table.DataCell>
             <Checkbox
               size={size}
-              indeterminate
-              onChange={() => toggleSelectedRow("all")}
+              indeterminate={selectedRows.length === 1}
+              onChange={() => {
+                if (selectedRows.length === 2) {
+                  selectedRows.forEach((id) => toggleSelectedRow(id));
+                } else {
+                  ["1", "2"].forEach((id) => {
+                    if (!selectedRows.includes(id)) {
+                      toggleSelectedRow(id);
+                    }
+                  });
+                }
+              }}
             >
               Select all
             </Checkbox>
@@ -133,7 +149,10 @@ const SelectionTable = ({ size = "medium" }: { size?: "small" | "medium" }) => {
           <Table.HeaderCell scope="col">Country</Table.HeaderCell>
           <Table.HeaderCell scope="col">Points</Table.HeaderCell>
         </Table.Row>
-        <Table.Row selected={selectedRows.includes("1")}>
+        <Table.Row
+          selected={selectedRows.includes("1")}
+          onRowSelect={onRowSelect ? () => toggleSelectedRow("1") : undefined}
+        >
           <Table.DataCell>
             <Checkbox
               size={size}
@@ -152,12 +171,15 @@ const SelectionTable = ({ size = "medium" }: { size?: "small" | "medium" }) => {
           <Table.DataCell>USA</Table.DataCell>
           <Table.DataCell>38</Table.DataCell>
         </Table.Row>
-        <Table.Row selected>
+        <Table.Row
+          selected={selectedRows.includes("2")}
+          onRowSelect={onRowSelect ? () => toggleSelectedRow("2") : undefined}
+        >
           <Table.DataCell>
             <Checkbox
               size={size}
               hideLabel
-              checked
+              checked={selectedRows.includes("2")}
               onChange={() => toggleSelectedRow("2")}
               aria-labelledby={`x_r2-${size}`}
             >
@@ -178,6 +200,7 @@ const SelectionTable = ({ size = "medium" }: { size?: "small" | "medium" }) => {
 
 export const Selection = () => <SelectionTable />;
 export const SelectionSmall = () => <SelectionTable size="small" />;
+export const SelectionInteractiveRow = () => <SelectionTable onRowSelect />;
 
 export const ColorRole = () => (
   <div data-color="brand-magenta">

--- a/@navikt/core/react/src/table/stories/table-1.stories.tsx
+++ b/@navikt/core/react/src/table/stories/table-1.stories.tsx
@@ -100,10 +100,10 @@ export const Buttons = () => <TableComponent size="small" button />;
 
 const SelectionTable = ({
   size = "medium",
-  onRowSelect = false,
+  onRowClick = false,
 }: {
   size?: "small" | "medium";
-  onRowSelect?: boolean;
+  onRowClick?: boolean;
 }) => {
   const useToggleList = (initialState) => {
     const [list, setList] = useState(initialState);
@@ -151,7 +151,7 @@ const SelectionTable = ({
         </Table.Row>
         <Table.Row
           selected={selectedRows.includes("1")}
-          onRowSelect={onRowSelect ? () => toggleSelectedRow("1") : undefined}
+          onRowClick={onRowClick ? () => toggleSelectedRow("1") : undefined}
         >
           <Table.DataCell>
             <Checkbox
@@ -173,7 +173,7 @@ const SelectionTable = ({
         </Table.Row>
         <Table.Row
           selected={selectedRows.includes("2")}
-          onRowSelect={onRowSelect ? () => toggleSelectedRow("2") : undefined}
+          onRowClick={onRowClick ? () => toggleSelectedRow("2") : undefined}
         >
           <Table.DataCell>
             <Checkbox
@@ -200,7 +200,7 @@ const SelectionTable = ({
 
 export const Selection = () => <SelectionTable />;
 export const SelectionSmall = () => <SelectionTable size="small" />;
-export const SelectionInteractiveRow = () => <SelectionTable onRowSelect />;
+export const SelectionInteractiveRow = () => <SelectionTable onRowClick />;
 
 export const ColorRole = () => (
   <div data-color="brand-magenta">

--- a/@navikt/core/react/src/table/stories/table-1.stories.tsx
+++ b/@navikt/core/react/src/table/stories/table-1.stories.tsx
@@ -267,6 +267,10 @@ export const Chromatic = {
         <h3>Selection small</h3>
         <SelectionSmall />
       </div>
+      <div>
+        <h3>Selection interactive row</h3>
+        <SelectionInteractiveRow />
+      </div>
       <h2>Expandable</h2>
       <div>
         <h3>Large</h3>


### PR DESCRIPTION
### Description

Resolves https://nav-it.slack.com/archives/C7NE7A8UF/p1758097541984589

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [x] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
