### PR TITLE
[Dialog] Removed 'aria-expanded' from Dialog.Trigger

### DIFF
--- a/.changeset/wicked-frogs-invite.md
+++ b/.changeset/wicked-frogs-invite.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Dialog: Removed 'aria-expanded' from Dialog.Trigger.

--- a/@navikt/core/react/src/dialog/Dialog.tests.stories.tsx
+++ b/@navikt/core/react/src/dialog/Dialog.tests.stories.tsx
@@ -634,13 +634,11 @@ export const AriaAttributes: Story = {
 
     const triggerButton = canvas.getByRole("button", { name: "Open Dialog" });
 
-    expect(triggerButton).toHaveAttribute("aria-expanded", "false");
     await userEvent.click(triggerButton);
     expectPopupOpen();
 
     const popupElement = canvas.getByTestId("popup");
 
-    expect(triggerButton).toHaveAttribute("aria-expanded", "true");
     expect(triggerButton).toHaveAttribute("aria-controls", "custom-popup-id");
 
     expect(popupElement).toHaveAttribute("id", "custom-popup-id");

--- a/@navikt/core/react/src/dialog/trigger/DialogTrigger.tsx
+++ b/@navikt/core/react/src/dialog/trigger/DialogTrigger.tsx
@@ -34,7 +34,6 @@ const DialogTrigger = forwardRef<HTMLButtonElement, DialogTriggerProps>(
           setOpen(!open, event.nativeEvent),
         )}
         aria-haspopup="dialog"
-        aria-expanded={open}
         aria-controls={open ? popupId : undefined}
       >
         {children}

--- a/aksel.nav.no/website/pages/eksempler/dialog/conditional-render.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/conditional-render.tsx
@@ -27,7 +27,6 @@ const Example = () => {
       <Button
         onClick={() => openDialog("user-1")}
         aria-haspopup="dialog"
-        aria-expanded={open}
         aria-controls={open ? "dialog-popup-example" : undefined}
       >
         Vis brukerdetaljer

--- a/aksel.nav.no/website/pages/eksempler/dialog/controlled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/controlled.tsx
@@ -10,7 +10,6 @@ const Example = () => {
       <Button
         onClick={() => setOpen(true)}
         aria-haspopup="dialog"
-        aria-expanded={open}
         aria-controls={open ? "dialog-popup-example" : undefined}
       >
         Åpne dialog

--- a/aksel.nav.no/website/pages/eksempler/dialog/form.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/form.tsx
@@ -18,7 +18,6 @@ const Example = () => {
       <Button
         onClick={() => setOpen(true)}
         aria-haspopup="dialog"
-        aria-expanded={open}
         aria-controls={open ? "dialog-popup-example" : undefined}
       >
         Åpne skjema

--- a/aksel.nav.no/website/pages/eksempler/dialog/position.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/position.tsx
@@ -20,11 +20,7 @@ const Example = () => {
 
   return (
     <div>
-      <PositionButtons
-        onPositionSelect={openWithPosition}
-        position={position}
-        open={open}
-      />
+      <PositionButtons onPositionSelect={openWithPosition} open={open} />
 
       <Dialog open={open} onOpenChange={setOpen}>
         <Dialog.Popup position={position} id="dialog-popup-position-example">
@@ -32,11 +28,7 @@ const Example = () => {
             <Dialog.Title>Position: {position}</Dialog.Title>
           </Dialog.Header>
           <Dialog.Body>
-            <PositionButtons
-              onPositionSelect={openWithPosition}
-              position={position}
-              open={open}
-            />
+            <PositionButtons onPositionSelect={openWithPosition} open={open} />
           </Dialog.Body>
           <Dialog.Footer>
             <Dialog.CloseTrigger>
@@ -51,17 +43,14 @@ const Example = () => {
 
 function PositionButtons({
   onPositionSelect,
-  position,
   open,
 }: {
   onPositionSelect: (pos: Position) => void;
-  position: Position;
   open: boolean;
 }) {
   const getDialogProps = (pos: Position) => {
     return {
       "aria-haspopup": "dialog" as const,
-      "aria-expanded": pos === position && open,
       "aria-controls": open ? "dialog-popup-position-example" : undefined,
       onClick: () => onPositionSelect(pos),
     };

--- a/aksel.nav.no/website/pages/eksempler/dialog/with-actionmenu.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/with-actionmenu.tsx
@@ -22,7 +22,6 @@ const Example = () => {
           <ActionMenu.Item
             onSelect={() => setOpen(true)}
             aria-haspopup="dialog"
-            aria-expanded={false}
           >
             Åpne dialog
           </ActionMenu.Item>


### PR DESCRIPTION
### Description

Based on a11y testing, Morten wanted it removed to avoid redundant noise.
- Since dialog is expected to be "open" when expanded would be true, this attrb had little effect anyways.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [x] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
