### PR TITLE
[Website] Use static encryption key for server-actions

### DIFF
--- a/.github/actions/build-website/action.yml
+++ b/.github/actions/build-website/action.yml
@@ -22,6 +22,9 @@ inputs:
   sanity_deploy_studio:
     description: "Sanity studio deployment token"
     required: false
+  next_encryption_key:
+    description: "Overrides default NEXT_SERVER_ACTIONS_ENCRYPTION_KEY for production builds"
+    required: false
   production:
     description: "Toggle to differentiate production build (inject stuff based on this)"
     default: false
@@ -49,6 +52,12 @@ runs:
       if: ${{ inputs.production == 'true' }}
       run: |
         echo "PRODUCTION=true" >> aksel.nav.no/website/.env
+      shell: bash
+
+    - name: Override encryption key for production
+      if: ${{ inputs.production == 'true' && inputs.next_encryption_key != '' }}
+      run: |
+        echo "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=${{ inputs.next_encryption_key }}" >> aksel.nav.no/website/.env
       shell: bash
 
     - name: Update sanity manifest

--- a/.github/actions/build-website/action.yml
+++ b/.github/actions/build-website/action.yml
@@ -54,12 +54,6 @@ runs:
         echo "PRODUCTION=true" >> aksel.nav.no/website/.env
       shell: bash
 
-    - name: Override encryption key for production
-      if: ${{ inputs.production == 'true' && inputs.next_encryption_key != '' }}
-      run: |
-        echo "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=${{ inputs.next_encryption_key }}" >> aksel.nav.no/website/.env
-      shell: bash
-
     - name: Update sanity manifest
       if: ${{ inputs.production == 'true' && inputs.sanity_deploy_studio != '' }}
       run: yarn update:sanity-manifest
@@ -72,6 +66,7 @@ runs:
       env:
         SANITY_READ: ${{ inputs.sanity_read_token }}
         SANITY_READ_NO_DRAFTS: ${{ inputs.sanity_read_no_drafts_token }}
+        NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: ${{ inputs.next_encryption_key }}
       shell: bash
 
     - name: Upload static files to Nav CDN

--- a/.github/workflows/aksel-prod.yml
+++ b/.github/workflows/aksel-prod.yml
@@ -53,6 +53,7 @@ jobs:
           sanity_read_token: ${{ secrets.SANITY_READ }}
           sanity_read_no_drafts_token: ${{ secrets.SANITY_READ_NO_DRAFTS }}
           sanity_deploy_studio: ${{ secrets.SANITY_DEPLOY_STUDIO }}
+          next_encryption_key: ${{ secrets.NEXT_ENCRYPTION_KEY }}
 
       - name: Get complete tag
         run: echo "TAG=PROD-$( date +%s )" >> $GITHUB_ENV


### PR DESCRIPTION
### Description

Right now each build generates a new hash/key for each action. This leads to each re-deploy breaking existing connections when they try to interact with said server-actions. 

https://nextjs.org/docs/app/guides/data-security#overwriting-encryption-keys-advanced

By using a static key, they will remain the same across builds. The exception is if we make any changes to the server-action code itself, but we seldom do that.


Encryption-key generated with 
```js
 node -e "const {randomBytes, createCipheriv} = require('crypto'); const secret = randomBytes(32); const aesKey = randomBytes(32); const iv = randomBytes(12); const c = createCipheriv('aes-256-gcm', aesKey, iv); const encrypted = Buffer.concat([c.update(secret), c.final()]); const tag = c.getAuthTag(); console.log(Buffer.concat([iv, tag, encrypted]).toString('base64'))"
```

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
