### PR TITLE
Darkside: Adjust GuidePanel arrow position

### DIFF
--- a/.changeset/gentle-aliens-unite.md
+++ b/.changeset/gentle-aliens-unite.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Darkside: Adjust GuidePanel arrow position

--- a/@navikt/core/css/darkside/guide-panel.darkside.css
+++ b/@navikt/core/css/darkside/guide-panel.darkside.css
@@ -105,14 +105,14 @@
   .aksel-guide-panel[data-poster="false"] & {
     top: calc(var(--__axc-guide-panel-guide-size) / 2);
     left: calc(var(--ax-space-20) * -1 - 2px);
-    transform: translateY(-48%) rotateZ(-90deg) scaleX(-1);
+    transform: translateY(-15%) rotateZ(-90deg) scaleX(-1);
   }
 
   @media (min-width: 480px) {
     .aksel-guide-panel[data-responsive="true"] & {
       top: calc(var(--__axc-guide-panel-guide-size) / 2);
       left: calc(var(--ax-space-20) * -1 - 2px);
-      transform: translateY(-48%) rotateZ(-90deg) scaleX(-1);
+      transform: translateY(-15%) rotateZ(-90deg) scaleX(-1);
     }
   }
 }


### PR DESCRIPTION
### Description

Jørgen adjusted the arrow on the default variant (in addition to the poster variant adjusted earlier):
https://www.figma.com/design/Mdz9YOiuISKdRxF6sUc2Av/GuidePanel--flytte-pil-?node-id=829-43233&t=uqDZuPnflvVFWas6-4

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
