### PR TITLE
[CLI] Interactive major-version codemod selection

### DIFF
--- a/.changeset/seven-actors-juggle.md
+++ b/.changeset/seven-actors-juggle.md
@@ -1,0 +1,5 @@
+---
+"@navikt/aksel": minor
+---
+
+CLI: Now has interactive codemod-selection for all major-versions.

--- a/@navikt/aksel/src/codemod/index.ts
+++ b/@navikt/aksel/src/codemod/index.ts
@@ -24,7 +24,7 @@ export function codemodCommand(
       chalk.gray(`\nAvailable migrations:\n${getMigrationString()}`),
     )
     .description("Migrations for Aksel components and more")
-    .argument("<migration>", "Migration name or version (e.g., v8.0.0)")
+    .argument("<migration>", "Migration name or version (e.g., v8)")
 
     .option("-e, --ext [extension]", "default: js,ts,jsx,tsx,css,scss,less")
     .option(
@@ -41,19 +41,19 @@ export function codemodCommand(
       "after",
       `\nExample:
   $ npx @navikt/aksel codemod --dry-run v2-css
-  $ npx @navikt/aksel codemod v8.0.0  # Interactive selection for version`,
+  $ npx @navikt/aksel codemod v8  # Interactive selection for version`,
     )
     .action(async (str, options) => {
       const versionKeys = getVersionKeys();
 
-      // Check if the argument is a version key for interactive selection
+      /* Check if the argument is a version key for interactive selection */
       if (versionKeys.includes(str)) {
         validateVersion(str, program);
         await runVersionMigration(str, options, program, overrideHandler);
         return;
       }
 
-      // Otherwise, treat it as a specific migration name
+      /* Otherwise, treat it as a specific migration name */
       validateMigration(str, program);
       validateGit(options, program);
       runCodeshift(str, options, program);

--- a/@navikt/aksel/src/codemod/index.ts
+++ b/@navikt/aksel/src/codemod/index.ts
@@ -24,7 +24,7 @@ export function codemodCommand(
       chalk.gray(`\nAvailable migrations:\n${getMigrationString()}`),
     )
     .description("Migrations for Aksel components and more")
-    .argument("<migration>", "Migration name or version (e.g., v8)")
+    .argument("<migration>", "Migration name or version (e.g. v8)")
 
     .option("-e, --ext [extension]", "default: js,ts,jsx,tsx,css,scss,less")
     .option(

--- a/@navikt/aksel/src/codemod/index.ts
+++ b/@navikt/aksel/src/codemod/index.ts
@@ -11,7 +11,9 @@ import { validateGit, validateMigration } from "./validation.js";
 
 const program = new Command();
 
-export function codemodCommand() {
+export function codemodCommand(
+  overrideHandler?: (migration: string) => Promise<void> | void,
+) {
   program.name(`${chalk.blueBright(`npx @navikt/aksel`)}`);
 
   program
@@ -47,7 +49,7 @@ export function codemodCommand() {
       // Check if the argument is a version key for interactive selection
       if (versionKeys.includes(str)) {
         validateVersion(str, program);
-        await runVersionMigration(str, options, program);
+        await runVersionMigration(str, options, program, overrideHandler);
         return;
       }
 

--- a/@navikt/aksel/src/codemod/index.ts
+++ b/@navikt/aksel/src/codemod/index.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { Command } from "commander";
 import figlet from "figlet";
-import { getMigrationString, getVersionKeys } from "./migrations.js";
+import { getMigrationString } from "./migrations.js";
 import { runCodeshift } from "./run-codeshift.js";
 import {
   runVersionMigration,
@@ -44,10 +44,8 @@ export function codemodCommand(
   $ npx @navikt/aksel codemod v8  # Interactive selection for version`,
     )
     .action(async (str, options) => {
-      const versionKeys = getVersionKeys();
-
       /* Check if the argument is a version key for interactive selection */
-      if (versionKeys.includes(str)) {
+      if (/^v\d+$/.test(str)) {
         validateVersion(str, program);
         await runVersionMigration(str, options, program, overrideHandler);
         return;

--- a/@navikt/aksel/src/codemod/index.ts
+++ b/@navikt/aksel/src/codemod/index.ts
@@ -1,8 +1,12 @@
 import chalk from "chalk";
 import { Command } from "commander";
 import figlet from "figlet";
-import { getMigrationString } from "./migrations.js";
+import { getMigrationString, getVersionKeys } from "./migrations.js";
 import { runCodeshift } from "./run-codeshift.js";
+import {
+  runVersionMigration,
+  validateVersion,
+} from "./run-version-migration.js";
 import { validateGit, validateMigration } from "./validation.js";
 
 const program = new Command();
@@ -18,7 +22,7 @@ export function codemodCommand() {
       chalk.gray(`\nAvailable migrations:\n${getMigrationString()}`),
     )
     .description("Migrations for Aksel components and more")
-    .argument("<migration>", "Migration name")
+    .argument("<migration>", "Migration name or version (e.g., v8.0.0)")
 
     .option("-e, --ext [extension]", "default: js,ts,jsx,tsx,css,scss,less")
     .option(
@@ -34,9 +38,20 @@ export function codemodCommand() {
     .addHelpText(
       "after",
       `\nExample:
-  $ npx @navikt/aksel --dry-run v2-css`,
+  $ npx @navikt/aksel codemod --dry-run v2-css
+  $ npx @navikt/aksel codemod v8.0.0  # Interactive selection for version`,
     )
-    .action((str, options) => {
+    .action(async (str, options) => {
+      const versionKeys = getVersionKeys();
+
+      // Check if the argument is a version key for interactive selection
+      if (versionKeys.includes(str)) {
+        validateVersion(str, program);
+        await runVersionMigration(str, options, program);
+        return;
+      }
+
+      // Otherwise, treat it as a specific migration name
       validateMigration(str, program);
       validateGit(options, program);
       runCodeshift(str, options, program);

--- a/@navikt/aksel/src/codemod/migrations.ts
+++ b/@navikt/aksel/src/codemod/migrations.ts
@@ -263,6 +263,13 @@ export function getMigrationsForVersion(version: string) {
 }
 
 /**
+ * Returns the override migrations available for a specific version.
+ */
+export function getOverridesForVersion(version: string) {
+  return migrationStringOverride[version] ?? [];
+}
+
+/**
  * Allows injecting additional migration names that are not part of the main migrations-list.
  * This is used for interactive migrations that should not be part of the main list.
  *
@@ -270,7 +277,7 @@ export function getMigrationsForVersion(version: string) {
  * which is not the case for interactive migrations that are handled differently.
  */
 export const migrationStringOverride = {
-  "v8.0.0": [
+  v8: [
     {
       value: "v8-tokens",
       description: "Starts interactive token migration for v8",

--- a/@navikt/aksel/src/codemod/migrations.ts
+++ b/@navikt/aksel/src/codemod/migrations.ts
@@ -30,7 +30,7 @@ type MigrationT = Record<
 >;
 
 export const migrations: MigrationT = {
-  "1.0.0": [
+  v1: [
     {
       description: "Runs all codemods for beta -> v1 migration",
       value: "v1-preset",
@@ -57,7 +57,7 @@ export const migrations: MigrationT = {
       ignoredExtensions: CSS_EXTENSIONS,
     },
   ],
-  "2.0.0": [
+  v2: [
     {
       description: "Patches changed css-variables",
       value: "v2-css",
@@ -83,7 +83,7 @@ export const migrations: MigrationT = {
       ignoredExtensions: JS_EXTENSIONS,
     },
   ],
-  "v3.0.0": [
+  v3: [
     {
       description:
         "Replaces deprecated <CopyToClipboard /> with <CopyButton />",
@@ -94,7 +94,7 @@ export const migrations: MigrationT = {
       ignoredExtensions: CSS_EXTENSIONS,
     },
   ],
-  "v4.0.0": [
+  v4: [
     {
       description:
         "Replaced deprecated 'internal'-component import to 'core'-imports",
@@ -121,7 +121,7 @@ export const migrations: MigrationT = {
       ignoredExtensions: CSS_EXTENSIONS,
     },
   ],
-  "v6.0.0": [
+  v6: [
     {
       description:
         "Removes `backgroundColor` and `avatarBgColor` properties from `Chat` and `Chat.Bubble`",
@@ -132,7 +132,7 @@ export const migrations: MigrationT = {
       ignoredExtensions: CSS_EXTENSIONS,
     },
   ],
-  "v8.0.0": [
+  v8: [
     {
       description:
         "Updates Box with legacy-tokens to Box using the new token system, and renames already migrated BoxNew/Box.New instances to Box.",
@@ -283,14 +283,6 @@ export const migrationStringOverride = {
 export function getMigrationString() {
   let str = "";
 
-  str += `\n${chalk.bold("Interactive version selection:")}\n`;
-  str += chalk.gray(
-    "Run with a version key to interactively select migrations:\n",
-  );
-  Object.keys(migrations).forEach((version) => {
-    str += `${chalk.blue(version)}: Interactive selection for ${version} migrations\n`;
-  });
-
   Object.entries(migrations).forEach(([version, vMigrations]) => {
     str += `\n${chalk.underline(version)}\n`;
 
@@ -302,6 +294,14 @@ export function getMigrationString() {
     vMigrations.forEach((migration) => {
       str += `${chalk.blue(migration.value)}: ${migration.description}\n`;
     });
+  });
+
+  str += `\n${chalk.bold(chalk.blueBright("Interactive version selection:"))}\n`;
+  str += chalk.gray(
+    "Run with a version key to interactively select migrations:\n",
+  );
+  Object.keys(migrations).forEach((version) => {
+    str += `${chalk.blue(version)}, `;
   });
 
   return str;

--- a/@navikt/aksel/src/codemod/migrations.ts
+++ b/@navikt/aksel/src/codemod/migrations.ts
@@ -249,6 +249,20 @@ export function getMigrationNames() {
 }
 
 /**
+ * Returns all available version keys from the migrations object.
+ */
+export function getVersionKeys(): string[] {
+  return Object.keys(migrations);
+}
+
+/**
+ * Returns the migrations available for a specific version.
+ */
+export function getMigrationsForVersion(version: string) {
+  return migrations[version] ?? [];
+}
+
+/**
  * Allows injecting additional migration names that are not part of the main migrations-list.
  * This is used for interactive migrations that should not be part of the main list.
  *
@@ -268,6 +282,14 @@ export const migrationStringOverride = {
 
 export function getMigrationString() {
   let str = "";
+
+  str += `\n${chalk.bold("Interactive version selection:")}\n`;
+  str += chalk.gray(
+    "Run with a version key to interactively select migrations:\n",
+  );
+  Object.keys(migrations).forEach((version) => {
+    str += `${chalk.blue(version)}: Interactive selection for ${version} migrations\n`;
+  });
 
   Object.entries(migrations).forEach(([version, vMigrations]) => {
     str += `\n${chalk.underline(version)}\n`;

--- a/@navikt/aksel/src/codemod/migrations.ts
+++ b/@navikt/aksel/src/codemod/migrations.ts
@@ -307,9 +307,7 @@ export function getMigrationString() {
   str += chalk.gray(
     "Run with a version key to interactively select migrations:\n",
   );
-  Object.keys(migrations).forEach((version) => {
-    str += `${chalk.blue(version)}, `;
-  });
+  str += chalk.blue(getVersionKeys().join(", "));
 
   return str;
 }

--- a/@navikt/aksel/src/codemod/run-codeshift.ts
+++ b/@navikt/aksel/src/codemod/run-codeshift.ts
@@ -28,7 +28,6 @@ export async function runCodeshift(
     `./transforms/${getMigrationPath(input)}.js`,
   );
 
-  console.info(chalk.greenBright.bold("\nWelcome to Aksel codemods!"));
   console.info("\nRunning migration:", chalk.green(input));
 
   const globList = options.glob ?? getDefaultGlob(options?.ext);

--- a/@navikt/aksel/src/codemod/run-version-migration.ts
+++ b/@navikt/aksel/src/codemod/run-version-migration.ts
@@ -1,0 +1,77 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import Enquirer from "enquirer";
+import { getMigrationsForVersion, getVersionKeys } from "./migrations.js";
+import { runCodeshift } from "./run-codeshift.js";
+import { validateGit } from "./validation.js";
+
+/**
+ * Validates that the provided version key exists in the migrations object.
+ */
+function validateVersion(version: string, program: Command) {
+  const versionKeys = getVersionKeys();
+
+  if (!versionKeys.includes(version)) {
+    program.error(
+      chalk.red(
+        `Version <${version}> not found!\n${chalk.gray(
+          `\nAvailable versions:\n${versionKeys.map((v) => `  ${v}`).join("\n")}`,
+        )}`,
+      ),
+    );
+  }
+}
+
+/**
+ * Runs interactive migration selection for a specific version.
+ */
+async function runVersionMigration(
+  version: string,
+  options: any,
+  program: Command,
+) {
+  const availableMigrations = getMigrationsForVersion(version);
+
+  if (availableMigrations.length === 0) {
+    program.error(chalk.red(`No migrations found for version ${version}`));
+  }
+
+  console.info(
+    chalk.greenBright.bold(`\nAvailable migrations for ${version}:\n`),
+  );
+
+  const response = await Enquirer.prompt<{ selectedMigrations: string[] }>({
+    type: "multiselect",
+    name: "selectedMigrations",
+    message: `Select migrations to run for ${version}`,
+    choices: availableMigrations.map((migration) => ({
+      name: migration.value,
+      message: `${chalk.blue(migration.value)}: ${migration.description}`,
+      value: migration.value,
+    })),
+  });
+
+  const { selectedMigrations } = response;
+
+  if (selectedMigrations.length === 0) {
+    console.info(chalk.yellow("\nNo migrations selected. Exiting."));
+    return;
+  }
+
+  console.info(
+    chalk.gray(
+      `\nRunning ${selectedMigrations.length} migration(s): ${selectedMigrations.join(", ")}\n`,
+    ),
+  );
+
+  validateGit(options, program);
+
+  for (const migration of selectedMigrations) {
+    console.info(chalk.blue(`\n--- Running: ${migration} ---\n`));
+    await runCodeshift(migration, options, program);
+  }
+
+  console.info(chalk.greenBright.bold("\nAll selected migrations completed!"));
+}
+
+export { runVersionMigration, validateVersion };

--- a/@navikt/aksel/src/codemod/run-version-migration.ts
+++ b/@navikt/aksel/src/codemod/run-version-migration.ts
@@ -44,9 +44,10 @@ async function runVersionMigration(
     type: "multiselect",
     name: "selectedMigrations",
     message: `Select migrations to run for ${version}`,
+
     choices: availableMigrations.map((migration) => ({
       name: migration.value,
-      message: `${chalk.blue(migration.value)}: ${migration.description}`,
+      message: `${chalk.blue(migration.value)}: ${chalk.gray(migration.description)}\n`,
       value: migration.value,
     })),
   });
@@ -67,7 +68,7 @@ async function runVersionMigration(
   validateGit(options, program);
 
   for (const migration of selectedMigrations) {
-    console.info(chalk.blue(`\n--- Running: ${migration} ---\n`));
+    console.info(chalk.blue(`\n\n--- Running: ${migration} ---`));
     await runCodeshift(migration, options, program);
   }
 

--- a/@navikt/aksel/src/codemod/run-version-migration.ts
+++ b/@navikt/aksel/src/codemod/run-version-migration.ts
@@ -90,7 +90,7 @@ async function runVersionMigration(
   for (const migration of selectedMigrations) {
     console.info(chalk.blue(`\n\n--- Running: ${migration} ---`));
 
-    // Check if this is an override migration that needs special handling
+    /* Check if this is an override migration that needs special handling */
     if (overrideValues.has(migration) && overrideHandler) {
       await overrideHandler(migration);
     } else {

--- a/@navikt/aksel/src/codemod/run-version-migration.ts
+++ b/@navikt/aksel/src/codemod/run-version-migration.ts
@@ -55,12 +55,12 @@ async function runVersionMigration(
   const choices = [
     ...overrideMigrations.map((migration) => ({
       name: migration.value,
-      message: `${chalk.blue(migration.value)}: ${chalk.gray(migration.description)}\n`,
+      message: `${chalk.blue(migration.value)}: ${chalk.gray(migration.description)}`,
       value: migration.value,
     })),
     ...availableMigrations.map((migration) => ({
       name: migration.value,
-      message: `${chalk.blue(migration.value)}: ${chalk.gray(migration.description)}\n`,
+      message: `${chalk.blue(migration.value)}: ${chalk.gray(migration.description)}`,
       value: migration.value,
     })),
   ];

--- a/@navikt/aksel/src/codemod/tests/migrations.test.ts
+++ b/@navikt/aksel/src/codemod/tests/migrations.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import {
   getMigrationNames,
   getMigrationPath,
+  getVersionKeys,
   migrationStringOverride,
 } from "../migrations";
 
@@ -33,5 +34,11 @@ describe("migrations", () => {
     });
 
     expect(values.filter((x) => overrideValues.has(x))).toEqual([]);
+  });
+
+  test("No global overrides", () => {
+    const versionNames = getVersionKeys();
+
+    expect(values.filter((x) => versionNames.includes(x))).toEqual([]);
   });
 });

--- a/@navikt/aksel/src/index.ts
+++ b/@navikt/aksel/src/index.ts
@@ -28,7 +28,11 @@ async function run() {
       return;
     }
 
-    codemodCommand();
+    codemodCommand((migration) => {
+      if (migration === "v8-tokens") {
+        darksideCommand();
+      }
+    });
     return;
   }
 


### PR DESCRIPTION
### Description

Allows running `npx @navikt/aksel codemod v8` for an interactive selection of all codemods related to that major-version

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
