### PR TITLE
ReadMore: Added tabIndex on content + some other adjustments

### DIFF
--- a/.changeset/famous-kings-happen.md
+++ b/.changeset/famous-kings-happen.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+ReadMore: You can now reach the content by tabbing

--- a/.changeset/fine-dodos-pay.md
+++ b/.changeset/fine-dodos-pay.md
@@ -1,5 +1,6 @@
 ---
 "@navikt/ds-react": patch
+"@navikt/ds-css": patch
 ---
 
 ReadMore: You can now reach the content by tabbing

--- a/@navikt/core/css/darkside/read-more.darkside.css
+++ b/@navikt/core/css/darkside/read-more.darkside.css
@@ -70,6 +70,11 @@
   margin-left: calc(var(--__axc-read-more-pi-start) + var(--__axc-read-more-icon-size) / 2 - 1px);
   padding-left: calc(var(--__axc-read-more-icon-size) / 2 - 1px + var(--ax-space-4));
 
+  &:focus-visible {
+    outline: 3px solid var(--ax-border-focus);
+    outline-offset: 3px;
+  }
+
   &[data-state="closed"] {
     display: none;
   }

--- a/@navikt/core/css/read-more.css
+++ b/@navikt/core/css/read-more.css
@@ -27,7 +27,8 @@
     color: ButtonText;
   }
 
-  .navds-read-more__button.navds-read-more__button:focus-visible {
+  .navds-read-more__button.navds-read-more__button:focus-visible,
+  .navds-read-more__content.navds-read-more__content:focus-visible {
     box-shadow: none;
     outline: 2px solid highlight;
     outline-offset: 2px;
@@ -43,13 +44,15 @@
   background-color: var(--ac-read-more-active-bg, var(--a-surface-active));
 }
 
-.navds-read-more__button:focus-visible {
+.navds-read-more__button:focus-visible,
+.navds-read-more__content:focus-visible {
   outline: none;
   box-shadow: var(--a-shadow-focus);
 }
 
 @supports not selector(:focus-visible) {
-  .navds-read-more__button:focus {
+  .navds-read-more__button:focus,
+  .navds-read-more__content:focus {
     outline: none;
     box-shadow: var(--a-shadow-focus);
   }

--- a/@navikt/core/react/src/read-more/ReadMore.tsx
+++ b/@navikt/core/react/src/read-more/ReadMore.tsx
@@ -26,11 +26,11 @@ export interface ReadMoreProps
    */
   defaultOpen?: boolean;
   /**
-   * Callback for current open-state
+   * Callback for current open-state.
    */
   onOpenChange?: (open: boolean) => void;
   /**
-   * Changes fontsize for content.
+   * Changes font size for content.
    * @default "medium"
    */
   size?: "large" | "medium" | "small";
@@ -42,14 +42,7 @@ export interface ReadMoreProps
  * @see 🏷️ {@link ReadMoreProps}
  *
  * @example
- * // Default
  * <ReadMore header="Dette regnes som helsemessige begrensninger">
- *  Med helsemessige begrensninger mener vi funksjonshemming, sykdom...
- * </ReadMore>
- *
- * @example
- * // Litt mindre versjon
- * <ReadMore size="small" header="Dette regnes som helsemessige begrensninger">
  *   Med helsemessige begrensninger mener vi funksjonshemming, sykdom...
  * </ReadMore>
  */
@@ -65,7 +58,7 @@ export const ReadMore = forwardRef<HTMLButtonElement, ReadMoreProps>(
       size = "medium",
       onOpenChange,
       ...rest
-    },
+    }: ReadMoreProps,
     ref,
   ) => {
     const { cn } = useRenameCSS();
@@ -107,7 +100,7 @@ export const ReadMore = forwardRef<HTMLButtonElement, ReadMoreProps>(
 
         <BodyLong
           as="div"
-          aria-hidden={!_open}
+          tabIndex={0}
           className={cn("navds-read-more__content", {
             "navds-read-more__content--closed": !_open,
           })}


### PR DESCRIPTION
### Description

Adds tabIndex=0 on content, as agreed on last doc meeting, so that you can tab to the content (don't have to go out of "form mode" in the screen reader).

### Component Checklist 📝

- [x] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
