### PR TITLE
:bug: Add color to search icon

### DIFF
--- a/.changeset/shy-monkeys-repeat.md
+++ b/.changeset/shy-monkeys-repeat.md
@@ -2,4 +2,4 @@
 "@navikt/ds-css": patch
 ---
 
-Search: Fixes edgecase where darkmode were used without color-scheme, making icons inverted in color.
+Search: Fixes edgecase where darkmode (in darkside) were used without color-scheme, making icons inverted in color.

--- a/.changeset/shy-monkeys-repeat.md
+++ b/.changeset/shy-monkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Search: Fixes edgecase where darkmode were used without color-scheme, making icons inverted in color.

--- a/@navikt/core/css/darkside/form/search.darkside.css
+++ b/@navikt/core/css/darkside/form/search.darkside.css
@@ -73,6 +73,7 @@
 
 /* ------------------------------- Search icon ------------------------------ */
 .aksel-search__search-icon {
+  color: var(--ax-text-neutral);
   position: absolute;
   left: var(--ax-space-8);
   top: 50%;


### PR DESCRIPTION
### Description

If user sets class "dark" without "color-scheme: dark", the icon-color is flipped.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
