### PR TITLE
[DismissableLayer] Avoid re-mounting react sub-tree when toggling enabled-state

### DIFF
--- a/.changeset/rotten-windows-fetch.md
+++ b/.changeset/rotten-windows-fetch.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-Popover: Children now longer re-mounts on open/close change.
+Popover: Children no longer re-mounts on open toggle.

--- a/.changeset/rotten-windows-fetch.md
+++ b/.changeset/rotten-windows-fetch.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Popover: Children now longer re-mounts on open/close change.

--- a/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
+++ b/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
@@ -271,6 +271,8 @@ const DismissableLayer = forwardRef<HTMLDivElement, DismissableLayerProps>(
      * because a change to `disableOutsidePointerEvents` would remove this layer from the stack
      * and add it to the end again so the layering order wouldn't be creation order.
      * We only want them to be removed from context stacks when unmounted.
+     *
+     * We depend on `enabled` to clean up when the layer is disabled.
      */
     // biome-ignore lint/correctness/useExhaustiveDependencies: We need to clean up after enabled changes.
     useEffect(() => {
@@ -278,9 +280,14 @@ const DismissableLayer = forwardRef<HTMLDivElement, DismissableLayerProps>(
         if (!node) {
           return;
         }
-        context.layers.delete(node);
-        context.layersWithOutsidePointerEventsDisabled.delete(node);
-        dispatchUpdate();
+        if (
+          context.layers.has(node) ||
+          context.layersWithOutsidePointerEventsDisabled.has(node)
+        ) {
+          context.layers.delete(node);
+          context.layersWithOutsidePointerEventsDisabled.delete(node);
+          dispatchUpdate();
+        }
       };
     }, [node, context, enabled]);
 

--- a/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
+++ b/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
@@ -64,27 +64,39 @@ interface DismissableLayerBaseProps
 type DismissableLayerProps = DismissableLayerBaseProps & AsChild;
 
 const DismissableLayer = forwardRef<HTMLDivElement, DismissableLayerProps>(
-  ({ enabled = true, ...restProps }: DismissableLayerProps, forwardedRef) => {
-    if (!enabled) {
-      const Component = restProps.asChild ? Slot : "div";
-      return (
-        <Component
-          {...omit(restProps, [
-            "asChild",
-            "disableOutsidePointerEvents",
-            "onDismiss",
-            "onEscapeKeyDown",
-            "onFocusOutside",
-            "onInteractOutside",
-            "onPointerDownOutside",
-            "safeZone",
-          ])}
-          ref={forwardedRef}
-        />
-      );
-    }
+  (
+    { enabled = true, asChild, children, ...restProps }: DismissableLayerProps,
+    forwardedRef,
+  ) => {
+    const Component = asChild ? Slot : "div";
+    const Wrapper = enabled ? DismissableLayerInternal : Slot;
 
-    return <DismissableLayerInternal {...restProps} ref={forwardedRef} />;
+    const cleanedProps = omit(restProps, [
+      "disableOutsidePointerEvents",
+      "onDismiss",
+      "onEscapeKeyDown",
+      "onFocusOutside",
+      "onInteractOutside",
+      "onPointerDownOutside",
+      "safeZone",
+    ]);
+
+    /**
+     * When `enabled` is `false`, we render a simple `div` or `Slot` (if `asChild` is `true`)
+     * that forwards all props except the ones specific to `DismissableLayer`.
+     *
+     * We do this instead of conditionally rendering `DismissableLayerInternal` to preserve the
+     * component tree structure and avoid unmounting/mounting issues.
+     */
+    return (
+      <Wrapper
+        ref={forwardedRef}
+        {...(enabled ? { asChild: true } : {})}
+        {...(enabled ? restProps : cleanedProps)}
+      >
+        <Component>{children}</Component>
+      </Wrapper>
+    );
   },
 );
 

--- a/@navikt/core/react/src/overlays/dismissablelayer/util/useEscapeKeydown.ts
+++ b/@navikt/core/react/src/overlays/dismissablelayer/util/useEscapeKeydown.ts
@@ -4,10 +4,15 @@ import { useCallbackRef } from "../../../util/hooks";
 export function useEscapeKeydown(
   callback?: (event: KeyboardEvent) => void,
   ownerDocument: Document = globalThis?.document,
+  enabled: boolean = true,
 ) {
   const onEscapeKeyDown = useCallbackRef(callback);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         onEscapeKeyDown(event);
@@ -15,7 +20,9 @@ export function useEscapeKeydown(
     };
 
     ownerDocument.addEventListener("keydown", handleKeyDown, true);
-    return () =>
+
+    return () => {
       ownerDocument.removeEventListener("keydown", handleKeyDown, true);
-  }, [onEscapeKeyDown, ownerDocument]);
+    };
+  }, [onEscapeKeyDown, ownerDocument, enabled]);
 }

