### PR TITLE
:lock: Disable scripts when running yarn install for sercurity

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,6 +12,7 @@ npmScopes:
     npmAuthToken: "${NPM_AUTH_TOKEN:-}"
     npmRegistryServer: "https://npm.pkg.github.com"
 
+enableScripts: false
 defaultSemverRangePrefix: ""
 npmMinimalAgeGate: "7d"
 npmPreapprovedPackages: ["@navikt/*"]


### PR DESCRIPTION
### Description

Affected packages
```
➤ YN0004: │ @bundled-es-modules/glob@npm:10.4.2 lists build scripts, but all build scripts have been disabled.
➤ YN0004: │ esbuild@npm:0.27.3 lists build scripts, but all build scripts have been disabled.
➤ YN0004: │ esbuild@npm:0.27.4 lists build scripts, but all build scripts have been disabled.
➤ YN0004: │ sharp@npm:0.33.5 lists build scripts, but all build scripts have been disabled.
➤ YN0004: │ sharp@npm:0.34.5 lists build scripts, but all build scripts have been disabled.
➤ YN0004: │ style-dictionary@npm:4.4.0 lists build scripts, but all build scripts have been disabled.
```

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
