### PR TITLE
[website] Fix warnings about NextImage

### DIFF
--- a/aksel.nav.no/website/app/(routes)/(produktbloggen)/produktbloggen/_ui/BloggList.tsx
+++ b/aksel.nav.no/website/app/(routes)/(produktbloggen)/produktbloggen/_ui/BloggList.tsx
@@ -14,9 +14,7 @@ type Blogg =
 export const BloggList = async ({ blogg }: { blogg: Blogg }) => {
   const avatars = queryToAvatars(blogg.writers);
 
-  const imageUrl = urlForImage(blogg?.seo?.image)
-    ?.quality(100)
-    .url();
+  const imageUrl = urlForImage(blogg?.seo?.image)?.quality(100).url();
 
   return (
     <li>
@@ -36,7 +34,6 @@ export const BloggList = async ({ blogg }: { blogg: Blogg }) => {
                 aria-hidden
                 priority
                 alt=""
-                quality={100}
               />
             ) : (
               <NextImage

--- a/aksel.nav.no/website/app/(routes)/(root)/_ui/FrontpageMasonryCard.tsx
+++ b/aksel.nav.no/website/app/(routes)/(root)/_ui/FrontpageMasonryCard.tsx
@@ -84,6 +84,7 @@ const Card = ({ article, visible }: CardProps) => {
             }
             alt={article.heading + " thumbnail"}
             fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
           />
         </LinkCardImage>
       )}

--- a/aksel.nav.no/website/app/(routes)/(root)/_ui/HighlightedArticle.tsx
+++ b/aksel.nav.no/website/app/(routes)/(root)/_ui/HighlightedArticle.tsx
@@ -71,9 +71,10 @@ export const Highlight = ({
             blurDataURL={imageBlurUrl}
             placeholder="blur"
             quality={100}
-            layout="fill"
+            fill
+            sizes="(max-width: 768px) 100vw, 50vw"
             aria-hidden
-            className={cl(`${styles.sectionImage}`, {
+            className={cl(styles.sectionImage, {
               [`${styles.betaHue}`]:
                 isKomponent(article) && article.status?.tag === "beta",
             })}
@@ -86,10 +87,11 @@ export const Highlight = ({
             blurDataURL={seoImageBlurUrl}
             placeholder="blur"
             quality={100}
-            layout="fill"
-            objectFit="cover"
+            fill
+            sizes="(max-width: 768px) 100vw, 50vw"
+            style={{ objectFit: "cover" }}
             aria-hidden
-            className={cl(`${styles.sectionImage}`, {
+            className={cl(styles.sectionImage, {
               [`${styles.betaHue}`]: getStatusTag() === "beta",
             })}
             decoding="auto"
@@ -98,8 +100,9 @@ export const Highlight = ({
         ) : (
           <NextImage
             src={fallbackImageUrl(article?.heading ?? "", "thumbnail")}
-            layout="fill"
-            objectFit="contain"
+            fill
+            sizes="(max-width: 768px) 100vw, 50vw"
+            style={{ objectFit: "contain" }}
             aria-hidden
             className={styles.sectionImage}
             decoding="auto"
@@ -112,7 +115,7 @@ export const Highlight = ({
           <Tag
             type={article._type}
             text={
-              isArticle(article) ? article.tema?.[0] ?? undefined : undefined
+              isArticle(article) ? (article.tema?.[0] ?? undefined) : undefined
             }
           />
           {getStatusTag() === "beta" && <BetaTag />}

--- a/aksel.nav.no/website/next.config.ts
+++ b/aksel.nav.no/website/next.config.ts
@@ -155,6 +155,7 @@ const nextConfig: NextConfig = {
       },
     ],
     dangerouslyAllowSVG: true,
+    qualities: [100],
   },
   output: "standalone",
   outputFileTracingRoot: path.join(__dirname, "../../"),

--- a/aksel.nav.no/website/next.config.ts
+++ b/aksel.nav.no/website/next.config.ts
@@ -155,7 +155,7 @@ const nextConfig: NextConfig = {
       },
     ],
     dangerouslyAllowSVG: true,
-    qualities: [100],
+    qualities: [75, 100],
   },
   output: "standalone",
   outputFileTracingRoot: path.join(__dirname, "../../"),


### PR DESCRIPTION
Fixed annoying console warnings from Next:

>Image with src "https://cdn.sanity.io/images/hnbe3yhs/production/0173e65c5110432199c7e2b0667e1452edd91e25-2400x1260.png?q=100&fit=max&auto=format" is using quality "100" which is not configured in images.qualities. This config will be required starting in Next.js 16.
>Read more: https://nextjs.org/docs/messages/next-image-unconfigured-qualities
>
>Image with src "https://cdn.sanity.io/images/hnbe3yhs/production/0173e65c5110432199c7e2b0667e1452edd91e25-2400x1260.png?q=100&fit=max&auto=format" has legacy prop "layout". Did you forget to run the codemod?
>Read more: https://nextjs.org/docs/messages/next-image-upgrade-to-13
>
>Image with src "https://cdn.sanity.io/images/hnbe3yhs/production/0173e65c5110432199c7e2b0667e1452edd91e25-2400x1260.png?q=100&fit=max&auto=format" has legacy prop "objectFit". Did you forget to run the codemod?
>Read more: https://nextjs.org/docs/messages/next-image-upgrade-to-13
>
>Image with src "https://cdn.sanity.io/images/hnbe3yhs/production/0173e65c5110432199c7e2b0667e1452edd91e25-2400x1260.png?q=100&fit=max&auto=format" has "fill" but is missing "sizes" prop. Please add it to improve page performance. >Read more: https://nextjs.org/docs/api-reference/next/image#sizes
