### PR TITLE
Biome/eslint adjustments

### DIFF
--- a/@navikt/aksel-icons/figma-plugin/src/ui/App.tsx
+++ b/@navikt/aksel-icons/figma-plugin/src/ui/App.tsx
@@ -155,7 +155,7 @@ const App = () => {
                       <div className="icons-wrapper">
                         {sub.icons.map((i) => {
                           // biome-ignore lint/performance/noDynamicNamespaceImportAccess: We do not know which icon will be rendered at build time
-                          const T = Icons[`${i.id}Icon`]; // eslint-disable-line import/namespace
+                          const T = Icons[`${i.id}Icon`];
                           if (T === undefined) {
                             return null;
                           }

--- a/@navikt/core/css/src/list.css
+++ b/@navikt/core/css/src/list.css
@@ -39,7 +39,6 @@
 
 /* SAFARI HACK START */
 
-/* biome-ignore lint/a11y/useGenericFontNames: Hack for targeting Safari */
 @supports (hanging-punctuation: first) and (font: -apple-system-body) and (-webkit-appearance: none) {
   .aksel-list ol {
     padding-left: 2.1rem;

--- a/@navikt/core/react/src/data/table/root/DataTableAuto.tsx
+++ b/@navikt/core/react/src/data/table/root/DataTableAuto.tsx
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/correctness/useHookAtTopLevel: False positive because of the way forwardRef() is added */
 import React, { forwardRef, useState } from "react";
 import { Checkbox } from "../../../form/checkbox";
 import { cl } from "../../../utils/helpers";

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/icon-page/IconPage.details.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/icon-page/IconPage.details.tsx
@@ -16,7 +16,7 @@ function IconDetails({
   iconSvg?: string;
 }) {
   // biome-ignore lint/performance/noDynamicNamespaceImportAccess: We do not know which icon will be rendered at build time
-  const IconComponent = Icons[`${iconName}Icon`]; // eslint-disable-line import/namespace
+  const IconComponent = Icons[`${iconName}Icon`];
   const metaData = iconName ? meta[iconName] : null;
 
   if (!IconComponent) {

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/icon-page/IconPage.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/icon-page/IconPage.tsx
@@ -27,8 +27,6 @@ import { IconPageProvider } from "./IconPage.provider";
 import { IconPageSidebar } from "./IconPage.sidebar";
 import { categorizeIcons, searchIcons } from "./IconPage.utils";
 
-/* eslint-disable import/namespace */
-
 function IconPage({
   iconName,
   iconQuery,

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "off" } } },
   "javascript": {
     "jsxRuntime": "reactClassic"
@@ -15,8 +15,23 @@
       "tailwindDirectives": true
     }
   },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
   "files": {
-    "maxSize": 2000000
+    "maxSize": 2000000,
+    "includes": [
+      "**",
+      "!**/public",
+      "!**/examples",
+      "!**/codemod/**/*.js",
+      "!**/modal/dialog-polyfill.ts",
+      "!**/_sanity/query-types.ts",
+      "!**/transforms/**/*.input.*",
+      "!**/transforms/**/*.output.*"
+    ]
   },
   "linter": {
     "enabled": true,
@@ -57,24 +72,6 @@
         "useArrowFunction": "off",
         "noImportantStyles": "off"
       }
-    },
-    "includes": [
-      "**",
-      "!**/node_modules/**",
-      "!**/lib/**",
-      "!**/public/**",
-      "!**/examples/**",
-      "!**/esm/**",
-      "!**/cjs/**",
-      "!**/dist/**",
-      "!**/figma/**/plugin.js",
-      "!**/codemod/**/*.js",
-      "!**/tailwind/tailwind.config.js",
-      "!**/.next/**",
-      "!**/modal/dialog-polyfill.ts",
-      "!**/_sanity/query-types.ts",
-      "!**/transforms/**/*.input.*",
-      "!**/transforms/**/*.output.*"
-    ]
+    }
   }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,6 +62,7 @@ module.exports = defineConfig([
       "react/prop-types": "off", // Temporary
       "react/display-name": "off", // Temporary
       "import/no-unresolved": "off",
+      "import/namespace": "off", // Biome has equivalent
       "import/no-named-as-default": "off", // Temporary
       "react-hooks/exhaustive-deps": [
         "warn",

--- a/package.json
+++ b/package.json
@@ -66,11 +66,9 @@
     "importOrderSortSpecifiers": true
   },
   "lint-staged": {
-    "*.js": "eslint --max-warnings=0 --no-warn-ignored",
-    "*.jsx": "eslint --max-warnings=0 --no-warn-ignored",
-    "*.ts": "eslint --max-warnings=0 --no-warn-ignored",
-    "*.tsx": "eslint --max-warnings=0 --no-warn-ignored",
+    "*.{ts,tsx,js,jsx}": "eslint --max-warnings=0 --no-warn-ignored",
     "*.css": "stylelint",
+    "*.{ts,tsx,js,jsx,css,json}": "biome lint",
     "*": "prettier --write --ignore-unknown"
   },
   "repository": {
@@ -78,7 +76,7 @@
     "url": "https://github.com/navikt/aksel.git"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.3.10",
+    "@biomejs/biome": "2.4.4",
     "@changesets/cli": "2.29.7",
     "@dnd-kit/react": "0.3.2",
     "@eslint/js": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,18 +1579,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@biomejs/biome@npm:2.3.10":
-  version: 2.3.10
-  resolution: "@biomejs/biome@npm:2.3.10"
+"@biomejs/biome@npm:2.4.4":
+  version: 2.4.4
+  resolution: "@biomejs/biome@npm:2.4.4"
   dependencies:
-    "@biomejs/cli-darwin-arm64": "npm:2.3.10"
-    "@biomejs/cli-darwin-x64": "npm:2.3.10"
-    "@biomejs/cli-linux-arm64": "npm:2.3.10"
-    "@biomejs/cli-linux-arm64-musl": "npm:2.3.10"
-    "@biomejs/cli-linux-x64": "npm:2.3.10"
-    "@biomejs/cli-linux-x64-musl": "npm:2.3.10"
-    "@biomejs/cli-win32-arm64": "npm:2.3.10"
-    "@biomejs/cli-win32-x64": "npm:2.3.10"
+    "@biomejs/cli-darwin-arm64": "npm:2.4.4"
+    "@biomejs/cli-darwin-x64": "npm:2.4.4"
+    "@biomejs/cli-linux-arm64": "npm:2.4.4"
+    "@biomejs/cli-linux-arm64-musl": "npm:2.4.4"
+    "@biomejs/cli-linux-x64": "npm:2.4.4"
+    "@biomejs/cli-linux-x64-musl": "npm:2.4.4"
+    "@biomejs/cli-win32-arm64": "npm:2.4.4"
+    "@biomejs/cli-win32-x64": "npm:2.4.4"
   dependenciesMeta:
     "@biomejs/cli-darwin-arm64":
       optional: true
@@ -1610,62 +1610,62 @@ __metadata:
       optional: true
   bin:
     biome: bin/biome
-  checksum: 10/c34427f06eee8559081fa7c93d79ddffc6d560ee6c8854cd1055907652ede717ed3944f314921e834d3f16ba20c75a98bd34b0d3e8712a7c30ac83fb2fe3903f
+  checksum: 10/caafef4170f2dbba61cb156c6c2bce60123234bcb7c239d6621bbea3b14eeaee060206fca75954fa20791d14f6d20f6b8b3e0896dac57dbaa0f2db72328c26fe
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-arm64@npm:2.3.10":
-  version: 2.3.10
-  resolution: "@biomejs/cli-darwin-arm64@npm:2.3.10"
+"@biomejs/cli-darwin-arm64@npm:2.4.4":
+  version: 2.4.4
+  resolution: "@biomejs/cli-darwin-arm64@npm:2.4.4"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-x64@npm:2.3.10":
-  version: 2.3.10
-  resolution: "@biomejs/cli-darwin-x64@npm:2.3.10"
+"@biomejs/cli-darwin-x64@npm:2.4.4":
+  version: 2.4.4
+  resolution: "@biomejs/cli-darwin-x64@npm:2.4.4"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64-musl@npm:2.3.10":
-  version: 2.3.10
-  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.3.10"
+"@biomejs/cli-linux-arm64-musl@npm:2.4.4":
+  version: 2.4.4
+  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.4.4"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64@npm:2.3.10":
-  version: 2.3.10
-  resolution: "@biomejs/cli-linux-arm64@npm:2.3.10"
+"@biomejs/cli-linux-arm64@npm:2.4.4":
+  version: 2.4.4
+  resolution: "@biomejs/cli-linux-arm64@npm:2.4.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64-musl@npm:2.3.10":
-  version: 2.3.10
-  resolution: "@biomejs/cli-linux-x64-musl@npm:2.3.10"
+"@biomejs/cli-linux-x64-musl@npm:2.4.4":
+  version: 2.4.4
+  resolution: "@biomejs/cli-linux-x64-musl@npm:2.4.4"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64@npm:2.3.10":
-  version: 2.3.10
-  resolution: "@biomejs/cli-linux-x64@npm:2.3.10"
+"@biomejs/cli-linux-x64@npm:2.4.4":
+  version: 2.4.4
+  resolution: "@biomejs/cli-linux-x64@npm:2.4.4"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-arm64@npm:2.3.10":
-  version: 2.3.10
-  resolution: "@biomejs/cli-win32-arm64@npm:2.3.10"
+"@biomejs/cli-win32-arm64@npm:2.4.4":
+  version: 2.4.4
+  resolution: "@biomejs/cli-win32-arm64@npm:2.4.4"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-x64@npm:2.3.10":
-  version: 2.3.10
-  resolution: "@biomejs/cli-win32-x64@npm:2.3.10"
+"@biomejs/cli-win32-x64@npm:2.4.4":
+  version: 2.4.4
+  resolution: "@biomejs/cli-win32-x64@npm:2.4.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -9216,7 +9216,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "aksel@workspace:."
   dependencies:
-    "@biomejs/biome": "npm:2.3.10"
+    "@biomejs/biome": "npm:2.4.4"
     "@changesets/cli": "npm:2.29.7"
     "@dnd-kit/react": "npm:0.3.2"
     "@eslint/js": "npm:^10.0.1"


### PR DESCRIPTION
- Disable eslint rule `import/namespace` since it's slow and Biome has a corresponding rule.
- Add Biome to lint-staged.
- Upgrade Biome to 2.4.4 (was the last version I could upgrade to without getting a bunch of new errors to handle).
- biome.json:
  - Move "includes" object into "files". According to docs, it seems like there is where it belongs, although it seems to work both places. However, the rule [useBiomeIgnoreFolder](https://biomejs.dev/linter/rules/use-biome-ignore-folder/) only works when "includes" in inside "files".
  - Remove trailing `/**` from "includes" entries (according to rule mentioned above).
  - Add config that makes it take into account `.gitignore`. Could remove some entries from "includes" then. **Number of files checked by `yarn lint:biome` went from 2869 to 1898 with this change.** I assume (hope) this is files that should have been ignored in the first place, and not files that actually should be linted 🤞