### PR TITLE
[website] Endringslogg: Don't clear input when toggling semver

### DIFF
--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
@@ -47,7 +47,7 @@ export default function SearchField({
             data-color="neutral"
             className={styles.searchField}
           />
-          <HStack align="center" gap="space-4">
+          <HStack align="center" gap="space-6">
             <Checkbox
               value="semver"
               onClick={() => {

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchForm.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchForm.tsx
@@ -49,10 +49,10 @@ export const SearchForm = ({
   const updateSearchParam = (param: string, newValue: string) => {
     const newParams = new URLSearchParams();
 
+    if (searchInput) {
+      newParams.set("fritekst", searchInput);
+    }
     if (param !== "semver") {
-      if (searchInput) {
-        newParams.set("fritekst", searchInput);
-      }
       if (semverSearch) {
         newParams.set("semver", "true");
       }


### PR DESCRIPTION
I find it quite annoying that the free text field is cleared when toggling semver search. 1) You might have entered a semver value before checking the semver box, and 2) you might have started to enter a semver value when the input clears (b.c. of the delay).