### PR TITLE
Primitives: Fix type issue with className

### DIFF
--- a/@navikt/core/react/src/layout/base/BasePrimitive.tsx
+++ b/@navikt/core/react/src/layout/base/BasePrimitive.tsx
@@ -6,10 +6,6 @@ import { ResponsiveProp, SpacingScale } from "../utilities/types";
 
 export type PrimitiveProps = {
   /**
-   * @private Hides prop from documentation
-   */
-  className?: string;
-  /**
    * Padding around children.
    * Accepts a [spacing token](https://aksel.nav.no/grunnleggende/styling/design-tokens#0cc9fb32f213)
    * or an object of spacing tokens for different breakpoints.
@@ -190,7 +186,6 @@ export type PrimitiveProps = {
 };
 
 export const PRIMITIVE_PROPS: (keyof PrimitiveProps)[] = [
-  "className",
   "padding",
   "paddingInline",
   "paddingBlock",
@@ -220,6 +215,10 @@ export const PRIMITIVE_PROPS: (keyof PrimitiveProps)[] = [
 
 interface BasePrimitiveProps extends PrimitiveProps {
   children: React.ReactElement;
+  /**
+   * @private Hides prop from documentation
+   */
+  className?: string;
 }
 
 export const BasePrimitive = ({

--- a/@navikt/core/react/src/layout/box/Box.darkside.tsx
+++ b/@navikt/core/react/src/layout/box/Box.darkside.tsx
@@ -109,7 +109,7 @@ export const BoxNew: OverridableComponent<BoxNewProps, HTMLDivElement> =
         style: _style,
         asChild,
         ...rest
-      },
+      }: BoxNewProps & { as?: React.ElementType },
       ref,
     ) => {
       const { cn } = useRenameCSS();

--- a/@navikt/core/react/src/layout/box/Box.tsx
+++ b/@navikt/core/react/src/layout/box/Box.tsx
@@ -105,7 +105,7 @@ export const BoxComponent: OverridableComponent<BoxProps, HTMLDivElement> =
         style: _style,
         asChild,
         ...rest
-      },
+      }: BoxProps & { as?: React.ElementType },
       ref,
     ) => {
       const themeContext = useThemeInternal();


### PR DESCRIPTION
### Description

First I noticed that all props became `any` in the Box components, so I added types as you see in Box.tsx/Box.darkside.tsx. This resulted in a TS error on this line: `omit(rest, PRIMITIVE_PROPS)` because `PRIMITIVE_PROPS` had "className" in it, which `rest` did not since it's destructured.

First I considered just removing "className" from `PRIMITIVE_PROPS`, but then I realized it might be cleaner to move the prop to `BasePrimitiveProps` instead. The consequence of this is that `className` now will appear in the prop-lists for the primitives (except BasePrimitive ofc.) on the website since they extend `PrimitiveProps` and not `BasePrimitiveProps`. Do we want this?

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
