### PR TITLE
[ActionMenu] :tada: Updated animation and fixed subtrigger icon bug

### DIFF
--- a/.changeset/calm-places-fail.md
+++ b/.changeset/calm-places-fail.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+ActionMenu: SubTrigger-icon is now right aligned, updated open-transition effect.

--- a/@navikt/core/css/src/action-menu.css
+++ b/@navikt/core/css/src/action-menu.css
@@ -13,30 +13,7 @@
   &[data-state="open"] {
     @starting-style {
       opacity: 0.8;
-    }
-
-    &[data-side="bottom"] {
-      @starting-style {
-        transform: scale3d(0.94, 0.94, 0.94);
-      }
-    }
-
-    &[data-side="top"] {
-      @starting-style {
-        transform: scale3d(0.94, 0.94, 0.94);
-      }
-    }
-
-    &[data-side="right"] {
-      @starting-style {
-        transform: scale3d(0.94, 0.94, 0.94);
-      }
-    }
-
-    &[data-side="left"] {
-      @starting-style {
-        transform: scale3d(0.94, 0.94, 0.94);
-      }
+      transform: scale3d(0.94, 0.94, 0.94);
     }
   }
 }

--- a/@navikt/core/css/src/action-menu.css
+++ b/@navikt/core/css/src/action-menu.css
@@ -4,11 +4,11 @@
   border-radius: var(--ax-radius-12);
   border: 1px solid var(--ax-border-neutral-subtleA);
   box-shadow: var(--ax-shadow-dialog);
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+  transform-origin: var(--__axc-action-menu-content-transform-origin);
   transition:
     transform 150ms ease allow-discrete,
     opacity 150ms ease allow-discrete;
-
-  --__acx-action-menu-transform-distance: 0.5rem;
 
   &[data-state="open"] {
     @starting-style {
@@ -17,39 +17,27 @@
 
     &[data-side="bottom"] {
       @starting-style {
-        transform: translate3d(0, calc(var(--__acx-action-menu-transform-distance) * -1), 0) scale3d(0.95, 0.95, 0.95);
+        transform: scale3d(0.94, 0.94, 0.94);
       }
     }
 
     &[data-side="top"] {
       @starting-style {
-        transform: translate3d(0, var(--__acx-action-menu-transform-distance), 0) scale3d(0.95, 0.95, 0.95);
+        transform: scale3d(0.94, 0.94, 0.94);
       }
     }
 
     &[data-side="right"] {
       @starting-style {
-        transform: translate3d(calc(var(--__acx-action-menu-transform-distance) * -1), 0, 0) scale3d(0.95, 0.95, 0.95);
+        transform: scale3d(0.94, 0.94, 0.94);
       }
     }
 
     &[data-side="left"] {
       @starting-style {
-        transform: translate3d(var(--__acx-action-menu-transform-distance), 0, 0) scale3d(0.95, 0.95, 0.95);
+        transform: scale3d(0.94, 0.94, 0.94);
       }
     }
-  }
-}
-
-.aksel-action-menu__sub-content {
-  --__acx-action-menu-transform-distance: 0rem;
-
-  &[data-side="right"] {
-    transform-origin: 0 0;
-  }
-
-  &[data-side="left"] {
-    transform-origin: 0 0;
   }
 }
 
@@ -63,8 +51,6 @@
   background-color: var(--ax-bg-raised);
   min-width: 128px;
   max-width: min(95vw, 640px);
-  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
-  transform-origin: var(--__axc-action-menu-content-transform-origin);
   animation-duration: 160ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   padding: var(--__axc-action-menu-content-p);
@@ -136,11 +122,6 @@
   display: flex;
   align-items: center;
   gap: var(--ax-space-4);
-
-  svg {
-    font-size: 18px;
-    flex-shrink: 0;
-  }
 }
 
 .aksel-action-menu__marker--right {
@@ -157,10 +138,22 @@
 }
 
 .aksel-action-menu__marker-icon {
+  svg {
+    font-size: 1.125rem;
+    flex-shrink: 0;
+  }
+
   &.aksel-action-menu__marker--right {
     margin-left: 0;
     padding-left: 0;
   }
+}
+
+.aksel-action-menu__sub-icon {
+  display: grid;
+  place-content: center;
+  font-size: 1.125rem;
+  margin-left: auto;
 }
 
 /* --------------------------- ActionMenu shortcut -------------------------- */

