### PR TITLE
Update JSDoc examples to use spacing tokens

### DIFF
--- a/@navikt/core/react/src/collapsible/Collapsible.tsx
+++ b/@navikt/core/react/src/collapsible/Collapsible.tsx
@@ -49,7 +49,7 @@ interface CollapsibleComponent extends React.ForwardRefExoticComponent<
  *     <Button>Button</Button>
  *   </Collapsible.Trigger>
  *   <Collapsible.Content asChild>
- *     <Box padding="4" background="info-soft">
+ *     <Box padding="space-16" background="info-soft">
  *       <div>lorem ipsum</div>
  *     </Box>
  *   </Collapsible.Content>

--- a/@navikt/core/react/src/form/file-upload/FileUpload.tsx
+++ b/@navikt/core/react/src/form/file-upload/FileUpload.tsx
@@ -14,10 +14,9 @@ interface FileUploadProps extends HTMLAttributes<HTMLDivElement> {
   translations?: ComponentTranslation<"FileUpload">;
 }
 
-interface FileUploadComponent
-  extends React.ForwardRefExoticComponent<
-    FileUploadProps & React.RefAttributes<HTMLDivElement>
-  > {
+interface FileUploadComponent extends React.ForwardRefExoticComponent<
+  FileUploadProps & React.RefAttributes<HTMLDivElement>
+> {
   /**
    * Framed area to drag-n-drop files, upload files with button-click or copy-paste.
    * @example
@@ -64,7 +63,7 @@ interface FileUploadComponent
    * Multiple items can be semantically grouped as a list.
    * ```jsx
    * <FileUpload>
-   *   <VStack gap="4" as="ul">
+   *   <VStack gap="space-16" as="ul">
    *     <FileUpload.Item as="li" file={file} />
    *     <FileUpload.Item as="li" file={file2} />
    *     <FileUpload.Item as="li" file={file3} status="uploading" />
@@ -117,7 +116,7 @@ interface FileUploadComponent
  * @example
  * Items
  * ```jsx
- * <VStack gap="4" as="ul">
+ * <VStack gap="space-16" as="ul">
  *   <FileUpload.Item as="li" file={myFile} />
  *   <FileUpload.Item as="li" file={mySecondFile} />
  * </VStack>

--- a/@navikt/core/react/src/layout/bleed/Bleed.tsx
+++ b/@navikt/core/react/src/layout/bleed/Bleed.tsx
@@ -61,7 +61,7 @@ export interface BleedProps extends React.HTMLAttributes<HTMLDivElement> {
  * @see [🤖 OverridableComponent](https://aksel.nav.no/grunnleggende/kode/overridablecomponent) support
  *
  * @example
- * <Box padding="4">
+ * <Box padding="space-16">
  *   <Bleed marginInline="space-16" marginBlock="space-16">
  *     <BodyLong>Some content</BodyLong>
  *   </Bleed>

--- a/@navikt/core/react/src/layout/responsive/Responsive.tsx
+++ b/@navikt/core/react/src/layout/responsive/Responsive.tsx
@@ -65,14 +65,14 @@ const Responsive = forwardRef<
  * @see 🏷️ {@link ResponsiveProps}
  *
  * @example
- * <HGrid columns={{ xs: 1, md: 2 }} gap="4">
+ * <HGrid columns={{ xs: 1, md: 2 }} gap="space-16">
  *   <div/>
  *   <Hide below="md" asChild>
  *      // Only visible above "md"
  *   </Hide>
  * </HGrid>
  * @example
- * <HGrid columns={{ xs: 1, md: 2 }} gap="4">
+ * <HGrid columns={{ xs: 1, md: 2 }} gap="space-16">
  *   <div/>
  *   <Hide above="md" asChild>
  *      // Only visible below "md"
@@ -90,14 +90,14 @@ export const Hide = forwardRef<HTMLDivElement, ResponsiveProps>(
  * @see 🏷️ {@link ResponsiveProps}
  *
  * @example
- * <HGrid columns={{ xs: 1, md: 2 }} gap="4">
+ * <HGrid columns={{ xs: 1, md: 2 }} gap="space-16">
  *   <div/>
  *   <Show below="md" asChild>
  *      // Only visible below "md"
  *   </Show>
  * </HGrid>
  * @example
- * <HGrid columns={{ xs: 1, md: 2 }} gap="4">
+ * <HGrid columns={{ xs: 1, md: 2 }} gap="space-16">
  *   <div/>
  *   <Show above="md" asChild>
  *      // Only visible above "md"

--- a/@navikt/core/react/src/layout/stack/HStack.tsx
+++ b/@navikt/core/react/src/layout/stack/HStack.tsx
@@ -13,14 +13,14 @@ export type HStackProps = PrimitiveAsChildProps & Omit<StackProps, "direction">;
  * @see [🤖 OverridableComponent](https://aksel.nav.no/grunnleggende/kode/overridablecomponent) support
  *
  * @example
- * <HStack gap="8">
+ * <HStack gap="space-32">
  *  <MyComponent />
  *  <MyComponent />
  * </HStack>
  *
  * @example
  * // Responsive gap
- * <HStack gap={{xs: "2", md: "6"}}>
+ * <HStack gap={{xs: "space-8", md: "space-24"}}>
  *  <MyComponent />
  *  <MyComponent />
  * </HStack>

--- a/@navikt/core/react/src/layout/stack/Spacer.tsx
+++ b/@navikt/core/react/src/layout/stack/Spacer.tsx
@@ -6,7 +6,7 @@ import React from "react";
  * @see [📝 Documentation](https://aksel.nav.no/komponenter/primitives/hstack)
  *
  * @example
- * <HStack gap="8">
+ * <HStack gap="space-32">
  *  <MyComponent />
  *  <Spacer />
  *  <MyComponent />

--- a/@navikt/core/react/src/layout/stack/VStack.tsx
+++ b/@navikt/core/react/src/layout/stack/VStack.tsx
@@ -14,14 +14,14 @@ export type VStackProps = PrimitiveAsChildProps &
  * @see [🤖 OverridableComponent](https://aksel.nav.no/grunnleggende/kode/overridablecomponent) support
  *
  * @example
- * <VStack gap="8">
+ * <VStack gap="space-32">
  *  <MyComponent />
  *  <MyComponent />
  * </VStack>
  *
  * @example
  * // Responsive gap
- * <VStack gap={{xs: "2", md: "6"}}>
+ * <VStack gap={{xs: "space-8", md: "space-24"}}>
  *  <MyComponent />
  *  <MyComponent />
  * </VStack>

--- a/@navikt/core/react/src/panel/Panel.tsx
+++ b/@navikt/core/react/src/panel/Panel.tsx
@@ -23,8 +23,8 @@ export type PanelType = OverridableComponent<PanelProps, HTMLElement>;
  * @deprecated
  * Use Box with padding and border instead
  * ```
- * <Box padding="4" borderRadius="2" />
- * <Box padding="4" borderWidth="1" borderRadius="2" />
+ * <Box padding="space-16" borderRadius="2" />
+ * <Box padding="space-16" borderWidth="1" borderRadius="2" />
  * ```
  * Component will be removed in a future major release
  */


### PR DESCRIPTION
### Description

Replace deprecated numeric spacing values with spacing tokens in the JSDoc examples.

### Component Checklist 📝

- [x] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
