### PR TITLE
- Vis hurtigtast ut fra enhetens OS i globalSearch.dialog

### DIFF
--- a/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.dialog.tsx
+++ b/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.dialog.tsx
@@ -4,7 +4,13 @@ import { BodyShort, Box, Dialog, Heading } from "@navikt/ds-react";
 import { Kbd } from "@/app/_ui/kbd/Kbd";
 import styles from "./GlobalSearch.module.css";
 
-function GlobalSearchDialog({ children }: { children: React.ReactNode }) {
+function GlobalSearchDialog({
+  children,
+  isMac,
+}: {
+  children: React.ReactNode;
+  isMac: boolean;
+}) {
   return (
     <Dialog.Popup
       position="center"
@@ -22,7 +28,7 @@ function GlobalSearchDialog({ children }: { children: React.ReactNode }) {
         as="span"
       >
         <span>
-          <Kbd>Ctrl</Kbd>
+          <Kbd>{isMac ? "⌘" : "Ctrl"}</Kbd>
           <Box as="span" marginInline="space-2">
             +
           </Box>

--- a/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.tsx
+++ b/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.tsx
@@ -74,7 +74,7 @@ function GlobalSearch({ isMac }: { isMac: boolean }) {
         <Activity mode={open ? "visible" : "hidden"}>
           <Suspense>
             <GlobalSearchResultProvider>
-              <GlobalSearchDialog>
+              <GlobalSearchDialog isMac={isMac}>
                 <GlobalSearchForm />
                 <div className={styles.searchResults}>
                   <GlobalSearchEmptyState />


### PR DESCRIPTION
### Description
- Bruker info fra header som her: https://github.com/navikt/aksel/commit/1a5aab396a230e48819b1e06d53962b4daa436f9#diff-b5209f40e8bb52c8e6f05f6ff5f353c65a5af0e2cd47f7a01c457c3ff2de5dcf
og sender ned som prop slik at hurtigtast også vises ut fra enhetens OS i søkedialogen. 

PS: Har ikke fått testet dette da jeg ikke får opp dialogen når jeg kjører opp lokalt uten tokens. 

<!-- PR description/motivation, summary of changes, links to issue/slack discussion etc. -->

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