--- a/@navikt/core/css/src/action-menu.css
+++ b/@navikt/core/css/src/action-menu.css
@@ -4,32 +4,52 @@
   border-radius: var(--ax-radius-12);
   border: 1px solid var(--ax-border-neutral-subtleA);
   box-shadow: var(--ax-shadow-dialog);
-  transition: transform 250ms cubic-bezier(0, 0, 0, 1) allow-discrete;
+  transition:
+    transform 150ms ease allow-discrete,
+    opacity 150ms ease allow-discrete;
+
+  --__acx-action-menu-transform-distance: 0.5rem;
 
   &[data-state="open"] {
+    @starting-style {
+      opacity: 0.8;
+    }
+
     &[data-side="bottom"] {
       @starting-style {
-        transform: translateY(-4px);
+        transform: translate3d(0, calc(var(--__acx-action-menu-transform-distance) * -1), 0) scale3d(0.95, 0.95, 0.95);
       }
     }
 
     &[data-side="top"] {
       @starting-style {
-        transform: translateY(4px);
+        transform: translate3d(0, var(--__acx-action-menu-transform-distance), 0) scale3d(0.95, 0.95, 0.95);
       }
     }
 
     &[data-side="right"] {
       @starting-style {
-        transform: translateX(-4px);
+        transform: translate3d(calc(var(--__acx-action-menu-transform-distance) * -1), 0, 0) scale3d(0.95, 0.95, 0.95);
       }
     }
 
     &[data-side="left"] {
       @starting-style {
-        transform: translateX(4px);
+        transform: translate3d(var(--__acx-action-menu-transform-distance), 0, 0) scale3d(0.95, 0.95, 0.95);
       }
     }
+  }
+}
+
+.aksel-action-menu__sub-content {
+  --__acx-action-menu-transform-distance: 0rem;
+
+  &[data-side="right"] {
+    transform-origin: 0 0;
+  }
+
+  &[data-side="left"] {
+    transform-origin: 0 0;
   }
 }
 
@@ -116,6 +136,11 @@
   display: flex;
   align-items: center;
   gap: var(--ax-space-4);
