### PR TITLE
[InlineMessage] :tada: Updated InlineMessage to use BodyLong based on review

### DIFF
--- a/.changeset/tall-snakes-enjoy.md
+++ b/.changeset/tall-snakes-enjoy.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+InlineMessage: Now uses BodyLong instead of BodyShort. Icon has some small adjustments to aligne with new typo.

--- a/@navikt/core/css/src/inline-message.css
+++ b/@navikt/core/css/src/inline-message.css
@@ -1,6 +1,6 @@
 .aksel-inline-message {
   display: flex;
-  gap: var(--ax-space-4);
+  gap: var(--ax-space-8);
   color: var(--ax-text-default);
 }
 
@@ -8,6 +8,7 @@
   color: var(--ax-text-subtle);
   font-size: 1.5rem;
   flex: 0 0 auto;
+  margin-block-start: var(--ax-space-2);
 
   .aksel-inline-message[data-size="small"] & {
     font-size: 1.25rem;

--- a/@navikt/core/react/src/inline-message/root/InlineMessage.tsx
+++ b/@navikt/core/react/src/inline-message/root/InlineMessage.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from "react";
 import { useThemeInternal } from "../../theme/Theme";
-import { BodyShort } from "../../typography";
+import { BodyLong, BodyShort } from "../../typography";
 import { type OverridableComponent, useId } from "../../utils-external";
 import { cl } from "../../utils/helpers";
 import { useI18n } from "../../utils/i18n/i18n.hooks";
@@ -64,7 +64,7 @@ export const InlineMessage: OverridableComponent<
     const contentId = useId();
 
     return (
-      <BodyShort
+      <BodyLong
         ref={forwardedRef}
         className={cl("aksel-inline-message", className)}
         data-color={status === "error" ? "danger" : status}
@@ -87,7 +87,7 @@ export const InlineMessage: OverridableComponent<
         >
           {children}
         </span>
-      </BodyShort>
+      </BodyLong>
     );
   },
 );

--- a/@navikt/core/react/src/inline-message/root/InlineMessage.tsx
+++ b/@navikt/core/react/src/inline-message/root/InlineMessage.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from "react";
 import { useThemeInternal } from "../../theme/Theme";
-import { BodyLong, BodyShort } from "../../typography";
+import { BodyLong } from "../../typography";
 import { type OverridableComponent, useId } from "../../utils-external";
 import { cl } from "../../utils/helpers";
 import { useI18n } from "../../utils/i18n/i18n.hooks";
@@ -75,9 +75,9 @@ export const InlineMessage: OverridableComponent<
       >
         <InlineMessageIcon status={status} />
         {status && (
-          <BodyShort id={statusId} aria-hidden visuallyHidden>
+          <BodyLong id={statusId} aria-hidden visuallyHidden>
             {`${translate(status)}: `}
-          </BodyShort>
+          </BodyLong>
         )}
         {/** biome-ignore lint/a11y/useAriaPropsSupportedByRole: Testing shows that this works. */}
         <span


### PR DESCRIPTION
### Description

https://github.com/orgs/navikt/projects/49/views/18?query=is%3Aopen+sort%3Aupdated-desc&pane=issue&itemId=157757452&issue=navikt%7Cteam-aksel%7C938

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
