### PR TITLE
[Darkside] Added "data-color" prop to components

### DIFF
--- a/@navikt/core/react/src/accordion/Accordion.tsx
+++ b/@navikt/core/react/src/accordion/Accordion.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from "react";
 import { useRenameCSS } from "../theme/Theme";
+import type { AkselColor } from "../types";
 import { omit } from "../util";
 import AccordionContent, { AccordionContentProps } from "./AccordionContent";
 import { AccordionContext } from "./AccordionContext";
@@ -52,6 +53,10 @@ export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
    * @deprecated No longer has any effect.
    */
   headingSize?: "large" | "medium" | "small" | "xsmall";
+  /**
+   * Overrides the accent color inherited from the Theme.
+   */
+  "data-color"?: AkselColor;
 }
 
 /**

--- a/@navikt/core/react/src/accordion/Accordion.tsx
+++ b/@navikt/core/react/src/accordion/Accordion.tsx
@@ -54,7 +54,12 @@ export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   headingSize?: "large" | "medium" | "small" | "xsmall";
   /**
-   * Overrides the accent color inherited from the Theme.
+   * Overrides inherited color.
+   *
+   *
+   * We recommend only using `accent` and `neutral`.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/accordion/Accordion.tsx
+++ b/@navikt/core/react/src/accordion/Accordion.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from "react";
+import type { AkselStatusColorRole } from "@navikt/ds-tokens/types";
 import { useRenameCSS } from "../theme/Theme";
 import type { AkselColor } from "../types";
 import { omit } from "../util";
@@ -57,11 +58,11 @@ export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
    * Overrides inherited color.
    *
    *
-   * We recommend only using `accent` and `neutral`.
+   * We recommend only using `accent` and `neutral`. We have dissalowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
-  "data-color"?: AkselColor;
+  "data-color"?: Exclude<AkselColor, AkselStatusColorRole>;
 }
 
 /**

--- a/@navikt/core/react/src/accordion/Accordion.tsx
+++ b/@navikt/core/react/src/accordion/Accordion.tsx
@@ -58,7 +58,7 @@ export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
    * Overrides inherited color.
    *
    *
-   * We recommend only using `accent` and `neutral`. We have dissalowed status-colors.
+   * We recommend only using `accent` and `neutral`. We have disallowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */

--- a/@navikt/core/react/src/accordion/AccordionContent.tsx
+++ b/@navikt/core/react/src/accordion/AccordionContent.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useContext } from "react";
-import { useRenameCSS } from "../theme/Theme";
+import { useRenameCSS, useThemeInternal } from "../theme/Theme";
 import { BodyLong } from "../typography";
 import { AccordionItemContext } from "./AccordionItem";
 