+
+  svg {
+    font-size: 18px;
+    flex-shrink: 0;
+  }
 }
 
 .aksel-action-menu__marker--right {
@@ -132,11 +157,6 @@
 }
 
 .aksel-action-menu__marker-icon {
-  svg {
-    font-size: 18px;
-    flex-shrink: 0;
-  }
-
   &.aksel-action-menu__marker--right {
     margin-left: 0;
     padding-left: 0;

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.stories.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.stories.tsx
@@ -4,6 +4,7 @@ import {
   ArrowDownRightIcon,
   CloudIcon,
   LeaveIcon,
+  MenuElipsisVerticalIcon,
   PencilIcon,
   StarIcon,
 } from "@navikt/aksel-icons";
@@ -11,6 +12,7 @@ import { Button } from "../../button";
 import { InternalHeader } from "../../internal-header";
 import { HStack, Spacer, VStack } from "../../layout/stack";
 import { Modal } from "../../modal";
+import { Table } from "../../table";
 import { Theme } from "../../theme";
 import { Tooltip } from "../../tooltip";
 import { BodyShort, Detail } from "../../typography";
@@ -782,3 +784,123 @@ export const IconPosition: Story = {
   },
   decorators: [DemoDecorator],
 };
+
+export const InTableDemo = () => (
+  <Table>
+    <Table.Header>
+      <Table.Row>
+        <Table.HeaderCell scope="col">ID</Table.HeaderCell>
+        <Table.HeaderCell scope="col">Status</Table.HeaderCell>
+        <Table.HeaderCell />
+      </Table.Row>
+    </Table.Header>
+    <Table.Body>
+      {[
+        {
+          id: "03121",
+          status: "Avslått",
+        },
+        {
+          id: "16066",
+          status: "Mottatt",
+        },
+        {
+          id: "18124",
+          status: "Godkjent",
+        },
+        {
+          id: "24082",
+          status: "Mottatt",
+        },
+      ].map(({ id, status }, i) => {
+        return (
+          <Table.Row key={i + status} shadeOnHover={false}>
+            <Table.HeaderCell scope="row">{id}</Table.HeaderCell>
+            <Table.DataCell>{status}</Table.DataCell>
+            <Table.DataCell align="right">
+              <ActionMenu>
+                <ActionMenu.Trigger>
+                  <Button
+                    data-color="neutral"
+                    variant="tertiary"
+                    icon={<MenuElipsisVerticalIcon title="Saksmeny" />}
+                    size="small"
+                  />
+                </ActionMenu.Trigger>
+                <ActionMenu.Content>
+                  <ActionMenu.Group label={`Sak #${id}`}>
+                    <ActionMenu.Item onSelect={console.info}>
+                      Ta sak
+                    </ActionMenu.Item>
+                    <ActionMenu.Sub>
+                      <ActionMenu.SubTrigger>
+                        Endre status
+                      </ActionMenu.SubTrigger>
+                      <ActionMenu.SubContent>
+                        <ActionMenu.Item onSelect={console.info}>
+                          Avslått
+                        </ActionMenu.Item>
+                        <ActionMenu.Item onSelect={console.info}>
+                          Godkjent
+                        </ActionMenu.Item>
+                        <ActionMenu.Sub>
+                          <ActionMenu.SubTrigger>
+                            Andre valg
+                          </ActionMenu.SubTrigger>
+                          <ActionMenu.SubContent>
+                            <ActionMenu.Item onSelect={console.info}>
+                              Til godkjenning
+                            </ActionMenu.Item>
+                            <ActionMenu.Item onSelect={console.info}>
+                              Under behandling
+                            </ActionMenu.Item>
+                            <ActionMenu.Item onSelect={console.info}>
+                              Under kontroll
+                            </ActionMenu.Item>
+                          </ActionMenu.SubContent>
+                        </ActionMenu.Sub>
+                      </ActionMenu.SubContent>
+                    </ActionMenu.Sub>
+                    <ActionMenu.Sub>
+                      <ActionMenu.SubTrigger>
+                        Tildel saksbehandler
+                      </ActionMenu.SubTrigger>
+                      <ActionMenu.SubContent>
+                        <ActionMenu.Group label="Saksbehandlere">
+                          <ActionMenu.Item onSelect={console.info}>
+                            Ola Normann
+                          </ActionMenu.Item>
+                          <ActionMenu.Item onSelect={console.info}>
+                            Bo Ramberg
+                          </ActionMenu.Item>
+                          <ActionMenu.Item onSelect={console.info} disabled>
+                            Ole Olsen
+                          </ActionMenu.Item>
+                          <ActionMenu.Item onSelect={console.info} disabled>
+                            Janne Nilssen
+                          </ActionMenu.Item>
+                          <ActionMenu.Item onSelect={console.info}>
+                            Karin Jakobsen
+                          </ActionMenu.Item>
+                          <ActionMenu.Item onSelect={console.info}>
+                            Kari Nordmann
+                          </ActionMenu.Item>
+                        </ActionMenu.Group>
+                      </ActionMenu.SubContent>
+                    </ActionMenu.Sub>
+
+                    <ActionMenu.Divider />
+
+                    <ActionMenu.Item variant="danger" onSelect={console.info}>
+                      Slett sak
+                    </ActionMenu.Item>
+                  </ActionMenu.Group>
+                </ActionMenu.Content>
+              </ActionMenu>
+            </Table.DataCell>
+          </Table.Row>
+        );
+      })}
+    </Table.Body>
+  </Table>
+);

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.stories.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.stories.tsx
@@ -343,6 +343,9 @@ export const Submenus: Story = {
           <ActionMenu.Item onSelect={() => console.log("Item 1 clicked")}>
             Item 1
           </ActionMenu.Item>
+          <ActionMenu.Item onSelect={() => console.log("Item 1 clicked")}>
+            Item 2 with a little longer name
+          </ActionMenu.Item>
           <ActionMenu.Sub open={props.open}>
             <ActionMenu.SubTrigger>Submenu 1</ActionMenu.SubTrigger>
             <ActionMenu.SubContent>
@@ -733,7 +736,7 @@ export const IconPosition: Story = {
               onSelect={() => console.log("Item 1 clicked")}
               icon={<StarIcon aria-hidden />}
             >
-              Item 1
+              Item 1 with quite a long text for testing
             </ActionMenu.Item>
             <ActionMenu.Item
               onSelect={() => console.log("Item 2 clicked")}

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -939,9 +939,9 @@ export const ActionMenuSubTrigger = forwardRef<
             {icon}
           </Marker>
         )}
-        <Marker placement="right">
+        <div className="aksel-action-menu__sub-icon">
           <ChevronRightIcon aria-hidden />
-        </Marker>
+        </div>
       </Menu.SubTrigger>
     );
   },
