### PR TITLE
[Timeline] Hides out of bound pins

### DIFF
--- a/.changeset/brown-steaks-try.md
+++ b/.changeset/brown-steaks-try.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Timeline: Pins before or after date-range arennow hidden.

--- a/.changeset/brown-steaks-try.md
+++ b/.changeset/brown-steaks-try.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-Timeline: Pins before or after date-range arennow hidden.
+Timeline: Pins before or after date-range are now hidden.

--- a/@navikt/core/react/src/timeline/Timeline.tsx
+++ b/@navikt/core/react/src/timeline/Timeline.tsx
@@ -2,7 +2,6 @@ import { endOfDay, isSameDay, startOfDay } from "date-fns";
 import React, { forwardRef, useMemo, useRef, useState } from "react";
 import { useRenameCSS } from "../theme/Theme";
 import { AxisLabels } from "./AxisLabels";
-import Pin, { PinType } from "./Pin";
 import TimelineRow, { TimelineRowType } from "./TimelineRow";
 import { RowContext } from "./hooks/useRowContext";
 import { TimelineContext } from "./hooks/useTimelineContext";
@@ -12,6 +11,7 @@ import {
   useTimelineRows,
 } from "./hooks/useTimelineRows";
 import Period, { PeriodType } from "./period";
+import Pin, { PinType } from "./pin/Pin";
 import { parseRows } from "./utils/timeline";
 import { AxisLabelTemplates } from "./utils/types.external";
 import Zoom, { ZoomType } from "./zoom";

--- a/@navikt/core/react/src/timeline/index.ts
+++ b/@navikt/core/react/src/timeline/index.ts
@@ -1,7 +1,7 @@
 "use client";
 export { default as Timeline, type TimelineProps } from "./Timeline";
 export { default as TimelineRow, type TimelineRowProps } from "./TimelineRow";
-export { default as TimelinePin, type TimelinePinProps } from "./Pin";
+export { default as TimelinePin, type TimelinePinProps } from "./pin/Pin";
 export { default as TimelinePeriod, type TimelinePeriodProps } from "./period";
 export {
   default as TimelineZoomButton,

--- a/@navikt/core/react/src/timeline/pin/Pin.tsx
+++ b/@navikt/core/react/src/timeline/pin/Pin.tsx
@@ -1,0 +1,43 @@
+import { isBefore } from "date-fns";
+import React, { forwardRef } from "react";
+import { useTimelineContext } from "../hooks/useTimelineContext";
+import { TimelineComponentTypes } from "../utils/types.internal";
+import PinInternal from "./PinInternal";
+
+export interface TimelinePinProps
+  extends React.HTMLAttributes<HTMLButtonElement> {
+  /**
+   * Date position for the pin.
+   */
+  date: Date;
+  /**
+   * Content in Pin Popover.
+   */
+  children?: React.ReactNode;
+}
+
+export interface PinType
+  extends React.ForwardRefExoticComponent<
+    TimelinePinProps & React.RefAttributes<HTMLButtonElement>
+  > {
+  componentType: TimelineComponentTypes;
+}
+
+export const Pin = forwardRef<HTMLButtonElement, TimelinePinProps>(
+  ({ date, ...restProps }, forwardedRef) => {
+    const { startDate, endDate } = useTimelineContext();
+
+    /**
+     * Out-of-bounds pins should not be rendered
+     */
+    if (isBefore(date, startDate) || isBefore(endDate, date)) {
+      return null;
+    }
+
+    return <PinInternal ref={forwardedRef} {...restProps} date={date} />;
+  },
+) as PinType;
+
+Pin.componentType = "pin";
+
+export default Pin;

--- a/@navikt/core/react/src/timeline/pin/Pin.tsx
+++ b/@navikt/core/react/src/timeline/pin/Pin.tsx
@@ -2,19 +2,7 @@ import { isBefore } from "date-fns";
 import React, { forwardRef } from "react";
 import { useTimelineContext } from "../hooks/useTimelineContext";
 import { TimelineComponentTypes } from "../utils/types.internal";
-import PinInternal from "./PinInternal";
-
-export interface TimelinePinProps
-  extends React.HTMLAttributes<HTMLButtonElement> {
-  /**
-   * Date position for the pin.
-   */
-  date: Date;
-  /**
-   * Content in Pin Popover.
-   */
-  children?: React.ReactNode;
-}
+import PinInternal, { type TimelinePinProps } from "./PinInternal";
 
 export interface PinType
   extends React.ForwardRefExoticComponent<
@@ -41,3 +29,5 @@ export const Pin = forwardRef<HTMLButtonElement, TimelinePinProps>(
 Pin.componentType = "pin";
 
 export default Pin;
+
+export type { TimelinePinProps };

--- a/@navikt/core/react/src/timeline/pin/PinInternal.tsx
+++ b/@navikt/core/react/src/timeline/pin/PinInternal.tsx
@@ -19,7 +19,6 @@ import { useMergeRefs } from "../../util/hooks/useMergeRefs";
 import { useI18n } from "../../util/i18n/i18n.hooks";
 import { useTimelineContext } from "../hooks/useTimelineContext";
 import { position } from "../utils/calc";
-import { TimelineComponentTypes } from "../utils/types.internal";
 
 export interface TimelinePinProps
   extends React.HTMLAttributes<HTMLButtonElement> {
@@ -31,13 +30,6 @@ export interface TimelinePinProps
    * Content in Pin Popover.
    */
   children?: React.ReactNode;
-}
-
-export interface PinType
-  extends React.ForwardRefExoticComponent<
-    TimelinePinProps & React.RefAttributes<HTMLButtonElement>
-  > {
-  componentType: TimelineComponentTypes;
 }
 
 export const PinInternal = forwardRef<HTMLButtonElement, TimelinePinProps>(
@@ -157,6 +149,6 @@ export const PinInternal = forwardRef<HTMLButtonElement, TimelinePinProps>(
       </>
     );
   },
-) as PinType;
+);
 
 export default PinInternal;

