### PR TITLE
[Darkside] JSDoc adjustments for data-color on some components

### DIFF
--- a/@navikt/core/react/src/accordion/Accordion.tsx
+++ b/@navikt/core/react/src/accordion/Accordion.tsx
@@ -57,7 +57,6 @@ export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Overrides inherited color.
    *
-   *
    * We recommend only using `accent` and `neutral`. We have disallowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)

--- a/@navikt/core/react/src/button/Button.tsx
+++ b/@navikt/core/react/src/button/Button.tsx
@@ -54,7 +54,6 @@ export interface ButtonProps
   /**
    * Overrides inherited color.
    *
-   *
    * We recommend only using `accent`, `neutral` and `danger`.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)

--- a/@navikt/core/react/src/chat/Chat.tsx
+++ b/@navikt/core/react/src/chat/Chat.tsx
@@ -55,8 +55,7 @@ export interface ChatProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Overrides inherited color.
    *
-   *
-   * We have disallowed status-colors
+   * We have disallowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)
    */

--- a/@navikt/core/react/src/copybutton/CopyButton.tsx
+++ b/@navikt/core/react/src/copybutton/CopyButton.tsx
@@ -18,10 +18,9 @@ export interface CopyButtonProps
   variant?: "action" | "neutral";
   /**
    * Overrides color.
-   * @default "neutral"
-   *
    *
    * We recommend only using `accent` and `neutral`. We have disallowed status-colors.
+   * @default "neutral"
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)
    */
@@ -47,7 +46,7 @@ export interface CopyButtonProps
    */
   onActiveChange?: (state: boolean) => void;
   /**
-   *  Icon shown when button is not clicked.
+   * Icon shown when button is not clicked.
    * @default <FilesIcon />
    */
   icon?: React.ReactNode;

--- a/@navikt/core/react/src/link-card/LinkCard.tsx
+++ b/@navikt/core/react/src/link-card/LinkCard.tsx
@@ -29,8 +29,7 @@ interface LinkCardProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Overrides inherited color.
    *
-   *
-   * We reccomend avoiding status-colors like `info`, `success`, `warning` and `danger` in LinkCards.
+   * We reccomend avoiding status-colors (`info`, `success`, `warning`, `danger`) in LinkCards.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)
    */

--- a/@navikt/core/react/src/link/Link.tsx
+++ b/@navikt/core/react/src/link/Link.tsx
@@ -30,7 +30,6 @@ export interface LinkProps
   /**
    * Overrides inherited color.
    *
-   *
    * We recommend only using `accent` and `neutral`. We have disallowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)

--- a/@navikt/core/react/src/pagination/Pagination.tsx
+++ b/@navikt/core/react/src/pagination/Pagination.tsx
@@ -72,10 +72,9 @@ export interface PaginationProps extends React.HTMLAttributes<HTMLElement> {
   };
   /**
    * Overrides color.
-   * @default "neutral"
-   *
    *
    * We have disallowed status-colors.
+   * @default "neutral"
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)
    * @private

--- a/@navikt/core/react/src/read-more/ReadMore.tsx
+++ b/@navikt/core/react/src/read-more/ReadMore.tsx
@@ -39,7 +39,6 @@ export interface ReadMoreProps
   /**
    * Overrides inherited color.
    *
-   *
    * We recommend only using `accent`. We have disallowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)

--- a/@navikt/core/react/src/toggle-group/ToggleGroup.types.ts
+++ b/@navikt/core/react/src/toggle-group/ToggleGroup.types.ts
@@ -36,7 +36,6 @@ export interface ToggleGroupProps
   /**
    * Overrides inherited color.
    *
-   *
    * We recommend only using `accent` and `neutral`. We have disallowed status-colors.
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)

--- a/@navikt/core/react/src/typography/BodyLong.tsx
+++ b/@navikt/core/react/src/typography/BodyLong.tsx
@@ -21,7 +21,6 @@ export interface BodyLongProps
    * Overrides inherited color.
    * @default "neutral"
    *
-   *
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)
    */

--- a/@navikt/core/react/src/typography/BodyShort.tsx
+++ b/@navikt/core/react/src/typography/BodyShort.tsx
@@ -21,7 +21,6 @@ export interface BodyShortProps
    * Overrides inherited color.
    * @default "neutral"
    *
-   *
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)
    */

--- a/@navikt/core/react/src/typography/Detail.tsx
+++ b/@navikt/core/react/src/typography/Detail.tsx
@@ -24,7 +24,6 @@ export interface DetailProps
    * Overrides inherited color.
    * @default "neutral"
    *
-   *
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)
    */

--- a/@navikt/core/react/src/typography/Heading.tsx
+++ b/@navikt/core/react/src/typography/Heading.tsx
@@ -25,7 +25,6 @@ export interface HeadingProps
    * Overrides inherited color.
    * @default "neutral"
    *
-   *
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)
    */

--- a/@navikt/core/react/src/typography/Label.tsx
+++ b/@navikt/core/react/src/typography/Label.tsx
@@ -21,7 +21,6 @@ export interface LabelProps
    * Overrides inherited color.
    * @default "neutral"
    *
-   *
    * @see 🏷️ {@link AkselColor}
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)
    */


### PR DESCRIPTION
### Component Checklist 📝

- [x] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
