### PR TITLE
DatePicker: Reset range when selecting a new day, upgrade react-day-picker

### DIFF
--- a/.changeset/spotty-sloths-wash.md
+++ b/.changeset/spotty-sloths-wash.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+DatePicker: Reset range when selecting a new day

--- a/.changeset/spotty-sloths-wash.md
+++ b/.changeset/spotty-sloths-wash.md
@@ -1,5 +1,5 @@
 ---
-"@navikt/ds-react": patch
+"@navikt/ds-react": minor
 ---
 
 DatePicker: Reset range when selecting a new day

--- a/.changeset/wacky-ways-mix.md
+++ b/.changeset/wacky-ways-mix.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-DatePicker, MonthPicker: ⬆️ Upgrade dependency react-day-picker
+DatePicker, MonthPicker: ⬆️ Upgrade dependency react-day-picker `9.7.0` -> `9.14.0`

--- a/.changeset/wacky-ways-mix.md
+++ b/.changeset/wacky-ways-mix.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+DatePicker, MonthPicker: ⬆️ Upgrade dependency react-day-picker

--- a/.changeset/wacky-ways-mix.md
+++ b/.changeset/wacky-ways-mix.md
@@ -1,5 +1,5 @@
 ---
-"@navikt/ds-react": patch
+"@navikt/ds-react": minor
 ---
 
 DatePicker, MonthPicker: ⬆️ Upgrade dependency react-day-picker `9.7.0` -> `9.14.0`

--- a/@navikt/core/react/package.json
+++ b/@navikt/core/react/package.json
@@ -708,7 +708,7 @@
     "@navikt/aksel-icons": "^8.9.1",
     "@navikt/ds-tokens": "^8.9.1",
     "date-fns": "^4.0.0",
-    "react-day-picker": "9.7.0"
+    "react-day-picker": "9.14.0"
   },
   "devDependencies": {
     "@testing-library/dom": "10.4.1",

--- a/@navikt/core/react/src/date/datepicker/parts/DatePicker.RDP.tsx
+++ b/@navikt/core/react/src/date/datepicker/parts/DatePicker.RDP.tsx
@@ -203,6 +203,7 @@ const ReactDayPicker = ({
       startMonth={fromDate}
       endMonth={toDate}
       month={clampDisplayMonth({ month, start: fromDate, end: toDate })}
+      resetOnSelect // Range mode: Starts a new range when selecting a day even when a range is already selected
       {...omit(rest, ["onSelect", "role", "id", "defaultSelected"])}
     />
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2369,13 +2369,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@date-fns/tz@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@date-fns/tz@npm:1.2.0"
-  checksum: 10/a9c2d32f98a5a5c655a7d3843046a5a36779b2ef0db803c608291976e6254e594a085777bf738379f50c7e9fc2ffebbf8bb836e9e9759a5ef2b703f91bb785de
-  languageName: node
-  linkType: hard
-
 "@date-fns/tz@npm:^1.4.1":
   version: 1.4.1
   resolution: "@date-fns/tz@npm:1.4.1"
@@ -4893,7 +4886,7 @@ __metadata:
     jscodeshift: "npm:17.3.0"
     jsdom: "npm:27.1.0"
     react: "npm:19.2.4"
-    react-day-picker: "npm:9.7.0"
+    react-day-picker: "npm:9.14.0"
     react-dom: "npm:19.2.4"
     react-router: "npm:^7.13.1"
     rimraf: "npm:6.1.3"
@@ -7711,6 +7704,13 @@ __metadata:
   dependencies:
     tslib: "npm:^2.8.0"
   checksum: 10/e3f32c6deeecfb0fa3f22edff03a7b358e7ce16d27b0f1c8b5cdc3042c5c4ce4da6eac0b781ab7cc4f54696ece657467d56734fb26883439fb00017385364c4c
+  languageName: node
+  linkType: hard
+
+"@tabby_ai/hijri-converter@npm:1.0.5":
+  version: 1.0.5
+  resolution: "@tabby_ai/hijri-converter@npm:1.0.5"
+  checksum: 10/35711b606870889eaafd76f8fb94bd095a15c5d066a3062d7c3987344949e9d7638726863cf7c9439f9c5efc9a56f289485fd9d99a77e5d29cd23897c8d748ce
   languageName: node
   linkType: hard
 
@@ -12041,7 +12041,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:4.1.0, date-fns@npm:^4.0.0, date-fns@npm:^4.1.0":
+"date-fns@npm:^4.0.0, date-fns@npm:^4.1.0":
   version: 4.1.0
   resolution: "date-fns@npm:4.1.0"
   checksum: 10/d5f6e9de5bbc52310f786099e18609289ed5e30af60a71e0646784c8185ddd1d0eebcf7c96b7faaaefc4a8366f3a3a4244d099b6d0866ee2bec80d1361e64342
@@ -20652,16 +20652,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-day-picker@npm:9.7.0":
-  version: 9.7.0
-  resolution: "react-day-picker@npm:9.7.0"
+"react-day-picker@npm:9.14.0":
+  version: 9.14.0
+  resolution: "react-day-picker@npm:9.14.0"
   dependencies:
-    "@date-fns/tz": "npm:1.2.0"
-    date-fns: "npm:4.1.0"
+    "@date-fns/tz": "npm:^1.4.1"
+    "@tabby_ai/hijri-converter": "npm:1.0.5"
+    date-fns: "npm:^4.1.0"
     date-fns-jalali: "npm:4.1.0-0"
   peerDependencies:
     react: ">=16.8.0"
-  checksum: 10/8755db4a978e10f1b35cfa23d544523682f3f18c97357e3774f43a6e223cdfaa9218537a683cf45fe72cd1e2e0a1fab3d55957815b8b23ef118220509f57a359
+  checksum: 10/a4e05e6af3d5535e34909aa1c258904765da73f5299ddf031838f92fff8493d4bad9140088e94ddc9041b07410f9803d3ee27e7fc67d78cf0d2c8622089723f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

1. Upgrade react-day-picker.
2. Add `resetOnSelect` (starts a new range when selecting a day even when a range is already selected).

Notable relevant changes in react-day-picker since 9.7.0:
>- feat(accessibility): enable Shift+Arrows to navigate between months/years
>- fix: select the same day in range mode when range is open and min prop is 0
>- fix: allow focused disabled days to remain focusable (i.e. no longer lose focus if focused day becomes disabled)
>- fix: ensure final week renders when endMonth clips the calendar (Rendered HTML now includes empty cells in grids when endMonth is set)
>- feat: add locale-aware labels and translated locale wrappers (https://daypicker.dev/changelog#v9120)
>- feat: add resetOnSelect prop to reset date range when selecting date with completed range
>- feat: add default lang prop to DayPicker root element

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
