### PR TITLE
[Actionmenu] Safezone handling while inside custom-components

### DIFF
--- a/.changeset/empty-balloons-roll.md
+++ b/.changeset/empty-balloons-roll.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+ActionMenu: Trigger handles trigger click while inside web-component better.

--- a/.changeset/empty-balloons-roll.md
+++ b/.changeset/empty-balloons-roll.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-ActionMenu: Trigger handles trigger click while inside web-component better.
+ActionMenu: Trigger handles click while inside web-component better.

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -17,7 +17,6 @@ import { Menu, MenuPortalProps } from "../floating-menu/Menu";
 type ActionMenuContextValue = {
   triggerId: string;
   triggerRef: React.RefObject<HTMLButtonElement | null>;
-  triggerPointerDownRef: React.MutableRefObject<boolean>;
   contentId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -250,7 +249,6 @@ const ActionMenuRoot = ({
   rootElement: rootElementProp,
 }: ActionMenuProps) => {
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const triggerPointerDownRef = useRef<boolean>(false);
 
   const modalContext = useModalContext(false);
   const rootElement = modalContext ? modalContext.ref.current : rootElementProp;
@@ -265,7 +263,6 @@ const ActionMenuRoot = ({
     <ActionMenuProvider
       triggerId={useId()}
       triggerRef={triggerRef}
-      triggerPointerDownRef={triggerPointerDownRef}
       contentId={useId()}
       open={open}
       onOpenChange={setOpen}
@@ -340,18 +337,6 @@ export const ActionMenuTrigger = forwardRef<
               event.preventDefault();
             }
           })}
-          onPointerDownCapture={() => {
-            context.triggerPointerDownRef.current = true;
-          }}
-          onPointerUp={() => {
-            context.triggerPointerDownRef.current = false;
-          }}
-          onPointerLeave={() => {
-            context.triggerPointerDownRef.current = false;
-          }}
-          onPointerCancel={() => {
-            context.triggerPointerDownRef.current = false;
-          }}
         >
           {requireReactElement(children)}
         </Slot>
