### PR TITLE
[Darkside] ExpansionCard.Content typography is no longer affected by 'app-color'

### DIFF
--- a/.changeset/smart-canyons-cut.md
+++ b/.changeset/smart-canyons-cut.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Darkside: Update how data-color affects nested typography.

--- a/.changeset/smart-canyons-cut.md
+++ b/.changeset/smart-canyons-cut.md
@@ -2,4 +2,4 @@
 "@navikt/ds-css": patch
 ---
 
-Darkside: ExpansioncardContent typography is no longer affected by 'app-color'.
+Darkside: ExpansionCardContent typography is no longer affected by 'app-color'.

--- a/.changeset/smart-canyons-cut.md
+++ b/.changeset/smart-canyons-cut.md
@@ -2,4 +2,4 @@
 "@navikt/ds-css": patch
 ---
 
-Darkside: Update how data-color affects nested typography.
+Darkside: ExpansioncardContent typography is no longer affected by 'app-color'.

--- a/@navikt/core/css/darkside/typography.darkside.css
+++ b/@navikt/core/css/darkside/typography.darkside.css
@@ -257,8 +257,12 @@
   width: 1px !important;
 }
 
+:is(.aksel-heading, .aksel-ingress, .aksel-body-long, .aksel-body-short, .aksel-label, .aksel-detail) {
+  color: var(--ax-text-neutral);
+}
+
 [data-color] {
-  &:where(.aksel-heading, .aksel-ingress, .aksel-body-long, .aksel-body-short, .aksel-label, .aksel-detail) {
+  &:is(.aksel-heading, .aksel-ingress, .aksel-body-long, .aksel-body-short, .aksel-label, .aksel-detail) {
     color: var(--ax-text-default);
   }
 }

--- a/@navikt/core/css/darkside/typography.darkside.css
+++ b/@navikt/core/css/darkside/typography.darkside.css
@@ -257,12 +257,8 @@
   width: 1px !important;
 }
 
-:is(.aksel-heading, .aksel-ingress, .aksel-body-long, .aksel-body-short, .aksel-label, .aksel-detail) {
-  color: var(--ax-text-neutral);
-}
-
 [data-color] {
-  &:is(.aksel-heading, .aksel-ingress, .aksel-body-long, .aksel-body-short, .aksel-label, .aksel-detail) {
+  &:where(.aksel-heading, .aksel-ingress, .aksel-body-long, .aksel-body-short, .aksel-label, .aksel-detail) {
     color: var(--ax-text-default);
   }
 }

--- a/@navikt/core/react/src/expansion-card/ExpansionCardContent.tsx
+++ b/@navikt/core/react/src/expansion-card/ExpansionCardContent.tsx
@@ -36,7 +36,12 @@ const ExpansionCardContent = forwardRef<
       size={panelContext.size}
       data-open={panelContext.open}
     >
-      <div className={cn("navds-expansioncard__content-inner")}>{children}</div>
+      <div
+        className={cn("navds-expansioncard__content-inner")}
+        data-color={themeContext?.color}
+      >
+        {children}
+      </div>
     </BodyLong>
   );
 });

--- a/@navikt/core/react/src/expansion-card/ExpansionCardContent.tsx
+++ b/@navikt/core/react/src/expansion-card/ExpansionCardContent.tsx
@@ -11,7 +11,7 @@ export interface ExpansionCardContentProps
 const ExpansionCardContent = forwardRef<
   HTMLDivElement,
   ExpansionCardContentProps
->(({ children, className, ...rest }, ref) => {
+>(({ children, className, "data-color": dataColor, ...rest }, ref) => {
   const { cn } = useRenameCSS();
   const panelContext = useContext(ExpansionCardContext);
   const themeContext = useThemeInternal();
@@ -25,7 +25,6 @@ const ExpansionCardContent = forwardRef<
 
   return (
     <BodyLong
-      data-color={themeContext?.color}
       {...rest}
       ref={ref}
       as="div"
@@ -38,7 +37,7 @@ const ExpansionCardContent = forwardRef<
     >
       <div
         className={cn("navds-expansioncard__content-inner")}
-        data-color={themeContext?.color}
+        data-color={dataColor ?? themeContext?.color}
       >
         {children}
       </div>


### PR DESCRIPTION
### Description

[As seen in this example](https://aksel.nav.no/komponenter/core/expansioncard?demo=expansioncarddemo-custom), the typo inside the ExpansionCard.Content is colored. 


This happens since 
```
[data-color] {
  &:is(.aksel-heading, .aksel-ingress, .aksel-body-long, .aksel-body-short, .aksel-label, .aksel-detail) {
    color: var(--ax-text-default);
  }
}
```
- Sets the typo color on the ExpansionCard.Content since its a `BodyLong`.
- Since we dont by-default set any color on typo (besides in baseline), all typo then inherits this color.




### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
