### PR TITLE
[Darkside] Removed legacy-tokens, added migration to codemod

### DIFF
--- a/@navikt/aksel/src/codemod/v8-tokens/tasks/status.ts
+++ b/@navikt/aksel/src/codemod/v8-tokens/tasks/status.ts
@@ -286,7 +286,6 @@ function getStatus(
             canAutoMigrate: true,
             fileName,
             name: match[0],
-            comment: `Deprecated token - migrate to ${config.replacement}`,
           });
 
           match = regex.exec(fileSrc);

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/css-edge-cases.input.css
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/css-edge-cases.input.css
@@ -16,4 +16,6 @@
 
   /* Comments - SHOULD change (regex based) */
   /* var(--a-spacing-4) */
+  border-radius: var(--a-border-radius-medium);
+  border-radius: var(--ax-border-radius-small);
 }

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/css-edge-cases.input.css
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/css-edge-cases.input.css
@@ -18,4 +18,11 @@
   /* var(--a-spacing-4) */
   border-radius: var(--a-border-radius-medium);
   border-radius: var(--ax-border-radius-small);
+
+  /* Border radius tokens - SHOULD migrate to numeric values */
+  border-radius: var(--ax-border-radius-full);
+  border-radius: var(--ax-border-radius-small);
+  border-radius: var(--ax-border-radius-medium);
+  border-radius: var(--ax-border-radius-large);
+  border-radius: var(--ax-border-radius-xlarge);
 }

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/css-edge-cases.output.css
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/css-edge-cases.output.css
@@ -16,4 +16,6 @@
 
   /* Comments - SHOULD change (regex based) */
   /* var(--ax-space-16) */
+  border-radius: var(--ax-radius-4);
+  border-radius: var(--ax-radius-2);
 }

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/css-edge-cases.output.css
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/css-edge-cases.output.css
@@ -18,4 +18,11 @@
   /* var(--ax-space-16) */
   border-radius: var(--ax-radius-4);
   border-radius: var(--ax-radius-2);
+
+  /* Border radius tokens - SHOULD migrate to numeric values */
+  border-radius: var(--ax-radius-full);
+  border-radius: var(--ax-radius-2);
+  border-radius: var(--ax-radius-4);
+  border-radius: var(--ax-radius-8);
+  border-radius: var(--ax-radius-12);
 }

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/darkside-tokens.test.ts
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/darkside-tokens.test.ts
@@ -1,7 +1,11 @@
 import { check } from "../../../utils/check";
 
 /* JS transforms */
