### PR TITLE
Accordion: Remove aria-hidden to prevent SiteImprove reporting an issue

### DIFF
--- a/.changeset/sparkly-monkeys-glow.md
+++ b/.changeset/sparkly-monkeys-glow.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-Accordion: Remove aria-hidden to prevent SiteImprove reporting an issue
+Accordion: Remove `aria-hidden` to prevent SiteImprove reporting an issue.

--- a/.changeset/sparkly-monkeys-glow.md
+++ b/.changeset/sparkly-monkeys-glow.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Accordion: Remove aria-hidden to prevent SiteImprove reporting an issue

--- a/@navikt/core/react/src/accordion/AccordionContent.tsx
+++ b/@navikt/core/react/src/accordion/AccordionContent.tsx
@@ -32,14 +32,9 @@ const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps>(
         ref={ref}
         className={cn(
           "navds-accordion__content",
-          {
-            "navds-accordion__content--closed": !context.open,
-          },
+          { "navds-accordion__content--closed": !context.open },
           className,
         )}
-        aria-hidden={
-          !context.open || undefined
-        } /* Added to fix bug with Radio component, where label text inside a span sometimes is ignored by screen readers after hiding/displaying the RadioGroup inside an Accordion */
       >
         {themeContext?.isDarkside ? (
           <div className={cn("navds-accordion__content-inner")}>{children}</div>


### PR DESCRIPTION
### Description

Should prevent this:
<img width="2197" height="1045" alt="image" src="https://github.com/user-attachments/assets/ad20457f-f2f8-4841-b4dc-e9d24958d7d3" />

Regarding the comment in the code about issues with Radio: I was unable to reproduce it, so I assume it's fixed. Besides, the comments on Slack said that it only happens when there are span tags inside the label, which darkside-Radio no longer has.
(PR: https://github.com/navikt/aksel/pull/2338)

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
