### PR TITLE
DatePicker: Add prop `fixedWeeks` to DatePickerProps

### DIFF
--- a/.changeset/all-chicken-give.md
+++ b/.changeset/all-chicken-give.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+DatePicker: Add prop `fixedWeeks` to DatePickerProps

--- a/@navikt/core/react/src/date/datepicker/DatePicker.stories.tsx
+++ b/@navikt/core/react/src/date/datepicker/DatePicker.stories.tsx
@@ -75,6 +75,7 @@ export const Default: StoryObj<DefaultStoryProps> = {
           {...newProps}
           locale={props.locale}
           disableWeekends={props.disableWeekends}
+          fixedWeeks={props.fixedWeeks}
         >
           {!props.standalone &&
             (props.inputfield && props.mode !== "multiple" ? (
@@ -129,6 +130,7 @@ export const Default: StoryObj<DefaultStoryProps> = {
       options: ["single", "multiple", "range"],
       control: { type: "radio" },
     },
+    fixedWeeks: { control: { type: "boolean" } },
   },
 };
 

--- a/@navikt/core/react/src/date/datepicker/DatePicker.types.ts
+++ b/@navikt/core/react/src/date/datepicker/DatePicker.types.ts
@@ -97,6 +97,11 @@ export interface DatePickerDefaultProps
    */
   showWeekNumber?: boolean;
   /**
+   * If datepicker should be fixed to 6 weeks, regardless of actual weeks in month.
+   * @default false
+   */
+  fixedWeeks?: boolean;
+  /**
    * Open state for user-controlled state. Component controlled by default.
    */
   open?: boolean;

--- a/@navikt/core/react/src/date/datepicker/parts/DatePicker.RDP.tsx
+++ b/@navikt/core/react/src/date/datepicker/parts/DatePicker.RDP.tsx
@@ -41,11 +41,6 @@ const LegacyClassNames: Partial<ClassNames> = {
 type ReactDayPickerProps = DatePickerDefaultProps &
   ConditionalModeProps & {
     /**
-     * If datepicker should be fixed to 6 weeks, regardless of actual weeks in month
-     * @default false
-     */
-    fixedWeeks?: boolean;
-    /**
      * Update selected date
      */
     handleSelect: (newSelected: any) => void;

--- a/@navikt/core/react/src/date/datepicker/parts/DatePicker.Standalone.tsx
+++ b/@navikt/core/react/src/date/datepicker/parts/DatePicker.Standalone.tsx
@@ -24,11 +24,6 @@ interface DatePickerStandaloneDefaultProps
    * Datepicker classname
    */
   className?: string;
-  /**
-   * If datepicker should be fixed to 6 weeks, regardless of actual weeks in month
-   * @default true
-   */
-  fixedWeeks?: boolean;
 }
 
 type StandaloneConditionalModeProps = SingleMode | MultipleMode | RangeMode;


### PR DESCRIPTION
### Description

Makes it so you can use `fixedWeeks` on `<DatePicker />` without getting TS error.

### Component Checklist 📝

- [x] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [x] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
