### PR TITLE
Add missing key prop to nested Tooltip shortcuts

### DIFF
--- a/.changeset/olive-sides-rule.md
+++ b/.changeset/olive-sides-rule.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Tooltip: Legger til manglende `key` prop for flere shortcuts.

--- a/@navikt/core/react/src/tooltip/Tooltip.tsx
+++ b/@navikt/core/react/src/tooltip/Tooltip.tsx
@@ -11,7 +11,7 @@ import {
   useHover,
   useInteractions,
 } from "@floating-ui/react";
-import React, { HTMLAttributes, forwardRef, useRef } from "react";
+import React, { Fragment, HTMLAttributes, forwardRef, useRef } from "react";
 import { useModalContext } from "../modal/Modal.context";
 import { Portal } from "../portal";
 import { HStack } from "../primitives/stack";
@@ -296,7 +296,7 @@ function TooltipShortcuts({ shortcuts }: { shortcuts: TooltipProps["keys"] }) {
     return (
       <span className="aksel-tooltip__keys" aria-hidden>
         {shortcuts.map((key, index) => (
-          <>
+          <Fragment key={key.join("+")}>
             <HStack gap="space-4">
               {key.map((k, i) => (
                 <Detail as="kbd" key={i} className="aksel-tooltip__key">
@@ -307,7 +307,7 @@ function TooltipShortcuts({ shortcuts }: { shortcuts: TooltipProps["keys"] }) {
             {index < shortcuts.length - 1 && (
               <span> {translate("shortcutSeparator")} </span>
             )}
-          </>
+          </Fragment>
         ))}
       </span>
     );


### PR DESCRIPTION
### Description

Tooltip shortcuts were missing `key` prop, causing errors in the console:

```
Each child in a list should have a unique "key" prop.

Check the render method of `TooltipShortcuts`.
```

Related issue: #4576
Related PR: #4604

### Component Checklist 📝

- [x] JSDoc
- [x] Examples
- [x] Documentation / Decision Records
- [x] Storybook
- [x] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [x] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [x] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [x] New component? CSS import (`@navikt/core/css/index.css`)
- [x] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
