### PR TITLE
feat(template): gjør oppsummeringsside-overskrift mer handlingsorientert

### DIFF
--- a/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside-real-examples/aap.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside-real-examples/aap.tsx
@@ -51,7 +51,7 @@ function Example() {
             </Link>
             <Box paddingBlock="6 5">
               <Heading level="2" size="large">
-                Oppsummering
+                Bekreft informasjonen og send søknaden
               </Heading>
             </Box>
             <FormProgress activeStep={9} totalSteps={9}>

--- a/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside-real-examples/dagpenger.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside-real-examples/dagpenger.tsx
@@ -51,7 +51,7 @@ function Example() {
             </Link>
             <Box paddingBlock="6 5">
               <Heading level="2" size="large">
-                Oppsummering
+                Bekreft informasjonen og send søknaden
               </Heading>
             </Box>
             <FormProgress activeStep={12} totalSteps={12}>

--- a/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside/meta.json
+++ b/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside/meta.json
@@ -1,6 +1,11 @@
 {
-  "version": 4,
+  "version": 5,
   "changelog": [
+    {
+      "description": "Endret overskriften fra «Oppsummering» til «Bekreft informasjonen og send søknaden» for å gjøre siste steg mer handlingsorientert.",
+      "date": "25.11.2025",
+      "version": 5
+    },
     {
       "description": "'Send søknad'-knappen kommer nå før 'Forrige steg'-knappen på mobil.",
       "date": "17.10.2025",

--- a/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside/standard.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside/standard.tsx
@@ -57,7 +57,7 @@ function Example() {
             </Link>
             <Box paddingBlock="6 5">
               <Heading level="2" size="large">
-                Oppsummering
+                Bekreft informasjonen og send søknaden
               </Heading>
             </Box>
             <FormProgress activeStep={3} totalSteps={3}>


### PR DESCRIPTION
Closes #4306

### Description

Gjør oppsummeringssider mer handlingsorienterte basert på funn fra brukertest.

- Søknad oppsummeringsside‑maler (`standard`, `dagpenger`, `AAP`): oppdaterer H2‑overskriften fra «Oppsummering» til «Bekreft informasjonen og send søknaden» for å signalisere at søknaden ennå ikke er sendt, men skal bekreftes og sendes fra denne siden. Dette svarer på tilbakemeldingen om at enkelte brukere trodde søknaden allerede var sendt, og hoppet over intro‑teksten.

---

### Component Checklist 📝

- [ ] JSDoc  
- [x] Examples – oppdatert oppsummeringsside‑maler  
- [x] Documentation / Decision Records – endringene er i dokumentasjons/eksempel‑kode (website/templates)  
- [ ] Storybook  
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)  
- [ ] Component tokens (`@navikt/core/css/tokens.json`)  
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)  
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)  
- [ ] New component? CSS import (`@navikt/core/css/index.css`)  
- [ ] Breaking change? Update migration guide. Consider codemod.  
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.") – ikke lagt til nå siden endringene kun berører eksempler/website, ikke selve komponent‑APIet.