### PR TITLE
:bug: Require node 22 for CLI caused by use of ESM in CJS file

### DIFF
--- a/.changeset/famous-swans-grow.md
+++ b/.changeset/famous-swans-grow.md
@@ -1,0 +1,5 @@
+---
+"@navikt/aksel": patch
+---
+
+CLI: Set min-requirement for node to v22.

--- a/@navikt/aksel/package.json
+++ b/@navikt/aksel/package.json
@@ -55,7 +55,7 @@
   },
   "sideEffects": false,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
### Description

https://nodejs.org/en/blog/announcements/v22-release-announce#support-requireing-synchronous-esm-graphs
Chalk is since v5 a "pure esm" package, while the CLI-tool is transpiled to commonjs. This makes all node-versions before 22 not able to run the code caused by errors:
```
const chalk_1 = __importDefault(require("chalk"));
Error [ERR_REQUIRE_ESM]: require() of ES Module
```

Simple fix is to just set minimum engine requirement to node 22 (almost 2 years old. They will then get a warning when running CLI
```
 WARN  Unsupported engine: wanted: {"node":">=20.0.0"} (current: {"node":"v19.9.0")
```

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
