### PR TITLE
[V8 codemods] Box migration nesting/idempotent bug and prefixing update

### DIFF
--- a/.changeset/few-singers-wish.md
+++ b/.changeset/few-singers-wish.md
@@ -1,0 +1,5 @@
+---
+"@navikt/aksel": patch
+---
+
+CLI: Update v8-box migration to properly handle background/border-prefixing and nesting.

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/box/box.ts
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/box/box.ts
@@ -36,7 +36,7 @@ export default function transformer(file: FileInfo, api: API) {
     },
   });
 
-  const existingReplacements = existingReplacementSet();
+  const predefinedReplacents = predefinedReplacentset();
 
   const tokenComments: TokenComments = [];
   for (const astElement of astElements.paths()) {
@@ -47,7 +47,7 @@ export default function transformer(file: FileInfo, api: API) {
           /**
            * Skips if the replacement token already set
            */
-          if (existingReplacements.has(addPrefix(attrvalue.value, prop))) {
+          if (predefinedReplacents.has(addPrefix(attrvalue.value, prop))) {
             return;
           }
 
@@ -73,7 +73,7 @@ export default function transformer(file: FileInfo, api: API) {
           /**
            * Skips if the replacement token already set
            */
-          if (existingReplacements.has(addPrefix(literal.value, prop))) {
+          if (predefinedReplacents.has(addPrefix(literal.value, prop))) {
             return;
           }
           const config = legacyTokenConfig[literal.value];
@@ -229,7 +229,7 @@ function addPrefix(
   return token;
 }
 
-function existingReplacementSet() {
+function predefinedReplacentset() {
   const set = new Set<string>();
   for (const key in legacyTokenConfig) {
     const config = legacyTokenConfig[key];

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/box.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/box.input.js
@@ -8,7 +8,7 @@ export const MyComponent = () => {
 		<Box background="bg-subtle" borderColor="border-alt-1" shadow="large">
       migratable + unmigratable (no comment)
 		</Box>
-		<Box background="surface-alt-3-strong" >
+		<Box background="surface-alt-3-strong">
       unmigratable (with comment)
 		</Box>
 		<Box borderWidth="4" padding={{ lg: "10", sm: "8" }} height="200rem">

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/box.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/box.output.js
@@ -10,19 +10,19 @@ import { Box } from "@navikt/ds-react"
 
 export const MyComponent = () => {
   return (<>
-    <Box background="bg-neutral-soft" borderColor="border-meta-purple">
+    <Box background="neutral-soft" borderColor="meta-purple">
       migratable
     </Box>
-    <Box background="bg-neutral-soft" borderColor="border-meta-purple" shadow="large">
+    <Box background="neutral-soft" borderColor="meta-purple" shadow="large">
       migratable + unmigratable (no comment)
     </Box>
-    <Box background="surface-alt-3-strong" >
+    <Box background="surface-alt-3-strong">
       unmigratable (with comment)
     </Box>
     <Box borderWidth="4" padding={{ lg: "10", sm: "8" }} height="200rem">
       old
     </Box>
-    <Box borderWidth="4" background="bg-neutral-soft">
+    <Box borderWidth="4" background="neutral-soft">
       old + migratable
     </Box>
   </>);

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/expression-container.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/expression-container.output.js
@@ -1,5 +1,5 @@
 import { Box } from "@navikt/ds-react";
 
 export const App = () => (
-  <Box background={"bg-default"} borderRadius={"12"} />
+  <Box background={"default"} borderRadius={"12"} />
 );

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/idempotent-2.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/idempotent-2.input.js
@@ -10,7 +10,7 @@ import { Box } from "@navikt/ds-react"
 
 export const MyComponent = () => {
   return (<>
-    <Box background="bg-neutral-soft" borderColor="border-meta-purple" shadow="large">
+    <Box background="neutral-soft" borderColor="meta-purple" shadow="large">
       migratable + unmigratable (no comment)
     </Box>
     <Box background="surface-alt-3-strong" >

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/idempotent-2.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/idempotent-2.output.js
@@ -10,7 +10,7 @@ import { Box } from "@navikt/ds-react"
 
 export const MyComponent = () => {
   return (<>
-    <Box background="bg-neutral-soft" borderColor="border-meta-purple" shadow="large">
+    <Box background="neutral-soft" borderColor="meta-purple" shadow="large">
       migratable + unmigratable (no comment)
     </Box>
     <Box background="surface-alt-3-strong" >

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/idempotent.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/idempotent.input.js
@@ -10,10 +10,10 @@ import { Box } from "@navikt/ds-react"
 
 export const MyComponent = () => {
   return (<>
-    <Box background="bg-neutral-soft" borderColor="border-meta-purple">
+    <Box background="neutral-soft" borderColor="meta-purple">
       migratable
     </Box>
-    <Box background="bg-neutral-soft" borderColor="border-meta-purple" shadow="large">
+    <Box background="neutral-soft" borderColor="meta-purple" shadow="large">
       migratable + unmigratable (no comment)
     </Box>
     <Box background="surface-alt-3-strong" >
@@ -22,7 +22,7 @@ export const MyComponent = () => {
     <Box borderWidth="4" padding={{ lg: "10", sm: "8" }} height="200rem">
       old
     </Box>
-    <Box borderWidth="4" background="bg-neutral-soft">
+    <Box borderWidth="4" background="neutral-soft">
       old + migratable
     </Box>
   </>);

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/idempotent.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/idempotent.output.js
@@ -10,10 +10,10 @@ import { Box } from "@navikt/ds-react"
 
 export const MyComponent = () => {
   return (<>
-    <Box background="bg-neutral-soft" borderColor="border-meta-purple">
+    <Box background="neutral-soft" borderColor="meta-purple">
       migratable
     </Box>
-    <Box background="bg-neutral-soft" borderColor="border-meta-purple" shadow="large">
+    <Box background="neutral-soft" borderColor="meta-purple" shadow="large">
       migratable + unmigratable (no comment)
     </Box>
     <Box background="surface-alt-3-strong" >
@@ -22,7 +22,7 @@ export const MyComponent = () => {
     <Box borderWidth="4" padding={{ lg: "10", sm: "8" }} height="200rem">
       old
     </Box>
-    <Box borderWidth="4" background="bg-neutral-soft">
+    <Box borderWidth="4" background="neutral-soft">
       old + migratable
     </Box>
   </>);

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/import.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/import.output.js
@@ -8,7 +8,7 @@ import { Box as AkselBox } from "@navikt/ds-react"
 
 export const MyComponent = () => {
 	return (<>
-		<AkselBox background="bg-neutral-soft" borderColor="border-meta-purple">
+		<AkselBox background="neutral-soft" borderColor="meta-purple">
 			simple rename of import
 		</AkselBox>
 		<AkselBox shadow="medium">

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/index.test.ts
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/index.test.ts
@@ -10,6 +10,7 @@ const fixtures = [
   "box-radius",
   "box-simple",
   "expression-container",
+  "real-examples",
 ];
 
 for (const fixture of fixtures) {

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/real-examples.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/real-examples.input.js
@@ -1,0 +1,36 @@
+import { Bleed, Box, HStack } from "@navikt/ds-react";
+import { withDsExample } from "@/web/examples/withDsExample";
+
+const Example = () => {
+  return (
+    <DemoWrapper>
+      <Bleed marginInline="space-40" asChild>
+        <Box padding="space-12" background="surface-alt-3-subtle">
+          <HStack justify="center">marginInline</HStack>
+        </Box>
+      </Bleed>
+    </DemoWrapper>
+  );
+};
+
+function DemoWrapper({ children }) {
+  return (
+    <Box background="surface-alt-3" padding="space-20" borderRadius="large">
+      <Box background="surface-subtle" padding="space-20" borderRadius="medium">
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
+// EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
+export default withDsExample(Example, { legacyOnly: true });
+
+/* Storybook story */
+export const Demo = {
+  render: Example,
+};
+
+export const args = {
+  index: 0,
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/real-examples.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/box/tests/real-examples.output.js
@@ -1,0 +1,36 @@
+import { Bleed, Box, HStack } from "@navikt/ds-react";
+import { withDsExample } from "@/web/examples/withDsExample";
+
+const Example = () => {
+  return (
+    <DemoWrapper>
+      <Bleed marginInline="space-40" asChild>
+        <Box padding="space-12" background="brand-blue-soft">
+          <HStack justify="center">marginInline</HStack>
+        </Box>
+      </Bleed>
+    </DemoWrapper>
+  );
+};
+
+function DemoWrapper({ children }) {
+  return (
+    <Box background="brand-blue-strong" padding="space-20" borderRadius="8">
+      <Box background="neutral-soft" padding="space-20" borderRadius="4">
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
+// EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
+export default withDsExample(Example, { legacyOnly: true });
+
+/* Storybook story */
+export const Demo = {
+  render: Example,
+};
+
+export const args = {
+  index: 0,
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/primitives-spacing/tests/composed.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/primitives-spacing/tests/composed.input.js
@@ -1,0 +1,76 @@
+import { Box, HStack, VStack } from "@navikt/ds-react";
+import { withDsExample } from "@/web/examples/withDsExample";
+
+const Example = () => {
+  return (
+    <VStack gap="space-48">
+      <HStack gap="space-12" align="center">
+        <Placeholder text="center" />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+      </HStack>
+      <HStack gap="space-12" align="end">
+        <Placeholder text="end" />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+      </HStack>
+      <HStack gap="space-12" align="start">
+        <Placeholder text="start" />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+      </HStack>
+      <HStack gap="space-12" align="stretch">
+        <Placeholder text="stretch" />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+      </HStack>
+      <HStack gap="space-12" align="baseline">
+        <Placeholder text="baseline" />
+        <Placeholder text="text" padding="0" />
+        <Placeholder text="text" padding="0 0 1rem" />
+        <Placeholder text="text" padding="1rem 0 0" />
+        <Placeholder text="text" padding="0" />
+      </HStack>
+    </VStack>
+  );
+};
+
+const Placeholder = ({
+  text,
+  padding = "0.5rem",
+}) => {
+  return (
+    <Box
+      background="surface-alt-3"
+      borderRadius="medium"
+      minHeight="1rem"
+      style={{ color: "var(--a-text-on-action)", padding }}
+    >
+      {text}
+    </Box>
+  );
+};
+
+// EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
+export default withDsExample(Example, {
+  showBreakpoints: true,
+  legacyOnly: true,
+});
+
+/* Storybook story */
+export const Demo = {
+  render: Example,
+};
+
+export const args = {
+  index: 2,
+  desc: "Endrer 'align-items'.",
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/primitives-spacing/tests/composed.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/primitives-spacing/tests/composed.output.js
@@ -1,0 +1,76 @@
+import { Box, HStack, VStack } from "@navikt/ds-react";
+import { withDsExample } from "@/web/examples/withDsExample";
+
+const Example = () => {
+  return (
+    <VStack gap="space-48">
+      <HStack gap="space-12" align="center">
+        <Placeholder text="center" />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+      </HStack>
+      <HStack gap="space-12" align="end">
+        <Placeholder text="end" />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+      </HStack>
+      <HStack gap="space-12" align="start">
+        <Placeholder text="start" />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+      </HStack>
+      <HStack gap="space-12" align="stretch">
+        <Placeholder text="stretch" />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+        <Placeholder />
+      </HStack>
+      <HStack gap="space-12" align="baseline">
+        <Placeholder text="baseline" />
+        <Placeholder text="text" padding="0" />
+        <Placeholder text="text" padding="0 0 1rem" />
+        <Placeholder text="text" padding="1rem 0 0" />
+        <Placeholder text="text" padding="0" />
+      </HStack>
+    </VStack>
+  );
+};
+
+const Placeholder = ({
+  text,
+  padding = "0.5rem",
+}) => {
+  return (
+    <Box
+      background="surface-alt-3"
+      borderRadius="medium"
+      minHeight="1rem"
+      style={{ color: "var(--a-text-on-action)", padding }}
+    >
+      {text}
+    </Box>
+  );
+};
+
+// EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
+export default withDsExample(Example, {
+  showBreakpoints: true,
+  legacyOnly: true,
+});
+
+/* Storybook story */
+export const Demo = {
+  render: Example,
+};
+
+export const args = {
+  index: 2,
+  desc: "Endrer 'align-items'.",
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/primitives-spacing/tests/spacing.test.ts
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/primitives-spacing/tests/spacing.test.ts
@@ -8,6 +8,7 @@ const fixtures = [
   "subComponent",
   "idempotent",
   "directImport",
+  "composed",
 ];
 
 for (const fixture of fixtures) {

--- a/@navikt/aksel/src/codemod/utils/ast.ts
+++ b/@navikt/aksel/src/codemod/utils/ast.ts
@@ -97,7 +97,7 @@ function findProps(input: {
 }) {
   const { j, path, name } = input;
 
-  return j(path).find(j.JSXAttribute, {
+  return j(path.get("openingElement")).find(j.JSXAttribute, {
     name: {
       name,
     },

--- a/package.json
+++ b/package.json
@@ -67,10 +67,10 @@
     "importOrderSortSpecifiers": true
   },
   "lint-staged": {
-    "*.js": "eslint --max-warnings=0",
-    "*.jsx": "eslint --max-warnings=0",
-    "*.ts": "eslint --max-warnings=0",
-    "*.tsx": "eslint --max-warnings=0",
+    "*.js": "eslint --max-warnings=0 --no-warn-ignored",
+    "*.jsx": "eslint --max-warnings=0 --no-warn-ignored",
+    "*.ts": "eslint --max-warnings=0 --no-warn-ignored",
+    "*.tsx": "eslint --max-warnings=0 --no-warn-ignored",
     "*.css": "stylelint",
     "*": "prettier --write --ignore-unknown"
   },


### PR DESCRIPTION
### Description

- bg- and border- prefix are removed from background and border-prop 
- Now skips updating prop if it can assume it is already migrated. This is done by checking if the value matches an existing "replacement"
- Avoids trying to parse "nested" elements, when we only want to check the element with a given name

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
