### PR TITLE
feat: suggested nextjs legacy link codemod

### DIFF
--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/nextjs-link.ts
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/nextjs-link.ts
@@ -1,0 +1,185 @@
+import type { API, FileInfo, JSXAttribute } from "jscodeshift";
+import { getLineTerminator } from "../../../utils/lineterminator";
+
+export default function transformer(file: FileInfo, api: API) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const toSourceOptions = getLineTerminator(file.source);
+
+  let hasChanges = false;
+
+  // Find all Next.js Link imports (both default and named)
+  const nextLinkImports = new Map<string, string>(); // localName -> importSource
+
+  root.find(j.ImportDeclaration).forEach((path) => {
+    const source = path.node.source.value;
+    if (
+      source === "next/link" ||
+      (typeof source === "string" && source.includes("/next-link"))
+    ) {
+      path.node.specifiers?.forEach((specifier) => {
+        if (specifier.type === "ImportDefaultSpecifier") {
+          nextLinkImports.set(specifier.local?.name || "Link", source);
+        } else if (specifier.type === "ImportSpecifier") {
+          nextLinkImports.set(
+            specifier.local?.name || specifier.imported.name,
+            source,
+          );
+        }
+      });
+    }
+  });
+
+  if (nextLinkImports.size === 0) {
+    return root.toSource(toSourceOptions);
+  }
+
+  // Process each Link component
+  nextLinkImports.forEach((importSource, linkName) => {
+    root.find(j.JSXElement).forEach((path) => {
+      const openingElement = path.node.openingElement;
+
+      // Check if this is a Next.js Link element
+      if (
+        openingElement.name.type !== "JSXIdentifier" ||
+        openingElement.name.name !== linkName
+      ) {
+        return;
+      }
+
+      const attributes = openingElement.attributes || [];
+
+      // Find legacyBehavior and passHref props
+      const hasLegacyBehavior = attributes.some(
+        (attr) =>
+          attr.type === "JSXAttribute" && attr.name.name === "legacyBehavior",
+      );
+
+      const hasPassHref = attributes.some(
+        (attr) => attr.type === "JSXAttribute" && attr.name.name === "passHref",
+      );
+
+      // Only transform if it has legacyBehavior or passHref
+      if (!hasLegacyBehavior && !hasPassHref) {
+        return;
+      }
+
+      // Get the href attribute
+      const hrefAttr = attributes.find(
+        (attr) => attr.type === "JSXAttribute" && attr.name.name === "href",
+      ) as JSXAttribute | undefined;
+
+      // Check if Link has a single child element
+      const children = path.node.children || [];
+      const childElements = children.filter(
+        (child) => child.type === "JSXElement",
+      );
+
+      if (childElements.length !== 1) {
+        // Skip if there's not exactly one child element
+        return;
+      }
+
+      const childElement = childElements[0];
+      if (childElement.type !== "JSXElement") {
+        return;
+      }
+
+      const childOpeningElement = childElement.openingElement;
+
+      // Check if the child has an "as" prop
+      const childAsAttr = (childOpeningElement.attributes || []).find(
+        (attr) => attr.type === "JSXAttribute" && attr.name.name === "as",
+      ) as JSXAttribute | undefined;
+
+      // Only transform if the child has as="a" or no "as" prop
+      if (childAsAttr && childAsAttr.value?.type === "StringLiteral") {
+        const asValue = childAsAttr.value.value;
+        if (asValue !== "a") {
+          return;
+        }
+      }
+
+      // Now perform the transformation:
+      // 1. Remove legacyBehavior and passHref from Link
+      // 2. Move href to child component
+      // 3. Change child's "as" prop to reference the Link component
+      // 4. Unwrap the Link (replace Link with just its child)
+
+      const newChildAttributes = [...(childOpeningElement.attributes || [])];
+
+      // Remove "as" prop from child if it's "a"
+      const asAttrIndex = newChildAttributes.findIndex(
+        (attr) => attr.type === "JSXAttribute" && attr.name.name === "as",
+      );
+      if (asAttrIndex !== -1) {
+        newChildAttributes.splice(asAttrIndex, 1);
+      }
+
+      // Add "as={LinkComponent}" to child
+      newChildAttributes.push(
+        j.jsxAttribute(
+          j.jsxIdentifier("as"),
+          j.jsxExpressionContainer(j.identifier(linkName)),
+        ),
+      );
+
+      // Add href to child if it exists
+      if (hrefAttr) {
+        // Check if child already has href
+        const childHasHref = newChildAttributes.some(
+          (attr) => attr.type === "JSXAttribute" && attr.name.name === "href",
+        );
+        if (!childHasHref) {
+          newChildAttributes.push(hrefAttr);
+        }
+      }
+
+      // Get other Link attributes (except legacyBehavior, passHref, href)
+      const otherLinkAttrs = attributes.filter(
+        (attr) =>
+          attr.type === "JSXAttribute" &&
+          attr.name.name !== "legacyBehavior" &&
+          attr.name.name !== "passHref" &&
+          attr.name.name !== "href",
+      );
+
+      // Add other Link attributes to child
+      otherLinkAttrs.forEach((attr) => {
+        // Check if child already has this attribute
+        const childHasAttr = newChildAttributes.some(
+          (childAttr) =>
+            childAttr.type === "JSXAttribute" &&
+            childAttr.name.name === (attr as JSXAttribute).name.name,
+        );
+        if (!childHasAttr) {
+          newChildAttributes.push(attr);
+        }
+      });
+
+      // Create new child element with updated attributes
+      const newChildOpeningElement = j.jsxOpeningElement(
+        childOpeningElement.name,
+        newChildAttributes,
+        childOpeningElement.selfClosing,
+      );
+
+      const newChildElement = j.jsxElement(
+        newChildOpeningElement,
+        childElement.closingElement,
+        childElement.children,
+      );
+
+      // Replace the Link element with the transformed child
+      j(path).replaceWith(newChildElement);
+      hasChanges = true;
+    });
+  });
+
+  if (hasChanges) {
+    return root.toSource(toSourceOptions);
+  }
+
+  return root.toSource(toSourceOptions);
+}

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/actionmenu.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/actionmenu.input.js
@@ -1,0 +1,17 @@
+import { ActionMenu } from "@navikt/ds-react";
+import NextLink from "next/link";
+
+const Example = () => {
+  return (
+    <ActionMenu>
+      <ActionMenu.Trigger>Menu</ActionMenu.Trigger>
+      <ActionMenu.Content>
+        <ActionMenu.Group>
+          <NextLink href="/eksempel" passHref legacyBehavior>
+            <ActionMenu.Item as="a">Next.js-lenke</ActionMenu.Item>
+          </NextLink>
+        </ActionMenu.Group>
+      </ActionMenu.Content>
+    </ActionMenu>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/actionmenu.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/actionmenu.output.js
@@ -1,0 +1,17 @@
+import { ActionMenu } from "@navikt/ds-react";
+import NextLink from "next/link";
+
+const Example = () => {
+  return (
+    <ActionMenu>
+      <ActionMenu.Trigger>Menu</ActionMenu.Trigger>
+      <ActionMenu.Content>
+        <ActionMenu.Group>
+          <ActionMenu.Item as={NextLink} href="/eksempel">
+            Next.js-lenke
+          </ActionMenu.Item>
+        </ActionMenu.Group>
+      </ActionMenu.Content>
+    </ActionMenu>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/button-variant.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/button-variant.input.js
@@ -1,0 +1,12 @@
+import NextLink from "next/link";
+import { Button } from "@navikt/ds-react";
+
+const Example = () => {
+  return (
+    <NextLink href="https://www.nav.no/min-cv" passHref legacyBehavior>
+      <Button variant="primary" as="a" role="link">
+        Tilbake til CV
+      </Button>
+    </NextLink>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/button-variant.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/button-variant.output.js
@@ -1,0 +1,15 @@
+import NextLink from "next/link";
+import { Button } from "@navikt/ds-react";
+
+const Example = () => {
+  return (
+    <Button
+      variant="primary"
+      role="link"
+      as={NextLink}
+      href="https://www.nav.no/min-cv"
+    >
+      Tilbake til CV
+    </Button>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/button.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/button.input.js
@@ -1,0 +1,10 @@
+import NextLink from "next/link";
+import { Button } from "@navikt/ds-react";
+
+const Example = () => {
+  return (
+    <NextLink href="#" passHref legacyBehavior>
+      <Button as="a">Lenke</Button>
+    </NextLink>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/button.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/button.output.js
@@ -1,0 +1,6 @@
+import NextLink from "next/link";
+import { Button } from "@navikt/ds-react";
+
+const Example = () => {
+  return <Button as={NextLink} href="#">Lenke</Button>;
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/dropdown.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/dropdown.input.js
@@ -1,0 +1,16 @@
+import { NextLink } from "@/app/_ui/next-link/NextLink";
+import { Dropdown } from "@navikt/ds-react";
+
+const Example = () => {
+  return (
+    <Dropdown>
+      <Dropdown.Menu>
+        <Dropdown.Menu.List>
+          <NextLink href="/" passHref legacyBehavior>
+            <Dropdown.Menu.List.Item as="a">Forside</Dropdown.Menu.List.Item>
+          </NextLink>
+        </Dropdown.Menu.List>
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/dropdown.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/dropdown.output.js
@@ -1,0 +1,16 @@
+import { NextLink } from "@/app/_ui/next-link/NextLink";
+import { Dropdown } from "@navikt/ds-react";
+
+const Example = () => {
+  return (
+    <Dropdown>
+      <Dropdown.Menu>
+        <Dropdown.Menu.List>
+          <Dropdown.Menu.List.Item as={NextLink} href="/">
+            Forside
+          </Dropdown.Menu.List.Item>
+        </Dropdown.Menu.List>
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/idempotent.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/idempotent.input.js
@@ -1,0 +1,6 @@
+import NextLink from "next/link";
+import { Button } from "@navikt/ds-react";
+
+const Example = () => {
+  return <Button as={NextLink} href="/">Already migrated</Button>;
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/idempotent.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/idempotent.output.js
@@ -1,0 +1,6 @@
+import NextLink from "next/link";
+import { Button } from "@navikt/ds-react";
+
+const Example = () => {
+  return <Button as={NextLink} href="/">Already migrated</Button>;
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/index.test.ts
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/index.test.ts
@@ -1,0 +1,22 @@
+import { check } from "../../../../utils/check";
+
+const migration = "nextjs-link";
+const fixtures = [
+  "actionmenu",
+  "button",
+  "dropdown",
+  "with-attributes",
+  "idempotent",
+  "navlink",
+  "plain-anchor",
+  "button-variant",
+  "linkpanel",
+];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    migration,
+    extension: "js",
+  });
+}

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/linkpanel.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/linkpanel.input.js
@@ -1,0 +1,19 @@
+import NextLink from "next/link";
+import { LinkPanel, BodyShort } from "@navikt/ds-react";
+
+const Example = ({ sykmelding, sykmeldingPeriod }) => {
+  return (
+    <NextLink href={`/sykmelding/${sykmelding.id}`} passHref legacyBehavior>
+      <LinkPanel border>
+        <div className="flex gap-3">
+          <div className="grow">
+            <BodyShort>{sykmeldingPeriod}</BodyShort>
+            <BodyShort size="large" className="font-semibold">
+              Sykmelding
+            </BodyShort>
+          </div>
+        </div>
+      </LinkPanel>
+    </NextLink>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/linkpanel.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/linkpanel.output.js
@@ -1,0 +1,17 @@
+import NextLink from "next/link";
+import { LinkPanel, BodyShort } from "@navikt/ds-react";
+
+const Example = ({ sykmelding, sykmeldingPeriod }) => {
+  return (
+    <LinkPanel border as={NextLink} href={`/sykmelding/${sykmelding.id}`}>
+      <div className="flex gap-3">
+        <div className="grow">
+          <BodyShort>{sykmeldingPeriod}</BodyShort>
+          <BodyShort size="large" className="font-semibold">
+            Sykmelding
+          </BodyShort>
+        </div>
+      </div>
+    </LinkPanel>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/navlink.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/navlink.input.js
@@ -1,0 +1,14 @@
+import NextLink from "next/link";
+import { Link as NavLink } from "@navikt/ds-react";
+import { ArrowLeftIcon } from "@navikt/aksel-icons";
+
+const Example = ({ backUrl, t }) => {
+  return (
+    <NextLink href={backUrl} passHref legacyBehavior>
+      <NavLink className="back-link">
+        <ArrowLeftIcon className="back-link-icon" aria-hidden={true} />
+        {t("button.previous")}
+      </NavLink>
+    </NextLink>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/navlink.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/navlink.output.js
@@ -1,0 +1,12 @@
+import NextLink from "next/link";
+import { Link as NavLink } from "@navikt/ds-react";
+import { ArrowLeftIcon } from "@navikt/aksel-icons";
+
+const Example = ({ backUrl, t }) => {
+  return (
+    <NavLink className="back-link" as={NextLink} href={backUrl}>
+      <ArrowLeftIcon className="back-link-icon" aria-hidden={true} />
+      {t("button.previous")}
+    </NavLink>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/plain-anchor.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/plain-anchor.input.js
@@ -1,0 +1,9 @@
+import Link from "next/link";
+
+const Example = ({ children, ...rest }) => {
+  return (
+    <Link href="/some/route" passHref legacyBehavior>
+      <a {...rest}>{children}</a>
+    </Link>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/plain-anchor.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/plain-anchor.output.js
@@ -1,0 +1,9 @@
+import Link from "next/link";
+
+const Example = ({ children, ...rest }) => {
+  return (
+    <a {...rest} as={Link} href="/some/route">
+      {children}
+    </a>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/with-attributes.input.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/with-attributes.input.js
@@ -1,0 +1,12 @@
+import NextLink from "next/link";
+import { Button } from "@navikt/ds-react";
+
+const Example = () => {
+  return (
+    <NextLink href="/" passHref legacyBehavior>
+      <Button as="a" className="custom-class" data-testid="button">
+        Click me
+      </Button>
+    </NextLink>
+  );
+};

--- a/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/with-attributes.output.js
+++ b/@navikt/aksel/src/codemod/transforms/v8.0.0/nextjs-link/tests/with-attributes.output.js
@@ -1,0 +1,15 @@
+import NextLink from "next/link";
+import { Button } from "@navikt/ds-react";
+
+const Example = () => {
+  return (
+    <Button
+      className="custom-class"
+      data-testid="button"
+      as={NextLink}
+      href="/"
+    >
+      Click me
+    </Button>
+  );
+};


### PR DESCRIPTION
### Description

I nyere versjoner av Next får brukere denne warningen, og selv om det finnes en migrering der ute av Next `pnpm dlx @next/codemod@latest new-link .`, så er den imperfect 🤔, og den plukker ikke opp at child av NextLink ikke er en direkte `<a>` men er vår Lenke-komponent i mange tilfeller?

Feks får jeg dette av Nextjs sin offisielle migrasjon:

```tsx
<NextLink href="/">
  {/* @next-codemod-error This Link previously used the now removed `legacyBehavior` prop, 
and has a child that might not be an anchor. The codemod bailed out of lifting the child props 
to the Link. Check that the child component does not render an anchor, and potentially move 
the props manually to Link. */
  }
  <Dropdown.Menu.List.Item as="a">Forside</Dropdown.Menu.List.Item>
</NextLink>
```

Alle aksel sine komponenter skal støtte `as=...` propen. så en migrering kan bli ganske clean / enkel.  [søker man etter passHrefs + legacyBehavior får man et par hits hvor child er en av våres komponenter.](https://github.com/search?type=code&auto_enroll=true&q=org%3Anavikt+NOT+is%3Aarchived+passHref+legacyBehavior), her kan vi hjelpe! 🙌 

```tsx
// Before (deprecated)
<NextLink href="/" passHref legacyBehavior>
  <Dropdown.Menu.List.Item as="a">Forside</Dropdown.Menu.List.Item>
</NextLink>
// After (recommended)
<Dropdown.Menu.List.Item as={NextLink} href="/">
  Forside
</Dropdown.Menu.List.Item>
```

### Component Checklist 📝

- [ ] Documentation / Decision Records
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
