### PR TITLE
Combobox: Fix bug in highlighting when using custom filtering logic

### DIFF
--- a/.changeset/orange-garlics-taste.md
+++ b/.changeset/orange-garlics-taste.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Combobox: Fix bug in highlighting when using custom filtering logic

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptionsItem.tsx
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/FilteredOptionsItem.tsx
@@ -13,6 +13,10 @@ const useTextHighlight = (text: string, searchTerm: string) => {
   const indexOfHighlightedText = text
     .toLowerCase()
     .indexOf(searchTerm.toLowerCase());
+  if (indexOfHighlightedText === -1) {
+    // This can happen if the consumer has implemented their own filtering logic
+    return [text, "", ""];
+  }
   const start = text.substring(0, indexOfHighlightedText);
   const highlight = text.substring(
     indexOfHighlightedText,


### PR DESCRIPTION
### Description

Should fix this: https://nav-it.slack.com/archives/C7NE7A8UF/p1760691389778829

I assume the problem is caused by custom filtering logic. The fix is to only highlight on exact match. This seemed like the easiest fix. Is it acceptable, or do we need an add an option to turn off highlighting entirely?

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
