### PR TITLE
ExpansionCard/AccordionItem: Remove redundant class `--no-animation`

### DIFF
--- a/.changeset/bold-deserts-bow.md
+++ b/.changeset/bold-deserts-bow.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+ExpansionCard: Remove redundant class name

--- a/.changeset/sweet-pillows-stare.md
+++ b/.changeset/sweet-pillows-stare.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+AccordionItem: Remove redundant class name

--- a/@navikt/core/css/src/accordion.css
+++ b/@navikt/core/css/src/accordion.css
@@ -164,11 +164,3 @@
     }
   }
 }
-
-/* ---------------- Accordion No Animation (defaultOpen) ---------------- */
-
-.aksel-accordion__item--no-animation {
-  & > .aksel-accordion__content {
-    transition: none;
-  }
-}

--- a/@navikt/core/css/src/expansioncard.css
+++ b/@navikt/core/css/src/expansioncard.css
@@ -167,10 +167,3 @@
   opacity: 0;
   transition: opacity 250ms cubic-bezier(0.2, 0, 0, 1);
 }
-
-/* ---------------- ExpansionCard No Animation (defaultOpen) ---------------- */
-.aksel-expansioncard--no-animation {
-  & :is(.aksel-expansioncard__content, .aksel-expansioncard__content-inner) {
-    transition: none;
-  }
-}

--- a/@navikt/core/react/src/accordion/AccordionItem.tsx
+++ b/@navikt/core/react/src/accordion/AccordionItem.tsx
@@ -1,28 +1,29 @@
-import React, { createContext, forwardRef, useContext, useRef } from "react";
+import React, { createContext, forwardRef, useContext } from "react";
 import { omit } from "../utils-external";
 import { cl } from "../utils/helpers";
 import { useControllableState } from "../utils/hooks";
 import { AccordionContext } from "./AccordionContext";
 
-export interface AccordionItemProps
-  extends React.HTMLAttributes<HTMLDivElement> {
+export interface AccordionItemProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
-   * Content in Accordion.Item
-   * Should include one Accordion.Header and one Accordion.Content
+   * Content in Accordion.Item.
+   *
+   * Should include one Accordion.Header and one Accordion.Content.
    */
   children: React.ReactNode;
   /**
-   * Controlled open-state
-   * Using this removes automatic control of open-state
+   * Controlled open-state.
+   *
+   * Using this removes automatic control of open-state.
    */
   open?: boolean;
   /**
-   * Defaults the accordion to open if not controlled
+   * The open state when initially rendered. Use when you do not need to control the open state.
    * @default false
    */
   defaultOpen?: boolean;
   /**
-   * Callback for current open-state
+   * Callback for current open-state.
    */
   onOpenChange?: (open: boolean) => void;
 }
@@ -48,13 +49,6 @@ const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
 
     const context = useContext(AccordionContext);
 
-    const shouldAnimate = useRef<boolean>(!(Boolean(open) || defaultOpen));
-
-    const handleOpen = () => {
-      _setOpen((x) => !x);
-      shouldAnimate.current = true;
-    };
-
     if (!context?.mounted) {
       console.error("<Accordion.Item> has to be used within an <Accordion>");
     }
@@ -63,7 +57,6 @@ const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
       <div
         className={cl("aksel-accordion__item", className, {
           "aksel-accordion__item--open": _open,
-          "aksel-accordion__item--no-animation": !shouldAnimate.current,
         })}
         data-expanded={_open}
         ref={ref}
@@ -72,7 +65,7 @@ const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
         <AccordionItemContext.Provider
           value={{
             open: _open,
-            toggleOpen: handleOpen,
+            toggleOpen: () => _setOpen((x) => !x),
           }}
         >
           {children}

--- a/@navikt/core/react/src/expansion-card/ExpansionCard.tsx
+++ b/@navikt/core/react/src/expansion-card/ExpansionCard.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef } from "react";
+import React, { forwardRef } from "react";
 import type { AkselColor } from "../types";
 import type { OverridableComponent } from "../utils-external";
 import { cl } from "../utils/helpers";
@@ -19,10 +19,9 @@ import {
 } from "./ExpansionCardTitle";
 import { ExpansionCardContext } from "./context";
 
-interface ExpansionCardComponent
-  extends React.ForwardRefExoticComponent<
-    ExpansionCardProps & React.RefAttributes<HTMLDivElement>
-  > {
+interface ExpansionCardComponent extends React.ForwardRefExoticComponent<
+  ExpansionCardProps & React.RefAttributes<HTMLDivElement>
+> {
   /**
    * @see 🏷️ {@link ExpansionCardHeaderProps}
    */
@@ -48,20 +47,23 @@ interface ExpansionCardComponent
   >;
 }
 
-interface ExpansionCardCommonProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, "onToggle"> {
+interface ExpansionCardCommonProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "onToggle"
+> {
   children: React.ReactNode;
   /**
-   * Callback for when Card is toggled open/closed
+   * Callback for when Card is opened/closed.
    */
   onToggle?: (open: boolean) => void;
   /**
-   * Controlled open-state
-   * Using this removes automatic control of open-state
+   * Controlled open-state.
+   *
+   * Using this removes automatic control of open-state.
    */
   open?: boolean;
   /**
-   * Defaults to open if not controlled
+   * The open state when initially rendered. Use when you do not need to control the open state.
    * @default false
    */
   defaultOpen?: boolean;
@@ -102,7 +104,7 @@ export type ExpansionCardProps = ExpansionCardCommonProps &
  *
  * @example
  * ```jsx
- * <ExpansionCard aria-label="default-demo">
+ * <ExpansionCard aria-label="Utbetaling av sykepenger">
  *   <ExpansionCard.Header>
  *     <ExpansionCard.Title>Utbetaling av sykepenger</ExpansionCard.Title>
  *   </ExpansionCard.Header>
@@ -125,14 +127,9 @@ export const ExpansionCard = forwardRef<HTMLDivElement, ExpansionCardProps>(
     },
     ref,
   ) => {
-    const shouldFade = useRef<boolean>(!(Boolean(open) || defaultOpen));
-
     const [_open, _setOpen] = useControllableState({
       value: open,
-      onChange: (newValue) => {
-        onToggle?.(newValue);
-        shouldFade.current = true;
-      },
+      onChange: onToggle,
       defaultValue: defaultOpen,
     });
 
@@ -151,9 +148,6 @@ export const ExpansionCard = forwardRef<HTMLDivElement, ExpansionCardProps>(
             "aksel-expansioncard",
             className,
             `aksel-expansioncard--${size}`,
-            {
-              "aksel-expansioncard--no-animation": !shouldFade.current,
-            },
           )}
           ref={ref}
         />


### PR DESCRIPTION
### Description

We no longer need to turn off the animation on initial render since we are using transition.

Also reviewed the JSDoc.

### Component Checklist 📝

- [x] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
