### PR TITLE
:wheelchair: Removed tabIndex 0 from content

### DIFF
--- a/.changeset/icy-lemons-brush.md
+++ b/.changeset/icy-lemons-brush.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+ReadMore: Removed tabIndex 0 from content.

--- a/.changeset/tiny-candles-cover.md
+++ b/.changeset/tiny-candles-cover.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+ReadMore: Removed focus styling for content, reverting #4116.

--- a/@navikt/core/css/darkside/read-more.darkside.css
+++ b/@navikt/core/css/darkside/read-more.darkside.css
@@ -70,11 +70,6 @@
   margin-left: calc(var(--__axc-read-more-pi-start) + var(--__axc-read-more-icon-size) / 2 - 1px);
   padding-left: calc(var(--__axc-read-more-icon-size) / 2 - 1px + var(--ax-space-4));
 
-  &:focus-visible {
-    outline: 3px solid var(--ax-border-focus);
-    outline-offset: 3px;
-  }
-
   &[data-state="closed"] {
     display: none;
   }

--- a/@navikt/core/css/read-more.css
+++ b/@navikt/core/css/read-more.css
@@ -27,8 +27,7 @@
     color: ButtonText;
   }
 
-  .navds-read-more__button.navds-read-more__button:focus-visible,
-  .navds-read-more__content.navds-read-more__content:focus-visible {
+  .navds-read-more__button.navds-read-more__button:focus-visible {
     box-shadow: none;
     outline: 2px solid highlight;
     outline-offset: 2px;
@@ -44,15 +43,13 @@
   background-color: var(--ac-read-more-active-bg, var(--a-surface-active));
 }
 
-.navds-read-more__button:focus-visible,
-.navds-read-more__content:focus-visible {
+.navds-read-more__button:focus-visible {
   outline: none;
   box-shadow: var(--a-shadow-focus);
 }
 
 @supports not selector(:focus-visible) {
-  .navds-read-more__button:focus,
-  .navds-read-more__content:focus {
+  .navds-read-more__button:focus {
     outline: none;
     box-shadow: var(--a-shadow-focus);
   }

--- a/@navikt/core/react/src/read-more/ReadMore.tsx
+++ b/@navikt/core/react/src/read-more/ReadMore.tsx
@@ -100,7 +100,6 @@ export const ReadMore = forwardRef<HTMLButtonElement, ReadMoreProps>(
 
         <BodyLong
           as="div"
-          tabIndex={0}
           className={cn("navds-read-more__content", {
             "navds-read-more__content--closed": !_open,
           })}


### PR DESCRIPTION
### Description

https://nav-it.slack.com/archives/C7NE7A8UF/p1767863869966759

This resolves current issue where Arc toolkit errors since content has no "role", and screen-readers groups all paragraphs together.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