@@ -959,7 +959,7 @@ interface ActionMenuSubContentProps extends React.HTMLAttributes<HTMLDivElement>
 export const ActionMenuSubContent = forwardRef<
   ActionMenuSubContentElement,
   ActionMenuSubContentProps
->(({ children, className, ...rest }: ActionMenuSubContentProps, ref) => {
+>(({ children, className, style, ...rest }: ActionMenuSubContentProps, ref) => {
   const context = useActionMenuContext();
 
   return (
@@ -974,6 +974,15 @@ export const ActionMenuSubContent = forwardRef<
           "aksel-action-menu__content aksel-action-menu__sub-content",
           className,
         )}
+        style={{
+          ...style,
+          ...{
+            "--__axc-action-menu-content-transform-origin":
+              "var(--__axc-floating-transform-origin)",
+            "--__axc-action-menu-content-available-height":
+              "var(--__axc-floating-available-height)",
+          },
+        }}
       >
         <div className="aksel-action-menu__content-inner">{children}</div>
       </Menu.SubContent>

--- a/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
+++ b/@navikt/core/react/src/overlays/action-menu/ActionMenu.tsx
@@ -939,7 +939,7 @@ export const ActionMenuSubTrigger = forwardRef<
             {icon}
           </Marker>
         )}
-        <Marker placement="right" className="aksel-action-menu__marker-icon">
+        <Marker placement="right">
           <ChevronRightIcon aria-hidden />
         </Marker>
       </Menu.SubTrigger>

--- a/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/Menu.tsx
@@ -251,7 +251,8 @@ type MenuContentInternalPrivateProps = {
 };
 
 interface MenuContentInternalProps
-  extends MenuContentInternalPrivateProps,
+  extends
+    MenuContentInternalPrivateProps,
     Omit<
       React.ComponentPropsWithoutRef<typeof Floating.Content>,
       "dir" | "onPlaced"

--- a/@navikt/core/react/src/overlays/floating-menu/parts/RovingFocus.tsx
+++ b/@navikt/core/react/src/overlays/floating-menu/parts/RovingFocus.tsx
@@ -4,8 +4,10 @@ import { composeEventHandlers, ownerDocument } from "../../../utils/helpers";
 import type { DescendantsManager } from "../../../utils/hooks";
 import { useEventCallback, useMergeRefs } from "../../../utils/hooks";
 
-interface RovingFocusProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, "tabIndex"> {
+interface RovingFocusProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "tabIndex"
+> {
   asChild?: boolean;
   descendants: DescendantsManager<HTMLDivElement, any>;
   onEntryFocus?: (event: Event) => void;

--- a/@navikt/core/react/src/overlays/floating/Floating.tsx
+++ b/@navikt/core/react/src/overlays/floating/Floating.tsx
@@ -315,6 +315,7 @@ const FloatingContent = forwardRef<HTMLDivElement, FloatingContentProps>(
             const { width: anchorWidth, height: anchorHeight } =
               rects.reference;
             const contentStyle = elements.floating.style;
+
             /**
              * Allows styling and animations based on the available space.
              */

--- a/@navikt/core/react/src/overlays/floating/Floating.utils.ts
+++ b/@navikt/core/react/src/overlays/floating/Floating.utils.ts
@@ -57,4 +57,4 @@ function getSideAndAlignFromPlacement(placement: Placement) {
 }
 
 export { getSideAndAlignFromPlacement, transformOrigin };
-export type { Side, Align, Measurable };
+export type { Align, Measurable, Side };


### PR DESCRIPTION
### Description

The subtrigger icon bug was not detected earlier since the examples did not have long-enough texts to provoke the scenario where the > chevron did not align right.

As for the transition, the current one is a feels a little to long. 
So made some small changes:
- moves a little further, but faster (150ms vs 250ms)
- Scales a little: 0.95
- Small change in opacity to have a subtle fade-in effect, but not completely from 0

- [x] Validate transition changes with design
https://nav-it.slack.com/archives/C07FGAM2ENS/p1770378194974519?thread_ts=1770377145.012769&cid=C07FGAM2ENS- [ ] 

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
- [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] 