### PR TITLE
remove the ability for a fake fnr to become real.

### DIFF
--- a/aksel.nav.no/website/pages/eksempler/checkbox/indeterminate.tsx
+++ b/aksel.nav.no/website/pages/eksempler/checkbox/indeterminate.tsx
@@ -3,7 +3,7 @@ import { Checkbox, Table } from "@navikt/ds-react";
 import { withDsExample } from "@/web/examples/withDsExample";
 
 const Example = () => {
-  const [selectedRows, setSelectedRows] = useState<string[]>(["18124441438"]);
+  const [selectedRows, setSelectedRows] = useState<string[]>(["18994441438"]);
 
   const toggleSelectedRow = (value) =>
     setSelectedRows((list) =>
@@ -75,27 +75,27 @@ const format = (date: Date) => {
 const data = [
   {
     name: "Jakobsen, Markus",
-    fnr: "03129265463",
+    fnr: "03999265463",
     start: "2020-04-28T19:12:14.358Z",
   },
   {
     name: "Halvorsen, Mari",
-    fnr: "16063634134",
+    fnr: "16993634134",
     start: "2022-01-29T09:51:19.833Z",
   },
   {
     name: "Christiansen, Mathias",
-    fnr: "18124441438",
+    fnr: "18994441438",
     start: "2021-06-04T20:57:29.159Z",
   },
   {
     name: "Fredriksen, Leah",
-    fnr: "24089080180",
+    fnr: "24999080180",
     start: "2015-08-31T15:47:36.293Z",
   },
   {
     name: "Evensen, Jonas",
-    fnr: "18106248460",
+    fnr: "18996248460",
     start: "2010-07-17T11:13:26.116Z",
   },
 ];

--- a/aksel.nav.no/website/pages/eksempler/copybutton/tooltip.tsx
+++ b/aksel.nav.no/website/pages/eksempler/copybutton/tooltip.tsx
@@ -5,7 +5,7 @@ import { withDsExample } from "@/web/examples/withDsExample";
 const Example = () => {
   return (
     <Tooltip content="Kopier fødselsnummer">
-      <CopyButton copyText="12003045000" icon={<FilesIcon aria-hidden />} />
+      <CopyButton copyText="12993045000" icon={<FilesIcon aria-hidden />} />
     </Tooltip>
   );
 };

--- a/aksel.nav.no/website/pages/eksempler/table/expandable.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/expandable.tsx
@@ -40,27 +40,27 @@ const format = (date: Date) => {
 const data = [
   {
     name: "Jakobsen, Markus",
-    fnr: "03129265463",
+    fnr: "03999265463",
     start: "2021-04-28T19:12:14.358Z",
   },
   {
     name: "Halvorsen, Mari",
-    fnr: "16063634134",
+    fnr: "16993634134",
     start: "2022-01-29T09:51:19.833Z",
   },
   {
     name: "Christiansen, Mathias",
-    fnr: "18124441438",
+    fnr: "18994441438",
     start: "2021-06-04T20:57:29.159Z",
   },
   {
     name: "Fredriksen, Leah",
-    fnr: "24089080180",
+    fnr: "24999080180",
     start: "2021-08-31T15:47:36.293Z",
   },
   {
     name: "Evensen, Jonas",
-    fnr: "18106248460",
+    fnr: "18996248460",
     start: "2021-07-17T11:13:26.116Z",
   },
 ];

--- a/aksel.nav.no/website/pages/eksempler/table/medium.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/medium.tsx
@@ -36,27 +36,27 @@ const format = (date: Date) => {
 const data = [
   {
     name: "Jakobsen, Markus",
-    fnr: "03129265463",
+    fnr: "03999265463",
     start: "2021-04-28T19:12:14.358Z",
   },
   {
     name: "Halvorsen, Mari",
-    fnr: "16063634134",
+    fnr: "16993634134",
     start: "2022-01-29T09:51:19.833Z",
   },
   {
     name: "Christiansen, Mathias",
-    fnr: "18124441438",
+    fnr: "18994441438",
     start: "2021-06-04T20:57:29.159Z",
   },
   {
     name: "Fredriksen, Leah",
-    fnr: "24089080180",
+    fnr: "24999080180",
     start: "2021-08-31T15:47:36.293Z",
   },
   {
     name: "Evensen, Jonas",
-    fnr: "18106248460",
+    fnr: "18996248460",
     start: "2021-07-17T11:13:26.116Z",
   },
 ];

--- a/aksel.nav.no/website/pages/eksempler/table/pagination.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/pagination.tsx
@@ -51,52 +51,52 @@ const format = (date: Date) => {
 const data = [
   {
     name: "Jakobsen, Markus",
-    fnr: "03129265463",
+    fnr: "03999265463",
     start: "2021-04-28T19:12:14.358Z",
   },
   {
     name: "Halvorsen, Mari",
-    fnr: "16063634134",
+    fnr: "16993634134",
     start: "2022-01-29T09:51:19.833Z",
   },
   {
     name: "Christiansen, Mathias",
-    fnr: "18124441438",
+    fnr: "18994441438",
     start: "2021-06-04T20:57:29.159Z",
   },
   {
     name: "Fredriksen, Leah",
-    fnr: "24089080180",
+    fnr: "24999080180",
     start: "2021-08-31T15:47:36.293Z",
   },
   {
     name: "Evensen, Jonas",
-    fnr: "18106248460",
+    fnr: "18996248460",
     start: "2021-07-17T11:13:26.116Z",
   },
   {
     name: "Strand, Thomas",
-    fnr: "11123693157",
+    fnr: "11993693157",
     start: "2021-08-14T14:15:44.597Z",
   },
   {
     name: "Eriksen, Sofie",
-    fnr: "07067878435",
+    fnr: "07997878435",
     start: "2021-12-20T15:55:02.613Z",
   },
   {
     name: "Jørgensen, Erik",
-    fnr: "02099681196",
+    fnr: "02999681196",
     start: "2021-09-05T11:33:19.361Z",
   },
   {
     name: "Carlsen, Sondre",
-    fnr: "23096491197",
+    fnr: "23996491197",
     start: "2022-01-25T16:10:47.223Z",
   },
   {
     name: "Berge, Martine",
-    fnr: "11090293151",
+    fnr: "11990293151",
     start: "2022-01-09T11:15:50.833Z",
   },
 ];

--- a/aksel.nav.no/website/pages/eksempler/table/selectable.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/selectable.tsx
@@ -75,27 +75,27 @@ const format = (date: Date) => {
 const data = [
   {
     name: "Jakobsen, Markus",
-    fnr: "03129265463",
+    fnr: "03999265463",
     start: "2020-04-28T19:12:14.358Z",
   },
   {
     name: "Halvorsen, Mari",
-    fnr: "16063634134",
+    fnr: "16993634134",
     start: "2022-01-29T09:51:19.833Z",
   },
   {
     name: "Christiansen, Mathias",
-    fnr: "18124441438",
+    fnr: "18994441438",
     start: "2021-06-04T20:57:29.159Z",
   },
   {
     name: "Fredriksen, Leah",
-    fnr: "24089080180",
+    fnr: "24999080180",
     start: "2015-08-31T15:47:36.293Z",
   },
   {
     name: "Evensen, Jonas",
-    fnr: "18106248460",
+    fnr: "18996248460",
     start: "2010-07-17T11:13:26.116Z",
   },
 ];

--- a/aksel.nav.no/website/pages/eksempler/table/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/small.tsx
@@ -36,27 +36,27 @@ const format = (date: Date) => {
 const data = [
   {
     name: "Jakobsen, Markus",
-    fnr: "03129265463",
+    fnr: "03999265463",
     start: "2021-04-28T19:12:14.358Z",
   },
   {
     name: "Halvorsen, Mari",
-    fnr: "16063634134",
+    fnr: "16993634134",
     start: "2022-01-29T09:51:19.833Z",
   },
   {
     name: "Christiansen, Mathias",
-    fnr: "18124441438",
+    fnr: "18994441438",
     start: "2021-06-04T20:57:29.159Z",
   },
   {
     name: "Fredriksen, Leah",
-    fnr: "24089080180",
+    fnr: "24999080180",
     start: "2021-08-31T15:47:36.293Z",
   },
   {
     name: "Evensen, Jonas",
-    fnr: "18106248460",
+    fnr: "18996248460",
     start: "2021-07-17T11:13:26.116Z",
   },
 ];

--- a/aksel.nav.no/website/pages/eksempler/table/sortable.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/sortable.tsx
@@ -87,27 +87,27 @@ const format = (date: Date) => {
 const data = [
   {
     name: "Jakobsen, Markus",
-    fnr: "03129265463",
+    fnr: "03999265463",
     start: "2020-04-28T19:12:14.358Z",
   },
   {
     name: "Halvorsen, Mari",
-    fnr: "16063634134",
+    fnr: "16993634134",
     start: "2022-01-29T09:51:19.833Z",
   },
   {
     name: "Christiansen, Mathias",
-    fnr: "18124441438",
+    fnr: "18994441438",
     start: "2021-06-04T20:57:29.159Z",
   },
   {
     name: "Fredriksen, Leah",
-    fnr: "24089080180",
+    fnr: "24999080180",
     start: "2015-08-31T15:47:36.293Z",
   },
   {
     name: "Evensen, Jonas",
-    fnr: "18106248460",
+    fnr: "18996248460",
     start: "2010-07-17T11:13:26.116Z",
   },
 ];

--- a/aksel.nav.no/website/pages/eksempler/table/with-input.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/with-input.tsx
@@ -51,27 +51,27 @@ const format = (date: Date) => {
 const data = [
   {
     name: "Jakobsen, Markus",
-    fnr: "03129265463",
+    fnr: "03999265463",
     start: "2021-04-28T19:12:14.358Z",
   },
   {
     name: "Halvorsen, Mari",
-    fnr: "16063634134",
+    fnr: "16993634134",
     start: "2022-01-29T09:51:19.833Z",
   },
   {
     name: "Christiansen, Mathias",
-    fnr: "18124441438",
+    fnr: "18994441438",
     start: "2021-06-04T20:57:29.159Z",
   },
   {
     name: "Fredriksen, Leah",
-    fnr: "24089080180",
+    fnr: "24999080180",
     start: "2021-08-31T15:47:36.293Z",
   },
   {
     name: "Evensen, Jonas",
-    fnr: "18106248460",
+    fnr: "18996248460",
     start: "2021-07-17T11:13:26.116Z",
   },
 ];

--- a/aksel.nav.no/website/pages/eksempler/table/zebraStripes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/zebraStripes.tsx
@@ -36,27 +36,27 @@ const format = (date: Date) => {
 const data = [
   {
     name: "Jakobsen, Markus",
-    fnr: "03129265463",
+    fnr: "03999265463",
     start: "2021-04-28T19:12:14.358Z",
   },
   {
     name: "Halvorsen, Mari",
-    fnr: "16063634134",
+    fnr: "16993634134",
     start: "2022-01-29T09:51:19.833Z",
   },
   {
     name: "Christiansen, Mathias",
-    fnr: "18124441438",
+    fnr: "18994441438",
     start: "2021-06-04T20:57:29.159Z",
   },
   {
     name: "Fredriksen, Leah",
-    fnr: "24089080180",
+    fnr: "24999080180",
     start: "2021-08-31T15:47:36.293Z",
   },
   {
     name: "Evensen, Jonas",
-    fnr: "18106248460",
+    fnr: "18996248460",
     start: "2021-07-17T11:13:26.116Z",
   },
 ];

--- a/aksel.nav.no/website/scripts/update-examples/__tests__/extract-jsx.test.ts
+++ b/aksel.nav.no/website/scripts/update-examples/__tests__/extract-jsx.test.ts
@@ -189,27 +189,27 @@ function complexExample() {
   const data = [
     {
       name: "Jakobsen, Markus",
-      fnr: "03129265463",
+      fnr: "03999265463",
       start: "2020-04-28T19:12:14.358Z",
     },
     {
       name: "Halvorsen, Mari",
-      fnr: "16063634134",
+      fnr: "16993634134",
       start: "2022-01-29T09:51:19.833Z",
     },
     {
       name: "Christiansen, Mathias",
-      fnr: "18124441438",
+      fnr: "18994441438",
       start: "2021-06-04T20:57:29.159Z",
     },
     {
       name: "Fredriksen, Leah",
-      fnr: "24089080180",
+      fnr: "24999080180",
       start: "2015-08-31T15:47:36.293Z",
     },
     {
       name: "Evensen, Jonas",
-      fnr: "18106248460",
+      fnr: "18996248460",
       start: "2010-07-17T11:13:26.116Z",
     },
   ];


### PR DESCRIPTION
These FNR might not be valid in the first place (correct checksum), but they look like they could be valid, rather than check each one, it's faster to simply overwrite each one with an invalid day or month.

Why could a currently unused FNR suddenly become real? eg a valid FNR (working checksum) set in the future _could_ end up being assigned to a real future unborn person, and even a senior citizen could become a norwegian citizen and even use a valid FNR from the past. Best to avoid them entirely.

It's not a big probability, but better safe than sorry. setting the month to 99 makes them so they would never be issued (similar to what Dolly does).

<img width="377" height="127" alt="image" src="https://github.com/user-attachments/assets/84edbdd0-56b8-479d-8929-8ef0685a749c" />
