### PR TITLE
[website] Hide chips when only one example

### DIFF
--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.navigation.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.navigation.tsx
@@ -13,7 +13,7 @@ function KodeEksemplerNavigation(props: {
   const { dir } = props.value;
   const { activeExample } = useKodeEksempler();
 
-  if (!dir?.filer || dir.filer.length === 0) {
+  if (!dir?.filer || dir.filer.length < 2) {
     return null;
   }
 


### PR DESCRIPTION
Before:

<img width="987" height="671" alt="image" src="https://github.com/user-attachments/assets/678c7ae3-f3fe-4547-b5aa-223f5a817730" />

After:

<img width="980" height="548" alt="image" src="https://github.com/user-attachments/assets/c39b091b-1dd2-4ba2-9b37-f29aa4ff488f" />
