### PR TITLE
Button: Use correct text color when inherited `data-color` is "neutral"

### DIFF
--- a/.changeset/nice-webs-count.md
+++ b/.changeset/nice-webs-count.md
@@ -3,4 +3,4 @@
 "@navikt/ds-css": patch
 ---
 
-Button: Set correct text color when a parent has data-color=neutral
+Button: Use correct text color when inherited `data-color` is "neutral"

--- a/.changeset/nice-webs-count.md
+++ b/.changeset/nice-webs-count.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+Button: Set correct text color when a parent has data-color=neutral

--- a/@navikt/core/css/src/button.css
+++ b/@navikt/core/css/src/button.css
@@ -44,7 +44,9 @@
     background-color: transparent;
     color: var(--ax-text-subtle);
 
-    &[data-color="neutral"] {
+    &[data-color="neutral"],
+    [data-color="neutral"] > &:not([data-color]),
+    [data-color="neutral"] :not([data-color]) &:not([data-color]) {
       color: var(--ax-text-default);
     }
 
@@ -62,7 +64,8 @@
       color: var(--ax-text-subtle);
       background-color: transparent;
 
-      &[data-color="neutral"] {
+      &[data-color="neutral"],
+      [data-color="neutral"] > &:not([data-color]) {
         color: var(--ax-text-default);
       }
     }
@@ -72,7 +75,9 @@
     background-color: transparent;
     color: var(--ax-text-subtle);
 
-    &[data-color="neutral"] {
+    &[data-color="neutral"],
+    [data-color="neutral"] > &:not([data-color]),
+    [data-color="neutral"] :not([data-color]) &:not([data-color]) {
       color: var(--ax-text-default);
     }
 
@@ -93,7 +98,8 @@
       color: var(--ax-text-subtle);
       background-color: transparent;
 
-      &[data-color="neutral"] {
+      &[data-color="neutral"],
+      [data-color="neutral"] > &:not([data-color]) {
         color: var(--ax-text-default);
       }
     }

--- a/@navikt/core/css/src/button.css
+++ b/@navikt/core/css/src/button.css
@@ -76,8 +76,8 @@
     color: var(--ax-text-subtle);
 
     &[data-color="neutral"],
-    [data-color="neutral"] > &:not([data-color]),
-    [data-color="neutral"] :not([data-color]) &:not([data-color]) {
+    [data-color="neutral"] > &:not([data-color], [data-pressed="true"]),
+    [data-color="neutral"] :not([data-color]) &:not([data-color], [data-pressed="true"]) {
       color: var(--ax-text-default);
     }
 

--- a/@navikt/core/react/src/button/button.stories.tsx
+++ b/@navikt/core/react/src/button/button.stories.tsx
@@ -158,7 +158,7 @@ export const DisabledAsLink: Story = {
 
 export const ColorRole = () => (
   <VStack gap="space-8">
-    <h2>Variants + data-color on parent</h2>
+    <h3>data-color on parent</h3>
     <HStack gap="space-8" data-color="danger">
       <Button variant="primary" icon={<StarIcon />}>
         Button
@@ -170,7 +170,7 @@ export const ColorRole = () => (
         Button
       </Button>
     </HStack>
-    <h2>Variants + data-color on button</h2>
+    <h3>data-color on button</h3>
     <HStack gap="space-8">
       <Button data-color="danger" variant="primary" icon={<StarIcon />}>
         Button
@@ -182,6 +182,149 @@ export const ColorRole = () => (
         Button
       </Button>
     </HStack>
+    <h3>data-color=neutral on wrapper and danger on button</h3>
+    <HStack gap="space-8" data-color="neutral">
+      <Button data-color="danger" variant="secondary" icon={<StarIcon />}>
+        Button
+      </Button>
+      <Button data-color="danger" variant="tertiary" icon={<StarIcon />}>
+        Button
+      </Button>
+      <Button
+        data-color="danger"
+        variant="secondary"
+        icon={<StarIcon />}
+        disabled
+      >
+        Button
+      </Button>
+      <Button
+        data-color="danger"
+        variant="tertiary"
+        icon={<StarIcon />}
+        disabled
+      >
+        Button
+      </Button>
+    </HStack>
+    <h3>data-color=neutral on parent wrapper and danger on button</h3>
+    <div data-color="neutral">
+      <HStack gap="space-8">
+        <Button data-color="danger" variant="secondary" icon={<StarIcon />}>
+          Button
+        </Button>
+        <Button data-color="danger" variant="tertiary" icon={<StarIcon />}>
+          Button
+        </Button>
+        <Button
+          data-color="danger"
+          variant="secondary"
+          icon={<StarIcon />}
+          disabled
+        >
+          Button
+        </Button>
+        <Button
+          data-color="danger"
+          variant="tertiary"
+          icon={<StarIcon />}
+          disabled
+        >
+          Button
+        </Button>
+      </HStack>
+    </div>
+    <h3>data-color=neutral on button</h3>
+    <HStack gap="space-8">
+      <Button data-color="neutral" variant="secondary" icon={<StarIcon />}>
+        Button
+      </Button>
+      <Button data-color="neutral" variant="tertiary" icon={<StarIcon />}>
+        Button
+      </Button>
+      <Button
+        data-color="neutral"
+        variant="secondary"
+        icon={<StarIcon />}
+        disabled
+      >
+        Button
+      </Button>
+      <Button
+        data-color="neutral"
+        variant="tertiary"
+        icon={<StarIcon />}
+        disabled
+      >
+        Button
+      </Button>
+    </HStack>
+    <h3>data-color=neutral on wrapper</h3>
+    <HStack gap="space-8" data-color="neutral">
+      <Button variant="secondary" icon={<StarIcon />}>
+        Button
+      </Button>
+      <Button variant="tertiary" icon={<StarIcon />}>
+        Button
+      </Button>
+      <Button variant="secondary" icon={<StarIcon />} disabled>
+        Button
+      </Button>
+      <Button variant="tertiary" icon={<StarIcon />} disabled>
+        Button
+      </Button>
+    </HStack>
+    <h3>data-color=neutral on parent wrapper</h3>
+    <div data-color="neutral">
+      <HStack gap="space-8">
+        <Button variant="secondary" icon={<StarIcon />}>
+          Button
+        </Button>
+        <Button variant="tertiary" icon={<StarIcon />}>
+          Button
+        </Button>
+        <Button variant="secondary" icon={<StarIcon />} disabled>
+          Button
+        </Button>
+        <Button variant="tertiary" icon={<StarIcon />} disabled>
+          Button
+        </Button>
+      </HStack>
+    </div>
+    <h3>data-color=neutral on parent wrapper and danger on wrapper</h3>
+    <div data-color="neutral">
+      <HStack gap="space-8" data-color="danger">
+        <Button variant="secondary" icon={<StarIcon />}>
+          Button
+        </Button>
+        <Button variant="tertiary" icon={<StarIcon />}>
+          Button
+        </Button>
+        <Button variant="secondary" icon={<StarIcon />} disabled>
+          Button
+        </Button>
+        <Button variant="tertiary" icon={<StarIcon />} disabled>
+          Button
+        </Button>
+      </HStack>
+    </div>
+    <h3>data-color=neutral on both wrappers</h3>
+    <div data-color="neutral">
+      <HStack gap="space-8" data-color="neutral">
+        <Button variant="secondary" icon={<StarIcon />}>
+          Button
+        </Button>
+        <Button variant="tertiary" icon={<StarIcon />}>
+          Button
+        </Button>
+        <Button variant="secondary" icon={<StarIcon />} disabled>
+          Button
+        </Button>
+        <Button variant="tertiary" icon={<StarIcon />} disabled>
+          Button
+        </Button>
+      </HStack>
+    </div>
   </VStack>
 );
 


### PR DESCRIPTION
### Description

Suggested fix for the issue where button does not get correct color when `data-color="neutral"` is set on a parent instead of directly on the button.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [x] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
