### PR TITLE
[Dialog] Footer action experiment

### DIFF
--- a/@navikt/core/css/darkside/dialog.darkside.css
+++ b/@navikt/core/css/darkside/dialog.darkside.css
@@ -221,7 +221,9 @@
   padding-block: var(--__axc-dialog-p-b);
   padding-inline: var(--__axc-dialog-p-i);
   display: flex;
+  justify-content: flex-end;
   gap: var(--ax-space-8);
+  flex-wrap: wrap;
 }
 
 .aksel-dialog__action-footer {

--- a/@navikt/core/css/darkside/dialog.darkside.css
+++ b/@navikt/core/css/darkside/dialog.darkside.css
@@ -230,7 +230,13 @@
   gap: var(--ax-space-8);
 
   @media (min-width: 480px) {
-    & :nth-of-type(2) {
+    /* 1 or 2 elements: margin-left on first to right-align all */
+    & > :first-child:nth-last-child(-n + 2) {
+      margin-left: auto;
+    }
+
+    /* 3+ elements: margin-left on second to split (1 left, rest right) */
+    & > :nth-child(2):nth-last-child(n + 2) {
       margin-left: auto;
     }
   }

--- a/@navikt/core/css/darkside/dialog.darkside.css
+++ b/@navikt/core/css/darkside/dialog.darkside.css
@@ -218,12 +218,26 @@
 }
 
 .aksel-dialog__footer {
-  justify-content: flex-start;
-  display: flex;
-  flex-flow: wrap;
-  gap: var(--ax-space-8);
   padding-block: var(--__axc-dialog-p-b);
   padding-inline: var(--__axc-dialog-p-i);
+  display: flex;
+  gap: var(--ax-space-8);
+}
+
+.aksel-dialog__action-footer {
+  display: flex;
+  flex-flow: wrap-reverse;
+  gap: var(--ax-space-8);
+
+  @media (min-width: 480px) {
+    & :nth-of-type(2) {
+      margin-left: auto;
+    }
+  }
+
+  @media (max-width: 479px) {
+    flex-flow: column-reverse;
+  }
 }
 
 @media (forced-colors: active) {

--- a/@navikt/core/react/src/dialog/Dialog.stories.tsx
+++ b/@navikt/core/react/src/dialog/Dialog.stories.tsx
@@ -3,7 +3,8 @@ import React, { useState } from "react";
 import { PencilIcon } from "@navikt/aksel-icons";
 import { Button } from "../button";
 import { Select } from "../form/select";
-import { VStack } from "../layout/stack";
+import { Hide, Show } from "../layout/responsive";
+import { HStack, Spacer, Stack, VStack } from "../layout/stack";
 import { Table } from "../table";
 import {
   Dialog,
@@ -56,11 +57,23 @@ export const Default = {
           <DialogBody>
             <ScrollContent />
           </DialogBody>
-          <DialogActionFooter>
-            <Button variant="tertiary">Back</Button>
-            <Button variant="secondary">Cancel</Button>
-            <Button>Send text with a little longer text</Button>
-          </DialogActionFooter>
+          <DialogFooter>
+            <HStack asChild gap="space-8" flexGrow="1">
+              <Show above="sm">
+                <Button variant="tertiary">Back</Button>
+                <Spacer />
+                <Button variant="secondary">Cancel</Button>
+                <Button>Send text with a little longer text</Button>
+              </Show>
+            </HStack>
+            <VStack asChild gap="space-8" flexGrow="1">
+              <Hide above="sm">
+                <Button>Send text with a little longer text</Button>
+                <Button variant="secondary">Cancel</Button>
+                <Button variant="tertiary">Back</Button>
+              </Hide>
+            </VStack>
+          </DialogFooter>
         </DialogPopup>
       </Dialog>
       <button onClick={() => alert("after")}>after dialog</button>

--- a/@navikt/core/react/src/dialog/Dialog.stories.tsx
+++ b/@navikt/core/react/src/dialog/Dialog.stories.tsx
@@ -59,14 +59,8 @@ export const Default = {
           <DialogActionFooter>
             <Button variant="tertiary">Back</Button>
             <Button variant="secondary">Cancel</Button>
-            <Button>Send button with long text</Button>
+            <Button>Send text with a little longer text</Button>
           </DialogActionFooter>
-          {/* <DialogFooter>
-            <Button variant="tertiary">Back</Button>
-            <Spacer />
-            <Button variant="secondary">Cancel</Button>
-            <Button>Send button with long text</Button>
-          </DialogFooter> */}
         </DialogPopup>
       </Dialog>
       <button onClick={() => alert("after")}>after dialog</button>

--- a/@navikt/core/react/src/dialog/Dialog.stories.tsx
+++ b/@navikt/core/react/src/dialog/Dialog.stories.tsx
@@ -7,6 +7,7 @@ import { VStack } from "../layout/stack";
 import { Table } from "../table";
 import {
   Dialog,
+  DialogActionFooter,
   DialogBody,
   DialogCloseTrigger,
   DialogDescription,
@@ -55,11 +56,17 @@ export const Default = {
           <DialogBody>
             <ScrollContent />
           </DialogBody>
-          <DialogFooter>
-            <DialogCloseTrigger>
-              <Button>Close</Button>
-            </DialogCloseTrigger>
-          </DialogFooter>
+          <DialogActionFooter>
+            <Button variant="tertiary">Back</Button>
+            <Button variant="secondary">Cancel</Button>
+            <Button>Send button with long text</Button>
+          </DialogActionFooter>
+          {/* <DialogFooter>
+            <Button variant="tertiary">Back</Button>
+            <Spacer />
+            <Button variant="secondary">Cancel</Button>
+            <Button>Send button with long text</Button>
+          </DialogFooter> */}
         </DialogPopup>
       </Dialog>
       <button onClick={() => alert("after")}>after dialog</button>

--- a/@navikt/core/react/src/dialog/action-footer/DialogActionFooter.tsx
+++ b/@navikt/core/react/src/dialog/action-footer/DialogActionFooter.tsx
@@ -1,0 +1,44 @@
+import React, { forwardRef } from "react";
+import { useRenameCSS } from "../../theme/Theme";
+
+type DialogActionFooterProps = React.HTMLAttributes<HTMLDivElement> & {};
+
+/**
+ * @see 🏷️ {@link DialogActionFooterProps}
+ * @example
+ * ```jsx
+ *  <Dialog>
+ *    <Dialog.Popup>
+ *      <Dialog.ActionFooter
+ *        actions={{
+ *          primary: <Button>Send</Button>,
+ *          secondary: <Button variant="secondary">Cancel</Button>,
+ *          tertiary: <Button variant="tertiary">Back</Button>,
+ *        }}
+ *      />
+ *    </Dialog.Popup>
+ *  </Dialog>
+ * ```
+ */
+const DialogActionFooter = forwardRef<HTMLDivElement, DialogActionFooterProps>(
+  ({ className, children, ...restProps }, forwardedRef) => {
+    const { cn } = useRenameCSS();
+
+    return (
+      <div
+        {...restProps}
+        ref={forwardedRef}
+        className={cn(
+          "navds-dialog__footer",
+          "navds-dialog__action-footer",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+export { DialogActionFooter };
+export type { DialogActionFooterProps };

--- a/@navikt/core/react/src/dialog/index.ts
+++ b/@navikt/core/react/src/dialog/index.ts
@@ -11,6 +11,8 @@ export { DialogHeader } from "./header/DialogHeader";
 export type { DialogHeaderProps } from "./header/DialogHeader";
 export { DialogFooter } from "./footer/DialogFooter";
 export type { DialogFooterProps } from "./footer/DialogFooter";
+export { DialogActionFooter } from "./action-footer/DialogActionFooter";
+export type { DialogActionFooterProps } from "./action-footer/DialogActionFooter";
 export { DialogTitle } from "./title/DialogTitle";
 export type { DialogTitleProps } from "./title/DialogTitle";
 export { DialogDescription } from "./description/DialogDescription";


### PR DESCRIPTION
### Description

Creating the "perfect" button handling seems kind of impossible at this point. Will always be some edgecases, or implementation specific contexts where they will need different handling. 

Just for testing, i have created a component `Dialog.ActionFooter`. The thought behind it was that "footer" is more generic, while "ActionFooter" is more controlled with its styling and expectations.
- But if we have a more "controlled" version, should it just have a prop `actions` that you give the primary, secondary action etc? `actions={{primary: <Button>123 </Button>, secondary: ...}}`
- That API would be mostly unique for our system, so unsure if DX would be the best

After looking through Metabase, most of the consumers of `Modal.Footer` just place 2-3 buttons directly on the Footer like expected without any customization. Would having a separate component `ActionFooter` be even necessary?


As for the other "issue", changing the wrapping from flex row -> column-reverse on mobile looks and works "mostly" ok as long as the buttons are not to long. Problem is tab-order that gets flipped.
- Since it is only the "mobile" version that get its tab-order flipped, are we comfortable with it being like that.

<img width="746" height="461" alt="Screenshot 2025-12-12 at 10 40 10" src="https://github.com/user-attachments/assets/65088d65-d37a-4730-a67c-1c43453d5af9" />
<img width="537" height="514" alt="Screenshot 2025-12-12 at 10 40 14" src="https://github.com/user-attachments/assets/3cda9cf5-eb3f-450e-a6a5-03fc5c58b56c" />
<img width="450" height="602" alt="Screenshot 2025-12-12 at 10 40 18" src="https://github.com/user-attachments/assets/6d079d7c-3942-418d-a2c8-4d20d80e8b86" />


There must be a smarter solution right? Or are we just overthinking it? No other systems are handling it at much complexity.