### PR TITLE
[Combobox] Locale update

### DIFF
--- a/.changeset/great-pugs-invent.md
+++ b/.changeset/great-pugs-invent.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Combobox: Add locale-support for 'Ingen søketreff' in Combobox.

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/NoSearchHitsMessage.tsx
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/NoSearchHitsMessage.tsx
@@ -18,7 +18,7 @@ const NoSearchHitsMessage = () => {
       className={cn("navds-combobox__list-item--no-options")}
       id={filteredOptionsUtil.getNoHitsId(id)}
     >
-      {translate("noOptions")}
+      {translate("noMatches")}
     </div>
   );
 };

--- a/@navikt/core/react/src/form/combobox/FilteredOptions/NoSearchHitsMessage.tsx
+++ b/@navikt/core/react/src/form/combobox/FilteredOptions/NoSearchHitsMessage.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { useRenameCSS } from "../../../theme/Theme";
+import { useI18n } from "../../../util/i18n/i18n.hooks";
 import { useInputContext } from "../Input/Input.context";
 import filteredOptionsUtil from "./filtered-options-util";
 
 const NoSearchHitsMessage = () => {
   const { cn } = useRenameCSS();
+
+  const translate = useI18n("Combobox");
 
   const {
     inputProps: { id },
@@ -15,7 +18,7 @@ const NoSearchHitsMessage = () => {
       className={cn("navds-combobox__list-item--no-options")}
       id={filteredOptionsUtil.getNoHitsId(id)}
     >
-      Ingen søketreff
+      {translate("noOptions")}
     </div>
   );
 };

--- a/@navikt/core/react/src/util/i18n/locales/en.ts
+++ b/@navikt/core/react/src/util/i18n/locales/en.ts
@@ -21,6 +21,7 @@ export default {
   },
   Combobox: {
     addOption: "Add",
+    noOptions: "No search hits",
     loading: "Searching…",
     maxSelected: "{selected} of max {limit} are selected.",
   },

--- a/@navikt/core/react/src/util/i18n/locales/en.ts
+++ b/@navikt/core/react/src/util/i18n/locales/en.ts
@@ -21,7 +21,7 @@ export default {
   },
   Combobox: {
     addOption: "Add",
-    noOptions: "No search hits",
+    noMatches: "No search hits",
     loading: "Searching…",
     maxSelected: "{selected} of max {limit} are selected.",
   },

--- a/@navikt/core/react/src/util/i18n/locales/nb.ts
+++ b/@navikt/core/react/src/util/i18n/locales/nb.ts
@@ -26,7 +26,7 @@ export default {
   Combobox: {
     /** The input value will be appended to the end of this text, e.g. `Legg til "input value"`. */
     addOption: "Legg til",
-    noOptions: "Ingen søketreff",
+    noMatches: "Ingen søketreff",
     /** Loader title */
     loading: "Søker…",
     maxSelected: "{selected} av maks {limit} er valgt.",

--- a/@navikt/core/react/src/util/i18n/locales/nb.ts
+++ b/@navikt/core/react/src/util/i18n/locales/nb.ts
@@ -26,6 +26,7 @@ export default {
   Combobox: {
     /** The input value will be appended to the end of this text, e.g. `Legg til "input value"`. */
     addOption: "Legg til",
+    noOptions: "Ingen søketreff",
     /** Loader title */
     loading: "Søker…",
     maxSelected: "{selected} av maks {limit} er valgt.",

--- a/@navikt/core/react/src/util/i18n/locales/nn.ts
+++ b/@navikt/core/react/src/util/i18n/locales/nn.ts
@@ -21,6 +21,7 @@ export default {
   },
   Combobox: {
     addOption: "Legg til",
+    noOptions: "Ingen søketreff",
     loading: "Søker…",
     maxSelected: "{selected} av maks {limit} er valt.",
   },

--- a/@navikt/core/react/src/util/i18n/locales/nn.ts
+++ b/@navikt/core/react/src/util/i18n/locales/nn.ts
@@ -21,7 +21,7 @@ export default {
   },
   Combobox: {
     addOption: "Legg til",
-    noOptions: "Ingen søketreff",
+    noMatches: "Ingen søketreff",
     loading: "Søker…",
     maxSelected: "{selected} av maks {limit} er valt.",
   },


### PR DESCRIPTION
### Description

Resolves #4311

```
<Provider
  locale={nb}
  translations={{ Combobox: { noOptions: "Custom text" } }}
>
  <UNSAFE_Combobox {...props} id="combobox" placeholder="placeholder" />
</Provider>
```

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
