### PR TITLE
:fire: Removed NPM-token needed for publish to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,7 @@ jobs:
           publish: yarn release
           createGithubReleases: false
         env:
-          NPM_TOKEN: ${{ secrets.NPM_AUTOMATION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION }}
 
       - name: Creating .npmrc
         run: |
@@ -70,9 +68,7 @@ jobs:
           publish: yarn changeset publish
           createGithubReleases: false
         env:
-          NPM_TOKEN: ${{ secrets.NPM_AUTOMATION }}
           GITHUB_TOKEN: ${{ secrets.GIT_REPO }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION }}
 
       - name: Generate icon.zip
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
### Description

All our packages has been linked to `release.yml` now, so we should no longer need to provide a token when publishing to NPM. Only way to test is in prod 🙁 

https://docs.npmjs.com/trusted-publishers

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
