### PR TITLE
[FocusBoundary] Refactor initial/return-focus handling, added modal-prop

### DIFF
--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -363,9 +363,7 @@ export const ActionMenuContent = forwardRef<
           align={align}
           sideOffset={4}
           collisionPadding={10}
-          onCloseAutoFocus={() => {
-            context.triggerRef.current?.focus();
-          }}
+          returnFocus={context.triggerRef}
           safeZone={{ anchor: context.triggerRef.current }}
           style={{
             ...style,

--- a/@navikt/core/react/src/overlays/floating-menu/Menu.stories.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/Menu.stories.tsx
@@ -344,7 +344,7 @@ const MenuWithAnchor = (props: MenuProps) => {
       <Menu.Portal>
         <Menu.Content
           className="content"
-          onCloseAutoFocus={(event) => event.preventDefault()}
+          returnFocus={false}
           align="start"
           {...contentProps}
         >
@@ -416,9 +416,7 @@ export const MenuWithOpenButton = () => {
           className="content"
           align="start"
           ref={contentRef}
-          onCloseAutoFocus={() => {
-            triggerRef.current?.focus();
-          }}
+          returnFocus={triggerRef}
         >
           <Menu.Item className="item" onSelect={() => window.alert("undo")}>
             Undo
@@ -482,11 +480,7 @@ export const TestMenu = () => {
         <button>Menu</button>
       </Menu.Anchor>
       <Menu.Portal>
-        <Menu.Content
-          className="content"
-          onCloseAutoFocus={(event) => event.preventDefault()}
-          align="start"
-        >
+        <Menu.Content className="content" returnFocus={false} align="start">
           <Menu.Item className="item" onSelect={() => window.alert("Undo")}>
             Undo
           </Menu.Item>

--- a/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
@@ -243,7 +243,7 @@ type DismissableLayerProps = React.ComponentPropsWithoutRef<
 >;
 
 type MenuContentInternalPrivateProps = {
-  onOpenAutoFocus?: FocusScopeProps["onMountAutoFocus"];
+  initialFocus?: FocusScopeProps["initialFocus"];
   onDismiss?: DismissableLayerProps["onDismiss"];
   disableOutsidePointerEvents?: DismissableLayerProps["disableOutsidePointerEvents"];
 };
@@ -254,11 +254,7 @@ interface MenuContentInternalProps
       React.ComponentPropsWithoutRef<typeof Floating.Content>,
       "dir" | "onPlaced"
     > {
-  /**
-   * Event handler called when auto-focusing after close.
-   * Can be prevented.
-   */
-  onCloseAutoFocus?: FocusScopeProps["onUnmountAutoFocus"];
+  returnFocus?: FocusScopeProps["returnFocus"];
   onEntryFocus?: RovingFocusProps["onEntryFocus"];
   onEscapeKeyDown?: DismissableLayerProps["onEscapeKeyDown"];
   onPointerDownOutside?: DismissableLayerProps["onPointerDownOutside"];
@@ -273,8 +269,8 @@ const MenuContentInternal = forwardRef<
 >(
   (
     {
-      onOpenAutoFocus,
-      onCloseAutoFocus,
+      initialFocus,
+      returnFocus,
       disableOutsidePointerEvents,
       onEntryFocus,
       onEscapeKeyDown,
@@ -301,13 +297,8 @@ const MenuContentInternal = forwardRef<
 
     return (
       <FocusBoundary
-        onMountAutoFocus={composeEventHandlers(onOpenAutoFocus, (event) => {
-          // when opening, explicitly focus the content area only and leave
-          // `onEntryFocus` in  control of focusing first item
-          event.preventDefault();
-          contentRef.current?.focus({ preventScroll: true });
-        })}
-        onUnmountAutoFocus={onCloseAutoFocus}
+        initialFocus={initialFocus ?? contentRef}
+        returnFocus={returnFocus}
         /* Focus trapping is handled in `Floating.Content: onKeyDown */
         trapped={false}
         loop={false}
@@ -917,15 +908,14 @@ const MenuSubContent = forwardRef<
         align="start"
         side="right"
         disableOutsidePointerEvents={false}
-        onOpenAutoFocus={(event) => {
-          // when opening a submenu, focus content for keyboard users only
+        initialFocus={() => {
           if (rootContext.isUsingKeyboardRef.current) {
-            ref.current?.focus();
+            return ref.current;
           }
-          event.preventDefault();
+          return undefined;
         }}
         /* Since we manually focus Subtrigger, we prevent use of auto-focus */
-        onCloseAutoFocus={(event) => event.preventDefault()}
+        returnFocus={false}
         onEscapeKeyDown={composeEventHandlers(
           props.onEscapeKeyDown,
           (event) => {

--- a/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
@@ -912,7 +912,7 @@ const MenuSubContent = forwardRef<
           if (rootContext.isUsingKeyboardRef.current) {
             return ref.current;
           }
-          return undefined;
+          return false;
         }}
         /* Since we manually focus Subtrigger, we prevent use of auto-focus */
         returnFocus={false}

--- a/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tests.stories.tsx
+++ b/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tests.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 // eslint-disable-next-line storybook/use-storybook-testing-library
 import { act } from "@testing-library/react";
 import React, { useState } from "react";
-import { expect, fireEvent, userEvent, within } from "storybook/test";
+import { expect, fireEvent, userEvent, waitFor, within } from "storybook/test";
 import { VStack } from "../../layout/stack";
 import { FocusBoundary, type FocusBoundaryProps } from "./FocusBoundary";
 
@@ -42,8 +42,9 @@ export const Loop: Story = {
     const last = canvas.getByText(BUTTON_THREE);
 
     /* Regular focus */
-    await fireEvent.focus(first);
-    expect(first).toHaveFocus();
+    first.focus();
+    await waitFor(() => expect(first).toHaveFocus());
+
     await userEvent.tab();
     expect(middle).toHaveFocus();
 
@@ -54,7 +55,7 @@ export const Loop: Story = {
     expect(first).toHaveFocus();
 
     /* Shift tab */
-    await fireEvent.focus(first);
+    first.focus();
     expect(first).toHaveFocus();
     await userEvent.tab({ shift: true });
     expect(last).toHaveFocus();
@@ -75,7 +76,8 @@ export const TrappedNoLoop: Story = {
 
     /* Regular focus */
     await fireEvent.focus(first);
-    expect(first).toHaveFocus();
+    await waitFor(() => expect(first).toHaveFocus());
+
     await userEvent.tab();
     expect(middle).toHaveFocus();
 
@@ -106,7 +108,7 @@ export const Trapped: Story = {
     const outsideElement = canvas.getByLabelText("outside");
 
     await fireEvent.focus(first);
-    expect(first).toHaveFocus();
+    await waitFor(() => expect(first).toHaveFocus());
 
     await fireEvent.focus(outsideElement);
     expect(first).toHaveFocus();
@@ -137,6 +139,8 @@ export const ReFocusPrevTrappedItem: Story = {
 
     /* Regular focus */
     await fireEvent.focus(first);
+    await waitFor(() => expect(first).toHaveFocus());
+
     await userEvent.tab();
     expect(middle).toHaveFocus();
 
@@ -178,7 +182,7 @@ export const MountAutofocus: Story = {
     const showButton = canvas.getByText("show");
     await userEvent.click(showButton);
     const first = canvas.getByLabelText(Field_ONE);
-    expect(first).toHaveFocus();
+    await waitFor(() => expect(first).toHaveFocus());
   },
   args: {
     showByDefault: false,
@@ -233,7 +237,7 @@ export const FocusPrevActiveItemOnUnmount: Story = {
 
     const showButton = canvas.getByText("show");
     await userEvent.click(showButton);
-    expect(canvas.getByLabelText(Field_ONE)).toHaveFocus();
+    await waitFor(() => expect(canvas.getByLabelText(Field_ONE)).toHaveFocus());
 
     const hideButton = canvas.getByText("hide");
     await userEvent.click(hideButton);
@@ -251,7 +255,7 @@ export const FocusBodyOnUnmount: Story = {
 
     const showButton = canvas.getByText("show");
     await userEvent.click(showButton);
-    expect(canvas.getByLabelText(Field_ONE)).toHaveFocus();
+    await waitFor(() => expect(canvas.getByLabelText(Field_ONE)).toHaveFocus());
 
     showButton.remove();
 
@@ -271,7 +275,7 @@ export const UnmountAutofocusPrevented: Story = {
 
     const showButton = canvas.getByText("show");
     await userEvent.click(showButton);
-    expect(canvas.getByLabelText(Field_ONE)).toHaveFocus();
+    await waitFor(() => expect(canvas.getByLabelText(Field_ONE)).toHaveFocus());
 
     const hideButton = canvas.getByText("hide");
     await userEvent.click(hideButton);

--- a/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tests.stories.tsx
+++ b/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tests.stories.tsx
@@ -222,7 +222,7 @@ export const MountAutofocusPrevented: Story = {
     expect(showButton).toHaveFocus();
   },
   args: {
-    onMountAutoFocus: (event) => event.preventDefault(),
+    initialFocus: false,
   },
 };
 
@@ -280,7 +280,7 @@ export const UnmountAutofocusPrevented: Story = {
     expect(document.body).toHaveFocus();
   },
   args: {
-    onUnmountAutoFocus: (event) => event.preventDefault(),
+    returnFocus: false,
     showByDefault: false,
   },
 };

--- a/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
+++ b/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
@@ -223,15 +223,13 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
         }
 
         let elToFocus: HTMLElement | null | undefined;
+        const fallbackelements = focusableElements[0] || container;
 
         /* `null` should fallback to default behavior in case of an empty ref. */
         if (resolvedInitialFocus === true || resolvedInitialFocus === null) {
-          elToFocus = focusableElements[0] || container;
+          elToFocus = fallbackelements;
         } else {
-          elToFocus =
-            resolveRef(resolvedInitialFocus) ||
-            focusableElements[0] ||
-            container;
+          elToFocus = resolveRef(resolvedInitialFocus) || fallbackelements;
         }
 
         const focusAlreadyInsideFloatingEl = container.contains(

--- a/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
+++ b/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
@@ -68,8 +68,8 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
     {
       loop = false,
       trapped = false,
-      initialFocus,
-      returnFocus,
+      initialFocus = true,
+      returnFocus = true,
       modal = false,
       ...restProps
     }: FocusBoundaryProps,
@@ -211,7 +211,6 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
             ? initialFocusValueOrFn()
             : initialFocusValueOrFn;
 
-        /* `null` should fallback to default behavior in case of an empty ref. */
         if (
           resolvedInitialFocus === undefined ||
           resolvedInitialFocus === false
@@ -220,6 +219,8 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
         }
 
         let elToFocus: HTMLElement | null | undefined;
+
+        /* `null` should fallback to default behavior in case of an empty ref. */
         if (resolvedInitialFocus === true || resolvedInitialFocus === null) {
           elToFocus = focusableElements[0] || container;
         } else {
@@ -253,7 +254,6 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
       function getReturnElement() {
         let resolvedReturnFocusValue = returnFocusRef.current;
 
-        // `null` should fallback to default behavior in case of an empty ref.
         if (
           resolvedReturnFocusValue === undefined ||
           resolvedReturnFocusValue === false
@@ -261,6 +261,7 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
           return null;
         }
 
+        /* `null` should fallback to default behavior in case of an empty ref. */
         if (resolvedReturnFocusValue === null) {
           resolvedReturnFocusValue = true;
         }

--- a/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
+++ b/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
@@ -6,18 +6,9 @@ import React, {
   useState,
 } from "react";
 import { Slot } from "../../slot/Slot";
-import { useMergeRefs } from "../../util/hooks";
-import { useEventCallback } from "../hooks/useEventCallback";
-
-const AUTOFOCUS_ON_MOUNT = "focusBoundary.autoFocusOnMount";
-const AUTOFOCUS_ON_UNMOUNT = "focusBoundary.autoFocusOnUnmount";
-const EVENT_OPTIONS = { bubbles: false, cancelable: true };
-
-/* TODO: Regular story */
-/**
- * TODO:
- * - owner(container) for corrent document
- */
+import { useClientLayoutEffect, useMergeRefs } from "../../util/hooks";
+import { useLatestRef } from "../hooks/useLatestRef";
+import { ownerDocument } from "../owner";
 
 /* -------------------------------------------------------------------------- */
 /*                                 FocusBoundary                                 */
@@ -48,15 +39,22 @@ interface FocusBoundaryProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   trapped?: boolean;
   /**
-   * Event handler called when auto-focusing on mount.
-   * Can be prevented.
+   * Will try to focus the given element on mount.
+   *
+   * If not provided, FocusBoundary will try to focus the first
+   * tabbable element inside the boundary.
    */
-  onMountAutoFocus?: (event: Event) => void;
+  initialFocus?:
+    | boolean
+    | React.MutableRefObject<HTMLElement | null>
+    | (() => boolean | HTMLElement | null | undefined);
   /**
-   * Event handler called when auto-focusing on unmount.
-   * Can be prevented.
+   * Tries to focus the previously focused element when unmounting.
+   *
+   * If not provided, FocusBoundary will try to focus the element
+   * that was focused before the FocusBoundary mounted.
    */
-  onUnmountAutoFocus?: (event: Event) => void;
+  returnFocus?: boolean | React.MutableRefObject<HTMLElement | null>;
 }
 
 const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
@@ -64,14 +62,14 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
     {
       loop = false,
       trapped = false,
-      onMountAutoFocus: onMountAutoFocusProp,
-      onUnmountAutoFocus: onUnmountAutoFocusProp,
+      initialFocus,
+      returnFocus,
       ...restProps
     }: FocusBoundaryProps,
     forwardedRef,
   ) => {
-    const onMountAutoFocus = useEventCallback(onMountAutoFocusProp);
-    const onUnmountAutoFocus = useEventCallback(onUnmountAutoFocusProp);
+    const initialFocusRef = useLatestRef(initialFocus);
+    const returnFocusRef = useLatestRef(returnFocus);
 
     const lastFocusedElementRef = useRef<HTMLElement | null>(null);
     const [container, setContainer] = useState<HTMLElement | null>(null);
@@ -166,88 +164,116 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
       };
     }, [trapped, container, focusBoundary.paused]);
 
-    /* Handles autofocus on mount and unmount */
+    /* Adds element to focus-stack */
     useEffect(() => {
       if (!container) {
         return;
       }
 
       focusBoundarysStack.add(focusBoundary);
-      const initialFocusedElement =
-        document.activeElement as HTMLElement | null;
-      const containsActiveElement =
-        initialFocusedElement && container.contains(initialFocusedElement);
-
-      /*
-       * We only autofocus on mount if container does not contain active element.
-       * If container has an element with `autoFocus` attribute, browser will
-       * have already moved focus there before this effect runs.
-       */
-      if (!containsActiveElement) {
-        const mountEvent = new CustomEvent(AUTOFOCUS_ON_MOUNT, EVENT_OPTIONS);
-        container.addEventListener(AUTOFOCUS_ON_MOUNT, onMountAutoFocus);
-        container.dispatchEvent(mountEvent);
-
-        /* If consumer does not manually prevent event and handle focus themselves */
-        if (!mountEvent.defaultPrevented) {
-          /**
-           * Attempts focusing the first element in a list of candidates.
-           * Stops when focus has actually moved.
-           */
-          const candidates = removeLinks(getTabbableCandidates(container));
-          const previouslyFocusedElement = document.activeElement;
-          for (const candidate of candidates) {
-            focus(candidate, { select: true });
-            if (document.activeElement !== previouslyFocusedElement) {
-              break;
-            }
-          }
-
-          /* focusFirst might not find any candidates, so we fall back to focusing container */
-          if (document.activeElement === initialFocusedElement) {
-            focus(container);
-          }
-        }
-      }
 
       return () => {
-        container.removeEventListener(AUTOFOCUS_ON_MOUNT, onMountAutoFocus);
-
-        /**
-         * https://github.com/facebook/react/issues/17894
-         * We delay to next tick to avoid issues with React's event system
-         * where calling `focus` inside a effect cleanup causes React to not call onFocus handlers.
-         */
         setTimeout(() => {
-          const unmountEvent = new CustomEvent(
-            AUTOFOCUS_ON_UNMOUNT,
-            EVENT_OPTIONS,
-          );
-          container.addEventListener(AUTOFOCUS_ON_UNMOUNT, onUnmountAutoFocus);
-          container.dispatchEvent(unmountEvent);
-
-          /* If consumer does not manually prevent event and handle focus themselves */
-          if (!unmountEvent.defaultPrevented) {
-            /* To avoid CPU-spikes on Chrome, we make sure element is still connected to the DOM. */
-            focus(
-              initialFocusedElement?.isConnected
-                ? initialFocusedElement
-                : document.body,
-              {
-                select: true,
-              },
-            );
-          }
-          /* Since this is inside a cleanup, we need to instantly remove the listener ourselves */
-          container.removeEventListener(
-            AUTOFOCUS_ON_UNMOUNT,
-            onUnmountAutoFocus,
-          );
-
           focusBoundarysStack.remove(focusBoundary);
         }, 0);
       };
-    }, [container, onMountAutoFocus, onUnmountAutoFocus, focusBoundary]);
+    }, [container, focusBoundary]);
+
+    /* Handles mount focus */
+    useClientLayoutEffect(() => {
+      if (!container || initialFocusRef.current === false) {
+        return;
+      }
+
+      const ownerDoc = ownerDocument(container);
+      const previouslyFocusedElement = ownerDoc.activeElement;
+
+      const focusableElements = removeLinks(getTabbableCandidates(container));
+      const initialFocusValueOrFn = initialFocusRef.current;
+      const resolvedInitialFocus =
+        typeof initialFocusValueOrFn === "function"
+          ? initialFocusValueOrFn()
+          : initialFocusValueOrFn;
+
+      /* `null` should fallback to default behavior in case of an empty ref. */
+      if (
+        resolvedInitialFocus === undefined ||
+        resolvedInitialFocus === false
+      ) {
+        return;
+      }
+
+      let elToFocus: HTMLElement | null | undefined;
+      if (resolvedInitialFocus === true || resolvedInitialFocus === null) {
+        elToFocus = focusableElements[0] || container;
+      } else {
+        elToFocus = resolveRef(resolvedInitialFocus);
+      }
+      elToFocus = elToFocus || focusableElements[0] || container;
+
+      const focusAlreadyInsideFloatingEl = container.contains(
+        previouslyFocusedElement,
+      );
+
+      if (focusAlreadyInsideFloatingEl) {
+        return;
+      }
+
+      focus(elToFocus, {
+        preventScroll: elToFocus === container,
+      });
+    }, [container, initialFocusRef]);
+
+    /* Handles unmount focus */
+    useClientLayoutEffect(() => {
+      if (!container) {
+        return;
+      }
+      const ownerDoc = ownerDocument(container);
+      const previouslyFocusedElement = ownerDoc.activeElement;
+
+      function getReturnElement() {
+        const returnFocusValueOrFn = returnFocusRef.current;
+        let resolvedReturnFocusValue = returnFocusValueOrFn;
+
+        // `null` should fallback to default behavior in case of an empty ref.
+        if (
+          resolvedReturnFocusValue === undefined ||
+          resolvedReturnFocusValue === false
+        ) {
+          return null;
+        }
+
+        if (resolvedReturnFocusValue === null) {
+          resolvedReturnFocusValue = true;
+        }
+
+        if (typeof resolvedReturnFocusValue === "boolean") {
+          const el = previouslyFocusedElement;
+          return el?.isConnected ? el : ownerDoc.body;
+        }
+
+        const fallback = previouslyFocusedElement || ownerDoc.body;
+
+        return resolveRef(resolvedReturnFocusValue) || fallback;
+      }
+
+      return () => {
+        const returnElement = getReturnElement() as HTMLElement | null;
+        const activeEl = ownerDoc.activeElement;
+
+        queueMicrotask(() => {
+          if (
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+            returnFocusRef.current &&
+            returnElement &&
+            returnElement !== activeEl
+          ) {
+            returnElement.focus({ preventScroll: true });
+          }
+        });
+      };
+    }, [container, returnFocusRef]);
 
     /* Takes care of looping focus */
     const handleKeyDown = useCallback(
@@ -387,14 +413,17 @@ function isHidden(node: HTMLElement, { upTo }: { upTo?: HTMLElement }) {
   return false;
 }
 
-function focus(element?: HTMLElement | null, { select = false } = {}) {
+function focus(
+  element?: HTMLElement | null,
+  { select = false, preventScroll = true } = {},
+) {
   if (!element?.focus) {
     return;
   }
 
   const previouslyFocusedElement = document.activeElement;
   /* Prevent scrolling on focus, to minimize jarring transitions */
-  element.focus({ preventScroll: true });
+  element.focus({ preventScroll });
 
   if (!select) {
     return;
@@ -447,6 +476,26 @@ function arrayRemove<T>(array: T[], item: T) {
 
 function removeLinks(items: HTMLElement[]) {
   return items.filter((item) => item.tagName !== "A");
+}
+
+/**
+ * If the provided argument is a ref object, returns its `current` value.
+ * Otherwise, returns the argument itself.
+ *
+ * Non-generic to safely handle refs whose `.current` may be `null`.
+ */
+function resolveRef(
+  maybeRef:
+    | HTMLElement
+    | null
+    | undefined
+    | React.RefObject<HTMLElement | null | undefined>,
+): HTMLElement | null | undefined {
+  if (maybeRef == null) {
+    return maybeRef;
+  }
+
+  return "current" in maybeRef ? maybeRef.current : maybeRef;
 }
 
 export { FocusBoundary };

--- a/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
+++ b/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
@@ -44,16 +44,20 @@ interface FocusBoundaryProps extends React.HTMLAttributes<HTMLDivElement> {
    *
    * If not provided, FocusBoundary will try to focus the first
    * tabbable element inside the boundary.
+   * 
+   * Set to `false` to not focus anything.
    */
   initialFocus?:
     | boolean
     | React.MutableRefObject<HTMLElement | null>
     | (() => boolean | HTMLElement | null | undefined);
   /**
-   * Tries to focus the previously focused element when unmounting.
-   *
+   * Will try to focus the given element on unmount.
+   * 
    * If not provided, FocusBoundary will try to focus the element
    * that was focused before the FocusBoundary mounted.
+   * 
+   * Set to `false` to not focus anything.
    */
   returnFocus?: boolean | React.MutableRefObject<HTMLElement | null>;
   /**
@@ -511,16 +515,8 @@ function removeLinks(items: HTMLElement[]) {
  * Non-generic to safely handle refs whose `.current` may be `null`.
  */
 function resolveRef(
-  maybeRef:
-    | HTMLElement
-    | null
-    | undefined
-    | React.RefObject<HTMLElement | null | undefined>,
+  maybeRef: HTMLElement | React.RefObject<HTMLElement | null | undefined>,
 ): HTMLElement | null | undefined {
-  if (maybeRef == null) {
-    return maybeRef;
-  }
-
   return "current" in maybeRef ? maybeRef.current : maybeRef;
 }
 

--- a/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
+++ b/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import { Slot } from "../../slot/Slot";
 import { useClientLayoutEffect, useMergeRefs } from "../../util/hooks";
+import { hideNonTargetElements } from "../hideNonTargetElements";
 import { useLatestRef } from "../hooks/useLatestRef";
 import { ownerDocument } from "../owner";
 
@@ -55,6 +56,11 @@ interface FocusBoundaryProps extends React.HTMLAttributes<HTMLDivElement> {
    * that was focused before the FocusBoundary mounted.
    */
   returnFocus?: boolean | React.MutableRefObject<HTMLElement | null>;
+  /**
+   * Hides all outside content from screen readers when true.
+   * @default false
+   */
+  modal?: boolean;
 }
 
 const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
@@ -64,6 +70,7 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
       trapped = false,
       initialFocus,
       returnFocus,
+      modal = false,
       ...restProps
     }: FocusBoundaryProps,
     forwardedRef,
@@ -178,6 +185,14 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
         }, 0);
       };
     }, [container, focusBoundary]);
+
+    useEffect(() => {
+      if (!container || !modal) {
+        return;
+      }
+
+      return hideNonTargetElements([container]);
+    });
 
     /* Handles mount focus */
     useClientLayoutEffect(() => {

--- a/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
+++ b/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
@@ -192,7 +192,7 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
       }
 
       return hideNonTargetElements([container]);
-    });
+    }, [container, modal]);
 
     /* Handles mount focus */
     useClientLayoutEffect(() => {

--- a/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
+++ b/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
@@ -203,40 +203,42 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
       const ownerDoc = ownerDocument(container);
       const previouslyFocusedElement = ownerDoc.activeElement;
 
-      const focusableElements = removeLinks(getTabbableCandidates(container));
-      const initialFocusValueOrFn = initialFocusRef.current;
-      const resolvedInitialFocus =
-        typeof initialFocusValueOrFn === "function"
-          ? initialFocusValueOrFn()
-          : initialFocusValueOrFn;
+      queueMicrotask(() => {
+        const focusableElements = removeLinks(getTabbableCandidates(container));
+        const initialFocusValueOrFn = initialFocusRef.current;
+        const resolvedInitialFocus =
+          typeof initialFocusValueOrFn === "function"
+            ? initialFocusValueOrFn()
+            : initialFocusValueOrFn;
 
-      /* `null` should fallback to default behavior in case of an empty ref. */
-      if (
-        resolvedInitialFocus === undefined ||
-        resolvedInitialFocus === false
-      ) {
-        return;
-      }
+        /* `null` should fallback to default behavior in case of an empty ref. */
+        if (
+          resolvedInitialFocus === undefined ||
+          resolvedInitialFocus === false
+        ) {
+          return;
+        }
 
-      let elToFocus: HTMLElement | null | undefined;
-      if (resolvedInitialFocus === true || resolvedInitialFocus === null) {
-        elToFocus = focusableElements[0] || container;
-      } else {
-        elToFocus = resolveRef(resolvedInitialFocus);
-      }
-      elToFocus = elToFocus || focusableElements[0] || container;
+        let elToFocus: HTMLElement | null | undefined;
+        if (resolvedInitialFocus === true || resolvedInitialFocus === null) {
+          elToFocus = focusableElements[0] || container;
+        } else {
+          elToFocus = resolveRef(resolvedInitialFocus);
+        }
+        elToFocus = elToFocus || focusableElements[0] || container;
 
-      const focusAlreadyInsideFloatingEl = container.contains(
-        previouslyFocusedElement,
-      );
+        const focusAlreadyInsideFloatingEl = container.contains(
+          previouslyFocusedElement,
+        );
 
-      if (focusAlreadyInsideFloatingEl) {
-        return;
-      }
+        if (focusAlreadyInsideFloatingEl) {
+          return;
+        }
 
-      focus(elToFocus, {
-        preventScroll: elToFocus === container,
-        sync: false,
+        focus(elToFocus, {
+          preventScroll: elToFocus === container,
+          sync: false,
+        });
       });
     }, [container, initialFocusRef]);
 

--- a/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
+++ b/@navikt/core/react/src/util/focus-boundary/FocusBoundary.tsx
@@ -44,7 +44,7 @@ interface FocusBoundaryProps extends React.HTMLAttributes<HTMLDivElement> {
    *
    * If not provided, FocusBoundary will try to focus the first
    * tabbable element inside the boundary.
-   * 
+   *
    * Set to `false` to not focus anything.
    */
   initialFocus?:
@@ -53,10 +53,10 @@ interface FocusBoundaryProps extends React.HTMLAttributes<HTMLDivElement> {
     | (() => boolean | HTMLElement | null | undefined);
   /**
    * Will try to focus the given element on unmount.
-   * 
+   *
    * If not provided, FocusBoundary will try to focus the element
    * that was focused before the FocusBoundary mounted.
-   * 
+   *
    * Set to `false` to not focus anything.
    */
   returnFocus?: boolean | React.MutableRefObject<HTMLElement | null>;
@@ -228,9 +228,11 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
         if (resolvedInitialFocus === true || resolvedInitialFocus === null) {
           elToFocus = focusableElements[0] || container;
         } else {
-          elToFocus = resolveRef(resolvedInitialFocus);
+          elToFocus =
+            resolveRef(resolvedInitialFocus) ||
+            focusableElements[0] ||
+            container;
         }
-        elToFocus = elToFocus || focusableElements[0] || container;
 
         const focusAlreadyInsideFloatingEl = container.contains(
           previouslyFocusedElement,


### PR DESCRIPTION
### Description

Issues with current solution:
Dispatching events in effect, then handling focus "outside" out boundary (in ActionMenu.Content/Dialog.Popup etc) causes issues with Voiceover + safari, and with chrome + aria-hidden

## Voiceover + Safari
Voiceover a11y-tree sometimes lag a little behind when animating in elements. To solve this we use `queueMicrotask` + making `focus()`-function use `requestAnimationFrame`. This allows the a11y-tree to settle before we focus the dialog/actionmenu. Without this fix, safari + voiceover won't consistently announce that the element has focus.

## Chrome + aria-hidden
When using `hideNonTargetElements`, we end up hiding the "trigger"-element. If we try to hide the element before we move focus to dialog/actionmenu, chrome errors and stops us from marking the element as it still has focus. 

When we try to handle this inside the component itself (Dialog.Popup), we can't predictably sync it with the effects in `FocusBoundary`. By moving it inside the boundary-component, we can ensure that this issue won't persist since effects runs consistently in order.

I can show this in a huddle if that is a little easier for explanation.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
