### PR TITLE
Make mergeRefs ready for React 19

### DIFF
--- a/@navikt/core/react/src/popover/popover.stories.tsx
+++ b/@navikt/core/react/src/popover/popover.stories.tsx
@@ -70,7 +70,13 @@ const Template = (props) => {
 
   return (
     <>
-      <Button ref={(el) => setAnchorEl(el)}>X</Button>
+      <Button
+        ref={(el) => {
+          setAnchorEl(el);
+        }}
+      >
+        X
+      </Button>
       <Popover {...props} open anchorEl={anchorEl}>
         <Popover.Content>
           Velit in consequat Lorem

--- a/@navikt/core/react/src/portal/Portal.stories.tsx
+++ b/@navikt/core/react/src/portal/Portal.stories.tsx
@@ -67,7 +67,9 @@ export const CustomPortalRootFromProvider = () => {
         </Box>
         <Box
           background="surface-alt-3-subtle"
-          ref={(el) => el && setPortalContainer(el)}
+          ref={(el) => {
+            el && setPortalContainer(el);
+          }}
         >
           <h1>Tree B</h1>
         </Box>

--- a/@navikt/core/react/src/util/hooks/useMergeRefs.ts
+++ b/@navikt/core/react/src/util/hooks/useMergeRefs.ts
@@ -1,20 +1,20 @@
 /* https://github.com/radix-ui/primitives/blob/main/packages/react/compose-refs/src/composeRefs.tsx */
 import React from "react";
 
-type PossibleRef<T> = React.LegacyRef<T> | undefined;
+type PossibleRef<T> = React.Ref<T> | undefined;
 
 // https://github.com/gregberge/react-merge-refs
 /**
  * Use `useMergeRefs`
  * @internal
  */
-export function mergeRefs<T>(refs: PossibleRef<T>[]): React.RefCallback<T> {
-  return (value) => {
+export function mergeRefs<T>(refs: PossibleRef<T>[]) {
+  return (instance: T | null) => {
     refs.forEach((ref) => {
       if (typeof ref === "function") {
-        ref(value);
+        ref(instance);
       } else if (ref !== null && ref !== undefined) {
-        (ref as React.MutableRefObject<T | null>).current = value;
+        (ref as React.MutableRefObject<T | null>).current = instance;
       }
     });
   };


### PR DESCRIPTION
Also updated two ref callbacks.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
