### PR TITLE
:tada: Support as-prop in Accordion and LinkCard

### DIFF
--- a/.changeset/clear-adults-cross-2.md
+++ b/.changeset/clear-adults-cross-2.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+Accordion: Now supports 'as'-prop for making element either: div or section.

--- a/.changeset/clear-adults-cross.md
+++ b/.changeset/clear-adults-cross.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+LinkCard: Now supports 'as'-prop for making element either: div, section or article.

--- a/@navikt/core/react/src/accordion/Accordion.tsx
+++ b/@navikt/core/react/src/accordion/Accordion.tsx
@@ -57,6 +57,16 @@ interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)
    */
   "data-color"?: Exclude<AkselColor, AkselStatusColorRole>;
+  /**
+   * Changes the HTML element used for the root element.
+   *
+   * **When using `section`, provide either `aria-label` or `aria-labelledby` for better accessibility.**
+   * `axe-core` might warn about unique landmarks if you have multiple Accordions on page with the same label.
+   * In those cases consider updating to unique `aria-label` or `aria-labelledby` props.
+   * @see [📝 Landmarks unique](https://dequeuniversity.com/rules/axe/4.6/landmark-unique)
+   * @default "div"
+   */
+  as?: "div" | "section";
 }
 
 /**
@@ -81,7 +91,14 @@ interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
  */
 export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
   (
-    { className, variant = "default", size = "medium", indent = true, ...rest },
+    {
+      className,
+      variant = "default",
+      size = "medium",
+      indent = true,
+      as: Component = "div",
+      ...rest
+    },
     ref,
   ) => {
     const localRef = useRef<HTMLDivElement | null>(null);
@@ -117,7 +134,7 @@ export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
           variant,
         }}
       >
-        <div
+        <Component
           {...omit(rest, ["headingSize"])}
           className={cl(
             "aksel-accordion",

--- a/@navikt/core/react/src/link-card/LinkCard.tsx
+++ b/@navikt/core/react/src/link-card/LinkCard.tsx
@@ -33,6 +33,19 @@ interface LinkCardProps extends HTMLAttributes<HTMLDivElement> {
    * @see [📝 Documentation](https://aksel.nav.no/grunnleggende/styling/farger-tokens)
    */
   "data-color"?: AkselColor;
+  /**
+   * Changes the HTML element used for the root element.
+   *
+   * **When using `section`, provide either `aria-label` or `aria-labelledby` for better accessibility.**
+   * `axe-core` might warn about unique landmarks if you have multiple Accordions on page with the same label.
+   * In those cases consider updating to unique `aria-label` or `aria-labelledby` props.
+   * @see [📝 Landmarks unique](https://dequeuniversity.com/rules/axe/4.6/landmark-unique)
+   *
+   *
+   * **When using `acticle`, make sure `<LinkCard.Title />` is a heading and **not** a `span`.**
+   * @default "div"
+   */
+  as?: "div" | "section" | "article";
 }
 
 type LinkCardContextProps = {
@@ -106,6 +119,7 @@ export const LinkCard = forwardRef<HTMLDivElement, LinkCardProps>(
       arrow = true,
       arrowPosition = "baseline",
       size = "medium",
+      as: Component = "div",
       ...restProps
     }: LinkCardProps,
     forwardedRef,
@@ -114,7 +128,7 @@ export const LinkCard = forwardRef<HTMLDivElement, LinkCardProps>(
       <LinkCardContextProvider size={size}>
         <LinkAnchorOverlay asChild>
           <BodyLong
-            as="div"
+            as={Component}
             size={size}
             ref={forwardedRef}
             data-color="neutral"

--- a/@navikt/core/react/src/link-card/LinkCard.tsx
+++ b/@navikt/core/react/src/link-card/LinkCard.tsx
@@ -42,7 +42,7 @@ interface LinkCardProps extends HTMLAttributes<HTMLDivElement> {
    * @see [📝 Landmarks unique](https://dequeuniversity.com/rules/axe/4.6/landmark-unique)
    *
    *
-   * **When using `acticle`, make sure `<LinkCard.Title />` is a heading and **not** a `span`.**
+   * **When using `article`, make sure `<LinkCard.Title />` is a heading and not a `span`.**
    * @default "div"
    */
   as?: "div" | "section" | "article";


### PR DESCRIPTION
### Description

https://nav-it.slack.com/archives/C7NE7A8UF/p1770868396177029

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
