### PR TITLE
Select: Remove the htmlSize prop

### DIFF
--- a/.changeset/chilly-horses-beg.md
+++ b/.changeset/chilly-horses-beg.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Select: Remove the htmlSize prop

--- a/@navikt/core/react/src/form/select/Select.tsx
+++ b/@navikt/core/react/src/form/select/Select.tsx
@@ -14,10 +14,6 @@ export interface SelectProps
    */
   children: React.ReactNode;
   /**
-   * Exposes the HTML size attribute.
-   */
-  htmlSize?: number;
-  /**
    * Sets inline-style on select wrapper.
    */
   style?: React.CSSProperties;
@@ -64,7 +60,6 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
       label,
       className,
       description,
-      htmlSize,
       hideLabel = false,
       style,
       ...rest
@@ -140,7 +135,6 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
               "navds-body-short",
               `navds-body-short--${size ?? "medium"}`,
             )}
-            size={htmlSize}
           >
             {children}
           </select>


### PR DESCRIPTION
### Description

It doesn't make any sense to have this prop on Select. [Just look at this example](https://aksel.nav.no/sandbox/index.html?code=N4Igxg9gJgpiBcJgApkEoAEBeAfB4AOgHYYaREDOALhgKIAeAhgLYAOANjNhutnoSVIYATjCoBXYSWTEhQgDwBlGJzA12jAEYqsBEADUVAcwyaI1GFAoaiUPRgAWVZu0UBLAF4xdIAMx6cWTkFCFYqNwgSADdGdnFvPQCAWgxDdhMbKAwk%2BQB6UPDIwMFgjHkCiOjY%2BJ8iCGEjGACAOXrGvIqioNLysMqMGLiEkAoomGE3RoDFMYn2-L6ukuDewqqhnyhGImZGYQBrAIARbd2DjsWiYp7c5VUqa6E0AG4ggF9XoiDRCSkyhhYHC4uRwnzeaHQb2IIAANCAAO5uKBUBwUBAAbV8ACYAAwwgDsADYABwAXTeQA).

Made it a patch change since no one is using this prop according to Metabase.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
