### PR TITLE
[Combobox] Now remains open when navigating with voiceover in "quick-nav"-mode

### DIFF
--- a/.changeset/lucky-hats-see.md
+++ b/.changeset/lucky-hats-see.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Combobox: Popup remains open when opening with voiceover in quick-nav mode.

--- a/@navikt/core/react/src/form/combobox/Combobox.tsx
+++ b/@navikt/core/react/src/form/combobox/Combobox.tsx
@@ -5,7 +5,6 @@ import { BodyShort, ErrorMessage, Label } from "../../typography";
 import { ReadOnlyIconWithTitle } from "../ReadOnlyIcon";
 import ComboboxWrapper from "./ComboboxWrapper";
 import FilteredOptions from "./FilteredOptions/FilteredOptions";
-import { useFilteredOptionsContext } from "./FilteredOptions/filteredOptionsContext";
 import { useInputContext } from "./Input/Input.context";
 import { InputController } from "./Input/InputController";
 import { ComboboxProps } from "./types";
@@ -20,8 +19,6 @@ export const Combobox = forwardRef<
   const { className, hideLabel = false, description, label, ...rest } = props;
 
   const { cn } = useRenameCSS();
-
-  const { toggleIsListOpen } = useFilteredOptionsContext();
 
   const {
     error,
@@ -41,7 +38,6 @@ export const Combobox = forwardRef<
         hasError={hasError}
         inputProps={inputProps}
         inputSize={size}
-        toggleIsListOpen={toggleIsListOpen}
       >
         <Label
           htmlFor={inputProps.id}

--- a/@navikt/core/react/src/form/combobox/ComboboxWrapper.tsx
+++ b/@navikt/core/react/src/form/combobox/ComboboxWrapper.tsx
@@ -11,7 +11,6 @@ type ComboboxWrapperProps = {
   };
   readOnly?: boolean;
   inputSize: string;
-  toggleIsListOpen: (isListOpen: boolean) => void;
 };
 
 const ComboboxWrapper = ({
@@ -20,7 +19,6 @@ const ComboboxWrapper = ({
   hasError,
   inputProps,
   inputSize,
-  toggleIsListOpen,
 }: ComboboxWrapperProps) => {
   const { cn } = useRenameCSS();
   const { toggleOpenButtonRef, clearInput, readOnly } = useInputContext();
@@ -39,7 +37,6 @@ const ComboboxWrapper = ({
 
   function onBlurWrapper(event: React.FocusEvent<HTMLDivElement>) {
     if (!wrapperRef.current?.contains(event.relatedTarget)) {
-      toggleIsListOpen(false);
       setHasFocusWithin(false);
       clearInput(event);
     }

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptions.tsx
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptions.tsx
@@ -65,6 +65,10 @@ const FilteredOptions = () => {
         dismissable: floatingRef.current,
       }}
       onDismiss={() => localOpen && toggleIsListOpen(false)}
+      onEscapeKeyDown={(event) => {
+        /* We handle this manually in Input */
+        event.preventDefault();
+      }}
       enabled={localOpen}
     >
       <Floating.Content

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptions.tsx
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptions.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
+import { DismissableLayer } from "../../../overlays/dismissablelayer/DismissableLayer";
 import { Floating } from "../../../overlays/floating/Floating";
 import { useRenameCSS, useThemeInternal } from "../../../theme/Theme";
 import { useClientLayoutEffect } from "../../../util";
@@ -17,6 +18,7 @@ const FilteredOptions = () => {
   const themeContext = useThemeInternal(false);
   const {
     inputProps: { id },
+    anchorRef,
   } = useInputContext();
 
   const {
@@ -27,8 +29,11 @@ const FilteredOptions = () => {
     setFilteredOptionsRef,
     isMouseLastUsedInputDevice,
     isValueNew,
+    toggleIsListOpen,
   } = useFilteredOptionsContext();
   const [localOpen, setLocalOpen] = useState(isListOpen);
+
+  const floatingRef = useRef<HTMLDivElement | null>(null);
 
   /**
    * This is a dirty hack to make the positioning-logic in Floating base the "flip" on the static 290px max-height,
@@ -53,53 +58,64 @@ const FilteredOptions = () => {
   const height = themeContext?.isDarkside ? "316px" : "290px";
 
   return (
-    <Floating.Content
-      className={cn("navds-combobox__list", {
-        "navds-combobox__list--closed": !isListOpen,
-        "navds-combobox__list--with-hover": isMouseLastUsedInputDevice,
-      })}
-      id={filteredOptionsUtil.getFilteredOptionsId(id)}
-      tabIndex={-1}
-      sideOffset={8}
-      side="bottom"
-      fallbackPlacements={["top"]}
-      enabled={isListOpen}
-      style={{
-        maxHeight: localOpen
-          ? `min(${height}, var(--ac-floating-available-height))`
-          : `${height}`,
+    <DismissableLayer
+      asChild
+      safeZone={{
+        anchor: anchorRef,
+        dismissable: floatingRef.current,
       }}
-      autoUpdateWhileMounted={false}
+      onDismiss={() => localOpen && toggleIsListOpen(false)}
+      enabled={localOpen}
     >
-      {shouldRenderNonSelectables && (
-        <div
-          className={cn("navds-combobox__list_non-selectables")}
-          role="status"
-        >
-          {isMultiSelect && maxSelected.limit && <MaxSelectedMessage />}
-          {isLoading && <LoadingMessage />}
-          {!isLoading && filteredOptions.length === 0 && !allowNewValues && (
-            <NoSearchHitsMessage />
-          )}
-        </div>
-      )}
+      <Floating.Content
+        ref={floatingRef}
+        className={cn("navds-combobox__list", {
+          "navds-combobox__list--closed": !isListOpen,
+          "navds-combobox__list--with-hover": isMouseLastUsedInputDevice,
+        })}
+        id={filteredOptionsUtil.getFilteredOptionsId(id)}
+        tabIndex={-1}
+        sideOffset={8}
+        side="bottom"
+        fallbackPlacements={["top"]}
+        enabled={isListOpen}
+        style={{
+          maxHeight: localOpen
+            ? `min(${height}, var(--ac-floating-available-height))`
+            : `${height}`,
+        }}
+        autoUpdateWhileMounted={false}
+      >
+        {shouldRenderNonSelectables && (
+          <div
+            className={cn("navds-combobox__list_non-selectables")}
+            role="status"
+          >
+            {isMultiSelect && maxSelected.limit && <MaxSelectedMessage />}
+            {isLoading && <LoadingMessage />}
+            {!isLoading && filteredOptions.length === 0 && !allowNewValues && (
+              <NoSearchHitsMessage />
+            )}
+          </div>
+        )}
 
-      {shouldRenderFilteredOptionsList && (
-        /* biome-ignore lint/a11y/useFocusableInteractive: Interaction is not handeled by listbox itself. */
-        <ul
-          ref={setFilteredOptionsRef}
-          role="listbox"
-          className={cn("navds-combobox__list-options")}
-        >
-          {isValueNew && !maxSelected.isLimitReached && allowNewValues && (
-            <AddNewOption />
-          )}
-          {filteredOptions.map((option) => (
-            <FilteredOptionsItem key={option.value} option={option} />
-          ))}
-        </ul>
-      )}
-    </Floating.Content>
+        {shouldRenderFilteredOptionsList && (
+          /* biome-ignore lint/a11y/useFocusableInteractive: Interaction is not handeled by listbox itself. */
+          <ul
+            ref={setFilteredOptionsRef}
+            role="listbox"
+            className={cn("navds-combobox__list-options")}
+          >
+            {isValueNew && !maxSelected.isLimitReached && allowNewValues && (
+              <AddNewOption />
+            )}
+            {filteredOptions.map((option) => (
+              <FilteredOptionsItem key={option.value} option={option} />
+            ))}
+          </ul>
+        )}
+      </Floating.Content>
+    </DismissableLayer>
   );
 };
 

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/useVirtualFocus.ts
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/useVirtualFocus.ts
@@ -67,6 +67,7 @@ const useVirtualFocus = (
 
     if (!activeElement) {
       setActiveAndScrollToElement(elementsAbleToReceiveFocus[0]);
+
       return;
     }
     const _currentIndex = elementsAbleToReceiveFocus.indexOf(activeElement);

--- a/@navikt/core/react/src/form/combobox/Input/Input.context.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/Input.context.tsx
@@ -18,6 +18,8 @@ interface InputContextValue extends FormFieldType {
   toggleOpenButtonRef: React.MutableRefObject<HTMLDivElement | null>;
   hideCaret: boolean;
   setHideCaret: React.Dispatch<React.SetStateAction<boolean>>;
+  anchorRef: HTMLDivElement | null;
+  setAnchorRef: React.Dispatch<React.SetStateAction<HTMLDivElement | null>>;
 }
 
 const [InputContextProvider, useInputContext] =
@@ -75,6 +77,7 @@ const InputProvider = ({ children, value: props }: Props) => {
   const toggleOpenButtonRef = useRef<HTMLDivElement>(null);
   const [internalValue, setInternalValue] = useState<string>(defaultValue);
   const [hideCaret, setHideCaret] = useState(false);
+  const [anchorRef, setAnchorRef] = useState<HTMLDivElement | null>(null);
 
   const value = useMemo(
     () => String(externalValue ?? internalValue),
@@ -127,6 +130,8 @@ const InputProvider = ({ children, value: props }: Props) => {
     toggleOpenButtonRef,
     hideCaret,
     setHideCaret,
+    anchorRef,
+    setAnchorRef,
   };
 
   return (

--- a/@navikt/core/react/src/form/combobox/Input/InputController.tsx
+++ b/@navikt/core/react/src/form/combobox/Input/InputController.tsx
@@ -49,6 +49,7 @@ export const InputController = forwardRef<
     inputRef,
     toggleOpenButtonRef,
     readOnly,
+    setAnchorRef,
   } = useInputContext();
 
   const { activeDecendantId, toggleIsListOpen } = useFilteredOptionsContext();
@@ -57,7 +58,7 @@ export const InputController = forwardRef<
   const mergedInputRef = useMergeRefs(inputRef, ref);
 
   return (
-    <Floating.Anchor asChild>
+    <Floating.Anchor asChild ref={setAnchorRef}>
       <div
         className={cn("navds-combobox__wrapper-inner navds-text-field__input", {
           "navds-combobox__wrapper-inner--virtually-unfocused":

--- a/@navikt/core/react/src/form/combobox/combobox.stories.tsx
+++ b/@navikt/core/react/src/form/combobox/combobox.stories.tsx
@@ -39,7 +39,10 @@ const options = [
 ];
 
 export const Default: StoryFn<ComboboxProps> = (props) => (
-  <UNSAFE_Combobox {...props} id="combobox" />
+  <div>
+    <button>test</button>
+    <UNSAFE_Combobox {...props} id="combobox" />
+  </div>
 );
 Default.args = {
   options,

--- a/@navikt/core/react/src/form/combobox/combobox.stories.tsx
+++ b/@navikt/core/react/src/form/combobox/combobox.stories.tsx
@@ -39,10 +39,7 @@ const options = [
 ];
 
 export const Default: StoryFn<ComboboxProps> = (props) => (
-  <div>
-    <button>test</button>
-    <UNSAFE_Combobox {...props} id="combobox" />
-  </div>
+  <UNSAFE_Combobox {...props} id="combobox" />
 );
 Default.args = {
   options,


### PR DESCRIPTION
### Description

Quick-nav is enabled by pressing arrow-left + arrow-right at the same time. When enabled, event.relatedTarget in onBlur is the html-element, causing popup to close instantly. 

While this fixes a small issue, combobox is not usable in quick-nav mode anyways since voiceover eats all keydown-events, making it impossible to handle arrow-up/down.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