-for (const fixture of ["js-replace-all", "js-replace-some"]) {
+for (const fixture of [
+  "js-replace-all",
+  "js-replace-some",
+  "js-replace-border",
+]) {
   check(__dirname, {
     fixture,
     migration: "v8-tokens-js",

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/js-replace-border.input.js
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/js-replace-border.input.js
@@ -1,0 +1,10 @@
+import { AxBorderRadiusFull, AxBorderRadiusSmall, AxBorderRadiusMedium, AxBorderRadiusLarge, AxBorderRadiusXlarge } from '@navikt/ds-tokens/js';
+
+/* Border radius tokens - SHOULD migrate to numeric values */
+const borderRadiusTokens = {
+  full: AxBorderRadiusFull,
+  small: AxBorderRadiusSmall,
+  medium: AxBorderRadiusMedium,
+  large: AxBorderRadiusLarge,
+  xlarge: AxBorderRadiusXlarge,
+};

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/js-replace-border.output.js
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/js-replace-border.output.js
@@ -1,0 +1,10 @@
+import { AxRadiusFull, AxRadius2, AxRadius4, AxRadius8, AxRadius12 } from '@navikt/ds-tokens/js';
+
+/* Border radius tokens - SHOULD migrate to numeric values */
+const borderRadiusTokens = {
+  full: AxRadiusFull,
+  small: AxRadius2,
+  medium: AxRadius4,
+  large: AxRadius8,
+  xlarge: AxRadius12,
+};

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/less-complete.input.less
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/less-complete.input.less
@@ -7,4 +7,11 @@
   background-color: @a-surface-subtle;
   /* Has no replacement */
   background-color: @a-surface-transparent;
+
+  /* Border radius tokens - SHOULD migrate to numeric values */
+  border-radius: @ax-border-radius-full;
+  border-radius: @ax-border-radius-small;
+  border-radius: @ax-border-radius-medium;
+  border-radius: @ax-border-radius-large;
+  border-radius: @ax-border-radius-xlarge;
 }

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/less-complete.output.less
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/less-complete.output.less
@@ -7,4 +7,11 @@
   background-color: @ax-bg-neutral-soft;
   /* Has no replacement */
   background-color: @a-surface-transparent;
+
+  /* Border radius tokens - SHOULD migrate to numeric values */
+  border-radius: @ax-radius-full;
+  border-radius: @ax-radius-2;
+  border-radius: @ax-radius-4;
+  border-radius: @ax-radius-8;
+  border-radius: @ax-radius-12;
 }

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/scss-complete.input.scss
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/scss-complete.input.scss
@@ -7,4 +7,11 @@
   background-color: $a-surface-subtle;
   /* Has no replacement */
   background-color: $a-surface-transparent;
+
+  /* Border radius tokens - SHOULD migrate to numeric values */
+  border-radius: $ax-border-radius-full;
+  border-radius: $ax-border-radius-small;
+  border-radius: $ax-border-radius-medium;
+  border-radius: $ax-border-radius-large;
+  border-radius: $ax-border-radius-xlarge;
 }

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/scss-complete.output.scss
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/tests/scss-complete.output.scss
@@ -7,4 +7,11 @@
   background-color: $ax-bg-neutral-soft;
   /* Has no replacement */
   background-color: $a-surface-transparent;
+
+  /* Border radius tokens - SHOULD migrate to numeric values */
+  border-radius: $ax-radius-full;
+  border-radius: $ax-radius-2;
+  border-radius: $ax-radius-4;
+  border-radius: $ax-radius-8;
+  border-radius: $ax-radius-12;
 }

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/v8-tokens-css.ts
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/v8-tokens-css.ts
@@ -1,6 +1,14 @@
 import type { FileInfo } from "jscodeshift";
 import { legacyTokenConfig } from "../config/legacy.tokens";
 
+const axBorderRadiusMap: Record<string, string> = {
+  "--ax-border-radius-full": "--ax-radius-full",
+  "--ax-border-radius-small": "--ax-radius-2",
+  "--ax-border-radius-medium": "--ax-radius-4",
+  "--ax-border-radius-large": "--ax-radius-8",
+  "--ax-border-radius-xlarge": "--ax-radius-12",
+};
+
 export default function transformer(file: FileInfo) {
   let src = file.source;
 
@@ -19,6 +27,18 @@ export default function transformer(file: FileInfo) {
         return `--ax-${config.replacement}`;
       }
       return match;
+    },
+  );
+
+  /*
+    Replace usages: --ax-border-radius-(full|small|medium|large|xlarge) -> --ax-radius-(full|2|4|8|12)
+    Matches "--ax-border-radius-*" with word boundaries.
+    Uses negative lookahead to skip definitions (--ax-border-radius-small:)
+  */
+  src = src.replace(
+    /(?<![\w-])(--ax-border-radius-(?:full|small|medium|large|xlarge))(?![\w-])(?!\s*:)/g,
+    (match, tokenName) => {
+      return axBorderRadiusMap[tokenName] ?? match;
     },
   );
 

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/v8-tokens-js.ts
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/v8-tokens-js.ts
@@ -5,6 +5,14 @@ import moveAndRenameImport from "../../utils/packageImports";
 import { translateToken } from "../../utils/translate-token";
 import { legacyTokenConfig } from "../config/legacy.tokens";
 
