### PR TITLE
[website] Fix "Oppdater godkjenningsdato" button

### DIFF
--- a/aksel.nav.no/website/sanity/schema/custom-components/updateInfo.tsx
+++ b/aksel.nav.no/website/sanity/schema/custom-components/updateInfo.tsx
@@ -38,7 +38,7 @@ const UpdateInfoInput: ComponentType<ObjectInputProps> = (props) => {
             `Failed to update lastVerified for document ${publishedId}. Document might not be published yet.`,
           );
         });
-      onChange(set(updatePayload));
+      onChange(set(updatePayload.updateInfo));
     } finally {
       setUpdating(false);
     }


### PR DESCRIPTION
Currently, the structure becomes like this when clicking the "Oppdater godkjenningsdato" button:
`updateInfo: { updateInfo: { lastVerified: "2026-03-06" } }`

Expected structure is:
`updateInfo: { lastVerified: "2026-03-06" }`

The change in this PR seems to fix it.