### PR TITLE
:bug: useScrollLock now handles scrollbar-gutter better

### DIFF
--- a/.changeset/better-trains-sneeze.md
+++ b/.changeset/better-trains-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Dialog: Improved scrollbar handling when opening dialog-popup.

--- a/@navikt/core/react/src/utils/hooks/Hooks.stories.tsx
+++ b/@navikt/core/react/src/utils/hooks/Hooks.stories.tsx
@@ -24,20 +24,6 @@ export const UseScrollLock: StoryObj = {
   },
 };
 
-export const UseScrollLockEdgecase: StoryObj = {
-  render: ScrollLockComponent,
-  decorators: [
-    (story) => (
-      <div style={{ height: "5000px", background: "var(--ax-bg-softA)" }}>
-        {story()}
-      </div>
-    ),
-  ],
-  parameters: {
-    layout: "fullscreen",
-  },
-};
-
 export const UseScrollLockScrollXAndY: StoryObj = {
   render: ScrollLockComponent,
   decorators: [

--- a/@navikt/core/react/src/utils/hooks/Hooks.stories.tsx
+++ b/@navikt/core/react/src/utils/hooks/Hooks.stories.tsx
@@ -24,6 +24,20 @@ export const UseScrollLock: StoryObj = {
   },
 };
 
+export const UseScrollLockEdgecase: StoryObj = {
+  render: ScrollLockComponent,
+  decorators: [
+    (story) => (
+      <div style={{ height: "5000px", background: "var(--ax-bg-softA)" }}>
+        {story()}
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
 export const UseScrollLockScrollXAndY: StoryObj = {
   render: ScrollLockComponent,
   decorators: [

--- a/@navikt/core/react/src/utils/hooks/useScrollLock.ts
+++ b/@navikt/core/react/src/utils/hooks/useScrollLock.ts
@@ -6,6 +6,39 @@ let originalHtmlStyles: Partial<CSSStyleDeclaration> = {};
 let originalBodyStyles: Partial<CSSStyleDeclaration> = {};
 let originalHtmlScrollBehavior = "";
 
+function supportsStableScrollbarGutter(referenceElement: Element | null) {
+  const supported =
+    typeof CSS !== "undefined" &&
+    CSS.supports &&
+    CSS.supports("scrollbar-gutter", "stable");
+
+  if (!supported || typeof document === "undefined") {
+    return false;
+  }
+
+  const doc = ownerDocument(referenceElement);
+  const html = doc.documentElement;
+  const body = doc.body;
+
+  const scrollContainer = isOverflowElement(html) ? html : body;
+
+  const originalScrollContainerOverflowY = scrollContainer.style.overflowY;
+  const originalHtmlStyleGutter = html.style.scrollbarGutter;
+
+  html.style.scrollbarGutter = "stable";
+
+  scrollContainer.style.overflowY = "scroll";
+  const before = scrollContainer.offsetWidth;
+
+  scrollContainer.style.overflowY = "hidden";
+  const after = scrollContainer.offsetWidth;
+
+  scrollContainer.style.overflowY = originalScrollContainerOverflowY;
+  html.style.scrollbarGutter = originalHtmlStyleGutter;
+
+  return before === after;
+}
+
 function hasInsetScrollbars(referenceElement: Element | null) {
   if (typeof document === "undefined") {
     return false;
@@ -59,6 +92,9 @@ function preventScrollStandard(referenceElement: Element | null) {
 
     const htmlStyles = win.getComputedStyle(html);
     const bodyStyles = win.getComputedStyle(body);
+    const htmlScrollbarGutterValue = htmlStyles.scrollbarGutter || "";
+    const hasBothEdges = htmlScrollbarGutterValue.includes("both-edges");
+    const scrollbarGutterValue = hasBothEdges ? "stable both-edges" : "stable";
 
     scrollTop = html.scrollTop;
     scrollLeft = html.scrollLeft;
@@ -103,26 +139,27 @@ function preventScrollStandard(referenceElement: Element | null) {
     /**
      * Check support for stable scrollbar gutter to avoid layout shift when scrollbars appear/disappear.
      */
-    const supportsStableScrollbarGutter =
-      typeof CSS !== "undefined" &&
-      CSS.supports?.("scrollbar-gutter", "stable");
+    const supportsScrollbarGutter =
+      supportsStableScrollbarGutter(referenceElement);
+
     /*
      * DOM writes:
      * Do not read the DOM past this point!
      */
 
+    if (supportsScrollbarGutter) {
+      const elementToLock = isOverflowElement(html) ? html : body;
+
+      html.style.scrollbarGutter = scrollbarGutterValue;
+      elementToLock.style.overflowY = "hidden";
+      elementToLock.style.overflowX = "hidden";
+      return;
+    }
+
     Object.assign(html.style, {
       scrollbarGutter: "stable",
-      overflowY:
-        !supportsStableScrollbarGutter &&
-        (isScrollableY || hasConstantOverflowY)
-          ? "scroll"
-          : "hidden",
-      overflowX:
-        !supportsStableScrollbarGutter &&
-        (isScrollableX || hasConstantOverflowX)
-          ? "scroll"
-          : "hidden",
+      overflowY: isScrollableY || hasConstantOverflowY ? "scroll" : "hidden",
+      overflowX: isScrollableX || hasConstantOverflowX ? "scroll" : "hidden",
     });
 
     Object.assign(body.style, {

--- a/@navikt/core/react/src/utils/hooks/useScrollLock.ts
+++ b/@navikt/core/react/src/utils/hooks/useScrollLock.ts
@@ -16,6 +16,13 @@ function supportsStableScrollbarGutter(referenceElement: Element | null) {
     return false;
   }
 
+  /*
+   * We need to do aditional checks since the scenario:
+   * - Scrollbar is edited with `::-webkit-scrollbar`
+   * - OS setting: Show scroll bars -> Automatically based on mouse or tracked
+   * Causes the calculation of scrollbar width to be incorrect, and thus the scrollbar gutter to not work as intended.
+   */
+
   const doc = ownerDocument(referenceElement);
   const html = doc.documentElement;
   const body = doc.body;

--- a/@navikt/core/react/src/utils/hooks/useScrollLock.ts
+++ b/@navikt/core/react/src/utils/hooks/useScrollLock.ts
@@ -19,7 +19,7 @@ function supportsStableScrollbarGutter(referenceElement: Element | null) {
   /*
    * We need to do aditional checks since the scenario:
    * - Scrollbar is edited with `::-webkit-scrollbar`
-   * - OS setting: Show scroll bars -> Automatically based on mouse or tracked
+   * - MacOS setting: Show scroll bars -> Automatically based on mouse or tracked
    * Causes the calculation of scrollbar width to be incorrect, and thus the scrollbar gutter to not work as intended.
    */
 


### PR DESCRIPTION
### Description

Now only adds width to "locked" element when scrollbar-gutter is not supported. This avoids having scrollbar-gutter + width causing layout shifts where one ends up with 2 emulated scrollbars
Before
<img width="81" height="113" alt="Screenshot 2026-03-06 at 13 34 27" src="https://github.com/user-attachments/assets/41400268-a28c-4f01-bc1a-69a08faa6b00" />

after
<img width="86" height="101" alt="Screenshot 2026-03-06 at 13 34 55" src="https://github.com/user-attachments/assets/b07e87cd-a702-46ad-8e2c-43219b075d75" />


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