+const axBorderRadiusMap: Record<string, string> = {
+  AxBorderRadiusFull: "AxRadiusFull",
+  AxBorderRadiusSmall: "AxRadius2",
+  AxBorderRadiusMedium: "AxRadius4",
+  AxBorderRadiusLarge: "AxRadius8",
+  AxBorderRadiusXlarge: "AxRadius12",
+};
+
 export default function transformer(file: FileInfo, api: API) {
   let src = file.source;
 
@@ -18,52 +26,69 @@ export default function transformer(file: FileInfo, api: API) {
     );
   });
 
-  if (jsImport.size() === 0) {
-    return src;
-  }
+  if (jsImport.size() > 0) {
+    for (const [oldToken, config] of Object.entries(legacyTokenConfig)) {
+      const oldCSSVar = `--a-${oldToken}`;
+      const oldJsVar = translateToken(oldCSSVar, "js");
 
-  for (const [oldToken, config] of Object.entries(legacyTokenConfig)) {
-    const oldCSSVar = `--a-${oldToken}`;
-    const oldJsVar = translateToken(oldCSSVar, "js");
+      let foundName: string | null = null;
 
-    let foundName: string | null = null;
-
-    getImportSpecifier(
-      j,
-      root,
-      oldJsVar,
-      "@navikt/ds-tokens/dist/tokens",
-    ).forEach((x) => {
-      foundName = x.node.imported.name;
-    });
-
-    if (!foundName) {
-      continue;
-    }
-
-    if (config.replacement.length > 0) {
-      /* We remove the prefix */
-      const jsToken = translateToken(`--ax-${config.replacement}`, "js").slice(
-        2,
-      );
-
-      const localName = moveAndRenameImport(j, root, {
-        fromImport: "@navikt/ds-tokens/dist/tokens",
-        toImport: "@navikt/ds-tokens/js",
-        fromName: foundName,
-        toName: jsToken,
-        ignoreAlias: true,
+      getImportSpecifier(
+        j,
+        root,
+        oldJsVar,
+        "@navikt/ds-tokens/dist/tokens",
+      ).forEach((x) => {
+        foundName = x.node.imported.name;
       });
 
-      let code = root.toSource(getLineTerminator(src));
+      if (!foundName) {
+        continue;
+      }
 
-      const rgx = new RegExp(`(\\s|^)?(${localName})(?=\\s|$|[^\\w-])`, "gm");
-      code = code.replace(rgx, jsToken);
-      src = code;
+      if (config.replacement.length > 0) {
+        /* We remove the prefix */
+        const jsToken = translateToken(
+          `--ax-${config.replacement}`,
+          "js",
+        ).slice(2);
 
-      root = j(code);
+        const localName = moveAndRenameImport(j, root, {
+          fromImport: "@navikt/ds-tokens/dist/tokens",
+          toImport: "@navikt/ds-tokens/js",
+          fromName: foundName,
+          toName: jsToken,
+          ignoreAlias: true,
+        });
+
+        let code = root.toSource(getLineTerminator(src));
+
+        const rgx = new RegExp(`(\\s|^)?(${localName})(?=\\s|$|[^\\w-])`, "gm");
+        code = code.replace(rgx, jsToken);
+        src = code;
+
+        root = j(code);
+      }
     }
   }
 
-  return root.toSource(getLineTerminator(src));
+  let output = root.toSource(getLineTerminator(src));
+
+  const jsV8TokenImport = root.find(j.ImportDeclaration).filter((x) => {
+    return ["@navikt/ds-tokens/js"].includes(x.node.source.value as string);
+  });
+
+  if (jsV8TokenImport.size() > 0) {
+    /*
+    Replace usages: AxBorderRadius(Full|Small|Medium|Large|Xlarge) -> AxRadius(Full|2|4|8|12)
+  */
+    output = output.replace(
+      /(?<!\w)(AxBorderRadius(?:Full|Small|Medium|Large|Xlarge))(?!\w)/g,
+      (match, tokenName) => {
+        return axBorderRadiusMap[tokenName] ?? match;
+      },
+    );
+  }
+
+  return output;
 }

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/v8-tokens-less.ts
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/v8-tokens-less.ts
@@ -2,6 +2,14 @@ import type { FileInfo } from "jscodeshift";
 import { translateToken } from "../../utils/translate-token";
 import { legacyTokenConfig } from "../config/legacy.tokens";
 
+const axBorderRadiusMap: Record<string, string> = {
+  "@ax-border-radius-full": "@ax-radius-full",
+  "@ax-border-radius-small": "@ax-radius-2",
+  "@ax-border-radius-medium": "@ax-radius-4",
+  "@ax-border-radius-large": "@ax-radius-8",
+  "@ax-border-radius-xlarge": "@ax-radius-12",
+};
+
 export default function transformer(file: FileInfo) {
   let src = file.source;
 
@@ -13,6 +21,16 @@ export default function transformer(file: FileInfo) {
       );
     }
   }
+
+  /*
+    Replace usages: @ax-border-radius-(full|small|medium|large|xlarge) -> @ax-radius-(full|2|4|8|12)
+  */
+  src = src.replace(
+    /(?<!\w)(@ax-border-radius-(?:full|small|medium|large|xlarge))(?!\w)/g,
+    (match, tokenName) => {
+      return axBorderRadiusMap[tokenName] ?? match;
+    },
+  );
 
   return src;
 }

--- a/@navikt/aksel/src/codemod/v8-tokens/transforms/v8-tokens-scss.ts
+++ b/@navikt/aksel/src/codemod/v8-tokens/transforms/v8-tokens-scss.ts
@@ -2,6 +2,14 @@ import type { FileInfo } from "jscodeshift";
 import { translateToken } from "../../utils/translate-token";
 import { legacyTokenConfig } from "../config/legacy.tokens";
 
+const axBorderRadiusMap: Record<string, string> = {
+  "$ax-border-radius-full": "$ax-radius-full",
+  "$ax-border-radius-small": "$ax-radius-2",
+  "$ax-border-radius-medium": "$ax-radius-4",
+  "$ax-border-radius-large": "$ax-radius-8",
+  "$ax-border-radius-xlarge": "$ax-radius-12",
+};
+
 export default function transformer(file: FileInfo) {
   let src = file.source;
 
@@ -13,6 +21,16 @@ export default function transformer(file: FileInfo) {
       );
     }
   }
