### PR TITLE
[Darkside] :tada: Legacy radius tokens reference new tokens

### DIFF
--- a/@navikt/core/tokens/src/tokens/radius.ts
+++ b/@navikt/core/tokens/src/tokens/radius.ts
@@ -9,63 +9,58 @@ export const radiusTokenConfig = {
     "2": {
       value: "2px",
       type: "global-radius",
-      comment: "TODO: Sjur fyller ut",
     },
     "4": {
       value: "4px",
       type: "global-radius",
-      comment: "TODO: Sjur fyller ut",
     },
     "8": {
       value: "8px",
       type: "global-radius",
-      comment: "TODO: Sjur fyller ut",
     },
     "12": {
       value: "12px",
       type: "global-radius",
-      comment: "TODO: Sjur fyller ut",
     },
     full: {
       value: "9999px",
       type: "global-radius",
-      comment: "TODO: Sjur fyller ut",
     },
   },
   border: {
     radius: {
       full: {
-        value: "9999px",
+        value: "{ax.radius.full.value}",
         type: "global-radius",
-        comment: "TODO: Sjur fyller ut",
+
         figmaIgnore: true,
         docsIgnore: true,
       },
       small: {
-        value: "2px",
+        value: "{ax.radius.2.value}",
         type: "global-radius",
-        comment: "TODO: Sjur fyller ut",
+
         figmaIgnore: true,
         docsIgnore: true,
       },
       medium: {
-        value: "4px",
+        value: "{ax.radius.4.value}",
         type: "global-radius",
-        comment: "TODO: Sjur fyller ut",
+
         figmaIgnore: true,
         docsIgnore: true,
       },
       large: {
-        value: "8px",
+        value: "{ax.radius.8.value}",
         type: "global-radius",
-        comment: "TODO: Sjur fyller ut",
+
         figmaIgnore: true,
         docsIgnore: true,
       },
       xlarge: {
-        value: "12px",
+        value: "{ax.radius.12.value}",
         type: "global-radius",
-        comment: "TODO: Sjur fyller ut",
+
         figmaIgnore: true,
         docsIgnore: true,
       },


### PR DESCRIPTION
### Description

This makes sure overrides on the "new" tokens updates the "old" tokens.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
