### PR TITLE
[Datepicker] Avoid rendering datepicker dialog when not open

### DIFF
--- a/.changeset/good-dodos-float.md
+++ b/.changeset/good-dodos-float.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Datepicker: Avoid rendering Datepicker dialog when not open.

--- a/@navikt/core/react/src/date/Date.Dialog.tsx
+++ b/@navikt/core/react/src/date/Date.Dialog.tsx
@@ -49,6 +49,10 @@ const DateDialog = ({
   const hideModal =
     useMedia("screen and (min-width: 768px)", true) && !isInModal;
 
+  if (!open) {
+    return null;
+  }
+
   if (hideModal) {
     return (
       <Popover


### PR DESCRIPTION
### Description

Resolves #4298

Risks: 
**Loss of state when closing/re-opening**: Can't see any downsides from this. With the hooks we manage this manually anyways, and without the hooks, i think its a good default to "reset" the currently viewed month when re-opening to the current month.


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
