### PR TITLE
:bug: Resolve Modal-bug where both HTML and Body were 'locked' 

### DIFF
--- a/.changeset/twelve-bats-mix.md
+++ b/.changeset/twelve-bats-mix.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Modal: Improve scroll-lock interaction for sticky elements.


### PR DESCRIPTION
### Description

This fix most likely also fixes this: https://nav-it.slack.com/archives/C7NE7A8UF/p1762347454913249

A little hard to create a story for, but can use this where `WithUseRef` is the first Modal story.
```
export const UseScrollLockScrollSticky: StoryObj = {
  render: () => {
    return (
      <div style={{ position: "relative" }}>
        <div style={{ position: "sticky", top: "1rem", background: "red" }}>
          Sticky
        </div>
        <WithUseRef />
      </div>
    );
  },
  parameters: {
    layout: "padded",
  },
};
```

As one can see in the images, the sticky element moves in the old implementation because of both HTML and Body element having overflow hidden.
<img width="1624" height="1060" alt="Screenshot 2025-11-07 at 21 38 39" src="https://github.com/user-attachments/assets/1e36c0b3-c611-426c-956b-1fd11ff05bb6" />
<img width="1624" height="1060" alt="Screenshot 2025-11-07 at 21 38 41" src="https://github.com/user-attachments/assets/46e9043f-3cf0-426f-b189-d3fc432cfc4c" />


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
