### PR TITLE
:sparkles: InternalHeader.User now supports ReactNode in props

### DIFF
--- a/.changeset/public-rings-doubt.md
+++ b/.changeset/public-rings-doubt.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+InternalHeader: InternalHeader.User-props supports React.ReactNode now.

--- a/@navikt/core/react/src/internal-header/InternalHeaderUser.tsx
+++ b/@navikt/core/react/src/internal-header/InternalHeaderUser.tsx
@@ -7,11 +7,11 @@ export interface InternalHeaderUserProps
   /**
    * User name
    */
-  name: string;
+  name: React.ReactNode;
   /**
    * User description
    */
-  description?: string;
+  description?: React.ReactNode;
 }
 
 export const InternalHeaderUser = forwardRef<
@@ -26,12 +26,12 @@ export const InternalHeaderUser = forwardRef<
       ref={ref}
       className={cn("navds-internalheader__user", className)}
     >
-      <span>
+      <div>
         <BodyShort size="small" as="div">
           {name}
         </BodyShort>
         {description && <Detail as="div">{description}</Detail>}
-      </span>
+      </div>
     </div>
   );
 });


### PR DESCRIPTION
### Description

https://nav-it.slack.com/archives/C7NE7A8UF/p1765959406580019

Also fixes dom-validation error where span is wrapped around divs.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
