### PR TITLE
[Tooltip] :tada: keys now accept multiple shortcuts

### DIFF
--- a/.changeset/floppy-hounds-wink.md
+++ b/.changeset/floppy-hounds-wink.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": minor
+"@navikt/ds-css": minor
+---
+
+Tooltip: Updated prop 'keys' to allow for multiple shortcuts.

--- a/@navikt/core/css/src/tooltip.css
+++ b/@navikt/core/css/src/tooltip.css
@@ -101,7 +101,7 @@
 .aksel-tooltip__keys {
   padding-bottom: var(--ax-space-4);
   display: flex;
-  gap: var(--ax-space-4);
+  gap: var(--ax-space-8);
 }
 
 .aksel-tooltip__key {

--- a/@navikt/core/css/src/tooltip.css
+++ b/@navikt/core/css/src/tooltip.css
@@ -101,7 +101,7 @@
 .aksel-tooltip__keys {
   padding-bottom: var(--ax-space-4);
   display: flex;
-  gap: var(--ax-space-8);
+  gap: var(--ax-space-4);
 }
 
 .aksel-tooltip__key {

--- a/@navikt/core/react/src/tooltip/Tooltip.stories.tsx
+++ b/@navikt/core/react/src/tooltip/Tooltip.stories.tsx
@@ -74,13 +74,23 @@ export const Placement = () => {
 
 export const Keys = () => {
   return (
-    <Tooltip
-      content="Tooltip example Laboris reprehenderit sit sunt nisi velit mollit esse excepteur. "
-      keys={["CMD", "I"]}
-      open={true}
-    >
-      <button>Element</button>
-    </Tooltip>
+    <div>
+      <Tooltip
+        content="Tooltip example with keys"
+        keys={["CMD", "I"]}
+        open={true}
+      >
+        <button>Element</button>
+      </Tooltip>
+      <Tooltip
+        content="Tooltip example with multiple keys"
+        keys={[["CMD", "I"], ["Home"]]}
+        open={true}
+        placement="bottom"
+      >
+        <button>Element</button>
+      </Tooltip>
+    </div>
   );
 };
 

--- a/@navikt/core/react/src/tooltip/Tooltip.tsx
+++ b/@navikt/core/react/src/tooltip/Tooltip.tsx
@@ -79,7 +79,7 @@ export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * List of Keyboard-keys for shortcuts.
    */
-  keys?: string[];
+  keys?: string[] | [string[], string[]];
   /**
    * When false, Tooltip labels the element, and child-elements content will be ignored by screen-readers.
    * When true, content is added as additional information to the child element.
@@ -204,7 +204,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
           ref={refs.setReference}
           {...getReferenceProps()}
           {...labelProps}
-          aria-keyshortcuts={keys ? keys.join("+") : undefined}
+          aria-keyshortcuts={ariaShortcuts(keys)}
         >
           {children}
         </Slot>
@@ -232,15 +232,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
               data-state="open"
             >
               {content}
-              {keys && (
-                <span className="aksel-tooltip__keys" aria-hidden>
-                  {keys.map((key) => (
-                    <Detail as="kbd" key={key} className="aksel-tooltip__key">
-                      {key}
-                    </Detail>
-                  ))}
-                </span>
-              )}
+              <TooltipShortcuts shortcuts={keys} />
               {_arrow && (
                 <div
                   ref={(node) => {
@@ -268,5 +260,47 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     );
   },
 );
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts
+ * Space-separated shortcuts is valid syntax
+ */
+function ariaShortcuts(shortcuts: TooltipProps["keys"]) {
+  if (!shortcuts) {
+    return undefined;
+  }
+
+  if (Array.isArray(shortcuts[0])) {
+    return shortcuts.map((key) => key.join("+")).join(" ");
+  }
+
+  return shortcuts.join("+");
+}
+
+function TooltipShortcuts({ shortcuts }: { shortcuts: TooltipProps["keys"] }) {
+  if (!shortcuts) {
+    return null;
+  }
+
+  if (Array.isArray(shortcuts[0])) {
+    return (
+      <span className="aksel-tooltip__keys" aria-hidden>
+        {shortcuts.map((key) => (
+          <Detail as="kbd" key={key} className="aksel-tooltip__key">
+            {key.join("+")}
+          </Detail>
+        ))}
+      </span>
+    );
+  }
+
+  return (
+    <span className="aksel-tooltip__keys" aria-hidden>
+      <Detail as="kbd" className="aksel-tooltip__key">
+        {shortcuts.join("+")}
+      </Detail>
+    </span>
+  );
+}
 
 export default Tooltip;

--- a/@navikt/core/react/src/tooltip/Tooltip.tsx
+++ b/@navikt/core/react/src/tooltip/Tooltip.tsx
@@ -263,16 +263,16 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
   },
 );
 
-/**
- * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts
- * Space-separated shortcuts is valid syntax
- */
 function isKeyShortcutNested(
   shortcuts: TooltipProps["keys"],
 ): shortcuts is [string[], string[]] {
   return Array.isArray(shortcuts?.[0]);
 }
 
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts
+ * Space-separated shortcuts is valid syntax
+ */
 function ariaShortcuts(shortcuts: TooltipProps["keys"]) {
   if (!shortcuts) {
     return undefined;
@@ -297,7 +297,7 @@ function TooltipShortcuts({ shortcuts }: { shortcuts: TooltipProps["keys"] }) {
       <span className="aksel-tooltip__keys" aria-hidden>
         {shortcuts.map((key, index) => (
           <>
-            <HStack gap="space-2">
+            <HStack gap="space-4">
               {key.map((k, i) => (
                 <Detail as="kbd" key={i} className="aksel-tooltip__key">
                   {k}

--- a/@navikt/core/react/src/tooltip/Tooltip.tsx
+++ b/@navikt/core/react/src/tooltip/Tooltip.tsx
@@ -305,7 +305,7 @@ function TooltipShortcuts({ shortcuts }: { shortcuts: TooltipProps["keys"] }) {
               ))}
             </HStack>
             {index < shortcuts.length - 1 && (
-              <span> {`${translate("shortcutSeparator")}`} </span>
+              <span> {translate("shortcutSeparator")} </span>
             )}
           </>
         ))}

--- a/@navikt/core/react/src/utils/i18n/locales/en.ts
+++ b/@navikt/core/react/src/utils/i18n/locales/en.ts
@@ -132,4 +132,7 @@ export default {
       reset: "Reset zoom",
     },
   },
+  Tooltip: {
+    shortcutSeparator: "or",
+  },
 } satisfies Translations;

--- a/@navikt/core/react/src/utils/i18n/locales/nb.ts
+++ b/@navikt/core/react/src/utils/i18n/locales/nb.ts
@@ -139,4 +139,7 @@ export default {
       reset: "Tilbakestill tidsperspektiv",
     },
   },
+  Tooltip: {
+    shortcutSeparator: "eller",
+  },
 } satisfies TranslationMap;

--- a/@navikt/core/react/src/utils/i18n/locales/nn.ts
+++ b/@navikt/core/react/src/utils/i18n/locales/nn.ts
@@ -132,4 +132,7 @@ export default {
       reset: "Tilbakestill tidsperspektiv",
     },
   },
+  Tooltip: {
+    shortcutSeparator: "eller",
+  },
 } satisfies Translations;


### PR DESCRIPTION
### Description

Resolves #4576

[Pending discussion](https://nav-it.slack.com/archives/C07FGAM2ENS/p1770211413985399)

<img width="605" height="283" alt="Screenshot 2026-02-04 at 14 28 46" src="https://github.com/user-attachments/assets/3a396db0-e4b7-4af6-a311-4d389df6245e" />


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [x] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
