### PR TITLE
:arrow_up: React-dom now a peerDependency of `@navikt/ds-react` package

### DIFF
--- a/.changeset/tricky-seas-invite.md
+++ b/.changeset/tricky-seas-invite.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+Dependencies: Added `react-dom` to `peerDependencies`.

--- a/@navikt/aksel-icons/package.json
+++ b/@navikt/aksel-icons/package.json
@@ -8,6 +8,9 @@
     "url": "git+https://github.com/navikt/aksel.git",
     "directory": "@navikt/aksel-icons"
   },
+  "bugs": {
+    "url": "https://github.com/navikt/aksel/issues"
+  },
   "keywords": [
     "Icons",
     "Nav",

--- a/@navikt/aksel-stylelint/package.json
+++ b/@navikt/aksel-stylelint/package.json
@@ -8,6 +8,9 @@
     "url": "git+https://github.com/navikt/aksel.git",
     "directory": "@navikt/aksel-stylelint"
   },
+  "bugs": {
+    "url": "https://github.com/navikt/aksel/issues"
+  },
   "keywords": [
     "aksel",
     "stylelint",

--- a/@navikt/aksel/package.json
+++ b/@navikt/aksel/package.json
@@ -28,6 +28,9 @@
     "directory": "@navikt/aksel"
   },
   "homepage": "https://aksel.nav.no/grunnleggende/kode/kommandolinje",
+  "bugs": {
+    "url": "https://github.com/navikt/aksel/issues"
+  },
   "dependencies": {
     "@navikt/ds-css": "^7.32.4",
     "@navikt/ds-tokens": "^7.32.4",

--- a/@navikt/core/css/package.json
+++ b/@navikt/core/css/package.json
@@ -24,7 +24,7 @@
   "bugs": {
     "url": "https://github.com/navikt/aksel/issues"
   },
-  "homepage": "https://aksel.nav.no/",
+  "homepage": "https://aksel.nav.no/designsystemet/",
   "scripts": {
     "build": "node config/bundle.js && yarn build:darkside",
     "css:get-version": "node config/get-version.js",

--- a/@navikt/core/css/package.json
+++ b/@navikt/core/css/package.json
@@ -21,6 +21,10 @@
     "url": "git+https://github.com/navikt/aksel.git",
     "directory": "@navikt/core/css"
   },
+  "bugs": {
+    "url": "https://github.com/navikt/aksel/issues"
+  },
+  "homepage": "https://aksel.nav.no/",
   "scripts": {
     "build": "node config/bundle.js && yarn build:darkside",
     "css:get-version": "node config/get-version.js",

--- a/@navikt/core/react/package.json
+++ b/@navikt/core/react/package.json
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/navikt/aksel/issues"
   },
-  "homepage": "https://aksel.nav.no/",
+  "homepage": "https://aksel.nav.no/designsystemet/",
   "sideEffects": false,
   "typings": "./esm/index.d.ts",
   "publishConfig": {

--- a/@navikt/core/react/package.json
+++ b/@navikt/core/react/package.json
@@ -15,6 +15,10 @@
     "url": "git+https://github.com/navikt/aksel.git",
     "directory": "@navikt/core/react"
   },
+  "bugs": {
+    "url": "https://github.com/navikt/aksel/issues"
+  },
+  "homepage": "https://aksel.nav.no/",
   "sideEffects": false,
   "typings": "./esm/index.d.ts",
   "publishConfig": {
@@ -678,8 +682,9 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@types/react": ">=17.0.30",
-    "react": ">=17.0.0 || >19.0.0-rc"
+    "@types/react": "^17.0.30 || ^18 || ^19",
+    "react": "^17 || ^18 || ^19 || >19.0.0-rc",
+    "react-dom": "^17 || ^18 || ^19"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/@navikt/core/react/package.json
+++ b/@navikt/core/react/package.json
@@ -683,7 +683,7 @@
   },
   "peerDependencies": {
     "@types/react": "^17.0.30 || ^18 || ^19",
-    "react": "^17 || ^18 || ^19 || >19.0.0-rc",
+    "react": "^17 || ^18 || ^19",
     "react-dom": "^17 || ^18 || ^19"
   },
   "peerDependenciesMeta": {

--- a/@navikt/core/tailwind/package.json
+++ b/@navikt/core/tailwind/package.json
@@ -24,6 +24,10 @@
     "url": "git+https://github.com/navikt/aksel.git",
     "directory": "@navikt/core/tailwind"
   },
+  "bugs": {
+    "url": "https://github.com/navikt/aksel/issues"
+  },
+  "homepage": "https://aksel.nav.no/",
   "devDependencies": {
     "@navikt/ds-tokens": "^7.32.4",
     "color": "5.0.0",

--- a/@navikt/core/tailwind/package.json
+++ b/@navikt/core/tailwind/package.json
@@ -27,7 +27,7 @@
   "bugs": {
     "url": "https://github.com/navikt/aksel/issues"
   },
-  "homepage": "https://aksel.nav.no/",
+  "homepage": "https://aksel.nav.no/grunnleggende/kode/tailwind/",
   "devDependencies": {
     "@navikt/ds-tokens": "^7.32.4",
     "color": "5.0.0",

--- a/@navikt/core/tokens/package.json
+++ b/@navikt/core/tokens/package.json
@@ -34,6 +34,10 @@
     "url": "git+https://github.com/navikt/aksel.git",
     "directory": "@navikt/core/tokens"
   },
+  "bugs": {
+    "url": "https://github.com/navikt/aksel/issues"
+  },
+  "homepage": "https://aksel.nav.no/",
   "devDependencies": {
     "@figma/plugin-typings": "^1.100.2",
     "colorjs.io": "^0.5.2",

--- a/@navikt/core/tokens/package.json
+++ b/@navikt/core/tokens/package.json
@@ -37,7 +37,7 @@
   "bugs": {
     "url": "https://github.com/navikt/aksel/issues"
   },
-  "homepage": "https://aksel.nav.no/",
+  "homepage": "https://aksel.nav.no/grunnleggende/styling/design-tokens/",
   "devDependencies": {
     "@figma/plugin-typings": "^1.100.2",
     "colorjs.io": "^0.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5156,7 +5156,7 @@ __metadata:
     vitest: "npm:^3.2.4"
   peerDependencies:
     "@types/react": ^17.0.30 || ^18 || ^19
-    react: ^17 || ^18 || ^19 || >19.0.0-rc
+    react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
   peerDependenciesMeta:
     "@types/react":

--- a/yarn.lock
+++ b/yarn.lock
@@ -5155,8 +5155,9 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:^3.2.4"
   peerDependencies:
-    "@types/react": ">=17.0.30"
-    react: ">=17.0.0 || >19.0.0-rc"
+    "@types/react": ^17.0.30 || ^18 || ^19
+    react: ^17 || ^18 || ^19 || >19.0.0-rc
+    react-dom: ^17 || ^18 || ^19
   peerDependenciesMeta:
     "@types/react":
       optional: true


### PR DESCRIPTION
### Description

Resolves #4231

React-dom is already a transitive dependency, so should not affect anyone.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
