### PR TITLE
useEventListener: Add return type to interface

### DIFF
--- a/.changeset/hot-cycles-kick.md
+++ b/.changeset/hot-cycles-kick.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+useEventListener: Add return type to interface

--- a/@navikt/core/react/src/utils-external/hooks/useEventListener.ts
+++ b/@navikt/core/react/src/utils-external/hooks/useEventListener.ts
@@ -7,13 +7,13 @@ interface ListenerT {
     name: string,
     handler: (event?: any) => void,
     ...args: any[]
-  );
+  ): void;
 
   removeEventListener(
     name: string,
     handler: (event?: any) => void,
     ...args: any[]
-  );
+  ): void;
 }
 
 /* https://github.com/streamich/react-use/blob/master/src/useEvent.ts */


### PR DESCRIPTION
### Description

Should avoid this: https://nav-it.slack.com/archives/C7NE7A8UF/p1770727705080949?thread_ts=1770725093.896809&cid=C7NE7A8UF

Even though this is strictly speaking not a bug on our side, it doesn't hurt to have proper types :)

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
