### PR TITLE
[Linting] Treat `useClientLayoutEffect` as a regular React-effect

### DIFF
--- a/.changeset/whole-cobras-prove.md
+++ b/.changeset/whole-cobras-prove.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Maintenance: Update dependency-arrays for some layout-effects.

--- a/@navikt/core/react/src/popover/Popover.tsx
+++ b/@navikt/core/react/src/popover/Popover.tsx
@@ -148,7 +148,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
 
     useClientLayoutEffect(() => {
       refs.setReference(anchorEl);
-    }, [anchorEl]);
+    }, [anchorEl, refs]);
 
     const floatingRef = useMergeRefs(refs.setFloating, ref);
 

--- a/@navikt/core/react/src/util/hooks/descendants/useDescendant.tsx
+++ b/@navikt/core/react/src/util/hooks/descendants/useDescendant.tsx
@@ -46,10 +46,13 @@ export function createDescendantContext<
     useClientLayoutEffect(() => {
       return () => {
         if (!ref.current) return;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         descendants.unregister(ref.current);
       };
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     useClientLayoutEffect(() => {
       if (!ref.current) return;
       const dataIndex = Number(ref.current.dataset.index);

--- a/@navikt/core/react/src/util/hooks/useLatestRef.ts
+++ b/@navikt/core/react/src/util/hooks/useLatestRef.ts
@@ -8,6 +8,7 @@ export function useLatestRef<T>(value: T) {
 
   latest.next = value;
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useClientLayoutEffect(latest.effect);
 
   return latest;

--- a/aksel.nav.no/website/app/(routes)/(root)/_ui/AnimationStopContext.tsx
+++ b/aksel.nav.no/website/app/(routes)/(root)/_ui/AnimationStopContext.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useState } from "react";
 
 type Context = {
   pauseAnimationState: boolean;
-  setPauseAnimationState: CallableFunction;
+  setPauseAnimationState: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const PauseAnimationContext = createContext<Context>({
@@ -12,7 +12,11 @@ export const PauseAnimationContext = createContext<Context>({
   setPauseAnimationState: () => {},
 });
 
-export const PauseAnimationProvider = ({ children }) => {
+export const PauseAnimationProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
   const [pauseAnimationState, setPauseAnimationState] = useState(false);
   return (
     <PauseAnimationContext.Provider

--- a/aksel.nav.no/website/app/(routes)/(root)/_ui/useShouldStopAnimation.tsx
+++ b/aksel.nav.no/website/app/(routes)/(root)/_ui/useShouldStopAnimation.tsx
@@ -22,7 +22,8 @@ function useShouldStopAnimation() {
       return;
     }
     setPauseAnimationState(JSON.parse(data ?? "false"));
-  }, [setPauseAnimationState]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return {
     shouldStopAnimation: pauseAnimationState || reducedMotion,

--- a/aksel.nav.no/website/app/(routes)/(root)/_ui/useShouldStopAnimation.tsx
+++ b/aksel.nav.no/website/app/(routes)/(root)/_ui/useShouldStopAnimation.tsx
@@ -22,7 +22,7 @@ function useShouldStopAnimation() {
       return;
     }
     setPauseAnimationState(JSON.parse(data ?? "false"));
-  }, []);
+  }, [setPauseAnimationState]);
 
   return {
     shouldStopAnimation: pauseAnimationState || reducedMotion,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,6 +61,10 @@ module.exports = tseslint.config([
       "react/display-name": "off", // Temporary
       "import/no-unresolved": "off",
       "import/no-named-as-default": "off", // Temporary
+      "react-hooks/exhaustive-deps": [
+        "warn",
+        { additionalHooks: "(useClientLayoutEffect)" },
+      ],
     },
   },
   {


### PR DESCRIPTION
### Description

Right now the linter does not pick up dependency arrays etc

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
