### PR TITLE
:bug: Tooltip now has z-index max int

### DIFF
--- a/.changeset/odd-rice-bet.md
+++ b/.changeset/odd-rice-bet.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-tokens": patch
+"@navikt/ds-css": patch
+---
+
+Tooltip: Update z-index to max int.

--- a/@navikt/core/css/darkside/tooltip.darkside.css
+++ b/@navikt/core/css/darkside/tooltip.darkside.css
@@ -1,5 +1,5 @@
 .aksel-tooltip {
-  z-index: 3000;
+  z-index: 2147483647;
   background-color: var(--ax-bg-neutral-strong);
   color: var(--ax-text-neutral-contrast);
   border-radius: var(--ax-radius-4);

--- a/@navikt/core/tokens/docs.json
+++ b/@navikt/core/tokens/docs.json
@@ -573,6 +573,6 @@
   "z-index": [
     { "name": "--a-z-index-focus", "value": 10 },
     { "name": "--a-z-index-popover", "value": 1000 },
-    { "name": "--a-z-index-tooltip", "value": 3000 }
+    { "name": "--a-z-index-tooltip", "value": 2147483647 }
   ]
 }

--- a/@navikt/core/tokens/src/index.js
+++ b/@navikt/core/tokens/src/index.js
@@ -62,7 +62,7 @@ module.exports = {
     "z-index": {
       popover: { value: 1000 },
       focus: { value: 10 },
-      tooltip: { value: 3000 },
+      tooltip: { value: 2147483647 },
     },
   },
 };


### PR DESCRIPTION
### Description

Resolved #4287

Tooltip should probably always be on top, so can just be max-int (largest possible in css)

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
