### PR TITLE
:tada: Moved admin-route above sanitylive to avoid page-reloads

### DIFF
--- a/aksel.nav.no/website/app/(admin)/AdminStudio.tsx
+++ b/aksel.nav.no/website/app/(admin)/AdminStudio.tsx
@@ -3,7 +3,7 @@
 import { NextStudio } from "next-sanity/studio";
 import { useTheme } from "next-themes";
 import { StudioThemeColorSchemeKey } from "sanity";
-import workspaceConfig from "../../../sanity/sanity.config";
+import workspaceConfig from "../../sanity/sanity.config";
 
 function AdminStudio() {
   const { theme, setTheme } = useTheme();

--- a/aksel.nav.no/website/app/(admin)/admin-dev/[[...index]]/page.tsx
+++ b/aksel.nav.no/website/app/(admin)/admin-dev/[[...index]]/page.tsx
@@ -1,4 +1,4 @@
-import { AdminStudio } from "@/app/(routes)/(admin)/AdminStudio";
+import { AdminStudio } from "@/app/(admin)/AdminStudio";
 
 export { metadata, viewport } from "next-sanity/studio";
 

--- a/aksel.nav.no/website/app/(admin)/admin/[[...index]]/page.tsx
+++ b/aksel.nav.no/website/app/(admin)/admin/[[...index]]/page.tsx
@@ -1,4 +1,4 @@
-import { AdminStudio } from "@/app/(routes)/(admin)/AdminStudio";
+import { AdminStudio } from "@/app/(admin)/AdminStudio";
 
 export { metadata, viewport } from "next-sanity/studio";
 

--- a/aksel.nav.no/website/app/(routes)/layout.tsx
+++ b/aksel.nav.no/website/app/(routes)/layout.tsx
@@ -1,0 +1,30 @@
+import { draftMode } from "next/headers";
+import { SanityLive } from "@/app/_sanity/live";
+import { ConsentBanner } from "@/app/_ui/consent-banner/ConsentBanner";
+import { CookieConsentProvider } from "@/app/_ui/cookie-consent/CookieConsent.Provider";
+import { DraftOverlay } from "@/app/_ui/draft-overlay/DraftOverlay";
+import { Umami } from "@/app/_ui/umami/Umami";
+
+export default async function IndexLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { isEnabled: isDraftMode } = await draftMode();
+
+  return (
+    <>
+      <CookieConsentProvider>
+        <Umami isDraftMode={isDraftMode} />
+        <ConsentBanner />
+        {children}
+        {isDraftMode && <DraftOverlay />}
+      </CookieConsentProvider>
+      <SanityLive
+        intervalOnGoAway={false}
+        refreshOnFocus={false}
+        refreshOnMount={false}
+      />
+    </>
+  );
+}

--- a/aksel.nav.no/website/app/layout.tsx
+++ b/aksel.nav.no/website/app/layout.tsx
@@ -1,12 +1,6 @@
 import { Metadata, Viewport } from "next";
-import { draftMode } from "next/headers";
 import "@navikt/ds-tokens/darkside-css";
-import { SanityLive } from "@/app/_sanity/live";
-import { ConsentBanner } from "@/app/_ui/consent-banner/ConsentBanner";
-import { CookieConsentProvider } from "@/app/_ui/cookie-consent/CookieConsent.Provider";
-import { DraftOverlay } from "@/app/_ui/draft-overlay/DraftOverlay";
 import { ThemeProvider } from "@/app/_ui/theming/ThemeProvider";
-import { Umami } from "@/app/_ui/umami/Umami";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -35,8 +29,6 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const { isEnabled: isDraftMode } = await draftMode();
-
   return (
     <html lang="no" suppressHydrationWarning>
       <head>
@@ -49,19 +41,7 @@ export default async function RootLayout({
         />
       </head>
       <body>
-        <CookieConsentProvider>
-          <Umami isDraftMode={isDraftMode} />
-          <ThemeProvider>
-            <ConsentBanner />
-            {children}
-            {isDraftMode && <DraftOverlay />}
-          </ThemeProvider>
-        </CookieConsentProvider>
-        <SanityLive
-          intervalOnGoAway={false}
-          refreshOnFocus={false}
-          refreshOnMount={false}
-        />
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/aksel.nav.no/website/sanity/sanity.config.ts
+++ b/aksel.nav.no/website/sanity/sanity.config.ts
@@ -33,6 +33,16 @@ export const workspaceConfig = defineConfig([
     document: {
       newDocumentOptions: newDocumentsCreator,
     },
+    scheduledDrafts: {
+      enabled: false,
+    },
+    beta: {
+      form: {
+        enhancedObjectDialog: {
+          enabled: true,
+        },
+      },
+    },
     plugins: [
       structureTool({
         title: "Editor",
@@ -75,6 +85,16 @@ export const workspaceConfig = defineConfig([
     schema,
     document: {
       newDocumentOptions: newDocumentsCreator,
+    },
+    scheduledDrafts: {
+      enabled: false,
+    },
+    beta: {
+      form: {
+        enhancedObjectDialog: {
+          enabled: true,
+        },
+      },
     },
     plugins: [
       structureTool({


### PR DESCRIPTION
### Description

Also disabled scheduled releases (unsure how this works with our overrides on publish-button), and enabled new dialog-view beta

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
