### PR TITLE
[Website] :bug: Avoid updating EVERY props/example document when deploying

### DIFF
--- a/aksel.nav.no/website/scripts/helpers/find-unequal-documents.ts
+++ b/aksel.nav.no/website/scripts/helpers/find-unequal-documents.ts
@@ -1,0 +1,92 @@
+import { isEqual } from "lodash";
+import { sanityClient } from "../../sanity/interface/client.server";
+
+/**
+ * Deep compare two sets of documents and return those that are unequal based on specified keys.
+ */
+function findUnequalDocuments({
+  newDocuments,
+  oldDocuments,
+  keysToCompare,
+}: {
+  newDocuments: any[];
+  oldDocuments: any[];
+  keysToCompare: string[];
+}) {
+  const transationClient = sanityClient.transaction();
+  const unequalDocuments: any[] = [];
+
+  for (const newDocument of newDocuments) {
+    const oldDocument = oldDocuments.find(
+      (r: any) => r._id === newDocument._id,
+    );
+
+    /**
+     * No old documents equal new document, so lets add it to the list for creation
+     */
+    if (!oldDocument) {
+      unequalDocuments.push(newDocument);
+      continue;
+    }
+
+    /**
+     * Sanity transactions serializes documents, making changes to data (removing undefined, etc).
+     * To get a correct comparison, we create a transaction for both documents, serialize them,
+     * and compare the serialized versions based on the provided keys.
+     */
+    transationClient.create(oldDocument);
+    transationClient.create(newDocument);
+
+    /**
+     * .create() just adds the documents withing a `{ create: {...document} }`-wrapper
+     */
+    const [serializedOldMutation, serializedNewMutation] =
+      transationClient.toJSON() as { create: any }[];
+
+    /* Clean up transaction for next run */
+    transationClient.reset();
+
+    /**
+     * When uploading/downloading documents, Sanity will modify the documents slightly.
+     * Mainly line-breaks and some strings are modified.
+     * local      : "type": "\\"medium\\" | \\"small\\"",\n'
+     * from sanity: "type": "\\"medium\\" | \\"small\\""\n'
+     *
+     * Running JSON.stringify() on both documents normalizes these differences,
+     * making the comparison more reliable.
+     */
+    const serializedOld = JSON.parse(
+      JSON.stringify(serializedOldMutation.create),
+    );
+    const serializedNew = JSON.parse(
+      JSON.stringify(serializedNewMutation.create),
+    );
+
+    for (const key of keysToCompare) {
+      const hasOldKey = key in serializedOld;
+      const hasNewKey = key in serializedNew;
+
+      /* If key exists in only one document, they're unequal */
+      if (hasOldKey !== hasNewKey) {
+        console.info(`Key mismatch on document ${newDocument._id}: ${key}`);
+        unequalDocuments.push(newDocument);
+        break;
+      }
+
+      /* Skip if both don't exist */
+      if (!hasOldKey && !hasNewKey) {
+        continue;
+      }
+
+      /* If key exists in both, compare values */
+      if (!isEqual(serializedOld[key], serializedNew[key])) {
+        unequalDocuments.push(newDocument);
+        break;
+      }
+    }
+  }
+
+  return unequalDocuments;
+}
+
+export { findUnequalDocuments };

--- a/aksel.nav.no/website/scripts/helpers/find-unequal-documents.ts
+++ b/aksel.nav.no/website/scripts/helpers/find-unequal-documents.ts
@@ -13,7 +13,7 @@ function findUnequalDocuments({
   oldDocuments: any[];
   keysToCompare: string[];
 }) {
-  const transationClient = sanityClient.transaction();
+  const transactionClient = sanityClient.transaction();
   const unequalDocuments: any[] = [];
 
   for (const newDocument of newDocuments) {
@@ -34,17 +34,17 @@ function findUnequalDocuments({
      * To get a correct comparison, we create a transaction for both documents, serialize them,
      * and compare the serialized versions based on the provided keys.
      */
-    transationClient.create(oldDocument);
-    transationClient.create(newDocument);
+    transactionClient.create(oldDocument);
+    transactionClient.create(newDocument);
 
     /**
      * .create() just adds the documents within a `{ create: {...document} }`-wrapper
      */
     const [serializedOldMutation, serializedNewMutation] =
-      transationClient.toJSON() as { create: any }[];
+      transactionClient.toJSON() as { create: any }[];
 
     /* Clean up transaction for next run */
-    transationClient.reset();
+    transactionClient.reset();
 
     /**
      * When uploading/downloading documents, Sanity will modify the documents slightly.

--- a/aksel.nav.no/website/scripts/helpers/find-unequal-documents.ts
+++ b/aksel.nav.no/website/scripts/helpers/find-unequal-documents.ts
@@ -38,7 +38,7 @@ function findUnequalDocuments({
     transationClient.create(newDocument);
 
     /**
-     * .create() just adds the documents withing a `{ create: {...document} }`-wrapper
+     * .create() just adds the documents within a `{ create: {...document} }`-wrapper
      */
     const [serializedOldMutation, serializedNewMutation] =
       transationClient.toJSON() as { create: any }[];

--- a/aksel.nav.no/website/scripts/update-props.tsx
+++ b/aksel.nav.no/website/scripts/update-props.tsx
@@ -25,27 +25,6 @@ async function updateProps() {
 
   const transactionClient = noCdnClient(token).transaction();
 
-  transactionClient.createIfNotExists({
-    _id: "ds_props",
-    _type: "document",
-    title: "Props Designsystemet",
-    displayname: "Props Designsystemet",
-    filepath: "./test/path.tsx",
-    proplist: [
-      { val: 1, prop: 2 },
-      {
-        val: 2,
-        prop: 3,
-        value: undefined,
-        nested: {
-          a: 1,
-          test: undefined,
-          what: [{ q: 123 }, undefined, { t: undefined }],
-        },
-      },
-    ],
-  });
-
   let updatedCount = 0;
 
   const unequalDocuments = findUnequalDocuments({
@@ -67,7 +46,6 @@ async function updateProps() {
   }
 
   if (updatedCount > 0) {
-    console.info(`Successfully updated ${updatedCount} prop-documentation(s)`);
     await transactionClient
       .commit()
       .then(() =>


### PR DESCRIPTION
### Description

Right now we are using `createOrReplace` to update props and example-documents. This is easy, but literally replaces all the data for an existing document, including `_updatedAt`. This causes the revalidation to trigger for each document, even when it has no changes. 

As a consequence, when we re-deploy aksel.nav.no, 755-revalidation triggers are sent out to EACH user currently visiting 😱 

<img width="916" height="79" alt="Screenshot 2026-01-29 at 14 21 29" src="https://github.com/user-attachments/assets/c5b86ed3-e1d6-46bd-8fca-f6da47095442" />


To fix this we can instead just compare the data then `createOrReplace´ if there are changes.


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
