### PR TITLE
:bug: Timeline period dialogs now has accessible names

### DIFF
--- a/.changeset/full-terms-lie.md
+++ b/.changeset/full-terms-lie.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-Timeline: Period popups now has an accessible name.
+Timeline: Popups now have an accessible name.

--- a/.changeset/full-terms-lie.md
+++ b/.changeset/full-terms-lie.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Timeline: Period popups now has an accessible name.

--- a/@navikt/core/react/src/timeline/Pin.tsx
+++ b/@navikt/core/react/src/timeline/Pin.tsx
@@ -94,6 +94,10 @@ export const Pin = forwardRef<HTMLButtonElement, TimelinePinProps>(
       left: "right",
     }[placement.split("-")[0]];
 
+    const label = translate("Pin.pin", {
+      date: format(date, translate("dateFormat")),
+    });
+
     return (
       <>
         <div
@@ -104,9 +108,7 @@ export const Pin = forwardRef<HTMLButtonElement, TimelinePinProps>(
             {...rest}
             ref={mergedRef}
             className={cn("navds-timeline__pin-button")}
-            aria-label={translate("Pin.pin", {
-              date: format(date, translate("dateFormat")),
-            })}
+            aria-label={label}
             type="button"
             aria-expanded={children ? open : undefined}
             {...getReferenceProps({
@@ -133,6 +135,7 @@ export const Pin = forwardRef<HTMLButtonElement, TimelinePinProps>(
               data-placement={placement}
               ref={refs.setFloating}
               role="dialog"
+              aria-label={label}
               {...getFloatingProps()}
               style={floatingStyles}
             >

--- a/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
@@ -106,6 +106,8 @@ const ClickablePeriod = React.memo(
       left: "right",
     }[placement.split("-")[0]];
 
+    const label = ariaLabel(start, end, status, statusLabel, translate);
+
     return (
       <>
         <button
@@ -116,7 +118,7 @@ const ClickablePeriod = React.memo(
             firstFocus && addFocusable(r, index);
             mergedRef(r);
           }}
-          aria-label={ariaLabel(start, end, status, statusLabel, translate)}
+          aria-label={label}
           className={cn(
             "navds-timeline__period--clickable",
             getConditionalClasses(cropped, direction, status),
@@ -168,6 +170,7 @@ const ClickablePeriod = React.memo(
               data-placement={placement}
               ref={refs.setFloating}
               role="dialog"
+              aria-label={label}
               {...getFloatingProps()}
               style={floatingStyles}
             >


### PR DESCRIPTION
### Description

https://nav-it.slack.com/archives/C7NE7A8UF/p1761904723739719

Tried using `aria-labelledby`, but since the label is set with `aria-label`, that did not work.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