@@ -16,6 +16,7 @@ const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps>(
     const context = useContext(AccordionItemContext);
 
     const { cn } = useRenameCSS();
+    const themeContext = useThemeInternal(false);
 
     if (context === null) {
       console.error(
@@ -26,6 +27,7 @@ const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps>(
 
     return (
       <BodyLong
+        data-color={themeContext?.color}
         {...rest}
         as="div"
         ref={ref}

--- a/@navikt/core/react/src/accordion/AccordionContent.tsx
+++ b/@navikt/core/react/src/accordion/AccordionContent.tsx
@@ -16,7 +16,7 @@ const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps>(
     const context = useContext(AccordionItemContext);
 
     const { cn } = useRenameCSS();
-    const themeContext = useThemeInternal(false);
+    const themeContext = useThemeInternal();
 
     if (context === null) {
       console.error(
@@ -27,7 +27,7 @@ const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps>(
 
     return (
       <BodyLong
-        data-color={themeContext?.color}
+        data-color={themeContext.color}
         {...rest}
         as="div"
         ref={ref}

--- a/@navikt/core/react/src/alert/base-alert/root/BaseAlertRoot.tsx
+++ b/@navikt/core/react/src/alert/base-alert/root/BaseAlertRoot.tsx
@@ -20,7 +20,9 @@ interface BaseAlertProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   size?: BaseAlertContextProps["size"];
   /**
-   * Overrides the accent color inherited from the Theme.
+   * Overrides inherited color.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
   /**

--- a/@navikt/core/react/src/alert/base-alert/root/BaseAlertRoot.tsx
+++ b/@navikt/core/react/src/alert/base-alert/root/BaseAlertRoot.tsx
@@ -20,7 +20,7 @@ interface BaseAlertProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   size?: BaseAlertContextProps["size"];
   /**
-   * Overrides color
+   * Overrides the accent color inherited from the Theme.
    */
   "data-color"?: AkselColor;
   /**

--- a/@navikt/core/react/src/alert/global-alert/root/GlobalAlertRoot.tsx
+++ b/@navikt/core/react/src/alert/global-alert/root/GlobalAlertRoot.tsx
@@ -20,6 +20,10 @@ import {
 interface GlobalAlertProps
   extends Omit<BaseAlert.RootProps, "type" | "global" | "data-color"> {
   status: Exclude<BaseAlert.RootProps["status"], undefined>;
+  /**
+   * data-color has no effect on GlobalAlert.
+   */
+  "data-color"?: never;
 }
 
 interface GlobalAlertComponent

--- a/@navikt/core/react/src/alert/local-alert/root/LocalAlertRoot.tsx
+++ b/@navikt/core/react/src/alert/local-alert/root/LocalAlertRoot.tsx
@@ -20,6 +20,10 @@ import {
 interface LocalAlertProps
   extends Omit<BaseAlert.RootProps, "type" | "global" | "data-color"> {
   status: Exclude<BaseAlert.RootProps["status"], undefined>;
+  /**
+   * data-color has no effect on GlobalAlert.
+   */
+  "data-color"?: never;
 }
 
 interface LocalAlertComponent

--- a/@navikt/core/react/src/alert/local-alert/root/LocalAlertRoot.tsx
+++ b/@navikt/core/react/src/alert/local-alert/root/LocalAlertRoot.tsx
@@ -21,7 +21,7 @@ interface LocalAlertProps
   extends Omit<BaseAlert.RootProps, "type" | "global" | "data-color"> {
   status: Exclude<BaseAlert.RootProps["status"], undefined>;
   /**
-   * data-color has no effect on GlobalAlert.
+   * data-color has no effect on LocalAlert.
    */
   "data-color"?: never;
 }

--- a/@navikt/core/react/src/button/Button.tsx
+++ b/@navikt/core/react/src/button/Button.tsx
@@ -52,7 +52,7 @@ export interface ButtonProps
    */
   iconPosition?: "left" | "right";
   /**
-   * Button color
+   * Overrides the accent color inherited from the Theme.
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/button/Button.tsx
+++ b/@navikt/core/react/src/button/Button.tsx
@@ -52,7 +52,9 @@ export interface ButtonProps
    */
   iconPosition?: "left" | "right";
   /**
-   * Overrides the accent color inherited from the Theme.
+   * Overrides inherited color.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/button/Button.tsx
+++ b/@navikt/core/react/src/button/Button.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from "react";
+import type { AkselStatusColorRole } from "@navikt/ds-tokens/types";
 import { Loader } from "../loader";
 import { useRenameCSS } from "../theme/Theme";
 import { AkselColor } from "../types";
@@ -53,10 +54,13 @@ export interface ButtonProps
   iconPosition?: "left" | "right";
   /**
    * Overrides inherited color.
+   *
+   *
+   * We recommend only using `accent`, `neutral` and `danger`. We have dissalowed other status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
-  "data-color"?: AkselColor;
+  "data-color"?: Exclude<AkselColor, Exclude<AkselStatusColorRole, "danger">>;
 }
 
 /**

--- a/@navikt/core/react/src/button/Button.tsx
+++ b/@navikt/core/react/src/button/Button.tsx
@@ -56,7 +56,7 @@ export interface ButtonProps
    * Overrides inherited color.
    *
    *
-   * We recommend only using `accent`, `neutral` and `danger`. We have dissalowed other status-colors.
+   * We recommend only using `accent`, `neutral` and `danger`. We have disallowed other status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */

--- a/@navikt/core/react/src/chat/Chat.tsx
+++ b/@navikt/core/react/src/chat/Chat.tsx
@@ -1,4 +1,5 @@
 import React, { HTMLAttributes, forwardRef } from "react";
+import type { AkselStatusColorRole } from "@navikt/ds-tokens/types";
 import { useRenameCSS } from "../theme/Theme";
 import { AkselColor } from "../types";
 import { BodyLong, HeadingProps } from "../typography";
@@ -55,10 +56,13 @@ export interface ChatProps extends HTMLAttributes<HTMLDivElement> {
   toptextHeadingLevel?: Exclude<HeadingProps["level"], "1">;
   /**
    * Overrides inherited color.
+   *
+   *
+   * We have dissalowed status-colors
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
-  "data-color"?: AkselColor;
+  "data-color"?: Exclude<AkselColor, AkselStatusColorRole>;
 }
 
 interface ChatComponent

--- a/@navikt/core/react/src/chat/Chat.tsx
+++ b/@navikt/core/react/src/chat/Chat.tsx
@@ -54,7 +54,9 @@ export interface ChatProps extends HTMLAttributes<HTMLDivElement> {
    */
   toptextHeadingLevel?: Exclude<HeadingProps["level"], "1">;
   /**
-   * Overrides the accent color inherited from the Theme.
+   * Overrides inherited color.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/chat/Chat.tsx
+++ b/@navikt/core/react/src/chat/Chat.tsx
@@ -58,7 +58,7 @@ export interface ChatProps extends HTMLAttributes<HTMLDivElement> {
    * Overrides inherited color.
    *
    *
-   * We have dissalowed status-colors
+   * We have disallowed status-colors
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */

--- a/@navikt/core/react/src/chat/Chat.tsx
+++ b/@navikt/core/react/src/chat/Chat.tsx
@@ -53,6 +53,10 @@ export interface ChatProps extends HTMLAttributes<HTMLDivElement> {
    * @default "3"
    */
   toptextHeadingLevel?: Exclude<HeadingProps["level"], "1">;
+  /**
+   * Overrides the accent color inherited from the Theme.
+   */
+  "data-color"?: AkselColor;
 }
 
 interface ChatComponent

--- a/@navikt/core/react/src/chips/Chips.tsx
+++ b/@navikt/core/react/src/chips/Chips.tsx
@@ -39,23 +39,23 @@ interface ChipsComponent
  *
  * @example
  * ```jsx
-      <Chips size="small">
-        {options.map((c) => (
-          <Chips.Toggle
-            selected={selected.includes(c)}
-            key={c}
-            onClick={() =>
-              setSelected(
-                selected.includes(c)
-                  ? selected.filter((x) => x !== c)
-                  : [...selected, c]
-              )
-            }
-          >
-            {c}
-          </Chips.Toggle>
-        ))}
-      </Chips>
+ *    <Chips size="small">
+ *      {options.map((c) => (
+ *        <Chips.Toggle
+ *          selected={selected.includes(c)}
+ *          key={c}
+ *          onClick={() =>
+ *            setSelected(
+ *              selected.includes(c)
+ *                ? selected.filter((x) => x !== c)
+ *                : [...selected, c]
+ *            )
+ *          }
+ *        >
+ *          {c}
+ *        </Chips.Toggle>
+ *      ))}
+ *    </Chips>
  * ```
  */
 export const Chips: ChipsComponent = forwardRef<HTMLUListElement, ChipsProps>(

--- a/@navikt/core/react/src/chips/Removable.tsx
+++ b/@navikt/core/react/src/chips/Removable.tsx
@@ -17,7 +17,7 @@ export interface ChipsRemovableProps
    */
   onDelete?: () => void;
   /**
-   * Chip color
+   * Overrides the accent color inherited from the Theme.
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/chips/Removable.tsx
+++ b/@navikt/core/react/src/chips/Removable.tsx
@@ -17,7 +17,9 @@ export interface ChipsRemovableProps
    */
   onDelete?: () => void;
   /**
-   * Overrides the accent color inherited from the Theme.
+   * Overrides inherited color.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/chips/Toggle.tsx
+++ b/@navikt/core/react/src/chips/Toggle.tsx
@@ -15,7 +15,7 @@ export interface ChipsToggleProps
    */
   variant?: "action" | "neutral";
   /**
-   * Chip color
+   * Overrides the accent color inherited from the Theme.
    */
   "data-color"?: AkselColor;
   /**

--- a/@navikt/core/react/src/chips/Toggle.tsx
+++ b/@navikt/core/react/src/chips/Toggle.tsx
@@ -15,7 +15,9 @@ export interface ChipsToggleProps
    */
   variant?: "action" | "neutral";
   /**
-   * Overrides the accent color inherited from the Theme.
+   * Overrides inherited color.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
   /**

--- a/@navikt/core/react/src/copybutton/CopyButton.tsx
+++ b/@navikt/core/react/src/copybutton/CopyButton.tsx
@@ -16,7 +16,7 @@ export interface CopyButtonProps
    */
   variant?: "action" | "neutral";
   /**
-   * CopyButton color.
+   * Overrides the color.
    * @default "neutral"
    */
   "data-color"?: AkselColor;

--- a/@navikt/core/react/src/copybutton/CopyButton.tsx
+++ b/@navikt/core/react/src/copybutton/CopyButton.tsx
@@ -1,5 +1,6 @@
 import React, { ButtonHTMLAttributes, forwardRef, useState } from "react";
 import { CheckmarkIcon, FilesIcon } from "@navikt/aksel-icons";
+import type { AkselStatusColorRole } from "@navikt/ds-tokens/types";
 import { Button, ButtonProps } from "../button";
 import { useRenameCSS } from "../theme/Theme";
 import type { AkselColor } from "../types/theme";
@@ -16,10 +17,15 @@ export interface CopyButtonProps
    */
   variant?: "action" | "neutral";
   /**
-   * Overrides the color.
+   * Overrides inherited color.
    * @default "neutral"
+   *
+   *
+   * We recommend only using `accent` and `neutral`. We have dissalowed status-colors.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
-  "data-color"?: AkselColor;
+  "data-color"?: Exclude<AkselColor, AkselStatusColorRole>;
   /**
    * Text to copy to clipboard.
    */
@@ -153,7 +159,7 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
 
 function variantToDataColor(
   variant: CopyButtonProps["variant"],
-): AkselColor | undefined {
+): Exclude<AkselColor, AkselStatusColorRole> | undefined {
   if (variant === "action") {
     return "accent";
   }

--- a/@navikt/core/react/src/copybutton/CopyButton.tsx
+++ b/@navikt/core/react/src/copybutton/CopyButton.tsx
@@ -17,7 +17,7 @@ export interface CopyButtonProps
    */
   variant?: "action" | "neutral";
   /**
-   * Overrides inherited color.
+   * Overrides color.
    * @default "neutral"
    *
    *

--- a/@navikt/core/react/src/copybutton/CopyButton.tsx
+++ b/@navikt/core/react/src/copybutton/CopyButton.tsx
@@ -21,7 +21,7 @@ export interface CopyButtonProps
    * @default "neutral"
    *
    *
-   * We recommend only using `accent` and `neutral`. We have dissalowed status-colors.
+   * We recommend only using `accent` and `neutral`. We have disallowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */

--- a/@navikt/core/react/src/expansion-card/ExpansionCard.tsx
+++ b/@navikt/core/react/src/expansion-card/ExpansionCard.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef, useRef } from "react";
 import { useRenameCSS } from "../theme/Theme";
+import type { AkselColor } from "../types";
 import { useControllableState } from "../util/hooks";
 import { OverridableComponent } from "../util/types";
 import ExpansionCardContent, {
@@ -68,6 +69,10 @@ interface ExpansionCardCommonProps
    * @default "medium"
    */
   size?: "medium" | "small";
+  /**
+   * Overrides the accent color inherited from the Theme.
+   */
+  "data-color"?: AkselColor;
 }
 
 type ExpansionCardConditionalProps =

--- a/@navikt/core/react/src/expansion-card/ExpansionCard.tsx
+++ b/@navikt/core/react/src/expansion-card/ExpansionCard.tsx
@@ -70,7 +70,9 @@ interface ExpansionCardCommonProps
    */
   size?: "medium" | "small";
   /**
-   * Overrides the accent color inherited from the Theme.
+   * Overrides inherited color.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/form/search/Search.tsx
+++ b/@navikt/core/react/src/form/search/Search.tsx
@@ -5,6 +5,7 @@ import React, {
   useState,
 } from "react";
 import { MagnifyingGlassIcon, XMarkIcon } from "@navikt/aksel-icons";
+import type { AkselStatusColorRole } from "@navikt/ds-tokens/types";
 import { Button } from "../../button";
 import { useRenameCSS } from "../../theme/Theme";
 import { AkselColor } from "../../types";
@@ -77,7 +78,7 @@ export interface SearchProps
   /**
    * @private
    */
-  "data-color"?: AkselColor;
+  "data-color"?: Exclude<AkselColor, AkselStatusColorRole>;
 }
 
 interface SearchComponent

--- a/@navikt/core/react/src/help-text/HelpText.tsx
+++ b/@navikt/core/react/src/help-text/HelpText.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useRef, useState } from "react";
 import { Popover, PopoverProps } from "../popover";
 import { useRenameCSS } from "../theme/Theme";
+import type { AkselColor } from "../types";
 import { composeEventHandlers } from "../util/composeEventHandlers";
 import { useMergeRefs } from "../util/hooks/useMergeRefs";
 import { useI18n } from "../util/i18n/i18n.hooks";
@@ -19,6 +20,11 @@ export interface HelpTextProps
    * Classname for wrapper
    */
   wrapperClassName?: string;
+  /**
+   * Overrides the color.
+   * @default "info"
+   */
+  "data-color"?: AkselColor;
 }
 
 /**

--- a/@navikt/core/react/src/help-text/HelpText.tsx
+++ b/@navikt/core/react/src/help-text/HelpText.tsx
@@ -21,8 +21,12 @@ export interface HelpTextProps
    */
   wrapperClassName?: string;
   /**
-   * Overrides the color.
+   * Overrides color.
    * @default "info"
+   *
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
+   * @private
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/inline-message/root/InlineMessage.tsx
+++ b/@navikt/core/react/src/inline-message/root/InlineMessage.tsx
@@ -16,6 +16,10 @@ interface InlineMessageProps extends React.HTMLAttributes<HTMLDivElement> {
    * @default "medium"
    */
   size?: "medium" | "small";
+  /**
+   * "data-color" has no effect on InlineMessage.
+   */
+  "data-color"?: never;
 }
 
 /**

--- a/@navikt/core/react/src/link-card/LinkCard.tsx
+++ b/@navikt/core/react/src/link-card/LinkCard.tsx
@@ -27,7 +27,9 @@ interface LinkCardProps extends HTMLAttributes<HTMLDivElement> {
    */
   size?: "small" | "medium";
   /**
-   * Overrides the accent color inherited from the Theme.
+   * Overrides inherited color.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/link-card/LinkCard.tsx
+++ b/@navikt/core/react/src/link-card/LinkCard.tsx
@@ -28,6 +28,9 @@ interface LinkCardProps extends HTMLAttributes<HTMLDivElement> {
   size?: "small" | "medium";
   /**
    * Overrides inherited color.
+   *
+   *
+   * We reccomend avoiding status-colors like `info`, `success`, `warning` and `danger` in LinkCards.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */

--- a/@navikt/core/react/src/link-card/LinkCard.tsx
+++ b/@navikt/core/react/src/link-card/LinkCard.tsx
@@ -1,5 +1,6 @@
 import React, { HTMLAttributes, forwardRef } from "react";
 import { useRenameCSS } from "../theme/Theme";
+import type { AkselColor } from "../types";
 import { BodyLong, Heading } from "../typography";
 import { createContext } from "../util/create-context";
 import {
@@ -25,6 +26,10 @@ interface LinkCardProps extends HTMLAttributes<HTMLDivElement> {
    * @default "medium"
    */
   size?: "small" | "medium";
+  /**
+   * Overrides the accent color inherited from the Theme.
+   */
+  "data-color"?: AkselColor;
 }
 
 type LinkCardContextProps = {

--- a/@navikt/core/react/src/link/Link.tsx
+++ b/@navikt/core/react/src/link/Link.tsx
@@ -26,6 +26,10 @@ export interface LinkProps
    * Link text
    */
   children: React.ReactNode;
+  /**
+   * Overrides the accent color inherited from the Theme.
+   */
+  "data-color"?: AkselColor;
 }
 
 /**

--- a/@navikt/core/react/src/link/Link.tsx
+++ b/@navikt/core/react/src/link/Link.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from "react";
+import type { AkselStatusColorRole } from "@navikt/ds-tokens/types";
 import { useRenameCSS } from "../theme/Theme";
 import { AkselColor } from "../types";
 import { OverridableComponent } from "../util/types";
@@ -28,10 +29,13 @@ export interface LinkProps
   children: React.ReactNode;
   /**
    * Overrides inherited color.
+   *
+   *
+   * We recommend only using `accent` and `neutral`. We have dissalowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
-  "data-color"?: AkselColor;
+  "data-color"?: Exclude<AkselColor, AkselStatusColorRole>;
 }
 
 /**

--- a/@navikt/core/react/src/link/Link.tsx
+++ b/@navikt/core/react/src/link/Link.tsx
@@ -31,7 +31,7 @@ export interface LinkProps
    * Overrides inherited color.
    *
    *
-   * We recommend only using `accent` and `neutral`. We have dissalowed status-colors.
+   * We recommend only using `accent` and `neutral`. We have disallowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */

--- a/@navikt/core/react/src/link/Link.tsx
+++ b/@navikt/core/react/src/link/Link.tsx
@@ -27,7 +27,9 @@ export interface LinkProps
    */
   children: React.ReactNode;
   /**
-   * Overrides the accent color inherited from the Theme.
+   * Overrides inherited color.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/loader/Loader.tsx
+++ b/@navikt/core/react/src/loader/Loader.tsx
@@ -35,7 +35,10 @@ export interface LoaderProps extends Omit<SVGProps<SVGSVGElement>, "ref"> {
    */
   variant?: "neutral" | "interaction" | "inverted";
   /**
-   * Overrides the color.
+   * Overrides color.
+   * 
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/loader/Loader.tsx
+++ b/@navikt/core/react/src/loader/Loader.tsx
@@ -35,7 +35,7 @@ export interface LoaderProps extends Omit<SVGProps<SVGSVGElement>, "ref"> {
    */
   variant?: "neutral" | "interaction" | "inverted";
   /**
-   * Overrides loader-color
+   * Overrides the color.
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/pagination/Pagination.tsx
+++ b/@navikt/core/react/src/pagination/Pagination.tsx
@@ -70,7 +70,7 @@ export interface PaginationProps extends React.HTMLAttributes<HTMLElement> {
     text: string;
   };
   /**
-   * Overrides the accent color inherited from the Theme.
+   * Overrides the color.
    * @default "neutral"
    * @private
    */

--- a/@navikt/core/react/src/pagination/Pagination.tsx
+++ b/@navikt/core/react/src/pagination/Pagination.tsx
@@ -70,6 +70,8 @@ export interface PaginationProps extends React.HTMLAttributes<HTMLElement> {
     text: string;
   };
   /**
+   * Overrides the accent color inherited from the Theme.
+   * @default "neutral"
    * @private
    */
   "data-color"?: AkselColor;

--- a/@navikt/core/react/src/pagination/Pagination.tsx
+++ b/@navikt/core/react/src/pagination/Pagination.tsx
@@ -1,6 +1,7 @@
 import cl from "clsx";
 import React, { forwardRef } from "react";
 import { ChevronLeftIcon, ChevronRightIcon } from "@navikt/aksel-icons";
+import type { AkselStatusColorRole } from "@navikt/ds-tokens/types";
 import { useRenameCSS } from "../theme/Theme";
 import { AkselColor } from "../types";
 import { BodyShort, Heading } from "../typography";
@@ -70,11 +71,16 @@ export interface PaginationProps extends React.HTMLAttributes<HTMLElement> {
     text: string;
   };
   /**
-   * Overrides the color.
+   * Overrides color.
    * @default "neutral"
+   *
+   *
+   * We have dissalowed status-colors.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    * @private
    */
-  "data-color"?: AkselColor;
+  "data-color"?: Exclude<AkselColor, AkselStatusColorRole>;
 }
 
 interface PaginationType

--- a/@navikt/core/react/src/pagination/Pagination.tsx
+++ b/@navikt/core/react/src/pagination/Pagination.tsx
@@ -75,7 +75,7 @@ export interface PaginationProps extends React.HTMLAttributes<HTMLElement> {
    * @default "neutral"
    *
    *
-   * We have dissalowed status-colors.
+   * We have disallowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    * @private

--- a/@navikt/core/react/src/progress-bar/ProgressBar.tsx
+++ b/@navikt/core/react/src/progress-bar/ProgressBar.tsx
@@ -47,7 +47,9 @@ interface ProgressBarPropsBase
    */
   "aria-label"?: string;
   /**
-   * Overrides the accent color inherited from the Theme.
+   * Overrides inherited color.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/progress-bar/ProgressBar.tsx
+++ b/@navikt/core/react/src/progress-bar/ProgressBar.tsx
@@ -1,5 +1,6 @@
 import React, { HTMLAttributes, forwardRef, useEffect } from "react";
 import { useRenameCSS } from "../theme/Theme";
+import type { AkselColor } from "../types";
 import { useLatestRef } from "../util/hooks/useLatestRef";
 import { useTimeout } from "../util/hooks/useTimeout";
 import { useI18n } from "../util/i18n/i18n.hooks";
@@ -45,6 +46,10 @@ interface ProgressBarPropsBase
    * Not needed if `aria-labelledby` is used.
    */
   "aria-label"?: string;
+  /**
+   * Overrides the accent color inherited from the Theme.
+   */
+  "data-color"?: AkselColor;
 }
 
 export type ProgressBarProps = ProgressBarPropsBase &

--- a/@navikt/core/react/src/read-more/ReadMore.tsx
+++ b/@navikt/core/react/src/read-more/ReadMore.tsx
@@ -40,7 +40,7 @@ export interface ReadMoreProps
    * Overrides inherited color.
    *
    *
-   * We recommend only using `accent`. We have dissalowed status-colors.
+   * We recommend only using `accent`. We have disallowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    * @private

--- a/@navikt/core/react/src/read-more/ReadMore.tsx
+++ b/@navikt/core/react/src/read-more/ReadMore.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from "react";
 import { ChevronDownIcon } from "@navikt/aksel-icons";
 import { useRenameCSS } from "../theme/Theme";
+import type { AkselColor } from "../types";
 import { BodyLong } from "../typography";
 import { composeEventHandlers } from "../util/composeEventHandlers";
 import { useControllableState } from "../util/hooks/useControllableState";
@@ -34,6 +35,10 @@ export interface ReadMoreProps
    * @default "medium"
    */
   size?: "large" | "medium" | "small";
+  /**
+   * Overrides the accent color inherited from the Theme.
+   */
+  "data-color"?: AkselColor;
 }
 
 /**

--- a/@navikt/core/react/src/read-more/ReadMore.tsx
+++ b/@navikt/core/react/src/read-more/ReadMore.tsx
@@ -36,7 +36,9 @@ export interface ReadMoreProps
    */
   size?: "large" | "medium" | "small";
   /**
-   * Overrides the accent color inherited from the Theme.
+   * Overrides inherited color.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
 }

--- a/@navikt/core/react/src/read-more/ReadMore.tsx
+++ b/@navikt/core/react/src/read-more/ReadMore.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from "react";
 import { ChevronDownIcon } from "@navikt/aksel-icons";
+import type { AkselStatusColorRole } from "@navikt/ds-tokens/types";
 import { useRenameCSS } from "../theme/Theme";
 import type { AkselColor } from "../types";
 import { BodyLong } from "../typography";
@@ -37,10 +38,14 @@ export interface ReadMoreProps
   size?: "large" | "medium" | "small";
   /**
    * Overrides inherited color.
+   *
+   *
+   * We recommend only using `accent`. We have dissalowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
+   * @private
    */
-  "data-color"?: AkselColor;
+  "data-color"?: Exclude<AkselColor, AkselStatusColorRole>;
 }
 
 /**

--- a/@navikt/core/react/src/timeline/period/index.tsx
+++ b/@navikt/core/react/src/timeline/period/index.tsx
@@ -27,6 +27,9 @@ export interface TimelinePeriodProps
   status?: "success" | "warning" | "danger" | "info" | "neutral";
   /**
    * Overrides color set by status.
+   * 
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
   /**

--- a/@navikt/core/react/src/timeline/period/index.tsx
+++ b/@navikt/core/react/src/timeline/period/index.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from "react";
+import type { AkselColor } from "../../types";
 import { usePeriodContext } from "../hooks/usePeriodContext";
 import { useRowContext } from "../hooks/useRowContext";
 import type { TimelineComponentTypes } from "../utils/types.internal";
@@ -24,6 +25,10 @@ export interface TimelinePeriodProps
    * @default "neutral"
    */
   status?: "success" | "warning" | "danger" | "info" | "neutral";
+  /**
+   * Overrides color set by status.
+   */
+  "data-color"?: AkselColor;
   /**
    * Status label for screen-readers
    * e.g "Sykemeldt", "foreldrepermisjon"

--- a/@navikt/core/react/src/toggle-group/ToggleGroup.types.ts
+++ b/@navikt/core/react/src/toggle-group/ToggleGroup.types.ts
@@ -33,7 +33,7 @@ export interface ToggleGroupProps
    */
   variant?: "action" | "neutral";
   /**
-   * ToggleButton color.
+   * Overrides the accent color inherited from the Theme.
    */
   "data-color"?: AkselColor;
   /**

--- a/@navikt/core/react/src/toggle-group/ToggleGroup.types.ts
+++ b/@navikt/core/react/src/toggle-group/ToggleGroup.types.ts
@@ -33,7 +33,9 @@ export interface ToggleGroupProps
    */
   variant?: "action" | "neutral";
   /**
-   * Overrides the accent color inherited from the Theme.
+   * Overrides inherited color.
+   * @see 🏷️ {@link AkselColor}
+   * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
   "data-color"?: AkselColor;
   /**

--- a/@navikt/core/react/src/toggle-group/ToggleGroup.types.ts
+++ b/@navikt/core/react/src/toggle-group/ToggleGroup.types.ts
@@ -1,4 +1,5 @@
 import { HTMLAttributes } from "react";
+import type { AkselStatusColorRole } from "@navikt/ds-tokens/types";
 import type { AkselColor } from "../types";
 
 export interface ToggleGroupProps
@@ -34,10 +35,13 @@ export interface ToggleGroupProps
   variant?: "action" | "neutral";
   /**
    * Overrides inherited color.
+   *
+   *
+   * We recommend only using `accent` and `neutral`. We have dissalowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */
-  "data-color"?: AkselColor;
+  "data-color"?: Exclude<AkselColor, AkselStatusColorRole>;
   /**
    * Stretch each button to fill avaliable space in container.
    * @default false

--- a/@navikt/core/react/src/toggle-group/ToggleGroup.types.ts
+++ b/@navikt/core/react/src/toggle-group/ToggleGroup.types.ts
@@ -37,7 +37,7 @@ export interface ToggleGroupProps
    * Overrides inherited color.
    *
    *
-   * We recommend only using `accent` and `neutral`. We have dissalowed status-colors.
+   * We recommend only using `accent` and `neutral`. We have disallowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/darkside/farger-darkside)
    */


### PR DESCRIPTION
### Description

Added data-color prop to relevant components

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
