### PR TITLE
[Website] :bug: Fix sanity-data that returns null-values

### DIFF
--- a/aksel.nav.no/website/app/(routes)/(god-praksis)/god-praksis/artikler/[slug]/page.tsx
+++ b/aksel.nav.no/website/app/(routes)/(god-praksis)/god-praksis/artikler/[slug]/page.tsx
@@ -30,6 +30,7 @@ import { TableOfContents } from "@/app/_ui/toc/TableOfContents";
 import { WebsiteList, WebsiteListItem } from "@/app/_ui/typography/WebsiteList";
 import { formatDateString } from "@/ui-utils/format-date";
 import { humanizeRedaksjonType } from "@/ui-utils/format-text";
+import { getValidRenderArray } from "@/ui-utils/valid-array";
 import styles from "./page.module.css";
 
 type Props = {
@@ -87,7 +88,10 @@ export default async function Page(props: Props) {
     pageData?._updatedAt;
 
   const outdated = differenceInMonths(new Date(), new Date(verifiedDate)) >= 12;
-  const writers = pageData.writers ?? [];
+  const writers = getValidRenderArray(pageData.writers);
+
+  const undertema = getValidRenderArray(pageData.undertema);
+  const relevanteArtikler = getValidRenderArray(pageData.relevante_artikler);
 
   return (
     <article className={styles.pageArticle}>
@@ -114,7 +118,7 @@ export default async function Page(props: Props) {
           {`Oppdatert ${formatDateString(verifiedDate)}`}
         </BodyShort>
         <HStack gap="space-8" marginBlock="space-16 space-48">
-          {pageData.undertema?.map(({ tema, title }) => {
+          {undertema?.map(({ tema, title }) => {
             const href = stegaClean(
               `/god-praksis/${tema?.slug}?undertema=${encodeURIComponent(
                 title ?? "",
@@ -146,13 +150,13 @@ export default async function Page(props: Props) {
           value={(pageData.content ?? []) as PortableTextBlock[]}
         />
 
-        {writers.length > 0 && (
+        {writers && (
           <VStack gap="space-8" marginBlock="space-48">
             <Label data-aksel-heading-color as="p">
               Medvirkende
             </Label>
             <HStack gap="space-32">
-              {pageData.writers?.map((writer) => {
+              {writers?.map((writer) => {
                 return (
                   <Avatar
                     type={humanizeRedaksjonType(writer.type)}
@@ -166,28 +170,27 @@ export default async function Page(props: Props) {
             </HStack>
           </VStack>
         )}
-        {pageData.relevante_artikler &&
-          pageData.relevante_artikler.length > 0 && (
-            <Box marginBlock="space-0 space-48">
-              <EditorPanel variant="links" heading="Relatert innhold fra Aksel">
-                <WebsiteList as="ul">
-                  {pageData.relevante_artikler.map((item) => (
-                    <WebsiteListItem key={item.heading} icon>
-                      <Link
-                        variant="neutral"
-                        href={`/${item.slug?.current}`}
-                        data-umami-event="navigere"
-                        data-umami-event-kilde="les ogsaa"
-                        data-umami-event-url={item.slug?.current ?? ""}
-                      >
-                        {item.heading}
-                      </Link>
-                    </WebsiteListItem>
-                  ))}
-                </WebsiteList>
-              </EditorPanel>
-            </Box>
-          )}
+        {relevanteArtikler && (
+          <Box marginBlock="space-0 space-48">
+            <EditorPanel variant="links" heading="Relatert innhold fra Aksel">
+              <WebsiteList as="ul">
+                {relevanteArtikler.map((item) => (
+                  <WebsiteListItem key={item.heading} icon>
+                    <Link
+                      variant="neutral"
+                      href={`/${item.slug?.current}`}
+                      data-umami-event="navigere"
+                      data-umami-event-kilde="les ogsaa"
+                      data-umami-event-url={item.slug?.current ?? ""}
+                    >
+                      {item.heading}
+                    </Link>
+                  </WebsiteListItem>
+                ))}
+              </WebsiteList>
+            </EditorPanel>
+          </Box>
+        )}
 
         <GodPraksisFeedback docId={pageData._id} />
       </div>

--- a/aksel.nav.no/website/app/_ui/utils/__tests__/valid-array.ts
+++ b/aksel.nav.no/website/app/_ui/utils/__tests__/valid-array.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import { getValidRenderArray } from "../valid-array";
+
+describe("getValidRenderArray", () => {
+  test("returns null for undefined input", () => {
+    expect(getValidRenderArray(undefined)).toBeNull();
+  });
+
+  test("returns null for null input", () => {
+    expect(getValidRenderArray(null)).toBeNull();
+  });
+
+  test("returns null for empty array", () => {
+    expect(getValidRenderArray([])).toBeNull();
+  });
+
+  test("returns null for array with only null values", () => {
+    expect(getValidRenderArray([null, null])).toBeNull();
+  });
+
+  test("returns null for array with only undefined values", () => {
+    expect(getValidRenderArray([undefined, undefined])).toBeNull();
+  });
+
+  test("returns null for array with mixed nullish values", () => {
+    expect(getValidRenderArray([null, undefined, null])).toBeNull();
+  });
+
+  test("returns valid items from array with strings", () => {
+    expect(getValidRenderArray(["a", "b", "c"])).toEqual(["a", "b", "c"]);
+  });
+
+  test("returns valid items from array with numbers", () => {
+    expect(getValidRenderArray([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  test("filters out null values from mixed array", () => {
+    expect(getValidRenderArray(["a", null, "b"])).toEqual(["a", "b"]);
+  });
+
+  test("filters out undefined values from mixed array", () => {
+    expect(getValidRenderArray([1, undefined, 2])).toEqual([1, 2]);
+  });
+
+  test("filters out both null and undefined from mixed array", () => {
+    expect(getValidRenderArray(["x", null, "y", undefined, "z"])).toEqual([
+      "x",
+      "y",
+      "z",
+    ]);
+  });
+
+  test("preserves falsy but valid values like 0 and empty string", () => {
+    expect(getValidRenderArray([0, "", false, null])).toEqual([0, "", false]);
+  });
+
+  test("works with object arrays", () => {
+    const obj1 = { id: 1 };
+    const obj2 = { id: 2 };
+    expect(getValidRenderArray([obj1, null, obj2])).toEqual([obj1, obj2]);
+  });
+
+  test("returns single item array when only one valid item exists", () => {
+    expect(getValidRenderArray([null, "only", undefined])).toEqual(["only"]);
+  });
+});

--- a/aksel.nav.no/website/app/_ui/utils/valid-array.ts
+++ b/aksel.nav.no/website/app/_ui/utils/valid-array.ts
@@ -1,0 +1,21 @@
+/**
+ * Filters out nullish values from an array and returns the result,
+ * or null if the input is invalid or the resulting array is empty.
+ *
+ * Useful for validating Sanity data where arrays may contain null entries.
+ */
+function getValidRenderArray<T>(
+  input: T[] | undefined | null,
+): NonNullable<T>[] | null {
+  if (!Array.isArray(input)) {
+    return null;
+  }
+
+  const validItems = input.filter(
+    (item): item is NonNullable<T> => item != null,
+  );
+
+  return validItems.length > 0 ? validItems : null;
+}
+
+export { getValidRenderArray };


### PR DESCRIPTION
### Description

In some cases, data from sanity might return an array `[null]` that passes both boolean and array.length > 0 tests. The util getValidRenderArray takes care of parsing these arrays.

If we decide to merge it, the rest of the pages can be updated to use the same API to.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
