### PR TITLE
yarnrc: Add navikt to npmPreapprovedPackages

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,5 +14,6 @@ npmScopes:
 
 defaultSemverRangePrefix: ""
 npmMinimalAgeGate: "7d"
+npmPreapprovedPackages: ["@navikt/*"]
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs


### PR DESCRIPTION
This avoids "No candidates found" when running yarn in one of the dirs in the examples dir (maybe other cases too, I saw Dependabot get this error once).