### PR TITLE
Textarea: Set height on first render to `auto` instead of `0px` to reduce layout shift when SSR

### DIFF
--- a/.changeset/cuddly-bikes-say.md
+++ b/.changeset/cuddly-bikes-say.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Textarea: Set height on first render to `auto` instead of `0px` to reduce layout shift when SSR

--- a/@navikt/core/react/src/form/textarea/Textarea.tsx
+++ b/@navikt/core/react/src/form/textarea/Textarea.tsx
@@ -109,14 +109,6 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       props?.defaultValue ?? "",
     );
 
-    const getMinRows = () => {
-      let rows = rest?.minRows ? rest?.minRows : 3;
-      if (size === "small") {
-        rows = rest?.minRows ? rest?.minRows : 2;
-      }
-      return rows;
-    };
-
     const describedBy = cl(inputProps["aria-describedby"], {
       [maxLengthId ?? ""]: hasMaxLength,
     });
@@ -169,7 +161,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
               ? (e) => setUncontrolledValue(e.target.value)
               : undefined,
           )}
-          minRows={getMinRows()}
+          minRows={rest.minRows || (size === "small" ? 2 : 3)}
           autoScrollbar={UNSAFE_autoScrollbar}
           ref={ref}
           readOnly={readOnly}

--- a/@navikt/core/react/src/util/TextareaAutoSize.tsx
+++ b/@navikt/core/react/src/util/TextareaAutoSize.tsx
@@ -219,8 +219,12 @@ const TextareaAutosize = forwardRef<HTMLTextAreaElement, TextareaAutosizeProps>(
     };
 
     const mainStyle: React.CSSProperties = {
-      "--__ac-textarea-height": state.outerHeightStyle + "px",
-      "--__axc-textarea-height": state.outerHeightStyle + "px",
+      "--__ac-textarea-height": state.outerHeightStyle
+        ? state.outerHeightStyle + "px"
+        : "auto",
+      "--__axc-textarea-height": state.outerHeightStyle
+        ? state.outerHeightStyle + "px"
+        : "auto",
       // Need a large enough difference to allow scrolling.
       // This prevents infinite rendering loop.
       overflow:


### PR DESCRIPTION
### Description

Mitigates [this](https://nav-it.slack.com/archives/C7NE7A8UF/p1762960089738199) to some degree.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
