### PR TITLE
[website] Fix bug when clicking on active example chip

### DIFF
--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.provider.tsx
@@ -86,10 +86,16 @@ function KodeEksemplerProvider(props: {
       return;
     }
 
-    setLoaded(false);
-
     const id = nameToId(dir?.title ?? "", exampleName);
-    router.push(pathname + "?" + createQueryString(id), { scroll: false });
+    const newQueryString = createQueryString(id);
+
+    if (newQueryString === searchParams?.toString()) {
+      iframeRef.current?.contentWindow?.location.reload();
+      return;
+    }
+
+    setLoaded(false);
+    router.push(pathname + "?" + newQueryString, { scroll: false });
     iframeRef.current?.focus({ preventScroll: true });
   };
 


### PR DESCRIPTION
Clicking the same example twice would cause `setLoaded(false)` to run without anything setting it back again. Made it so that the iframe instead reloads when this happens.