### PR TITLE
RadioGroup: Set `role="radiogroup"`, and set `aria-invalid` on error

### DIFF
--- a/.changeset/huge-news-invite.md
+++ b/.changeset/huge-news-invite.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+RadioGroup: Set `role="radiogroup"`, and set `aria-invalid` on error.

--- a/@navikt/core/react/src/form/fieldset/fieldset.stories.tsx
+++ b/@navikt/core/react/src/form/fieldset/fieldset.stories.tsx
@@ -41,13 +41,6 @@ const content = (
   </>
 );
 
-const contentWithError = (
-  <>
-    <TextField label="Textfield label" hideLabel error="Må være fylt ut" />
-    <TextField label="Textfield label" hideLabel />
-  </>
-);
-
 export const Default: Story = {
   args: {
     legend: "Mollit eiusmod",
@@ -69,21 +62,22 @@ export const Small: Story = {
   },
 };
 
-export const ErrorPropagation: Story = {
-  args: {
-    legend: "Mollit eiusmod",
-    description:
-      "Do ullamco amet mollit labore tempor minim cupidatat dolore voluptate velit irure.",
-    errorPropagation: false,
-    children: contentWithError,
-  },
-};
-
 export const WithError: Story = {
   args: {
     legend: "Mollit eiusmod",
     description:
       "Do ullamco amet mollit labore tempor minim cupidatat dolore voluptate velit irure.",
+    children: content,
+    error: "Laborum officia nisi aliqua esse minim in amet.",
+  },
+};
+
+export const WithErrorNoPropagation: Story = {
+  args: {
+    legend: "Mollit eiusmod",
+    description:
+      "Do ullamco amet mollit labore tempor minim cupidatat dolore voluptate velit irure.",
+    errorPropagation: false,
     children: content,
     error: "Laborum officia nisi aliqua esse minim in amet.",
   },
@@ -113,7 +107,7 @@ export const Chromatic = renderStoriesForChromatic(
   {
     Default,
     Small,
-    ErrorPropagation,
+    WithErrorNoPropagation,
     WithError,
     WithErrorSmall: {
       ...WithError,

--- a/@navikt/core/react/src/form/fieldset/useFieldset.ts
+++ b/@navikt/core/react/src/form/fieldset/useFieldset.ts
@@ -1,19 +1,20 @@
 import { cl } from "../../utils/helpers";
-import {
-  type FormFieldProps,
-  containsReadMore,
-  useFormField,
-} from "../useFormField";
+import { containsReadMore, useFormField } from "../useFormField";
+import type { FieldsetProps } from "./Fieldset";
 
 /**
  * Handles props for Fieldset in context with parent Fieldset.
  */
-export const useFieldset = (props: FormFieldProps, legendId: string) => {
+export const useFieldset = (props: FieldsetProps, legendId: string) => {
   const formField = useFormField(props, "fieldset");
 
   return {
     ...formField,
     inputProps: {
+      ...(props.role === "radiogroup"
+        ? { "aria-invalid": formField.inputProps["aria-invalid"] }
+        : {}),
+
       // Having both legend and description in labelledby seems to work best, ref. https://mortentollefsen.no/demo/radio-description.html
       "aria-labelledby":
         props["aria-labelledby"] ||

--- a/@navikt/core/react/src/form/radio/RadioGroup.tsx
+++ b/@navikt/core/react/src/form/radio/RadioGroup.tsx
@@ -15,6 +15,7 @@ export interface RadioGroupContextProps {
 export const RadioGroupContext =
   React.createContext<RadioGroupContextProps | null>(null);
 
+// TODO: Omit "role" in next major
 export interface RadioGroupProps extends Omit<
   FieldsetProps,
   "onChange" | "errorPropagation" | "defaultValue" | "nativeReadOnly"
@@ -76,6 +77,7 @@ export const RadioGroup = forwardRef<HTMLFieldSetElement, RadioGroupProps>(
 
     return (
       <Fieldset
+        role="radiogroup"
         {...rest}
         readOnly={readOnly}
         ref={ref}


### PR DESCRIPTION
### Description

1. Set `role="radiogroup"`.
2. Set `aria-invalid` on error.

TODO: Set `aria-invalid` on CheckboxGroup as well (separate PR).

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [x] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>.` E.g. "Button: :sparkles: Add feature xyz.")
