### PR TITLE
[Website] :tada: Auto-link to relevant changelogs

### DIFF
--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
@@ -83,7 +83,7 @@ function KomponentLinks({
         </Link>
       )}
       <Link
-        href={`/grunnleggende/endringslogg${heading ? `?fritekst=${removeEmojiesFromText(heading).toLowerCase().trim()}` : ""}`}
+        href={`/grunnleggende/endringslogg${heading ? `?fritekst=${removeEmojiesFromText(heading).trim()}` : ""}`}
         data-color="neutral"
         onClick={() =>
           umamiTrack("navigere", {

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
@@ -5,6 +5,7 @@ import { HStack, Link } from "@navikt/ds-react";
 import { KOMPONENT_BY_SLUG_QUERY_RESULT } from "@/app/_sanity/query-types";
 import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { FigmaIcon, GithubIcon } from "@/assets/Icons";
+import { removeEmojiesFromText } from "@/ui-utils/format-text";
 
 const GITHUB_CONFIG = {
   "ds-react": {
@@ -33,7 +34,13 @@ const GITHUB_CONFIG = {
   },
 } as const;
 
-function KomponentLinks({ data }: { data: KOMPONENT_BY_SLUG_QUERY_RESULT }) {
+function KomponentLinks({
+  data,
+  heading,
+}: {
+  data: KOMPONENT_BY_SLUG_QUERY_RESULT;
+  heading?: string;
+}) {
   const pack = data?.kodepakker?.[0];
   const gitConfig = pack ? (GITHUB_CONFIG[pack] ?? null) : null;
 
@@ -76,12 +83,12 @@ function KomponentLinks({ data }: { data: KOMPONENT_BY_SLUG_QUERY_RESULT }) {
         </Link>
       )}
       <Link
-        href="/grunnleggende/endringslogg"
+        href={`/grunnleggende/endringslogg${heading ? `?fritekst=${removeEmojiesFromText(heading).toLowerCase().trim()}` : ""}`}
         data-color="neutral"
         onClick={() =>
           umamiTrack("navigere", {
             kilde: "komponent-header",
-            url: "/grunnleggende/endringslogg",
+            url: `/grunnleggende/endringslogg`,
           })
         }
       >

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/DesignsystemetPage.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/DesignsystemetPage.tsx
@@ -87,7 +87,9 @@ async function DesignsystemetPageHeader({ data }: DesignsystemetPageT) {
           </BodyShort>
         )}
       </HStack>
-      {isComponentPage && <KomponentLinks data={data} />}
+      {isComponentPage && (
+        <KomponentLinks data={data} heading={data?.heading} />
+      )}
       <DesignsystemetThumbnail thumbnailUrl={imageUrl} />
     </Box>
   );

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/styling/design-tokens/page.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/styling/design-tokens/page.tsx
@@ -46,7 +46,7 @@ const Page = async () => {
               Figma-community
             </Link>
             <Link
-              href="https://aksel.nav.no/grunnleggende/endringslogg"
+              href="https://aksel.nav.no/grunnleggende/endringslogg?fritekst=tokens"
               variant="neutral"
             >
               <ClockDashedIcon aria-hidden />


### PR DESCRIPTION
### Description

<!-- PR description/motivation, summary of changes, links to issue/slack discussion etc. -->

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
