### PR TITLE
CheckboxGroup: Set aria-invalid on error

### DIFF
--- a/.changeset/common-guests-march.md
+++ b/.changeset/common-guests-march.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+CheckboxGroup: Set `aria-invalid` on error

--- a/@navikt/core/react/src/form/checkbox/CheckboxGroup.context.ts
+++ b/@navikt/core/react/src/form/checkbox/CheckboxGroup.context.ts
@@ -1,6 +1,6 @@
 import { createContext } from "react";
 
-interface CheckboxGroupContextProps {
+export interface CheckboxGroupContextProps {
   readonly defaultValue?: readonly any[];
   readonly value?: readonly any[];
   toggleValue(value: any): void;

--- a/@navikt/core/react/src/form/checkbox/CheckboxGroup.context.ts
+++ b/@navikt/core/react/src/form/checkbox/CheckboxGroup.context.ts
@@ -1,0 +1,10 @@
+import { createContext } from "react";
+
+interface CheckboxGroupContextProps {
+  readonly defaultValue?: readonly any[];
+  readonly value?: readonly any[];
+  toggleValue(value: any): void;
+}
+
+export const CheckboxGroupContext =
+  createContext<CheckboxGroupContextProps | null>(null);

--- a/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
+++ b/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
@@ -1,17 +1,8 @@
-import React, { createContext, forwardRef, useContext, useState } from "react";
+import React, { forwardRef, useContext, useState } from "react";
 import { cl } from "../../utils/helpers";
 import { Fieldset, FieldsetProps } from "../fieldset";
 import { FieldsetContext } from "../fieldset/context";
-
-export interface CheckboxGroupState {
-  readonly defaultValue?: readonly any[];
-  readonly value?: readonly any[];
-  toggleValue(value: any): void;
-}
-
-export const CheckboxGroupContext = createContext<CheckboxGroupState | null>(
-  null,
-);
+import { CheckboxGroupContext } from "./CheckboxGroup.context";
 
 export interface CheckboxGroupProps extends Omit<
   FieldsetProps,

--- a/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
+++ b/@navikt/core/react/src/form/checkbox/CheckboxGroup.tsx
@@ -73,26 +73,25 @@ export const CheckboxGroup = forwardRef<
     };
 
     return (
-      <Fieldset
-        {...rest}
-        ref={ref}
-        className={cl(
-          className,
-          "aksel-checkbox-group",
-          `aksel-checkbox-group--${rest.size ?? fieldset?.size ?? "medium"}`,
-        )}
-        _fieldsSupportNativeReadOnly={false}
+      <CheckboxGroupContext.Provider
+        value={{
+          value,
+          defaultValue,
+          toggleValue,
+        }}
       >
-        <CheckboxGroupContext.Provider
-          value={{
-            value,
-            defaultValue,
-            toggleValue,
-          }}
+        <Fieldset
+          {...rest}
+          ref={ref}
+          className={cl(
+            className,
+            "aksel-checkbox-group",
+            `aksel-checkbox-group--${rest.size ?? fieldset?.size ?? "medium"}`,
+          )}
         >
           <div className="aksel-checkboxes">{children}</div>
-        </CheckboxGroupContext.Provider>
-      </Fieldset>
+        </Fieldset>
+      </CheckboxGroupContext.Provider>
     );
   },
 );

--- a/@navikt/core/react/src/form/checkbox/useCheckbox.ts
+++ b/@navikt/core/react/src/form/checkbox/useCheckbox.ts
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import { omit } from "../../utils-external";
 import { useFormField } from "../useFormField";
-import { CheckboxGroupContext } from "./CheckboxGroup";
+import { CheckboxGroupContext } from "./CheckboxGroup.context";
 import { CheckboxProps } from "./types";
 
 /**

--- a/@navikt/core/react/src/form/fieldset/Fieldset.tsx
+++ b/@navikt/core/react/src/form/fieldset/Fieldset.tsx
@@ -26,10 +26,6 @@ export interface FieldsetProps
    * @default true
    */
   errorPropagation?: boolean;
