### PR TITLE
[Combobox] :bug: Single-select text did not respect size-prop

### DIFF
--- a/.changeset/hot-memes-invite.md
+++ b/.changeset/hot-memes-invite.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Combobox: Single-select typo now scales based on 'size'-prop

--- a/@navikt/core/css/src/form/combobox.css
+++ b/@navikt/core/css/src/form/combobox.css
@@ -157,6 +157,11 @@
   line-height: var(--ax-font-line-height-large);
   margin: 0;
   padding-left: 0.25rem;
+
+  .aksel-form-field--small & {
+    font-size: var(--ax-font-size-medium);
+    line-height: var(--ax-font-line-height-medium);
+  }
 }
 
 .aksel-combobox__input-wrapper {


### PR DESCRIPTION
### Description

- After: 16px
- Before: 18px
<img width="350" height="92" alt="Screenshot 2026-02-11 at 16 00 41" src="https://github.com/user-attachments/assets/8de64d83-75b2-4351-9455-84e63d314912" />
<img width="350" height="92" alt="Screenshot 2026-02-11 at 16 00 58" src="https://github.com/user-attachments/assets/e1c6511c-48a4-40af-96e5-5f8141faf536" />


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
