### PR TITLE
:sparkles: Sync BodyShort size large line-height with figma

### DIFF
--- a/.changeset/nice-chicken-give.md
+++ b/.changeset/nice-chicken-give.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+BodyShort: Line-height for `size="large"` is now 28px, adjusted from 24px.

--- a/@navikt/core/css/darkside/typography.darkside.css
+++ b/@navikt/core/css/darkside/typography.darkside.css
@@ -141,7 +141,7 @@
 .aksel-body-short--large {
   font-size: var(--ax-font-size-xlarge);
   letter-spacing: -0.0013em;
-  line-height: var(--ax-font-line-height-large);
+  line-height: var(--ax-font-line-height-xlarge);
 }
 
 .aksel-body-short--large.aksel-typo--spacing {

--- a/@navikt/core/css/typography.css
+++ b/@navikt/core/css/typography.css
@@ -148,7 +148,7 @@
 .navds-body-short--large {
   font-size: var(--a-font-size-xlarge);
   letter-spacing: -0.0013em;
-  line-height: var(--a-font-line-height-large);
+  line-height: var(--a-font-line-height-xlarge);
 }
 
 .navds-body-short--large.navds-typo--spacing {


### PR DESCRIPTION
### Description

Now 28px, increased from 24px.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