--- a/@navikt/core/react/src/timeline/pin/PinInternal.tsx
+++ b/@navikt/core/react/src/timeline/pin/PinInternal.tsx
@@ -14,12 +14,12 @@ import {
 } from "@floating-ui/react";
 import { format } from "date-fns";
 import React, { forwardRef, useRef, useState } from "react";
-import { useRenameCSS, useThemeInternal } from "../theme/Theme";
-import { useMergeRefs } from "../util/hooks/useMergeRefs";
-import { useI18n } from "../util/i18n/i18n.hooks";
-import { useTimelineContext } from "./hooks/useTimelineContext";
-import { position } from "./utils/calc";
-import { TimelineComponentTypes } from "./utils/types.internal";
+import { useRenameCSS, useThemeInternal } from "../../theme/Theme";
+import { useMergeRefs } from "../../util/hooks/useMergeRefs";
+import { useI18n } from "../../util/i18n/i18n.hooks";
+import { useTimelineContext } from "../hooks/useTimelineContext";
+import { position } from "../utils/calc";
+import { TimelineComponentTypes } from "../utils/types.internal";
 
 export interface TimelinePinProps
   extends React.HTMLAttributes<HTMLButtonElement> {
@@ -40,7 +40,7 @@ export interface PinType
   componentType: TimelineComponentTypes;
 }
 
-export const Pin = forwardRef<HTMLButtonElement, TimelinePinProps>(
+export const PinInternal = forwardRef<HTMLButtonElement, TimelinePinProps>(
   ({ date, children, ...rest }, ref) => {
     const { cn } = useRenameCSS();
     const { startDate, endDate, direction } = useTimelineContext();
@@ -159,6 +159,4 @@ export const Pin = forwardRef<HTMLButtonElement, TimelinePinProps>(
   },
 ) as PinType;
 
-Pin.componentType = "pin";
-
-export default Pin;
+export default PinInternal;

--- a/@navikt/core/react/src/timeline/timeline.stories.tsx
+++ b/@navikt/core/react/src/timeline/timeline.stories.tsx
@@ -177,7 +177,7 @@ export const WithPins: StoryFn = () => {
   return (
     <div style={{ width: "80vw" }}>
       <Timeline>
-        <Timeline.Pin date={new Date("Apr 15 2022")}>Pin 1</Timeline.Pin>
+        <Timeline.Pin date={new Date("Dec 20 2021")}>Pin 1</Timeline.Pin>
         <Timeline.Pin date={new Date("Jun 12 2022")}>Pin 2</Timeline.Pin>
         <Timeline.Pin date={new Date("Jul 28 2022")}>Pin 3</Timeline.Pin>
         <Timeline.Row


### PR DESCRIPTION
### Description

https://nav-it.slack.com/archives/C7NE7A8UF/p1762429883605099

TODO: Need to update prop-connection in sanity after merge since Pin-file is moved.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
