### PR TITLE
:bug: Avoid screen-readers announcing Helptext title twice

### DIFF
--- a/.changeset/cool-plums-happen.md
+++ b/.changeset/cool-plums-happen.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Helptext: Avoid screen-readers reading title twice.

--- a/@navikt/core/react/src/help-text/HelpText.tsx
+++ b/@navikt/core/react/src/help-text/HelpText.tsx
@@ -70,9 +70,10 @@ export const HelpText = forwardRef<HTMLButtonElement, HelpTextProps>(
           className={cn(className, "navds-help-text__button")}
           type="button"
           aria-expanded={open}
+          aria-label={titleWithFallback}
         >
-          <HelpTextIcon title={titleWithFallback} />
-          <HelpTextIcon filled title={titleWithFallback} />
+          <HelpTextIcon />
+          <HelpTextIcon filled />
         </button>
         <Popover
           onClose={() => setOpen(false)}

--- a/@navikt/core/react/src/help-text/HelpTextIcon.tsx
+++ b/@navikt/core/react/src/help-text/HelpTextIcon.tsx
@@ -1,18 +1,9 @@
 import React from "react";
 import { useRenameCSS } from "../theme/Theme";
-import { useId } from "../util/hooks";
 
-export const HelpTextIcon = ({
-  title,
-  filled = false,
-}: {
-  title: string;
-  filled?: boolean;
-}) => {
+export const HelpTextIcon = ({ filled = false }: { filled?: boolean }) => {
   const { cn } = useRenameCSS();
 
-  let titleId: string | undefined = useId();
-  titleId = title ? `title-${titleId}` : undefined;
   return (
     <svg
       width="1em"
@@ -22,12 +13,11 @@ export const HelpTextIcon = ({
       xmlns="http://www.w3.org/2000/svg"
       focusable={false}
       role="img"
-      aria-labelledby={titleId}
       className={cn("navds-help-text__icon", {
         "navds-help-text__icon--filled": filled,
       })}
+      aria-hidden
     >
-      {title ? <title id={titleId}>{title}</title> : null}
       <circle
         cx="12"
         cy="12"


### PR DESCRIPTION
### Description

Resolves #4145

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
