### PR TITLE
:bug: AccordionContent-text had blue tint inherited from app color.

### DIFF
--- a/.changeset/some-knives-live.md
+++ b/.changeset/some-knives-live.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Accordion: Avoid AccordionContent inheriting app-color for all text.

--- a/@navikt/core/react/src/accordion/AccordionContent.tsx
+++ b/@navikt/core/react/src/accordion/AccordionContent.tsx
@@ -27,7 +27,6 @@ const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps>(
 
     return (
       <BodyLong
-        data-color={themeContext.color}
         {...rest}
         as="div"
         ref={ref}
@@ -37,7 +36,12 @@ const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps>(
           className,
         )}
       >
-        <div className="aksel-accordion__content-inner">{children}</div>
+        <div
+          className="aksel-accordion__content-inner"
+          data-color={themeContext.color}
+        >
+          {children}
+        </div>
       </BodyLong>
     );
   },


### PR DESCRIPTION
### Description

Before/after
<img width="629" height="612" alt="Screenshot 2026-01-19 at 10 43 30" src="https://github.com/user-attachments/assets/8d09b010-7cd0-40cb-a24e-f2f4c5ed97c5" />

<img width="562" height="598" alt="Screenshot 2026-01-19 at 10 43 25" src="https://github.com/user-attachments/assets/b434381f-9008-430a-8800-5981e4a97852" />


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