@@ -400,21 +385,6 @@ export const ActionMenuContent = forwardRef<
           returnFocus={context.triggerRef}
           safeZone={{
             anchor: context.triggerRef.current,
-            /**
-             * If actionmenu is wrapped inside a custom-component,
-             * the target will be a generic "custom-component".
-             * Therefore, we check if the pointerdown originated from the trigger itself since
-             * anchor will never match the target in that case.
-             */
-            isEventSafe: (eventType) => {
-              const currentValue = context.triggerPointerDownRef.current;
-              context.triggerPointerDownRef.current = false;
-              if (eventType !== "pointerdown") {
-                return false;
-              }
-
-              return currentValue;
-            },
           }}
           style={{
             ...style,

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -17,6 +17,7 @@ import { Menu, MenuPortalProps } from "../floating-menu/Menu";
 type ActionMenuContextValue = {
   triggerId: string;
   triggerRef: React.RefObject<HTMLButtonElement | null>;
+  triggerPointerDownRef: React.MutableRefObject<boolean>;
   contentId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -249,6 +250,7 @@ const ActionMenuRoot = ({
   rootElement: rootElementProp,
 }: ActionMenuProps) => {
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const triggerPointerDownRef = useRef<boolean>(false);
 
   const modalContext = useModalContext(false);
   const rootElement = modalContext ? modalContext.ref.current : rootElementProp;
@@ -263,6 +265,7 @@ const ActionMenuRoot = ({
     <ActionMenuProvider
       triggerId={useId()}
       triggerRef={triggerRef}
+      triggerPointerDownRef={triggerPointerDownRef}
       contentId={useId()}
       open={open}
       onOpenChange={setOpen}
@@ -338,6 +341,18 @@ export const ActionMenuTrigger = forwardRef<
               event.preventDefault();
             }
           })}
+          onPointerDownCapture={() => {
+            context.triggerPointerDownRef.current = true;
+          }}
+          onPointerUp={() => {
+            context.triggerPointerDownRef.current = false;
+          }}
+          onPointerLeave={() => {
+            context.triggerPointerDownRef.current = false;
+          }}
+          onPointerCancel={() => {
+            context.triggerPointerDownRef.current = false;
+          }}
         >
           {requireReactElement(children)}
         </Slot>
@@ -384,7 +399,10 @@ export const ActionMenuContent = forwardRef<
           sideOffset={4}
           collisionPadding={10}
           returnFocus={context.triggerRef}
-          safeZone={{ anchor: context.triggerRef.current }}
+          safeZone={{
+            anchor: context.triggerRef.current,
+            isTargetAnchorRef: context.triggerPointerDownRef,
+          }}
           style={{
             ...style,
             ...{

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -318,7 +318,6 @@ export const ActionMenuTrigger = forwardRef<
     ref,
   ) => {
     const context = useActionMenuContext();
-
     const mergedRefs = useMergeRefs(ref, context.triggerRef);
 
     return (
@@ -401,7 +400,21 @@ export const ActionMenuContent = forwardRef<
           returnFocus={context.triggerRef}
           safeZone={{
             anchor: context.triggerRef.current,
-            isTargetAnchorRef: context.triggerPointerDownRef,
+            /**
+             * If actionmenu is wrapped inside a custom-component,
+             * the target will be a generic "custom-component".
+             * Therefore, we check if the pointerdown originated from the trigger itself since
+             * anchor will never match the target in that case.
+             */
+            isEventSafe: (eventType) => {
+              const currentValue = context.triggerPointerDownRef.current;
+              context.triggerPointerDownRef.current = false;
+              if (eventType !== "pointerdown") {
+                return false;
+              }
+
+              return currentValue;
+            },
           }}
           style={{
             ...style,

--- a/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
+++ b/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
@@ -64,7 +64,7 @@ interface DismissableLayerBaseProps
    */
   safeZone?: {
     anchor?: Element | null;
-    isTargetAnchorRef?: React.MutableRefObject<boolean>;
+    isEventSafe?: (eventType: "pointerdown" | "focusin") => boolean;
   };
   /**
    * @default true
@@ -143,10 +143,14 @@ const DismissableLayer = forwardRef<HTMLDivElement, DismissableLayerProps>(
         return;
       }
 
-      if (
-        safeZone.isTargetAnchorRef?.current &&
-        event.detail.originalEvent.type === "pointerdown"
-      ) {
+      const eventType = event.detail.originalEvent.type as
+        | "pointerdown"
+        | "focusin";
+
+      /**
+       * Allows caller to define custom logic to determine if the event is "safe".
+       */
+      if (safeZone.isEventSafe?.(eventType)) {
         event.preventDefault();
         return;
       }

--- a/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
+++ b/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
@@ -64,6 +64,7 @@ interface DismissableLayerBaseProps
    */
   safeZone?: {
     anchor?: Element | null;
+    isTargetAnchorRef?: React.MutableRefObject<boolean>;
   };
   /**
    * @default true
@@ -139,6 +140,14 @@ const DismissableLayer = forwardRef<HTMLDivElement, DismissableLayerProps>(
      */
     function handleOutsideEvent(event: CustomFocusEvent | CustomPointerEvent) {
       if (!safeZone?.anchor) {
+        return;
+      }
+
+      if (
+        safeZone.isTargetAnchorRef?.current &&
+        event.detail.originalEvent.type === "pointerdown"
+      ) {
+        event.preventDefault();
         return;
       }
 

--- a/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
+++ b/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
@@ -322,19 +322,6 @@ const DismissableLayer = forwardRef<HTMLDivElement, DismissableLayerProps>(
       };
     }, [safeZone?.anchor]);
 
-    /* onPointerDownCapture={() => {
-            context.triggerPointerDownRef.current = true;
-          }}
-          onPointerUp={() => {
-            context.triggerPointerDownRef.current = false;
-          }}
-          onPointerLeave={() => {
-            context.triggerPointerDownRef.current = false;
-          }}
-          onPointerCancel={() => {
-            context.triggerPointerDownRef.current = false;
-          }} */
-
     /**
      * Handles registering `layers` and `layersWithOutsidePointerEventsDisabled`.
      */

--- a/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
+++ b/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
@@ -155,35 +155,12 @@ const DismissableLayer = forwardRef<HTMLDivElement, DismissableLayerProps>(
         return;
       }
 
-      let hasPointerDownOutside = false;
-
-      if (!event.defaultPrevented) {
-        if (event.detail.originalEvent.type === "pointerdown") {
-          hasPointerDownOutside = true;
-        }
-      }
-
       const target = event.target as HTMLElement;
 
       const targetIsAnchor =
         safeZone.anchor.contains(target) || target === safeZone.anchor;
 
       if (targetIsAnchor) {
-        event.preventDefault();
-      }
-
-      /**
-       * In Safari, if the trigger element is inside a container with tabIndex={0}, a click on the trigger
-       * will first fire a 'pointerdownoutside' event on the trigger itself. However, it will then fire a
-       * 'focusoutside' event on the container.
-       *
-       * To handle this, we ignore any 'focusoutside' events if a 'pointerdownoutside' event has already occurred.
-       * 'pointerdownoutside' event is sufficient to indicate interaction outside the DismissableLayer.
-       */
-      if (
-        event.detail.originalEvent.type === "focusin" &&
-        hasPointerDownOutside
-      ) {
         event.preventDefault();
       }
     }

--- a/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
+++ b/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
@@ -61,10 +61,14 @@ interface DismissableLayerBaseProps
   onDismiss?: (event: Event) => void;
   /**
    * Stops `onDismiss` from beeing called when interacting with the `safeZone` elements.
+   * - anchor: The element that should be considered safe to interact with.
+   * - isEventSafe: Optional function to determine if the event is safe based on custom logic.
    */
   safeZone?: {
     anchor?: Element | null;
-    isEventSafe?: (eventType: "pointerdown" | "focusin") => boolean;
+    isEventSafe?: (
+      eventType: "pointerdown" | "pointerup" | "focusin",
+    ) => boolean;
   };
   /**
    * @default true
@@ -144,6 +148,7 @@ const DismissableLayer = forwardRef<HTMLDivElement, DismissableLayerProps>(
       }
 
       const eventType = event.detail.originalEvent.type as
+        | "pointerup"
         | "pointerdown"
         | "focusin";
 

--- a/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
+++ b/@navikt/core/react/src/overlays/dismissablelayer/DismissableLayer.tsx
@@ -156,26 +156,23 @@ const DismissableLayer = forwardRef<HTMLDivElement, DismissableLayerProps>(
         | "pointerdown"
         | "focusin";
 
-      /**
-       * If anchor is wrapped inside a custom-component,
-       * the target will be a generic "custom-component".
-       * Therefore, we check if the pointerdown originated from the trigger itself since
-       * anchor will never match the target in that case.
-       */
-      if (
-        eventType === "pointerdown" &&
-        triggerPointerDownRef.current === true
-      ) {
-        event.preventDefault();
-        return;
-      }
-
       const target = event.target as HTMLElement;
 
       const targetIsAnchor =
         safeZone.anchor.contains(target) || target === safeZone.anchor;
 
       if (targetIsAnchor) {
+        event.preventDefault();
+      }
+
+      /**
+       * If the target is inside a custom element, event.target will be that element on pointerdown.
+       * Therefore, checking anchor.contains(target) etc. won't work in that case.
+       */
+      if (
+        eventType === "pointerdown" &&
+        triggerPointerDownRef.current === true
+      ) {
         event.preventDefault();
       }
 

--- a/examples/shadow-dom/main.tsx
+++ b/examples/shadow-dom/main.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import ReactDOM from "react-dom/client";
+import { ChevronDownIcon } from "@navikt/aksel-icons";
 import styles from "@navikt/ds-css/dist/index.css?inline";
 import {
+  ActionMenu,
   Button,
   Checkbox,
   CheckboxGroup,
@@ -20,6 +22,7 @@ class CustomComponent extends HTMLElement {
     ReactDOM.createRoot(appElement).render(
       <Provider rootElement={rootElement}>
         <style>{styles}</style>
+        <ActionMenuDemo />
         <Button>Click me!</Button>
         <CheckboxGroup legend="Legend" defaultValue={["tekst2"]}>
           <Checkbox value="tekst">Checkboxtekst</Checkbox>
@@ -45,6 +48,37 @@ const ModalWrapper = () => {
         <Modal.Body>modal content</Modal.Body>
       </Modal>
     </>
+  );
+};
+
+const ActionMenuDemo = () => {
+  return (
+    <ActionMenu>
+      <ActionMenu.Trigger>
+        <Button
+          variant="secondary-neutral"
+          icon={<ChevronDownIcon aria-hidden />}
+          iconPosition="right"
+        >
+          Meny
+        </Button>
+      </ActionMenu.Trigger>
+      <ActionMenu.Content>
+        <ActionMenu.Group label="Systemer og oppslagsverk">
+          <ActionMenu.Item onSelect={console.info}>A-inntekt</ActionMenu.Item>
+          <ActionMenu.Item onSelect={console.info}>
+            Aa-registeret
+          </ActionMenu.Item>
+          <ActionMenu.Item onSelect={console.info}>Gosys</ActionMenu.Item>
+          <ActionMenu.Item onSelect={console.info}>
+            Modia Sykefraværsoppfølging
+          </ActionMenu.Item>
+          <ActionMenu.Item onSelect={console.info}>
+            Modia Personoversikt
+          </ActionMenu.Item>
+        </ActionMenu.Group>
+      </ActionMenu.Content>
+    </ActionMenu>
   );
 };
 

--- a/examples/shadow-dom/main.tsx
+++ b/examples/shadow-dom/main.tsx
@@ -8,8 +8,10 @@ import {
   Checkbox,
   CheckboxGroup,
   Modal,
+  Popover,
   Provider,
   Tooltip,
+  UNSAFE_Combobox,
 } from "@navikt/ds-react";
 
 class CustomComponent extends HTMLElement {
@@ -32,6 +34,8 @@ class CustomComponent extends HTMLElement {
           <Button>Tooltip</Button>
         </Tooltip>
         <ModalWrapper />
+        <PopoverDemo />
+        <ComboboxDemo />
         <br />
       </Provider>,
     );
@@ -81,5 +85,52 @@ const ActionMenuDemo = () => {
     </ActionMenu>
   );
 };
+
+const PopoverDemo = () => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [openState, setOpenState] = useState(false);
+
+  return (
+    <>
+      <Button
+        ref={setAnchorEl}
+        onClick={() => setOpenState(!openState)}
+        aria-expanded={openState}
+      >
+        Åpne popover
+      </Button>
+
+      <Popover
+        open={openState}
+        onClose={() => setOpenState(false)}
+        anchorEl={anchorEl}
+      >
+        <Popover.Content>Innhold her!</Popover.Content>
+      </Popover>
+    </>
+  );
+};
+
+const ComboboxDemo = () => {
+  return (
+    <UNSAFE_Combobox label="Hva er din favorittfrukt?" options={options} />
+  );
+};
+
+const options = [
+  "ananas",
+  "banan",
+  "bringebær",
+  "drue",
+  "eple",
+  "grapefrukt",
+  "jordbær",
+  "kiwi",
+  "mandarin",
+  "mango",
+  "pære",
+  "pasjonsfrukt",
+  "vannmelon",
+];
 
 window.customElements.define("custom-component", CustomComponent);

--- a/examples/shadow-dom/yarn.lock
+++ b/examples/shadow-dom/yarn.lock
@@ -639,28 +639,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/aksel-icons@npm:^7.34.0":
-  version: 7.34.0
-  resolution: "@navikt/aksel-icons@npm:7.34.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Faksel-icons%2F7.34.0%2Fe0ec5f786c00d1ec4c24973b10c52b15f62ed988"
-  checksum: 10/fe73fc5cec11ad3676fab6c1c01a6c20dff0d4ba90433187acd23bcde82c225454eca73a1a4ab2216538976cc596f2c9e110f2817908a94223d8ab4c47da9887
+"@navikt/aksel-icons@npm:^7.36.0":
+  version: 7.36.0
+  resolution: "@navikt/aksel-icons@npm:7.36.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Faksel-icons%2F7.36.0%2F5d01680f20cd3ad3c447ea53fd4f71d9e40056e1"
+  checksum: 10/85625f0b31a7c12bcd528706b753cb936a212d8703684ac09f8b11fa971a452775049db8752aa0e0a80416373c48545b2b0bac3b8493d1d227036a139a37d089
   languageName: node
   linkType: hard
 
 "@navikt/ds-css@file:./../../@navikt/core/css::locator=shadow-dom%40workspace%3A.":
-  version: 7.34.0
-  resolution: "@navikt/ds-css@file:./../../@navikt/core/css#./../../@navikt/core/css::hash=219188&locator=shadow-dom%40workspace%3A."
-  checksum: 10/60952ff58b18cce7b24fdecfd0fba75ab98b32927df55b3aa0446ea7ddca7d3bb40d47213755646a3601da388bb5e7e8347352ce31f5a3c8b2445bf77eae0608
+  version: 7.36.0
+  resolution: "@navikt/ds-css@file:./../../@navikt/core/css#./../../@navikt/core/css::hash=366a36&locator=shadow-dom%40workspace%3A."
+  checksum: 10/98ed5693e1de1cac861992dcc139e1289a899e92403ff5ba233aa79365587e4ac4d9eb7a85c7997521e9b14beaa42aa109aa44e998f17e7a621773d544d22e89
   languageName: node
   linkType: hard
 
 "@navikt/ds-react@file:./../../@navikt/core/react::locator=shadow-dom%40workspace%3A.":
-  version: 7.34.0
-  resolution: "@navikt/ds-react@file:./../../@navikt/core/react#./../../@navikt/core/react::hash=99c1bc&locator=shadow-dom%40workspace%3A."
+  version: 7.36.0
+  resolution: "@navikt/ds-react@file:./../../@navikt/core/react#./../../@navikt/core/react::hash=92392b&locator=shadow-dom%40workspace%3A."
   dependencies:
     "@floating-ui/react": "npm:0.27.8"
     "@floating-ui/react-dom": "npm:^2.1.6"
-    "@navikt/aksel-icons": "npm:^7.34.0"
-    "@navikt/ds-tokens": "npm:^7.34.0"
+    "@navikt/aksel-icons": "npm:^7.36.0"
+    "@navikt/ds-tokens": "npm:^7.36.0"
     clsx: "npm:^2.1.0"
     date-fns: "npm:^4.0.0"
     react-day-picker: "npm:9.7.0"
@@ -671,14 +671,14 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/53cf1a4fcf79699ca15d108b25cff0cbcc6d0de14f84b0bfcb025495693a10390f5bb8c20b662a9561314d78b7fe16f6bdbf34bcc99b7b65501e2fcd7dee9581
+  checksum: 10/060936a33579f9139e7f5fd846982ec7a7595070fabe2b4dbff6276fea3641aac43afe157c364a1bbb23907e85bbd94ad4568383d024ab4df33abe48ca31c4f2
   languageName: node
   linkType: hard
 
-"@navikt/ds-tokens@npm:^7.34.0":
-  version: 7.34.0
-  resolution: "@navikt/ds-tokens@npm:7.34.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fds-tokens%2F7.34.0%2Faea8f6932bdf5aec384d1fbbeb5930c2c69dc6d1"
-  checksum: 10/0be62d2cbf4f41657f7b8fbd5f6c0aabb9659e3b490d1d84bfaa5a309d545614c169c61aee8bc8517d300a4847ca188dbd4ee68e8c89370d6c49dce9c7dc7f8f
+"@navikt/ds-tokens@npm:^7.36.0":
+  version: 7.36.0
+  resolution: "@navikt/ds-tokens@npm:7.36.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fds-tokens%2F7.36.0%2Fad3ab2a9f2179c5a4703738de33233af54336dc2"
+  checksum: 10/af67ef47d54d1deab60a541ab12c5a03b0e54399889748f39a92e3b40062249db3964c4e4edd8a599af827bac7d3eb3654b5ad80f85d996515746dfa3e758bcc
   languageName: node
   linkType: hard
 

--- a/examples/shadow-dom/yarn.lock
+++ b/examples/shadow-dom/yarn.lock
@@ -655,7 +655,7 @@ __metadata:
 
 "@navikt/ds-react@file:./../../@navikt/core/react::locator=shadow-dom%40workspace%3A.":
   version: 7.36.0
-  resolution: "@navikt/ds-react@file:./../../@navikt/core/react#./../../@navikt/core/react::hash=4b1130&locator=shadow-dom%40workspace%3A."
+  resolution: "@navikt/ds-react@file:./../../@navikt/core/react#./../../@navikt/core/react::hash=327066&locator=shadow-dom%40workspace%3A."
   dependencies:
     "@floating-ui/react": "npm:0.27.8"
     "@floating-ui/react-dom": "npm:^2.1.6"
@@ -671,7 +671,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ad8a60a07cfdc46786bf43db025fb95a699e90eb8da789add32aab5d5b96723c85e772c36ac4746681ebece93ff2e9422c87ed9e59c0a48ff03e31b64da1689b
+  checksum: 10/cbe537ee992b12d2f1d7868e7f40ce2587946ae35cedc0531dabd12fe19ce829ee2f0d1121f6f1b2a745dabda1dc48e48a2c703a5d588680b7586f2367880804
   languageName: node
   linkType: hard
 

--- a/examples/shadow-dom/yarn.lock
+++ b/examples/shadow-dom/yarn.lock
@@ -655,7 +655,7 @@ __metadata:
 
 "@navikt/ds-react@file:./../../@navikt/core/react::locator=shadow-dom%40workspace%3A.":
   version: 7.36.0
-  resolution: "@navikt/ds-react@file:./../../@navikt/core/react#./../../@navikt/core/react::hash=92392b&locator=shadow-dom%40workspace%3A."
+  resolution: "@navikt/ds-react@file:./../../@navikt/core/react#./../../@navikt/core/react::hash=e16436&locator=shadow-dom%40workspace%3A."
   dependencies:
     "@floating-ui/react": "npm:0.27.8"
     "@floating-ui/react-dom": "npm:^2.1.6"
@@ -671,7 +671,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/060936a33579f9139e7f5fd846982ec7a7595070fabe2b4dbff6276fea3641aac43afe157c364a1bbb23907e85bbd94ad4568383d024ab4df33abe48ca31c4f2
+  checksum: 10/354258b3aa05f60ea65bcdcf277d1365f2973dc01b4254ee6e6f5c0ada5a15728d453b92be8b1a547d8d8d952af987049a7c410a870dfb0b3ba18b424e772e25
   languageName: node
   linkType: hard
 

--- a/examples/shadow-dom/yarn.lock
+++ b/examples/shadow-dom/yarn.lock
@@ -648,14 +648,14 @@ __metadata:
 
 "@navikt/ds-css@file:./../../@navikt/core/css::locator=shadow-dom%40workspace%3A.":
   version: 7.36.0
-  resolution: "@navikt/ds-css@file:./../../@navikt/core/css#./../../@navikt/core/css::hash=366a36&locator=shadow-dom%40workspace%3A."
-  checksum: 10/98ed5693e1de1cac861992dcc139e1289a899e92403ff5ba233aa79365587e4ac4d9eb7a85c7997521e9b14beaa42aa109aa44e998f17e7a621773d544d22e89
+  resolution: "@navikt/ds-css@file:./../../@navikt/core/css#./../../@navikt/core/css::hash=74d344&locator=shadow-dom%40workspace%3A."
+  checksum: 10/1e1a2be06dd1e8bb92798dde863bc3703263a6d9136cadfaa55cb00809e23ef1e88e901737a883fd3107cebbebb88db53ba5b2f322ee43cc797daa6b0f54c679
   languageName: node
   linkType: hard
 
 "@navikt/ds-react@file:./../../@navikt/core/react::locator=shadow-dom%40workspace%3A.":
   version: 7.36.0
-  resolution: "@navikt/ds-react@file:./../../@navikt/core/react#./../../@navikt/core/react::hash=e16436&locator=shadow-dom%40workspace%3A."
+  resolution: "@navikt/ds-react@file:./../../@navikt/core/react#./../../@navikt/core/react::hash=4b1130&locator=shadow-dom%40workspace%3A."
   dependencies:
     "@floating-ui/react": "npm:0.27.8"
     "@floating-ui/react-dom": "npm:^2.1.6"
@@ -671,7 +671,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/354258b3aa05f60ea65bcdcf277d1365f2973dc01b4254ee6e6f5c0ada5a15728d453b92be8b1a547d8d8d952af987049a7c410a870dfb0b3ba18b424e772e25
+  checksum: 10/ad8a60a07cfdc46786bf43db025fb95a699e90eb8da789add32aab5d5b96723c85e772c36ac4746681ebece93ff2e9422c87ed9e59c0a48ff03e31b64da1689b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Scenario: 
- Actionmenu or app is wrapped inside custom-component
- User opens menu
- User clicks trigger

What should happen:
- Menu stays open onPointerDown
- Menu closes onPointerUp

What did happen:
- Menu closes onPointerDown
- Menu re-opens onPointerUp


This is because the "target" will always be a generic `custom-component` when checking if menu should close in DismissableLayer. 

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
