### PR TITLE
:bug: Discrete events did not handle react-19 well with event-batching

### DIFF
--- a/.changeset/cute-hands-invite.md
+++ b/.changeset/cute-hands-invite.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Internal: Updated DismissableLayer-API for better event-batching.

--- a/@navikt/core/react/src/overlays/dismissablelayer/util/dispatchCustomEvent.ts
+++ b/@navikt/core/react/src/overlays/dismissablelayer/util/dispatchCustomEvent.ts
@@ -1,53 +1,15 @@
-import ReactDOM from "react-dom";
-
 type CustomFocusEvent = CustomEvent<{ originalEvent: FocusEvent }>;
 type CustomPointerEvent = CustomEvent<{
   originalEvent: PointerEvent;
 }>;
 
-export type { CustomFocusEvent, CustomPointerEvent };
-
-export const CUSTOM_EVENTS = {
+const CUSTOM_EVENTS = {
   FOCUS_OUTSIDE: "AKSEL_FOCUS_OUTSIDE",
   POINTER_DOWN_OUTSIDE: "AKSEL_POINTER_DOWN_OUTSIDE",
   POINTER_UP_OUTSIDE: "AKSEL_POINTER_UP_OUTSIDE",
 };
 
-/**
- * Use of `discrete` flushes custom event dispatch. This is to mimic the behavior React has for `discrete` events.
- * https://github.com/facebook/react/blob/a8a4742f1c54493df00da648a3f9d26e3db9c8b5/packages/react-dom/src/events/ReactDOMEventListener.js#L318
- *
- * React batches *all* event handlers since version 18, this introduces certain considerations when using custom event types.
- *
- * Internally, React prioritises events in the following order:
- *  - discrete
- *  - continuous
- *  - default
- *
- * `discrete` is an  important distinction as updates within these events are applied immediately.
- * React however, is not able to infer the priority of custom event types due to how they are detected internally.
- * Because of this, it's possible for updates from custom events to be unexpectedly batched when
- * dispatched by another `discrete` event.
- *
- * In order to ensure that updates from custom events are applied predictably, we need to manually flush the batch.
- * This utility should be used when dispatching a custom event from within another `discrete` event, this utility
- * is not nessesary when dispatching known event types, or if dispatching a custom type inside a non-discrete event.
- * For example:
- *
- * dispatching a known click 👎
- * target.dispatchEvent(new Event(‘click’))
- *
- * dispatching a custom type within a non-discrete event 👎
- * onScroll={(event) => event.target.dispatchEvent(new CustomEvent(‘customType’))}
- *
- * dispatching a custom type within a `discrete` event 👍
- * onPointerDown={(event) => dispatchDiscreteCustomEvent(event.target, new CustomEvent(‘customType’))}
- *
- * Note: though React classifies `focus`, `focusin` and `focusout` events as `discrete`, it's  not recommended to use
- * this utility with them. This is because it's possible for those handlers to be called implicitly during render
- * e.g. when focus is within a component as it is unmounted, or when managing focus on mount.
- */
-export function dispatchCustomEvent<
+function dispatchCustomEvent<
   E extends CustomEvent,
   OriginalEvent extends Event,
 >(
@@ -56,7 +18,6 @@ export function dispatchCustomEvent<
   detail: { originalEvent: OriginalEvent } & (E extends CustomEvent<infer D>
     ? D
     : never),
-  { discrete }: { discrete: boolean } = { discrete: false },
 ) {
   if (!handler) {
     return;
@@ -69,10 +30,8 @@ export function dispatchCustomEvent<
   });
 
   target.addEventListener(name, handler as EventListener, { once: true });
-
-  if (discrete && target) {
-    ReactDOM.flushSync(() => target.dispatchEvent(event));
-  } else {
-    target.dispatchEvent(event);
-  }
+  target.dispatchEvent(event);
 }
+
+export { CUSTOM_EVENTS, dispatchCustomEvent };
+export type { CustomFocusEvent, CustomPointerEvent };

--- a/@navikt/core/react/src/overlays/dismissablelayer/util/usePointerDownOutside.ts
+++ b/@navikt/core/react/src/overlays/dismissablelayer/util/usePointerDownOutside.ts
@@ -35,16 +35,12 @@ export function usePointerDownOutside(
        * Altrough `pointerdown` is already a cancelable event,
        * to to make sure the batching of events works corretly with `focusIn` in `useFocusOutside`,
        * we still use a custom event like in `useFocusOutside`.
-       *
-       * Since pointer-events are `discrete` events in React: https://github.com/facebook/react/blob/a8a4742f1c54493df00da648a3f9d26e3db9c8b5/packages/react-dom/src/events/ReactDOMEventListener.js#L318
-       * we need to to use flushSync to ensure that the event is dispatched before the next event is raised.
        */
       function dispatchPointerEvent() {
         dispatchCustomEvent(
           CUSTOM_EVENTS.POINTER_DOWN_OUTSIDE,
           handlePointerDownOutside,
           { originalEvent: event },
-          { discrete: true },
         );
       }
 

--- a/@navikt/core/react/src/overlays/dismissablelayer/util/usePointerUpOutside.ts
+++ b/@navikt/core/react/src/overlays/dismissablelayer/util/usePointerUpOutside.ts
@@ -31,17 +31,14 @@ export function usePointerUpOutside(
        * The `DismisableLayer`-API is based on the ability to stop events from propagating and in the end calling `onDismiss`
        * if `usePointerUpOutside`-callback does not run `event.preventDefault()`.
        *
-       * Although `pointerup` is already a cancelable event, we still dispatch a custom event (discrete)
+       * Although `pointerup` is already a cancelable event, we still dispatch a custom event
        * to keep parity with focus outside handling and ensure ordering.
-       *
-       * Since pointer events are `discrete` in React we rely on the same custom dispatch strategy.
        */
       if (event.target && !isPointerInsideReactTreeRef.current) {
         dispatchCustomEvent(
           CUSTOM_EVENTS.POINTER_UP_OUTSIDE,
           handlePointerUpOutside,
           { originalEvent: event },
-          { discrete: true },
         );
       }
       /* Reset for next interaction. */


### PR DESCRIPTION
### Description

React 19 changes event-batching a little, breaking our current implementation of Dismissablelayer
- PointerUp/Down are "discrete" events. This lead to different event behaviour based on mount-order (order of pointer event mounting). 
- The reason we needed discrete events for pointer is to avoid running pointer-event and focus-event right after eachother, leading `onDismiss` being called twice in scenarios where element should unmount after pointerDown event.
- Fix for this is to just disable focus-events from running for 1 tick after pointerdown event is detected like [FloatingFocusManager does](https://github.com/mui/base-ui/blob/7e2813bfa129a066902e61fae4178e094e6fead4/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx#L459-L464), use: https://github.com/mui/base-ui/blob/7e2813bfa129a066902e61fae4178e094e6fead4/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx#L566 

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
