### PR TITLE
[GlobalAlert, LocalAlert] Content outline changed from 4px to 2px.

### DIFF
--- a/.changeset/strong-forks-pump.md
+++ b/.changeset/strong-forks-pump.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+GlobalAlert, LocalAlert: Content outline changed from 4px to 2px.

--- a/@navikt/core/css/src/alert.css
+++ b/@navikt/core/css/src/alert.css
@@ -117,8 +117,8 @@
   }
 
   &[data-variant="strong"] {
-    outline: 4px solid var(--ax-border-default);
-    outline-offset: -4px;
+    outline: 2px solid var(--ax-border-default);
+    outline-offset: -2px;
 
     &[data-color="neutral"] {
       outline-color: var(--ax-border-strong);


### PR DESCRIPTION
### Description

<!-- PR description/motivation, summary of changes, links to issue/slack discussion etc. -->

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [x] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