-  /**
-   * @private
-   */
-  _fieldsSupportNativeReadOnly?: boolean;
 }
 
 /**
@@ -60,6 +56,7 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
       size,
       readOnly,
       inputDescriptionId,
+      readOnlyIconNeedsTitle,
     } = useFieldset(props, legendId);
 
     const fieldset = useContext(FieldsetContext);
@@ -71,7 +68,6 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
       legend,
       description,
       hideLegend,
-      _fieldsSupportNativeReadOnly = true,
       ...rest
     } = props;
 
@@ -112,10 +108,10 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
             visuallyHidden={!!hideLegend}
           >
             {readOnly &&
-              (_fieldsSupportNativeReadOnly ? (
-                <ReadOnlyIcon />
-              ) : (
+              (readOnlyIconNeedsTitle ? (
                 <ReadOnlyIconWithTitle />
+              ) : (
+                <ReadOnlyIcon />
               ))}
             {legend}
           </Label>

--- a/@navikt/core/react/src/form/fieldset/useFieldset.ts
+++ b/@navikt/core/react/src/form/fieldset/useFieldset.ts
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import { cl } from "../../utils/helpers";
-import { CheckboxGroupContext } from "../checkbox/CheckboxGroup";
-import { RadioGroupContext } from "../radio/RadioGroup";
+import { CheckboxGroupContext } from "../checkbox/CheckboxGroup.context";
+import { RadioGroupContext } from "../radio/RadioGroup.context";
 import { containsReadMore, useFormField } from "../useFormField";
 import type { FieldsetProps } from "./Fieldset";
 

--- a/@navikt/core/react/src/form/fieldset/useFieldset.ts
+++ b/@navikt/core/react/src/form/fieldset/useFieldset.ts
@@ -15,7 +15,7 @@ export const useFieldset = (props: FieldsetProps, legendId: string) => {
 
   return {
     ...formField,
-    readOnlyIconNeedsTitle: !checkboxGroupContext && !radioGroupContext,
+    readOnlyIconNeedsTitle: checkboxGroupContext || radioGroupContext,
     inputProps: {
       ...(checkboxGroupContext || radioGroupContext
         ? { "aria-invalid": formField.inputProps["aria-invalid"] }

--- a/@navikt/core/react/src/form/fieldset/useFieldset.ts
+++ b/@navikt/core/react/src/form/fieldset/useFieldset.ts
@@ -1,4 +1,7 @@
+import { useContext } from "react";
 import { cl } from "../../utils/helpers";
+import { CheckboxGroupContext } from "../checkbox/CheckboxGroup";
+import { RadioGroupContext } from "../radio/RadioGroup";
 import { containsReadMore, useFormField } from "../useFormField";
 import type { FieldsetProps } from "./Fieldset";
 
@@ -7,11 +10,14 @@ import type { FieldsetProps } from "./Fieldset";
  */
 export const useFieldset = (props: FieldsetProps, legendId: string) => {
   const formField = useFormField(props, "fieldset");
+  const checkboxGroupContext = useContext(CheckboxGroupContext);
+  const radioGroupContext = useContext(RadioGroupContext);
 
   return {
     ...formField,
+    readOnlyIconNeedsTitle: !checkboxGroupContext && !radioGroupContext,
     inputProps: {
-      ...(props.role === "radiogroup"
+      ...(checkboxGroupContext || radioGroupContext
         ? { "aria-invalid": formField.inputProps["aria-invalid"] }
         : {}),
 

--- a/@navikt/core/react/src/form/radio/RadioGroup.context.ts
+++ b/@navikt/core/react/src/form/radio/RadioGroup.context.ts
@@ -1,0 +1,13 @@
+import { createContext } from "react";
+
+interface RadioGroupContextProps {
+  name: string;
+  defaultValue?: any;
+  value?: any;
+  onChange: (value: any) => void;
+  required?: boolean;
+}
+
+export const RadioGroupContext = createContext<RadioGroupContextProps | null>(
+  null,
+);

--- a/@navikt/core/react/src/form/radio/RadioGroup.context.ts
+++ b/@navikt/core/react/src/form/radio/RadioGroup.context.ts
@@ -1,6 +1,6 @@
 import { createContext } from "react";
 
-interface RadioGroupContextProps {
+export interface RadioGroupContextProps {
   name: string;
   defaultValue?: any;
   value?: any;

--- a/@navikt/core/react/src/form/radio/RadioGroup.tsx
+++ b/@navikt/core/react/src/form/radio/RadioGroup.tsx
@@ -76,30 +76,29 @@ export const RadioGroup = forwardRef<HTMLFieldSetElement, RadioGroupProps>(
     const nameId = useId();
 
     return (
-      <Fieldset
-        role="radiogroup"
-        {...rest}
-        readOnly={readOnly}
-        ref={ref}
-        className={cl(
-          className,
-          "aksel-radio-group",
-          `aksel-radio-group--${rest.size ?? fieldset?.size ?? "medium"}`,
-        )}
-        _fieldsSupportNativeReadOnly={false}
+      <RadioGroupContext.Provider
+        value={{
+          name: name ?? `radioGroupName-${nameId}`,
+          defaultValue,
+          value,
+          onChange,
+          required,
+        }}
       >
-        <RadioGroupContext.Provider
-          value={{
-            name: name ?? `radioGroupName-${nameId}`,
-            defaultValue,
-            value,
-            onChange,
-            required,
-          }}
+        <Fieldset
+          role="radiogroup"
+          {...rest}
+          readOnly={readOnly}
+          ref={ref}
+          className={cl(
+            className,
+            "aksel-radio-group",
+            `aksel-radio-group--${rest.size ?? fieldset?.size ?? "medium"}`,
+          )}
         >
           <div className="aksel-radio-buttons">{children}</div>
-        </RadioGroupContext.Provider>
-      </Fieldset>
+        </Fieldset>
+      </RadioGroupContext.Provider>
     );
   },
 );

--- a/@navikt/core/react/src/form/radio/RadioGroup.tsx
+++ b/@navikt/core/react/src/form/radio/RadioGroup.tsx
@@ -3,17 +3,7 @@ import { useId } from "../../utils-external";
 import { cl } from "../../utils/helpers";
 import { Fieldset, FieldsetProps } from "../fieldset";
 import { FieldsetContext } from "../fieldset/context";
-
-export interface RadioGroupContextProps {
-  name: string;
-  defaultValue?: any;
-  value?: any;
-  onChange: (value: any) => void;
-  required?: boolean;
-}
-
-export const RadioGroupContext =
-  React.createContext<RadioGroupContextProps | null>(null);
+import { RadioGroupContext } from "./RadioGroup.context";
 
 // TODO: Omit "role" in next major
 export interface RadioGroupProps extends Omit<

--- a/@navikt/core/react/src/form/radio/useRadio.ts
+++ b/@navikt/core/react/src/form/radio/useRadio.ts
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import { omit } from "../../utils-external";
 import { useFormField } from "../useFormField";
-import { RadioGroupContext } from "./RadioGroup";
+import { RadioGroupContext } from "./RadioGroup.context";
 import { RadioProps } from "./types";
 
 /**


### PR DESCRIPTION
### Description

Set `aria-invalid` on fieldset on error.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
