### PR TITLE
Storybook: Fix story naming in Chromatic for templates

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -19,8 +19,7 @@ export default {
     const customIndexer = async (fileName: string, opts: any) => {
       let code = readFileSync(fileName, "utf-8").toString();
 
-      const matches = indexRegex.exec(code);
-      const prefix = matches ? `${matches[1]} | ` : "";
+      const index = indexRegex.exec(code)?.[1];
 
       code = code.split(
         /\/\/ EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE/,
@@ -31,8 +30,8 @@ export default {
         .replace(".tsx", "")
         .split("/");
       const storyName = process.env.CHROMATIC
-        ? `${templateName} | ${prefix}${name}` // Chromatic does not support folders
-        : `${prefix}${name}`;
+        ? `${templateName} [${index}] ${name}` // Chromatic does not support folders, and doesn't like |
+        : `${index} | ${name}`;
 
       code += `
         export default { title: "Templates/${templateName}/${storyName}" };


### PR DESCRIPTION
Something happened with the story names of template stories in Chromatic:

<img width="370" height="1054" alt="image" src="https://github.com/user-attachments/assets/5f523940-2626-4142-9951-ff7e6084aeb7" />

The names should have been `templateName | index | storyName`, e.g. `skjemavalidering | 2 | react-hook-form`. For some reason, only the index is shown now. Maybe pipe has some special meaning now.

Anyways, using brackets seems to work (also tried slashes):

<img width="531" height="1046" alt="image" src="https://github.com/user-attachments/assets/cf1d8fe8-153b-450a-9f7f-7694b0886df4" />