+
+  /*
+    Replace usages: $ax-border-radius-(full|small|medium|large|xlarge) -> $ax-radius-(full|2|4|8|12)
+  */
+  src = src.replace(
+    /(?<!\w)(\$ax-border-radius-(?:full|small|medium|large|xlarge))(?!\w)/g,
+    (match, tokenName) => {
+      return axBorderRadiusMap[tokenName] ?? match;
+    },
+  );
 
   return src;
 }

--- a/@navikt/core/css/src/link-card.css
+++ b/@navikt/core/css/src/link-card.css
@@ -2,7 +2,7 @@
   --__axc-link-card-padding-block: var(--ax-space-16);
   --__axc-link-card-padding-inline: var(--ax-space-20);
 
-  border-radius: var(--ax-border-radius-xlarge);
+  border-radius: var(--ax-radius-12);
   text-decoration: none;
   color: var(--ax-text-neutral);
   transition-property: border-color, box-shadow, transform, background-color;
@@ -103,7 +103,7 @@
   grid-area: image;
   margin-block: calc(var(--__axc-link-card-padding-block) * -1) var(--__axc-link-card-padding-block);
   margin-inline: calc(var(--__axc-link-card-padding-inline) * 1 * -1);
-  border-radius: calc(var(--ax-border-radius-xlarge) - 1px);
+  border-radius: calc(var(--ax-radius-12) - 1px);
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
   position: relative;

--- a/@navikt/core/tokens/src/tokens/colors/create-alpha.ts
+++ b/@navikt/core/tokens/src/tokens/colors/create-alpha.ts
@@ -1,16 +1,16 @@
 import Color from "colorjs.io";
 import type { GlobalColorScale } from "../../../internal-types";
-import { AkselColor, AkselColorTheme } from "../../../types";
+import { AkselColorRole, AkselColorTheme } from "../../../types";
 import { GlobalColorEntry } from "../../tokens.util";
 import { GlobalConfigWithoutAlpha } from "./colors.types";
 import { semanticRootTokens } from "./semantic-root.tokens";
 
 type GlobalConfigWithAlpha = Record<