--- a/@navikt/core/react/src/overlays/dismissablelayer/util/useFocusOutside.ts
+++ b/@navikt/core/react/src/overlays/dismissablelayer/util/useFocusOutside.ts
@@ -12,11 +12,16 @@ import {
 export function useFocusOutside(
   callback?: (event: CustomFocusEvent) => void,
   ownerDocument: Document = globalThis?.document,
+  enabled: boolean = true,
 ) {
   const handleFocusOutside = useCallbackRef(callback) as EventListener;
   const isFocusInsideReactTreeRef = useRef(false);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     const handleFocus = (event: FocusEvent) => {
       if (event.target && !isFocusInsideReactTreeRef.current) {
         const eventDetail = { originalEvent: event };
@@ -38,8 +43,10 @@ export function useFocusOutside(
       }
     };
     ownerDocument.addEventListener("focusin", handleFocus);
-    return () => ownerDocument.removeEventListener("focusin", handleFocus);
-  }, [ownerDocument, handleFocusOutside]);
+    return () => {
+      ownerDocument.removeEventListener("focusin", handleFocus);
+    };
+  }, [ownerDocument, handleFocusOutside, enabled]);
 
   /**
    * By directly setting isFocusInsideReactTreeRef on focus-events at the root of the "dismissable" element,

--- a/@navikt/core/react/src/overlays/dismissablelayer/util/usePointerDownOutside.ts
+++ b/@navikt/core/react/src/overlays/dismissablelayer/util/usePointerDownOutside.ts
@@ -16,6 +16,7 @@ import {
 export function usePointerDownOutside(
   callback?: (event: CustomPointerDownEvent) => void,
   ownerDocument: Document = globalThis?.document,
+  enabled: boolean = true,
 ) {
   const handlePointerDownOutside = useCallbackRef(callback) as EventListener;
   const isPointerInsideReactTreeRef = useRef(false);
@@ -23,6 +24,10 @@ export function usePointerDownOutside(
   const timeout = useTimeout();
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     const handlePointerDown = (event: PointerEvent) => {
       /**
        * The `DismisableLayer`-API is based on the ability to stop events from propagating and in the end calling `onDismiss`
@@ -87,7 +92,7 @@ export function usePointerDownOutside(
       ownerDocument.removeEventListener("pointerdown", handlePointerDown);
       ownerDocument.removeEventListener("click", handleClickRef.current);
     };
-  }, [ownerDocument, handlePointerDownOutside, timeout]);
+  }, [ownerDocument, handlePointerDownOutside, timeout, enabled]);
 
   return {
     // ensures we check React component tree (not just DOM tree)

--- a/@navikt/core/react/src/popover/popover.stories.tsx
+++ b/@navikt/core/react/src/popover/popover.stories.tsx
@@ -1,7 +1,5 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import { Button } from "../button";
-import { Dropdown } from "../dropdown";
-import { Modal } from "../modal";
 import Popover from "./Popover";
 
 const placements = [
@@ -87,112 +85,6 @@ const Template = (props) => {
         </Popover.Content>
       </Popover>
     </>
-  );
-};
-
-function TestElement() {
-  const [modalOpen, setModalOpen] = useState(false);
-  console.log("TestElement rendered");
-
-  useEffect(() => {
-    console.log("TestElement mounted");
-    return () => {
-      console.log("TestElement unmounted");
-    };
-  }, []);
-
-  return (
-    <div>
-      <Button onClick={() => setModalOpen(true)}>Open Modal</Button>
-      {modalOpen && (
-        <Modal
-          open
-          portal
-          onClose={() => null}
-          header={{
-            label: "Optional label",
-            heading: "Title",
-            size: "small",
-          }}
-          closeOnBackdropClick
-        >
-          MODAL
-        </Modal>
-      )}
-    </div>
-  );
-}
-
-export const DialogTest = () => {
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-  const [open, setOpen] = useState(false);
-
-  return (
-    <>
-      <Button onClick={() => setOpen((x) => !x)} ref={setAnchorEl}>
-        OPEN
-      </Button>
-      <Popover anchorEl={anchorEl} open={open} onClose={() => setOpen(false)}>
-        <Popover.Content>
-          <ÅpneModalKnapp />
-        </Popover.Content>
-      </Popover>
-    </>
-  );
-};
-
-const ÅpneModalKnapp = () => {
-  const [visModal, settVisModal] = useState(false);
-
-  console.log("visModal", visModal);
-
-  useEffect(() => {
-    console.log("mounted");
-    return () => {
-      console.log("unmounted");
-    };
-  }, []);
-
-  return (
-    <div>
-      <Dropdown.Menu.List.Item
-        onClick={() => {
-          console.info("opening modal");
-          settVisModal(true);
-        }}
-      >
-        Åpne modal
-      </Dropdown.Menu.List.Item>
-      {visModal && (
-        <Modal
-          open
-          portal
-          header={{
-            heading: "Modal header",
-            size: "medium",
-          }}
-          onClose={() => {
-            console.info("closing modal");
-            settVisModal(false);
-          }}
-        >
-          <Modal.Body>Dette er en modal</Modal.Body>
-        </Modal>
-      )}
-    </div>
-  );
-};
-
-export const Example = () => {
-  return (
-    <Dropdown>
-      <Button as={Dropdown.Toggle}>Toggle</Button>
-      <Dropdown.Menu>
-        <Dropdown.Menu.List>
-          <ÅpneModalKnapp />
-        </Dropdown.Menu.List>
-      </Dropdown.Menu>
-    </Dropdown>
   );
 };
 

--- a/@navikt/core/react/src/popover/popover.stories.tsx
+++ b/@navikt/core/react/src/popover/popover.stories.tsx
@@ -1,5 +1,7 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Button } from "../button";
+import { Dropdown } from "../dropdown";
+import { Modal } from "../modal";
 import Popover from "./Popover";
 
 const placements = [
@@ -85,6 +87,112 @@ const Template = (props) => {
         </Popover.Content>
       </Popover>
     </>
+  );
+};
+
+function TestElement() {
+  const [modalOpen, setModalOpen] = useState(false);
+  console.log("TestElement rendered");
+
+  useEffect(() => {
+    console.log("TestElement mounted");
+    return () => {
+      console.log("TestElement unmounted");
+    };
+  }, []);
+
+  return (
+    <div>
+      <Button onClick={() => setModalOpen(true)}>Open Modal</Button>
+      {modalOpen && (
+        <Modal
+          open
+          portal
+          onClose={() => null}
+          header={{
+            label: "Optional label",
+            heading: "Title",
+            size: "small",
+          }}
+          closeOnBackdropClick
+        >
+          MODAL
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+export const DialogTest = () => {
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setOpen((x) => !x)} ref={setAnchorEl}>
+        OPEN
+      </Button>
+      <Popover anchorEl={anchorEl} open={open} onClose={() => setOpen(false)}>
+        <Popover.Content>
+          <ÅpneModalKnapp />
+        </Popover.Content>
+      </Popover>
+    </>
+  );
+};
+
+const ÅpneModalKnapp = () => {
+  const [visModal, settVisModal] = useState(false);
+
+  console.log("visModal", visModal);
+
+  useEffect(() => {
+    console.log("mounted");
+    return () => {
+      console.log("unmounted");
+    };
+  }, []);
+
+  return (
+    <div>
+      <Dropdown.Menu.List.Item
+        onClick={() => {
+          console.info("opening modal");
+          settVisModal(true);
+        }}
+      >
+        Åpne modal
+      </Dropdown.Menu.List.Item>
+      {visModal && (
+        <Modal
+          open
+          portal
+          header={{
+            heading: "Modal header",
+            size: "medium",
+          }}
+          onClose={() => {
+            console.info("closing modal");
+            settVisModal(false);
+          }}
+        >
+          <Modal.Body>Dette er en modal</Modal.Body>
+        </Modal>
+      )}
+    </div>
+  );
+};
+
+export const Example = () => {
+  return (
+    <Dropdown>
+      <Button as={Dropdown.Toggle}>Toggle</Button>
+      <Dropdown.Menu>
+        <Dropdown.Menu.List>
+          <ÅpneModalKnapp />
+        </Dropdown.Menu.List>
+      </Dropdown.Menu>
+    </Dropdown>
   );
 };
 


### PR DESCRIPTION
### Description

**How to fix: Always render DismissableLayer, but just disable callbacks/events**

Since we changed the component structure when toggling enabled true/false, all children were re-mounted. This lead to all state of children being reset when changed.

How to test (for old solution):
- Toggle open-state for Popover
- See mount/unmount happening every open/close. This indicates that the component re-mounts every change.

```
<Popover>
   <MyComponent />
</Popover>

const MyComponent = () => {
useEffect(() => {
  console.info("mounted");
  return () => console.info("unmounted");
},[])
return null;
}
```


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
