### PR TITLE
[Dialog] Links are now a valid focusable target when tabbing

### DIFF
--- a/.changeset/rare-seas-trade.md
+++ b/.changeset/rare-seas-trade.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-Dialog: Fixed issue where tabbing would not work when focusable element was a link.
+Dialog: Fixed issue where tabbing would not always work with links.

--- a/.changeset/rare-seas-trade.md
+++ b/.changeset/rare-seas-trade.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Dialog: Fixed issue where tabbing would not work when focusable element was a link.

--- a/@navikt/core/react/src/dialog/Dialog.tests.stories.tsx
+++ b/@navikt/core/react/src/dialog/Dialog.tests.stories.tsx
@@ -653,6 +653,46 @@ export const AriaAttributes: Story = {
   },
 };
 
+export const TabToLinks: Story = {
+  render: () => {
+    return (
+      <Dialog defaultOpen aria-labelledby="popup-title">
+        <DialogPopup className="popupCSS" data-testid="popup">
+          <DialogTitle id="popup-title">Dialog title</DialogTitle>
+          <Dialog.Body>
+            <input placeholder="test" type="text" />
+            <a data-testid="link-1" href="#123">
+              Test link
+            </a>
+            <a data-testid="link-2" href="#123">
+              Test link
+            </a>
+            <a data-testid="link-3" href="#123">
+              Test link
+            </a>
+            <a data-testid="link-4" href="#123">
+              Test link
+            </a>
+          </Dialog.Body>
+        </DialogPopup>
+      </Dialog>
+    );
+  },
+  beforeEach: withoutAnimations,
+  play: async ({ canvasElement, args }) => {
+    const { canvas } = testUtils(canvasElement, args);
+
+    await userEvent.tab();
+    expect(canvas.getByPlaceholderText("test")).toHaveFocus();
+    await userEvent.tab();
+    expect(canvas.getByTestId("link-1")).toHaveFocus();
+    await userEvent.tab();
+    expect(canvas.getByTestId("link-2")).toHaveFocus();
+    await userEvent.tab({ shift: true });
+    expect(canvas.getByTestId("link-1")).toHaveFocus();
+  },
+};
+
 /* ------------------------------- Test setup ------------------------------- */
 type BaseDialogProps = {
   rootProps?: Omit<DialogProps, "children"> & { children?: React.ReactNode };

--- a/@navikt/core/react/src/utils/components/focus-boundary/FocusBoundary.tsx
+++ b/@navikt/core/react/src/utils/components/focus-boundary/FocusBoundary.tsx
@@ -31,7 +31,6 @@ interface FocusBoundaryProps extends React.HTMLAttributes<HTMLDivElement> {
    * tabbing. If focus is moved outside the boundary programmatically or by
    * pointer, it will not be moved back.
    *
-   * - Links (`<a>` elements), are not considered tabbable for the purpose of looping.
    * - Hidden inputs (i.e. `<input type="hidden">`) are not considered tabbable.
    * - Elements that are `display: none` or `visibility: hidden` are not considered tabbable.
    * - Elements with `tabIndex < 0` are not considered tabbable.
@@ -392,7 +391,7 @@ const FocusBoundary = forwardRef<HTMLDivElement, FocusBoundaryProps>(
  * Returns the first and last tabbable elements inside a container as a tuple.
  */
 function getTabbableEdges(container: HTMLElement) {
-  const candidates = getTabbableCandidates(container);
+  const candidates = getTabbableCandidates(container, { omitLinks: false });
   return [
     findFirstVisible(candidates, container),
     findFirstVisible(candidates.reverse(), container),

--- a/@navikt/core/react/src/utils/helpers/focus.ts
+++ b/@navikt/core/react/src/utils/helpers/focus.ts
@@ -5,7 +5,10 @@
  * See: https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker
  * Credit: https://github.com/discord/focus-layers/blob/master/src/util/wrapFocus.tsx#L1
  */
-function getTabbableCandidates(container: HTMLElement) {
+function getTabbableCandidates(
+  container: HTMLElement,
+  { omitLinks = true } = {},
+) {
   const nodes: HTMLElement[] = [];
   const walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, {
     acceptNode: (node: any) => {
@@ -29,7 +32,7 @@ function getTabbableCandidates(container: HTMLElement) {
     nodes.push(walker.currentNode as HTMLElement);
   }
 
-  return removeLinks(nodes);
+  return omitLinks ? removeLinks(nodes) : nodes;
 }
 
 function removeLinks(items: HTMLElement[]) {


### PR DESCRIPTION
### Description

Resolves #4744

Links were previously omitted when getting all focus-targets. This was done to avoid auto-focusing a random link inside some body text when opening the dialog. But since the same function was used to validate targets when tabbing (keydown), the user could no longer tab to content inside the dialog if it was a link. 

The fix is to give a boolean-option to disabled omitting links when using keydown

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
