### PR TITLE
[Website] :test_tube: Test less agressive live refresh of content

### DIFF
--- a/aksel.nav.no/website/app/(routes)/layout.tsx
+++ b/aksel.nav.no/website/app/(routes)/layout.tsx
@@ -24,6 +24,7 @@ export default async function IndexLayout({
         intervalOnGoAway={false}
         refreshOnFocus={false}
         refreshOnMount={false}
+        refreshOnReconnect={false}
       />
     </>
   );


### PR DESCRIPTION
### Description

Theory: When user visits Aksel.nav.no, then moves to another tab some browser enter some sort of "sleep"-mode. The content on the page might be disconnected, but the browser keeps "polling" in intervals to see if something has changed.

`refreshOnReconnect` is then triggered, revalidating quite a bit of content. By disabling it, it stops polling.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
