### PR TITLE
:tada: Removed tabindex-change based on open-state in Date.Input

### DIFF
--- a/.changeset/smooth-lizards-pay.md
+++ b/.changeset/smooth-lizards-pay.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+DatePicker, MonthPicker: Removed controlled tabindex on Input-button based on open-state.

--- a/@navikt/core/react/src/date/Date.Input.tsx
+++ b/@navikt/core/react/src/date/Date.Input.tsx
@@ -154,7 +154,7 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>((props, ref) => {
         />
         <button
           disabled={inputProps.disabled || readOnly}
-          tabIndex={readOnly ? -1 : context?.open ? -1 : 0}
+          tabIndex={readOnly ? -1 : undefined}
           onClick={() => {
             context?.onOpen();
             setAnchorRef?.(buttonRef.current);


### PR DESCRIPTION
### Description

#4695


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [x] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
