### PR TITLE
Darkside: Remove [hidden] style

### DIFF
--- a/.changeset/breezy-hotels-speak.md
+++ b/.changeset/breezy-hotels-speak.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Darkside: Remove `display: none` on `[hidden]` since browsers have this built-in

--- a/@navikt/core/css/darkside/baseline/baseline.darkside.css
+++ b/@navikt/core/css/darkside/baseline/baseline.darkside.css
@@ -7,10 +7,6 @@ body,
 }
 
 /* ---------------------------- Inline utilities ---------------------------- */
-[hidden] {
-  /* CSS-layers reverses "!important" ordering, so we can't set this to important if we want to override it later. */
-  display: none;
-}
 
 /* https://web.dev/prefers-reduced-motion/ */
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
### Description

Browsers already hide items with the `hidden` attribute with `display: none`. Setting this ourselves makes it harder to use `hidden="until-found"`, both for ourselves and consumers. This is because "until-found" relies on `content-visibility` instead of `display`.

This change shouldn't affect anything since we haven't used "until-found" anywhere yet. Not sure if we should have a changeset for this?

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