-  Extract<AkselColor, "neutral">,
+  Extract<AkselColorRole, "neutral">,
   Record<GlobalColorScale, GlobalColorEntry>
 > &
   Record<
-    Exclude<AkselColor, "neutral">,
+    Exclude<AkselColorRole, "neutral">,
     Record<Exclude<GlobalColorScale, "000">, GlobalColorEntry>
   >;
 
@@ -28,7 +28,7 @@ export function globalConfigWithAlphaTokens({
   const localConfig = structuredClone(globalConfig) as GlobalConfigWithAlpha;
 
   Object.keys(globalConfig).forEach((key) => {
-    const _key = key as AkselColor;
+    const _key = key as AkselColorRole;
     const scopedConfig = localConfig[_key];
 
     scopedConfig["100A"] = {

--- a/@navikt/core/tokens/src/tokens/radius.ts
+++ b/@navikt/core/tokens/src/tokens/radius.ts
@@ -1,7 +1,4 @@
-import {
-  AkselBorderRadiusToken,
-  AkselLegacyBorderRadiusToken,
-} from "../../types";
+import { AkselBorderRadiusToken } from "../../types";
 import { type StyleDictionaryToken } from "../tokens.util";
 
 export const radiusTokenConfig = {
@@ -22,56 +19,15 @@ export const radiusTokenConfig = {
       value: "12px",
       type: "global-radius",
     },
+    "16": {
+      value: "16px",
+      type: "global-radius",
+    },
     full: {
       value: "9999px",
       type: "global-radius",
     },
   },
-  border: {
-    radius: {
-      full: {
-        value: "{ax.radius.full.value}",
-        type: "global-radius",
-
-        figmaIgnore: true,
-        docsIgnore: true,
-      },
-      small: {
-        value: "{ax.radius.2.value}",
-        type: "global-radius",
-
-        figmaIgnore: true,
-        docsIgnore: true,
-      },
-      medium: {
-        value: "{ax.radius.4.value}",
-        type: "global-radius",
-
-        figmaIgnore: true,
-        docsIgnore: true,
-      },
-      large: {
-        value: "{ax.radius.8.value}",
-        type: "global-radius",
-
-        figmaIgnore: true,
-        docsIgnore: true,
-      },
-      xlarge: {
-        value: "{ax.radius.12.value}",
-        type: "global-radius",
-
-        figmaIgnore: true,
-        docsIgnore: true,
-      },
-    },
-  },
 } satisfies {
   radius: Record<AkselBorderRadiusToken, StyleDictionaryToken<"global-radius">>;
-  border: {
-    radius: Record<
-      AkselLegacyBorderRadiusToken,
-      StyleDictionaryToken<"global-radius">
-    >;
-  };
 };

--- a/@navikt/core/tokens/types.ts
+++ b/@navikt/core/tokens/types.ts
@@ -113,7 +113,7 @@ type AkselShadowToken = "dialog";
 export type { AkselShadowToken };
 
 /* ------------------------------ Border Radius tokens --------------------- */
-type AkselBorderRadiusToken = "2" | "4" | "8" | "12" | "full";
+type AkselBorderRadiusToken = "2" | "4" | "8" | "12" | "16" | "full";
 
 export type { AkselBorderRadiusToken };
 

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/styling/design-tokens/_ui/config.ts
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/styling/design-tokens/_ui/config.ts
@@ -53,7 +53,7 @@ const COLOR_ROLES: ColorRoleT[] = [
     id: "root",
     title: "Root",
     description:
-      "Root brukes på elementer i spesialtilfeller som for å skape dypde i skjermbildet eller der elementet ikke har en bestemt rolle.",
+      "Root-tokens er spissede farger som løser spesifikke behov i et grensesnitt.",
   },
   {
     id: "neutral",


### PR DESCRIPTION
### Description

Also added 16px border-radius

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] Component tokens (`@navikt/core/css/tokens.json`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
