### PR TITLE
[CLI] Show status and print legacy/component tokens

### DIFF
--- a/.changeset/young-cloths-sniff.md
+++ b/.changeset/young-cloths-sniff.md
@@ -2,4 +2,4 @@
 "@navikt/aksel": patch
 ---
 
-CLI: Avoid renaming redefined tokens, now shows status for component and legacy-token definitions.
+CLI: Update v8-tokens codemod to avoid renaming redefined tokens. Now shows status for component and legacy-token definitions.

--- a/.changeset/young-cloths-sniff.md
+++ b/.changeset/young-cloths-sniff.md
@@ -1,0 +1,5 @@
+---
+"@navikt/aksel": patch
+---
+
+CLI: Avoid renaming redefined tokens, now shows status for component and legacy-token definitions.

--- a/@navikt/aksel/src/darkside/config/TokenStatus.ts
+++ b/@navikt/aksel/src/darkside/config/TokenStatus.ts
@@ -217,6 +217,9 @@ class TokenStatus {
     const componentTokens = this.status.component.legacy.length;
     if (componentTokens > 0) {
       console.info(chalk.underline(`\nCOMPONENT Tokens Migration`));
+      console.info(
+        `${chalk.yellow("!")} Found ${componentTokens} component token definition${componentTokens > 1 ? "s" : ""} that require manual migration.`,
+      );
 
       console.info(
         `We no longer support component tokens. Please migrate to the new darkside tokens. using theming or other methods.`,
@@ -225,15 +228,13 @@ class TokenStatus {
 
     const deprecatedTokens = this.status.deprecated.legacy.length;
     if (deprecatedTokens > 0) {
-      console.info(
-        chalk.underline(`\nDEPRECATED Tokens (--aksel-v7-deprecated__*)`),
-      );
+      console.info(chalk.underline(`\nLEGACY TOKEN DEFINITIONS (--a-token:)`));
 
       console.info(
-        `${chalk.yellow("!")} Found ${deprecatedTokens} deprecated token${deprecatedTokens > 1 ? "s" : ""} that require manual migration.`,
+        `${chalk.yellow("!")} Found ${deprecatedTokens} legacy token definition${deprecatedTokens > 1 ? "s" : ""} that require manual migration.`,
       );
       console.info(
-        `These tokens were marked as deprecated during the automated migration and need to be replaced with new darkside tokens.`,
+        `These are custom property definitions using legacy tokens that need to be updated to use new darkside tokens.`,
       );
     }
   }

--- a/@navikt/aksel/src/darkside/config/TokenStatus.ts
+++ b/@navikt/aksel/src/darkside/config/TokenStatus.ts
@@ -222,7 +222,7 @@ class TokenStatus {
       );
 
       console.info(
-        `We no longer support component tokens. Please migrate to the new darkside tokens. using theming or other methods.`,
+        `We no longer support component tokens. Please migrate to the new darkside tokens using theming or other methods.`,
       );
     }
 

--- a/@navikt/aksel/src/darkside/config/TokenStatus.ts
+++ b/@navikt/aksel/src/darkside/config/TokenStatus.ts
@@ -22,6 +22,7 @@ type StatusT = {
   js: StatusDataT;
   tailwind: StatusDataT;
   component: StatusDataT;
+  deprecated: StatusDataT;
 };
 
 class TokenStatus {
@@ -39,6 +40,7 @@ class TokenStatus {
       js: { legacy: [], updated: [] },
       tailwind: { legacy: [], updated: [] },
       component: { legacy: [], updated: [] },
+      deprecated: { legacy: [], updated: [] },
     };
   }
 
@@ -72,6 +74,12 @@ class TokenStatus {
         break;
       case "tailwind":
         this.status.tailwind[statusType].push(hit);
+        break;
+      case "component":
+        this.status.component[statusType].push(hit);
+        break;
+      case "deprecated":
+        this.status.deprecated[statusType].push(hit);
         break;
     }
   }
@@ -208,12 +216,25 @@ class TokenStatus {
 
     const componentTokens = this.status.component.legacy.length;
     if (componentTokens > 0) {
-      console.info(chalk.underline(`COMPONENT Tokens Migration`));
+      console.info(chalk.underline(`\nCOMPONENT Tokens Migration`));
 
       console.info(
         `We no longer support component tokens. Please migrate to the new darkside tokens. using theming or other methods.`,
       );
-      console.info(`You can read more at https://aksel.nav.no/darkside`);
+    }
+
+    const deprecatedTokens = this.status.deprecated.legacy.length;
+    if (deprecatedTokens > 0) {
+      console.info(
+        chalk.underline(`\nDEPRECATED Tokens (--aksel-v7-deprecated__*)`),
+      );
+
+      console.info(
+        `${chalk.yellow("!")} Found ${deprecatedTokens} deprecated token${deprecatedTokens > 1 ? "s" : ""} that require manual migration.`,
+      );
+      console.info(
+        `These tokens were marked as deprecated during the automated migration and need to be replaced with new darkside tokens.`,
+      );
     }
   }
 }

