### PR TITLE
[Dialog] Remove asChild-API from child-components

### DIFF
--- a/@navikt/core/css/darkside/dialog.darkside.css
+++ b/@navikt/core/css/darkside/dialog.darkside.css
@@ -200,8 +200,6 @@
 }
 
 .aksel-dialog__close-button {
-  margin-block-start: var(--__axc-dialog-p-b);
-  margin-inline-end: var(--__axc-dialog-p-i);
   align-self: start;
   float: right;
 }

--- a/@navikt/core/css/dialog.css
+++ b/@navikt/core/css/dialog.css
@@ -208,8 +208,6 @@
 
 .navds-dialog__close-button {
   grid-area: closebutton;
-  margin-block-start: var(--__ac-dialog-p-b);
-  margin-inline-end: var(--__ac-dialog-p-i);
   align-self: start;
 }
 

--- a/@navikt/core/react/src/dialog/Dialog.tests.stories.tsx
+++ b/@navikt/core/react/src/dialog/Dialog.tests.stories.tsx
@@ -658,7 +658,7 @@ export const AriaAttributes: Story = {
 /* ------------------------------- Test setup ------------------------------- */
 type BaseDialogProps = {
   rootProps?: Omit<DialogProps, "children"> & { children?: React.ReactNode };
-  popupProps?: Omit<DialogPopupProps, "children" | "asChild"> & {
+  popupProps?: Omit<DialogPopupProps, "children"> & {
     children?: React.ReactNode;
   };
   closeButtonProps?: Omit<DialogCloseTriggerProps, "children"> & {

--- a/@navikt/core/react/src/dialog/body/DialogBody.tsx
+++ b/@navikt/core/react/src/dialog/body/DialogBody.tsx
@@ -1,9 +1,7 @@
 import React, { forwardRef } from "react";
-import { Slot } from "../../slot/Slot";
 import { useRenameCSS } from "../../theme/Theme";
-import type { AsChild } from "../../util/types/AsChild";
 
-type DialogBodyProps = React.HTMLAttributes<HTMLDivElement> & AsChild;
+type DialogBodyProps = React.HTMLAttributes<HTMLDivElement>;
 
 /**
  * @see 🏷️ {@link DialogBodyProps}
@@ -19,19 +17,17 @@ type DialogBodyProps = React.HTMLAttributes<HTMLDivElement> & AsChild;
  * ```
  */
 const DialogBody = forwardRef<HTMLDivElement, DialogBodyProps>(
-  ({ className, children, asChild = false, ...restProps }, forwardedRef) => {
+  ({ className, children, ...restProps }, forwardedRef) => {
     const { cn } = useRenameCSS();
 
-    const Component = asChild ? Slot : "div";
-
     return (
-      <Component
+      <div
         {...restProps}
         ref={forwardedRef}
         className={cn("navds-dialog__body", className)}
       >
         {children}
-      </Component>
+      </div>
     );
   },
 );

--- a/@navikt/core/react/src/dialog/footer/DialogFooter.tsx
+++ b/@navikt/core/react/src/dialog/footer/DialogFooter.tsx
@@ -1,9 +1,7 @@
 import React, { forwardRef } from "react";
-import { Slot } from "../../slot/Slot";
 import { useRenameCSS } from "../../theme/Theme";
-import type { AsChild } from "../../util/types/AsChild";
 
-type DialogFooterProps = React.HTMLAttributes<HTMLDivElement> & AsChild;
+type DialogFooterProps = React.HTMLAttributes<HTMLDivElement>;
 
 /**
  * @see 🏷️ {@link DialogFooterProps}
@@ -21,19 +19,17 @@ type DialogFooterProps = React.HTMLAttributes<HTMLDivElement> & AsChild;
  * ```
  */
 const DialogFooter = forwardRef<HTMLDivElement, DialogFooterProps>(
-  ({ className, children, asChild, ...restProps }, forwardedRef) => {
+  ({ className, children, ...restProps }, forwardedRef) => {
     const { cn } = useRenameCSS();
 
-    const Component = asChild ? Slot : "div";
-
     return (
-      <Component
+      <div
         {...restProps}
         ref={forwardedRef}
         className={cn("navds-dialog__footer", className)}
       >
         {children}
-      </Component>
+      </div>
     );
   },
 );

--- a/@navikt/core/react/src/dialog/header/DialogHeader.tsx
+++ b/@navikt/core/react/src/dialog/header/DialogHeader.tsx
@@ -36,26 +36,24 @@ const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
     const translate = useI18n("global");
 
     return (
-      <>
-        <div
-          {...restProps}
-          ref={forwardedRef}
-          className={cn("navds-dialog__header", className)}
-        >
-          {withClosebutton && (
-            <DialogCloseTrigger>
-              <Button
-                type="button"
-                className={cn("navds-dialog__close-button")}
-                size="small"
-                variant="tertiary-neutral"
-                icon={<XMarkIcon title={translate("close")} />}
-              />
-            </DialogCloseTrigger>
-          )}
-          {children}
-        </div>
-      </>
+      <div
+        {...restProps}
+        ref={forwardedRef}
+        className={cn("navds-dialog__header", className)}
+      >
+        {withClosebutton && (
+          <DialogCloseTrigger>
+            <Button
+              type="button"
+              className={cn("navds-dialog__close-button")}
+              size="small"
+              variant="tertiary-neutral"
+              icon={<XMarkIcon title={translate("close")} />}
+            />
+          </DialogCloseTrigger>
+        )}
+        {children}
+      </div>
     );
   },
 );

--- a/@navikt/core/react/src/dialog/header/DialogHeader.tsx
+++ b/@navikt/core/react/src/dialog/header/DialogHeader.tsx
@@ -1,21 +1,18 @@
 import React, { forwardRef } from "react";
 import { XMarkIcon } from "@navikt/aksel-icons";
 import { Button } from "../../button";
-import { Slot } from "../../slot/Slot";
 import { useRenameCSS } from "../../theme/Theme";
 import { useI18n } from "../../util/i18n/i18n.hooks";
-import type { AsChild } from "../../util/types/AsChild";
 import { DialogCloseTrigger } from "../close-trigger/DialogCloseTrigger";
 
-type DialogHeaderProps = React.HTMLAttributes<HTMLDivElement> &
-  AsChild & {
-    /**
-     * Whether to show a close button in the header.
-     * Will trigger `onOpenChange` when clicked.
-     * @default true
-     */
-    withClosebutton?: boolean;
-  };
+interface DialogHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Whether to show a close button in the header.
+   * Will trigger `onOpenChange` when clicked.
+   * @default true
+   */
+  withClosebutton?: boolean;
+}
 
 /**
  * @see 🏷️ {@link DialogHeaderProps}
@@ -32,34 +29,32 @@ type DialogHeaderProps = React.HTMLAttributes<HTMLDivElement> &
  */
 const DialogHeader = forwardRef<HTMLDivElement, DialogHeaderProps>(
   (
-    { className, children, withClosebutton = true, asChild, ...restProps },
+    { className, children, withClosebutton = true, ...restProps },
     forwardedRef,
   ) => {
     const { cn } = useRenameCSS();
     const translate = useI18n("global");
 
-    const Component = asChild ? Slot : "div";
-
     return (
       <>
-        {withClosebutton && (
-          <DialogCloseTrigger>
-            <Button
-              type="button"
-              className={cn("navds-dialog__close-button")}
-              size="small"
-              variant="tertiary-neutral"
-              icon={<XMarkIcon title={translate("close")} />}
-            />
-          </DialogCloseTrigger>
-        )}
-        <Component
+        <div
           {...restProps}
           ref={forwardedRef}
           className={cn("navds-dialog__header", className)}
         >
+          {withClosebutton && (
+            <DialogCloseTrigger>
+              <Button
+                type="button"
+                className={cn("navds-dialog__close-button")}
+                size="small"
+                variant="tertiary-neutral"
+                icon={<XMarkIcon title={translate("close")} />}
+              />
+            </DialogCloseTrigger>
+          )}
           {children}
-        </Component>
+        </div>
       </>
     );
   },

--- a/@navikt/core/react/src/dialog/popup/DialogPopupInternal.tsx
+++ b/@navikt/core/react/src/dialog/popup/DialogPopupInternal.tsx
@@ -9,73 +9,72 @@ import { useMergeRefs } from "../../util/hooks";
 import { useOpenChangeAnimationComplete } from "../../util/hooks/useOpenChangeAnimationComplete";
 import { useScrollLock } from "../../util/hooks/useScrollLock";
 import { createTransitionStatusAttribute } from "../../util/hooks/useTransitionStatus";
-import type { AsChild } from "../../util/types/AsChild";
 import { useDialogContext } from "../root/DialogRoot.context";
 
 type DialogPosition = "center" | "bottom" | "left" | "right" | "fullscreen";
 
-type DialogPopupInternalProps = React.HTMLAttributes<HTMLDivElement> &
-  AsChild & {
-    /**
-     * Determines if the dialog enters a modal state when open.
-     * - `true`: user interaction is limited to just the dialog: focus is trapped, document page scroll is locked, and pointer interactions on outside elements are disabled.
-     * - `'trap-focus'`: focus is trapped inside the dialog, but document page scroll is not locked and pointer interactions outside of it remain enabled.
-     * @default true
-     */
-    modal?: true | "trap-focus";
-    /**
-     * Determines if the dialog should close on outside clicks.
-     * @default true
-     */
-    closeOnOutsideClick?: boolean;
-    /**
-     * Will try to focus the given element on mount.
-     *
-     * If not provided, Dialog will focus the popup itself.
-     */
-    initialFocus?:
-      | React.RefObject<HTMLElement | null>
-      | (() => HTMLElement | null | undefined);
-    /**
-     * Will try to focus the given element on unmount.
-     *
-     * If not provided, Dialog will try to focus the `Dialog.Trigger` element
-     * or the last focused element before the dialog opened.
-     */
-    returnFocus?:
-      | React.RefObject<HTMLElement | null>
-      | (() => HTMLElement | null | undefined);
+interface DialogPopupInternalProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Determines if the dialog enters a modal state when open.
+   * - `true`: user interaction is limited to just the dialog: focus is trapped, document page scroll is locked, and pointer interactions on outside elements are disabled.
+   * - `'trap-focus'`: focus is trapped inside the dialog, but document page scroll is not locked and pointer interactions outside of it remain enabled.
+   * @default true
+   */
+  modal?: true | "trap-focus";
+  /**
+   * Determines if the dialog should close on outside clicks.
+   * @default true
+   */
+  closeOnOutsideClick?: boolean;
+  /**
+   * Will try to focus the given element on mount.
+   *
+   * If not provided, Dialog will focus the popup itself.
+   */
+  initialFocus?:
+    | React.RefObject<HTMLElement | null>
+    | (() => HTMLElement | null | undefined);
+  /**
+   * Will try to focus the given element on unmount.
+   *
+   * If not provided, Dialog will try to focus the `Dialog.Trigger` element
+   * or the last focused element before the dialog opened.
+   */
+  returnFocus?:
+    | React.RefObject<HTMLElement | null>
+    | (() => HTMLElement | null | undefined);
 
-    /**
-     * The position of the dialog relative to the viewport.
-     * @default "center"
-     */
-    position?: DialogPosition;
-    /**
-     * CSS `width`
-     *
-     * Has no effect when `position` is set to `fullscreen`.
-     *
-     * @default "medium"
-     */
-    width?: ResponsiveProp<string & {}> | "small" | "medium" | "large";
-    /**
-     * CSS `height`
-     *
-     * Has no effect when `position` is set to `fullscreen`, `left` or `right`.
-     */
-    height?: ResponsiveProp<string & {}> | "small" | "medium" | "large";
-    /**
-     * Adds a backdrop behind the dialog popup.
-     * @default true
-     */
-    withBackdrop?: boolean;
-    /**
-     * ARIA role for the dialog popup.
-     * @default "dialog"
-     */
-    role?: "dialog" | "alertdialog";
-  };
+  /**
+   * The position of the dialog relative to the viewport.
+   * @default "center"
+   */
+  position?: DialogPosition;
+  /**
+   * CSS `width`
+   *
+   * Has no effect when `position` is set to `fullscreen`.
+   *
+   * @default "medium"
+   */
+  width?: ResponsiveProp<string & {}> | "small" | "medium" | "large";
+  /**
+   * CSS `height`
+   *
+   * Has no effect when `position` is set to `fullscreen`, `left` or `right`.
+   */
+  height?: ResponsiveProp<string & {}> | "small" | "medium" | "large";
+  /**
+   * Adds a backdrop behind the dialog popup.
+   * @default true
+   */
+  withBackdrop?: boolean;
+  /**
+   * ARIA role for the dialog popup.
+   * @default "dialog"
+   */
+  role?: "dialog" | "alertdialog";
+}
 
 const DialogPopupInternal = forwardRef<
   HTMLDivElement,


### PR DESCRIPTION
### Description

And move CloseButton to within DialogHeader-wrapper
This allows for more predictable placement for CloseButton 

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
