### PR TITLE
:sparkles: Popover now flips in Datepicker/MonthPicker

### DIFF
--- a/.changeset/short-weeks-sip.md
+++ b/.changeset/short-weeks-sip.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-Datepicker/MonthPicker: Popover now flips if there is more avaliable space above input.
+Datepicker/MonthPicker: Popover now flips if there is more available space above input.

--- a/.changeset/short-weeks-sip.md
+++ b/.changeset/short-weeks-sip.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Datepicker/MonthPicker: Popover now flips if there is more avaliable space above input.

--- a/.changeset/wicked-beers-enter.md
+++ b/.changeset/wicked-beers-enter.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Popover: Placement-prop now respects 'alignment' when flipping.

--- a/@navikt/core/react/src/date/Date.Dialog.tsx
+++ b/@navikt/core/react/src/date/Date.Dialog.tsx
@@ -65,7 +65,6 @@ const DateDialog = ({
         className={cn("navds-date__popover", {
           "navds-date": variant === "month",
         })}
-        flip={false}
         {...popoverProps}
       >
         {children}

--- a/@navikt/core/react/src/popover/Popover.tsx
+++ b/@navikt/core/react/src/popover/Popover.tsx
@@ -7,7 +7,6 @@ import {
   useFloating,
 } from "@floating-ui/react";
 import React, { HTMLAttributes, forwardRef, useRef } from "react";
-import { useDateInputContext } from "../date/Date.Input";
 import { useModalContext } from "../modal/Modal.context";
 import { DismissableLayer } from "../overlays/dismissablelayer/DismissableLayer";
 import { useRenameCSS, useThemeInternal } from "../theme/Theme";
@@ -121,9 +120,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
     const { cn } = useRenameCSS();
     const arrowRef = useRef<HTMLDivElement | null>(null);
     const isInModal = useModalContext(false) !== undefined;
-    const datepickerContext = useDateInputContext(false);
     const chosenStrategy = userStrategy ?? (isInModal ? "fixed" : "absolute");
-    const chosenFlip = datepickerContext ? false : _flip;
 
     const themeContext = useThemeInternal(false);
 
@@ -139,8 +136,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       open,
       middleware: [
         flOffset(offset ?? (themeContext?.isDarkside ? 8 : arrow ? 16 : 4)),
-        chosenFlip &&
-          flip({ padding: 5, fallbackPlacements: ["bottom", "top"] }),
+        _flip && flip({ padding: 5, fallbackPlacements: ["bottom", "top"] }),
         shift({ padding: 12 }),
         flArrow({ element: arrowRef, padding: 8 }),
       ],

--- a/@navikt/core/react/src/popover/Popover.tsx
+++ b/@navikt/core/react/src/popover/Popover.tsx
@@ -1,4 +1,7 @@
 import {
+  Alignment,
+  Placement,
+  Side,
   autoUpdate,
   arrow as flArrow,
   offset as flOffset,
@@ -136,7 +139,11 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       open,
       middleware: [
         flOffset(offset ?? (themeContext?.isDarkside ? 8 : arrow ? 16 : 4)),
-        _flip && flip({ padding: 5, fallbackPlacements: ["bottom", "top"] }),
+        _flip &&
+          flip({
+            padding: 5,
+            fallbackPlacements: getOppositePlacement(placement),
+          }),
         shift({ padding: 12 }),
         flArrow({ element: arrowRef, padding: 8 }),
       ],
@@ -204,6 +211,32 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
     );
   },
 ) as PopoverComponent;
+
+const oppositeSideMap: Record<Side, Side> = {
+  top: "bottom",
+  bottom: "top",
+  left: "right",
+  right: "left",
+};
+
+/**
+ * If placement is side+alignment, we want to preserve the alignment
+ * when flipping to the opposite side.
+ */
+function getOppositePlacement(placement: Placement): Placement[] {
+  /**
+   * In most cases, the fallback for left/right should be top/bottom
+   * as there is usually more space vertically than horizontally.
+   */
+  if (placement.startsWith("left") || placement.startsWith("right")) {
+    return ["bottom", "top"];
+  }
+
+  const [side, alignment] = placement.split("-") as [Side, Alignment?];
+  const oppositeSide = oppositeSideMap[side];
+
+  return [alignment ? `${oppositeSide}-${alignment}` : oppositeSide];
+}
 
 Popover.Content = PopoverContent;
 


### PR DESCRIPTION
### Description

Resolves #4409

Could find some discussions on this here: https://nav-it.slack.com/archives/C7NE7A8UF/p1727161300911749
but the argument then was that the popover would cover label/error-message. But since the anchor is on the wrapper, this will never happen now:
<img width="670" height="662" alt="Screenshot 2025-12-17 at 18 42 16" src="https://github.com/user-attachments/assets/e726c2e2-6370-459f-8519-6582052c7032" />



### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