--- a/@navikt/aksel/src/darkside/transforms/darkside-tokens-css.ts
+++ b/@navikt/aksel/src/darkside/transforms/darkside-tokens-css.ts
@@ -5,34 +5,22 @@ export default function transformer(file: FileInfo) {
   let src = file.source;
 
   /*
-    1. Replace definitions: --a-token: -> --aksel-legacy__a-token:
-    Matches "--a-token" followed by optional whitespace and a colon.
-    Uses negative lookbehind to ensure we don't match "--not-a-token".
+    Replace usages: --a-token -> --ax-replacement
+    Matches "--a-token" with word boundaries.
+    Uses negative lookahead to skip definitions (--a-token:)
   */
   src = src.replace(
-    /(?<![\w-])(--a-[\w-]+)(\s*:)/g,
-    (match, tokenName, suffix) => {
+    /(?<![\w-])(--a-[\w-]+)(?![\w-])(?!\s*:)/g,
+    (match, tokenName) => {
       const key = tokenName.replace("--a-", "");
-      if (legacyTokenConfig[key]) {
-        return `--aksel-v7-deprecated${tokenName.replace("--", "__")}${suffix}`;
+      const config = legacyTokenConfig[key];
+
+      if (config?.replacement) {
+        return `--ax-${config.replacement}`;
       }
       return match;
     },
   );
-
-  /*
-    2. Replace usages: --a-token -> --ax-replacement
-    Matches "--a-token" with word boundaries.
-  */
-  src = src.replace(/(?<![\w-])(--a-[\w-]+)(?![\w-])/g, (match, tokenName) => {
-    const key = tokenName.replace("--a-", "");
-    const config = legacyTokenConfig[key];
-
-    if (config?.replacement) {
-      return `--ax-${config.replacement}`;
-    }
-    return match;
-  });
 
   return src;
 }

--- a/@navikt/aksel/src/darkside/transforms/darkside-tokens-css.ts
+++ b/@navikt/aksel/src/darkside/transforms/darkside-tokens-css.ts
@@ -14,7 +14,7 @@ export default function transformer(file: FileInfo) {
     (match, tokenName, suffix) => {
       const key = tokenName.replace("--a-", "");
       if (legacyTokenConfig[key]) {
-        return `--aksel-legacy${tokenName.replace("--", "__")}${suffix}`;
+        return `--aksel-v7-deprecated${tokenName.replace("--", "__")}${suffix}`;
       }
       return match;
     },

--- a/@navikt/aksel/src/darkside/transforms/tests/css-complete.input.css
+++ b/@navikt/aksel/src/darkside/transforms/tests/css-complete.input.css
@@ -8,9 +8,11 @@
   /* Has no replacement */
   background-color: var(--a-surface-transparent);
 
-  /* Is tagged as legacy */
+  /* Is detected as legacy */
   --a-surface-neutral: red;
   --a-surface-subtle: orange;
+  --a-surface-action:blue;
+  --a-surface-action-selected :red;
 
   /* Border-radius */
   border-radius: var(--a-border-radius-small);

--- a/@navikt/aksel/src/darkside/transforms/tests/css-complete.output.css
+++ b/@navikt/aksel/src/darkside/transforms/tests/css-complete.output.css
@@ -8,9 +8,11 @@
   /* Has no replacement */
   background-color: var(--a-surface-transparent);
 
-  /* Is tagged as legacy */
-  --aksel-v7-deprecated__a-surface-neutral: red;
-  --aksel-v7-deprecated__a-surface-subtle: orange;
+  /* Is detected as legacy */
+  --a-surface-neutral: red;
+  --a-surface-subtle: orange;
+  --a-surface-action:blue;
+  --a-surface-action-selected :red;
 
   /* Border-radius */
   border-radius: var(--ax-radius-2);

--- a/@navikt/aksel/src/darkside/transforms/tests/css-complete.output.css
+++ b/@navikt/aksel/src/darkside/transforms/tests/css-complete.output.css
@@ -9,8 +9,8 @@
   background-color: var(--a-surface-transparent);
 
   /* Is tagged as legacy */
-  --aksel-legacy__a-surface-neutral: red;
-  --aksel-legacy__a-surface-subtle: orange;
+  --aksel-v7-deprecated__a-surface-neutral: red;
+  --aksel-v7-deprecated__a-surface-subtle: orange;
 
   /* Border-radius */
   border-radius: var(--ax-radius-2);

--- a/@navikt/aksel/src/darkside/transforms/tests/css-edge-cases.input.css
+++ b/@navikt/aksel/src/darkside/transforms/tests/css-edge-cases.input.css
@@ -4,7 +4,7 @@
   color: var(--not-a-surface-action);
   margin: var(--a-spacing-4-extra);
 
-  /* Whitespace in definitions - SHOULD change */
+  /* Whitespace in definitions - SHOULD be detected */
   --a-surface-action : blue;
   --a-surface-action-selected  : red;
 

--- a/@navikt/aksel/src/darkside/transforms/tests/css-edge-cases.output.css
+++ b/@navikt/aksel/src/darkside/transforms/tests/css-edge-cases.output.css
@@ -5,8 +5,8 @@
   margin: var(--a-spacing-4-extra);
 
   /* Whitespace in definitions - SHOULD change */
-  --aksel-legacy__a-surface-action : blue;
-  --aksel-legacy__a-surface-action-selected  : red;
+  --aksel-v7-deprecated__a-surface-action : blue;
+  --aksel-v7-deprecated__a-surface-action-selected  : red;
 
   /* Multiple tokens on one line - SHOULD change */
   padding: var(--ax-space-16) var(--ax-space-16);

--- a/@navikt/aksel/src/darkside/transforms/tests/css-edge-cases.output.css
+++ b/@navikt/aksel/src/darkside/transforms/tests/css-edge-cases.output.css
@@ -4,9 +4,9 @@
   color: var(--not-a-surface-action);
   margin: var(--a-spacing-4-extra);
 
-  /* Whitespace in definitions - SHOULD change */
-  --aksel-v7-deprecated__a-surface-action : blue;
-  --aksel-v7-deprecated__a-surface-action-selected  : red;
+  /* Whitespace in definitions - SHOULD be detected */
+  --a-surface-action : blue;
+  --a-surface-action-selected  : red;
 
   /* Multiple tokens on one line - SHOULD change */
   padding: var(--ax-space-16) var(--ax-space-16);


### PR DESCRIPTION
### Description

Also avoid renaming re-defined tokens, since they can be easily found with search on --a- or --ac-
<img width="853" height="143" alt="Screenshot 2025-12-11 at 20 40 40" src="https://github.com/user-attachments/assets/eb2577e6-666a-47ec-910f-117676bdead3" />
<img width="616" height="170" alt="Screenshot 2025-12-11 at 20 40 43" src="https://github.com/user-attachments/assets/353286bd-579d-4d49-9d77-267881f64bc6" />
<img width="891" height="119" alt="Screenshot 2025-12-11 at 20 40 50" src="https://github.com/user-attachments/assets/1fa8faa6-de66-4092-a102-423d9c6e30be" />


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
