### PR TITLE
sporing-dev.js script + potentially useful tracking events

### DIFF
--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/DesignsystemetPage.parts.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ClockDashedIcon } from "@navikt/aksel-icons";
+import { Events } from "@navikt/analytics-types";
 import { HStack, Link } from "@navikt/ds-react";
 import { KOMPONENT_BY_SLUG_QUERY_RESULT } from "@/app/_sanity/query-types";
 import { umamiTrack } from "@/app/_ui/umami/Umami.track";
@@ -56,9 +57,10 @@ function KomponentLinks({
           rel="noreferrer noopener"
           href={gitConfig.git}
           onClick={() =>
-            umamiTrack("navigere", {
-              kilde: "komponent-header",
-              url: gitConfig.git,
+            umamiTrack(Events.NAVIGERE, {
+              lenketekst: "Github",
+              destinasjon: gitConfig.git,
+              lenkegruppe: "komponent-header",
             })
           }
           data-color="neutral"
@@ -72,9 +74,10 @@ function KomponentLinks({
           rel="noreferrer noopener"
           href={data.figma_link}
           onClick={() =>
-            umamiTrack("navigere", {
-              kilde: "komponent-header",
-              url: data.figma_link ?? "",
+            umamiTrack(Events.NAVIGERE, {
+              lenketekst: "Figma",
+              destinasjon: data.figma_link ?? "",
+              lenkegruppe: "komponent-header",
             })
           }
           data-color="neutral"
@@ -86,9 +89,10 @@ function KomponentLinks({
         href={`/grunnleggende/endringslogg${heading ? `?fritekst=${removeEmojiesFromText(heading).trim()}` : ""}`}
         data-color="neutral"
         onClick={() =>
-          umamiTrack("navigere", {
-            kilde: "komponent-header",
-            url: `/grunnleggende/endringslogg`,
+          umamiTrack(Events.NAVIGERE, {
+            lenketekst: "Endringslogg",
+            destinasjon: `/grunnleggende/endringslogg`,
+            lenkegruppe: "komponent-header",
           })
         }
       >

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/icon-page/IconPage.form.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/icon-page/IconPage.form.tsx
@@ -25,7 +25,6 @@ function IconPageForm({
           params.set("iconQuery", query);
           umamiTrack(Events.SOK, {
             tekst: "ikonsøk",
-            sokefrase: query,
             seksjon: "ikonside",
           });
         } else {

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/icon-page/IconPage.form.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/icon-page/IconPage.form.tsx
@@ -2,7 +2,9 @@
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
+import { Events } from "@navikt/analytics-types";
 import { HGrid, Search, ToggleGroup, debounce } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 
 function IconPageForm({
   iconToggle,
@@ -21,6 +23,11 @@ function IconPageForm({
         const params = new URLSearchParams(searchParams?.toString());
         if (query && query.length > 2) {
           params.set("iconQuery", query);
+          umamiTrack(Events.SOK, {
+            tekst: "ikonsøk",
+            sokefrase: query,
+            seksjon: "ikonside",
+          });
         } else {
           params.delete("iconQuery");
         }
@@ -33,6 +40,11 @@ function IconPageForm({
     const params = new URLSearchParams(searchParams?.toString());
     if (query) {
       params.set("iconToggle", query);
+      umamiTrack(Events.FILTERVALG, {
+        kategori: "ikonvariant",
+        filternavn: query,
+        seksjon: "ikonside",
+      });
     } else {
       params.delete("iconToggle");
     }

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/icon-page/IconPage.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/icon-page/IconPage.tsx
@@ -3,6 +3,7 @@
 import * as Icons from "@navikt/aksel-icons";
 import { BrailleIcon, DownloadIcon } from "@navikt/aksel-icons";
 import meta from "@navikt/aksel-icons/metadata";
+import { Events } from "@navikt/analytics-types";
 import {
   BodyLong,
   Box,
@@ -62,9 +63,11 @@ function IconPage({
               href="https://www.figma.com/community/file/1214869602572392330"
               data-color="neutral"
               onClick={() =>
-                umamiTrack("navigere", {
-                  kilde: "ikonside",
-                  url: "https://www.figma.com/community/file/1214869602572392330",
+                umamiTrack(Events.NAVIGERE, {
+                  lenketekst: "Figma",
+                  destinasjon:
+                    "https://www.figma.com/community/file/1214869602572392330",
+                  lenkegruppe: "ikonside",
                 })
               }
             >
@@ -78,9 +81,10 @@ function IconPage({
               href="/god-praksis/artikler/tilgjengelig-ikonbruk"
               data-color="neutral"
               onClick={() =>
-                umamiTrack("navigere", {
-                  kilde: "ikonside",
-                  url: "/god-praksis/artikler/tilgjengelig-ikonbruk",
+                umamiTrack(Events.NAVIGERE, {
+                  lenketekst: "Tilgjengelighet",
+                  destinasjon: "/god-praksis/artikler/tilgjengelig-ikonbruk",
+                  lenkegruppe: "ikonside",
                 })
               }
             >
@@ -94,7 +98,7 @@ function IconPage({
               href="https://cdn.nav.no/aksel/icons/zip/aksel-icons.zip"
               download="Ikonpakke"
               onClick={() =>
-                umamiTrack("last ned", {
+                umamiTrack(Events.LAST_NED, {
                   tema: "ikon",
                   type: "zip",
                   tittel: "ikonpakke",

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/sidebar/Sidebar.item.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/sidebar/Sidebar.item.tsx
@@ -3,6 +3,7 @@
 import { stegaClean } from "next-sanity";
 import { usePathname } from "next/navigation";
 import { SquareGridFillIcon, SquareGridIcon } from "@navikt/aksel-icons";
+import { Events } from "@navikt/analytics-types";
 import { BodyShort, HStack, Tag } from "@navikt/ds-react";
 import { useMobileNav } from "@/app/_ui/mobile-nav/MobileNav.provider";
 import { NextLink } from "@/app/_ui/next-link/NextLink";
@@ -53,9 +54,10 @@ function DesignsystemSidebarItem(props: {
         data-current={active}
         aria-current={active ? "page" : undefined}
         onClick={() =>
-          umamiTrack("navigere", {
-            kilde: "sidebar",
-            url: `/${page.slug}`,
+          umamiTrack(Events.NAVIGERE, {
+            lenketekst: page.heading,
+            destinasjon: `/${page.slug}`,
+            lenkegruppe: "sidebar",
           })
         }
       >

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/sidebar/Sidebar.subnav.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/_ui/sidebar/Sidebar.subnav.tsx
@@ -4,6 +4,7 @@ import { stegaClean } from "next-sanity";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { ChevronDownIcon } from "@navikt/aksel-icons";
+import { Events } from "@navikt/analytics-types";
 import { HStack } from "@navikt/ds-react";
 import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { SidebarGroupedPagesT } from "@/types";
@@ -32,8 +33,9 @@ function DesignsystemSidebarSubNav(
         type="button"
         onClick={() => {
           setOpen(!open);
-          umamiTrack("sidebar-subnav", {
-            kategori: title,
+          umamiTrack(Events.FILTERVALG, {
+            kategori: "sidebar",
+            filternavn: title,
           });
         }}
         className={`${styles.navListSubButton} ${styles.navListNotch}`}

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/FilterGroup.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/FilterGroup.tsx
@@ -1,6 +1,8 @@
 // import { usePathname, useRouter, useSearchParams } from "next/navigation";
 // import { startTransition, useOptimistic } from "react";
+import { Events } from "@navikt/analytics-types";
 import { Chips, Label, VStack } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { capitalizeText } from "@/ui-utils/format-text";
 
 export default function FilterGroup({
@@ -54,6 +56,11 @@ export default function FilterGroup({
               onClick={() => {
                 if (selected !== option) {
                   setSelected(option);
+                  umamiTrack(Events.FILTERVALG, {
+                    kategori: label,
+                    filternavn: option,
+                    seksjon: "endringslogg",
+                  });
                 } else {
                   setSelected("");
                 }

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/FilterGroup.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/FilterGroup.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // import { usePathname, useRouter, useSearchParams } from "next/navigation";
 // import { startTransition, useOptimistic } from "react";
 import { Events } from "@navikt/analytics-types";

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
@@ -33,7 +33,6 @@ export default function SearchField({
     onSearch();
     umamiTrack(Events.SOK, {
       tekst: "endringslogg søk",
-      sokefrase: searchInput,
       seksjon: "endringslogg",
     });
   }

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/SearchField.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Dispatch, SetStateAction } from "react";
+import { Events } from "@navikt/analytics-types";
 import {
   BodyLong,
   Checkbox,
@@ -11,6 +12,7 @@ import {
   VStack,
 } from "@navikt/ds-react";
 import { Code } from "@/app/_ui/typography/Code";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import styles from "./SearchField.module.css";
 
 export default function SearchField({
@@ -29,6 +31,11 @@ export default function SearchField({
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     onSearch();
+    umamiTrack(Events.SOK, {
+      tekst: "endringslogg søk",
+      sokefrase: searchInput,
+      seksjon: "endringslogg",
+    });
   }
 
   return (

--- a/aksel.nav.no/website/app/(routes)/(god-praksis)/_ui/chips-navigation/ChipsNavigation.button.tsx
+++ b/aksel.nav.no/website/app/(routes)/(god-praksis)/_ui/chips-navigation/ChipsNavigation.button.tsx
@@ -2,6 +2,7 @@
 
 import { stegaClean } from "next-sanity";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Events } from "@navikt/analytics-types";
 import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import styles from "./ChipsNavigation.module.css";
 
@@ -38,10 +39,10 @@ function GodPrakisChipsNavigationButton(props: GpChipNavigationButtonProps) {
       params.set(type, title);
     }
 
-    umamiTrack("god-praksis-chip", {
-      kilde: "sidebar",
-      type: props.type,
-      url: pathname ?? undefined,
+    umamiTrack(Events.FILTERVALG, {
+      kategori: props.type,
+      filternavn: title,
+      seksjon: "god praksis",
     });
 
     push(getHref(), { scroll: false });

--- a/aksel.nav.no/website/app/(routes)/(god-praksis)/_ui/feedback/GodPraksisFeedback.parts.tsx
+++ b/aksel.nav.no/website/app/(routes)/(god-praksis)/_ui/feedback/GodPraksisFeedback.parts.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/dist/client/components/navigation";
 import { useState, useTransition } from "react";
 import { PersonIcon } from "@navikt/aksel-icons";
+import { Events } from "@navikt/analytics-types";
 import {
   BodyLong,
   BodyShort,
@@ -92,9 +93,8 @@ function GodPraksisFeedbackForm({
           error: "Noe gikk galt ved innsending, ta kontakt med team Aksel",
         });
 
-        umamiTrack("skjema validering feilet", {
+        umamiTrack(Events.SKJEMA_VALIDERING_FEILET, {
           skjemanavn: "slack-feedback",
-          skjemaId: docId,
         });
 
         return;
@@ -120,9 +120,8 @@ function GodPraksisFeedbackForm({
           error: result.error,
         });
 
-        umamiTrack("skjema validering feilet", {
+        umamiTrack(Events.SKJEMA_VALIDERING_FEILET, {
           skjemanavn: "slack-feedback",
-          skjemaId: docId,
         });
         return;
       }
@@ -132,9 +131,8 @@ function GodPraksisFeedbackForm({
         error: null,
       });
 
-      umamiTrack("skjema fullfort", {
+      umamiTrack(Events.SKJEMA_FULLFORT, {
         skjemanavn: "slack-feedback",
-        skjemaId: docId,
       });
     });
   };

--- a/aksel.nav.no/website/app/(routes)/(god-praksis)/_ui/hero/Hero.provider.tsx
+++ b/aksel.nav.no/website/app/(routes)/(god-praksis)/_ui/hero/Hero.provider.tsx
@@ -7,7 +7,9 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { Events } from "@navikt/analytics-types";
 import { Box } from "@navikt/ds-react";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { useEscapeKeydown } from "@/hooks/useEscapeKeydown";
 import styles from "./Hero.module.css";
 
@@ -60,6 +62,7 @@ function GodPraksisHeroProvider(props: GodPraksisHeroProviderProps) {
         y: e.currentTarget.offsetTop + rect.height / 2,
       });
       setOpenDialog(true);
+      umamiTrack(Events.MODAL_APNET, { tittel: "Tema" });
 
       // Since we cant focus elements inside `display: none` elements, we need to
       // wait for the dialog to be open before we focus the close button
@@ -73,6 +76,7 @@ function GodPraksisHeroProvider(props: GodPraksisHeroProviderProps) {
 
   const handleClose = useCallback(() => {
     setOpenDialog(false);
+    umamiTrack(Events.MODAL_LUKKET, { tittel: "Tema" });
     setTimeout(() => openDialogButton?.focus());
   }, [openDialogButton]);
 

--- a/aksel.nav.no/website/app/(routes)/(root)/_ui/FrontpageMasonryCard.tsx
+++ b/aksel.nav.no/website/app/(routes)/(root)/_ui/FrontpageMasonryCard.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { Events } from "@navikt/analytics-types";
 import { Tag as DsTag, HStack, LinkCard, VStack } from "@navikt/ds-react";
 import {
   LinkCardAnchor,
@@ -105,9 +106,10 @@ const Card = ({ article, visible }: CardProps) => {
         <LinkCardAnchor asChild>
           <NextLink
             onNavigate={() =>
-              umamiTrack("navigere", {
-                kilde: "forsidekort",
-                url: `/${article.slug}`,
+              umamiTrack(Events.NAVIGERE, {
+                lenketekst: article.heading ?? "",
+                destinasjon: `/${article.slug}`,
+                lenkegruppe: "forsidekort",
               })
             }
             href={`/${article.slug}`}

--- a/aksel.nav.no/website/app/(routes)/(root)/_ui/FrontpageMasonryCard.tsx
+++ b/aksel.nav.no/website/app/(routes)/(root)/_ui/FrontpageMasonryCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import { Events } from "@navikt/analytics-types";
 import { Tag as DsTag, HStack, LinkCard, VStack } from "@navikt/ds-react";

--- a/aksel.nav.no/website/app/(routes)/(root)/_ui/GpFrontpageCard.tsx
+++ b/aksel.nav.no/website/app/(routes)/(root)/_ui/GpFrontpageCard.tsx
@@ -43,7 +43,7 @@ const GpFrontpageCard = ({ image, children, href }: GpFrontpageCardProps) => {
           </svg>
         )}
       </Box>
-      <UmamiLink href={href} umamiKilde="God Praksis Forside">
+      <UmamiLink href={href} lenkegruppe="God Praksis Forside">
         {children}
       </UmamiLink>
     </HStack>

--- a/aksel.nav.no/website/app/(routes)/(root)/_ui/HighlightedArticle.tsx
+++ b/aksel.nav.no/website/app/(routes)/(root)/_ui/HighlightedArticle.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import NextImage from "next/image";
 import { Events } from "@navikt/analytics-types";
 import {

--- a/aksel.nav.no/website/app/(routes)/(root)/_ui/HighlightedArticle.tsx
+++ b/aksel.nav.no/website/app/(routes)/(root)/_ui/HighlightedArticle.tsx
@@ -1,4 +1,5 @@
 import NextImage from "next/image";
+import { Events } from "@navikt/analytics-types";
 import {
   BodyLong,
   Tag as DsTag,
@@ -135,9 +136,10 @@ export const Highlight = ({
           <Link
             as={NextLink}
             onClick={() =>
-              umamiTrack("navigere", {
-                kilde: "global sok",
-                url: `/${article.slug}`,
+              umamiTrack(Events.NAVIGERE, {
+                lenketekst: article?.heading ?? "",
+                destinasjon: `/${article.slug}`,
+                lenkegruppe: "fremhevet artikkel",
               })
             }
             href={`/${article.slug}`}

--- a/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
+++ b/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
@@ -3,8 +3,10 @@
 import { Highlight } from "prism-react-renderer";
 import { useId, useRef } from "react";
 import { ChevronDownUpIcon, ChevronUpDownIcon } from "@navikt/aksel-icons";
+import { Events } from "@navikt/analytics-types";
 import { Button, CopyButton, HStack, Spacer, Tabs } from "@navikt/ds-react";
 import { TabsList, TabsPanel, TabsTab } from "@navikt/ds-react/Tabs";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import styles from "./CodeBlock.module.css";
 import {
   CodeBlockProvider,
@@ -45,7 +47,17 @@ function CodeBlockView(props: React.HTMLAttributes<HTMLDivElement>) {
         className={styles.codeBlock}
         {...props}
       >
-        <Tabs defaultValue={tabs[0].value ?? ""} onChange={codeSnippet.update}>
+        <Tabs
+          defaultValue={tabs[0].value ?? ""}
+          onChange={(value) => {
+            codeSnippet.update(value);
+            const tab = tabs.find((t) => t.value === value);
+            umamiTrack(Events.FANE_BYTTET, {
+              tilFane: value,
+              tilFaneTekst: tab?.text ?? value,
+            });
+          }}
+        >
           <CodeBlockHeader />
           {tabs?.map((tab) => (
             <CodeBlockEditor
@@ -257,7 +269,13 @@ function ActionButtons() {
         }
       />
       {codeSnippet.current && (
-        <CopyButton copyText={codeSnippet.current} size="small" />
+        <CopyButton
+          copyText={codeSnippet.current}
+          size="small"
+          onCopy={() =>
+            umamiTrack(Events.TEKST_KOPIERT, { tekst: "kodeblokk" })
+          }
+        />
       )}
     </HStack>
   );

--- a/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
+++ b/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
@@ -272,7 +272,7 @@ function ActionButtons() {
         <CopyButton
           copyText={codeSnippet.current}
           size="small"
-          onCopy={() =>
+          onClick={() =>
             umamiTrack(Events.TEKST_KOPIERT, { tekst: "kodeblokk" })
           }
         />

--- a/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.button.tsx
+++ b/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.button.tsx
@@ -2,8 +2,10 @@
 
 import { type ButtonHTMLAttributes, forwardRef } from "react";
 import { MagnifyingGlassIcon } from "@navikt/aksel-icons";
+import { Events } from "@navikt/analytics-types";
 import { Bleed, Button, Detail, Dialog, HStack, Show } from "@navikt/ds-react";
 import { Kbd } from "@/app/_ui/kbd/Kbd";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import styles from "./GlobalSearch.module.css";
 
 /**
@@ -30,13 +32,17 @@ function GlobalSearchButton({
 const SearchButton = forwardRef<
   HTMLButtonElement,
   ButtonHTMLAttributes<HTMLButtonElement> & { isMac: boolean }
->(({ isMac, ...rest }, forwardedRef) => {
+>(({ isMac, onClick, ...rest }, forwardedRef) => {
   return (
     <Button
       {...rest}
       ref={forwardedRef}
       variant="secondary-neutral"
       aria-keyshortcuts={isMac ? "Meta+k" : "Control+k"}
+      onClick={(e) => {
+        umamiTrack(Events.MODAL_APNET, { tittel: "Søk" });
+        onClick?.(e);
+      }}
     >
       <Bleed asChild marginInline={{ xs: "space-8", md: "space-8 space-0" }}>
         <HStack gap="space-6" align="center" as="span">

--- a/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.hit.tsx
+++ b/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.hit.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import React from "react";
+import { Events } from "@navikt/analytics-types";
 import { Heading } from "@navikt/ds-react";
 import {
   useGlobalSearch,
@@ -74,7 +75,11 @@ function GlobalSearchLink(props: {
             as={NextLink}
             href={href}
             onClick={() =>
-              umamiTrack("navigere", { kilde: "global sok", url: href })
+              umamiTrack(Events.NAVIGERE, {
+                lenketekst: hit.item.heading,
+                destinasjon: href,
+                lenkegruppe: "globalt søk",
+              })
             }
             onNavigate={() => {
               context.closeSearch();

--- a/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.provider.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   useTransition,
 } from "react";
+import { Events } from "@navikt/analytics-types";
 import { debounce } from "@navikt/ds-react";
 import {
   type GlobalSearchActionReturnT,
@@ -38,7 +39,7 @@ function GlobalSearchResultProvider({
       debounce((query: string) => {
         maybeEnableComicSans(query);
 
-        umamiTrack("sok", {});
+        umamiTrack(Events.SOK, { sokefrase: query });
         setParam(query);
       }, 200),
     [setParam],

--- a/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/global-search/GlobalSearch.provider.tsx
@@ -39,7 +39,7 @@ function GlobalSearchResultProvider({
       debounce((query: string) => {
         maybeEnableComicSans(query);
 
-        umamiTrack(Events.SOK, { sokefrase: query });
+        umamiTrack(Events.SOK, { tekst: "global søk" });
         setParam(query);
       }, 200),
     [setParam],

--- a/aksel.nav.no/website/app/_ui/header/Header.link.tsx
+++ b/aksel.nav.no/website/app/_ui/header/Header.link.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import { Events } from "@navikt/analytics-types";
 import { NextLink } from "@/app/_ui/next-link/NextLink";
 import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import styles from "./Header.module.css";
@@ -36,7 +37,13 @@ function HeaderLink({ name, href }: HeaderLinkProps) {
       data-current={active}
       aria-current={active ? true : undefined}
       className={styles.headerLink}
-      onClick={() => umamiTrack("navigere", { kilde: "header", url: href })}
+      onClick={() =>
+        umamiTrack(Events.NAVIGERE, {
+          lenketekst: name,
+          destinasjon: href,
+          lenkegruppe: "header",
+        })
+      }
     >
       {name}
     </NextLink>

--- a/aksel.nav.no/website/app/_ui/relatert-innhold/RelatertInnhold.link.tsx
+++ b/aksel.nav.no/website/app/_ui/relatert-innhold/RelatertInnhold.link.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Events } from "@navikt/analytics-types";
 import { Link } from "@navikt/ds-react";
 import { NextLink } from "@/app/_ui/next-link/NextLink";
 import { umamiTrack } from "@/app/_ui/umami/Umami.track";
@@ -16,9 +17,9 @@ function RelatertInnholdLink({
       as={NextLink}
       href={href}
       onClick={() =>
-        umamiTrack("navigere", {
-          kilde: "relatert innhold",
-          url: href,
+        umamiTrack(Events.NAVIGERE, {
+          lenketekst: "relatert innhold",
+          destinasjon: href,
         })
       }
       variant="neutral"

--- a/aksel.nav.no/website/app/_ui/toc/TableOfContents.tsx
+++ b/aksel.nav.no/website/app/_ui/toc/TableOfContents.tsx
@@ -2,6 +2,7 @@
 
 import { stegaClean } from "next-sanity";
 import { SparklesIcon } from "@navikt/aksel-icons";
+import { Events } from "@navikt/analytics-types";
 import { BodyShort, Button, Detail } from "@navikt/ds-react";
 import { TOC_BY_SLUG_QUERY_RESULT } from "@/app/_sanity/query-types";
 import { NextLink } from "@/app/_ui/next-link/NextLink";
@@ -74,9 +75,12 @@ function TableOfContents({
                   href={`#${node.id}`}
                   onClick={() => {
                     tocCtx.setActiveId(node.id);
-                    umamiTrack("navigere", {
-                      kilde: "toc",
-                      url: `#${node.id}`,
+                    umamiTrack(Events.NAVIGERE, {
+                      lenketekst: removeEmojiesFromText(
+                        stegaClean(node.title),
+                      ).trim(),
+                      destinasjon: `#${node.id}`,
+                      lenkegruppe: "innholdsfortegnelse",
                     });
                   }}
                   className={cl(styles.tocNavListItemLink, {
@@ -112,7 +116,12 @@ function TableOfContentsLinks({
         size="small"
         icon={<SparklesIcon aria-hidden />}
         href={`https://github.com/navikt/aksel/issues/new?labels=foresp%C3%B8rsel+%F0%9F%A5%B0%2Ckomponenter+%F0%9F%A7%A9&template=update-component.yml&title=%5BInnspill%5D%20${feedback.name}`}
-        onClick={() => umamiTrack("feedback-designsystem", { kilde: "toc" })}
+        onClick={() =>
+          umamiTrack(Events.KNAPP_KLIKKET, {
+            tekst: feedback.text,
+            seksjon: "innholdsfortegnelse",
+          })
+        }
         target="_blank"
         rel="noreferrer"
       >

--- a/aksel.nav.no/website/app/_ui/typography/WebsiteLink.tsx
+++ b/aksel.nav.no/website/app/_ui/typography/WebsiteLink.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { Events } from "@navikt/analytics-types";
 import { Link } from "@navikt/ds-react";
 import { NextLink } from "@/app/_ui/next-link/NextLink";
 import { umamiTrack } from "@/app/_ui/umami/Umami.track";
@@ -20,7 +21,11 @@ function WebsiteLink({ href, children }: Props) {
       href={href}
       inlineText
       onClick={() =>
-        umamiTrack("navigere", { kilde: "inline lenke", url: href })
+        umamiTrack(Events.NAVIGERE, {
+          lenketekst: typeof children === "string" ? children : href,
+          destinasjon: href,
+          lenkegruppe: "inline lenke",
+        })
       }
       {...(isOutbound
         ? {

--- a/aksel.nav.no/website/app/_ui/umami/Umami.track.ts
+++ b/aksel.nav.no/website/app/_ui/umami/Umami.track.ts
@@ -1,16 +1,19 @@
-type UmamiNavigationProps = {
-  kilde: string;
-  url: string;
-};
+import {
+  type EventName,
+  type EventPropertiesMap,
+} from "@navikt/analytics-types";
 
-type UmamiTrackDefaultProps = Record<string, string | undefined> | undefined;
-
-function umamiTrack<T extends `navigere` | string>(
+// Overload 1: taxonomy event — fully typed
+function umamiTrack<T extends EventName>(
   event: T,
-  data: T extends "navigere" ? UmamiNavigationProps : UmamiTrackDefaultProps,
-): void {
+  properties: EventPropertiesMap[T],
+): void;
+// Overload 2: custom/non-taxonomy event — loose typing
+function umamiTrack(event: string, properties?: Record<string, unknown>): void;
+
+function umamiTrack(event: string, properties?: Record<string, unknown>): void {
   if (typeof window !== "undefined" && window.umami) {
-    window.umami.track(event, data);
+    window.umami.track(event, properties);
   }
 }
 

--- a/aksel.nav.no/website/app/_ui/umami/Umami.tsx
+++ b/aksel.nav.no/website/app/_ui/umami/Umami.tsx
@@ -6,7 +6,7 @@ import { useCookieConsent } from "@/app/_ui/cookie-consent/CookieConsent.Provide
 import { IS_NEXT_SERVERSIDE } from "@/ui-utils/is-server";
 
 const trackingId = process.env.UMAMI_TRACKING_ID;
-const hostUrl = process.env.UMAMI_HOST_URL;
+const isProduction = process.env.PRODUCTION === "true";
 
 type UmamiTag = "organic" | "polluted";
 
@@ -33,11 +33,14 @@ function Umami({ isDraftMode = false }: { isDraftMode?: boolean }) {
     return null;
   }
 
+  const sporingScript = isProduction
+    ? "https://cdn.nav.no/team-researchops/sporing/sporing.js"
+    : "https://cdn.nav.no/team-researchops/sporing/sporing-dev.js";
+
   return (
     <Script
       defer
-      src="https://cdn.nav.no/team-researchops/sporing/sporing.js"
-      data-host-url={hostUrl}
+      src={sporingScript}
       data-website-id={trackingId}
       data-tag={umamiTag}
       data-exclude-search="true"

--- a/aksel.nav.no/website/app/_ui/umami/UmamiLink.tsx
+++ b/aksel.nav.no/website/app/_ui/umami/UmamiLink.tsx
@@ -8,16 +8,20 @@ import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import styles from "./UmamiLink.module.css";
 
 export const UmamiLink = ({
-  umamiKilde,
+  lenkegruppe,
   ...props
-}: LinkProps & { umamiKilde: string }) => {
+}: LinkProps & { lenkegruppe: string }) => {
   return (
     <Link
       {...props}
       onClick={() =>
         umamiTrack(Events.NAVIGERE, {
-          lenketekst: stegaClean(umamiKilde),
+          lenketekst:
+            typeof props.children === "string"
+              ? stegaClean(props.children)
+              : stegaClean(props.href)!,
           destinasjon: stegaClean(props.href)!,
+          lenkegruppe: stegaClean(lenkegruppe),
         })
       }
       className={styles.umamiLink}

--- a/aksel.nav.no/website/app/_ui/umami/UmamiLink.tsx
+++ b/aksel.nav.no/website/app/_ui/umami/UmamiLink.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { stegaClean } from "next-sanity";
+import { Events } from "@navikt/analytics-types";
 import { Link, LinkProps } from "@navikt/ds-react";
 import { NextLink } from "@/app/_ui/next-link/NextLink";
 import { umamiTrack } from "@/app/_ui/umami/Umami.track";
@@ -14,9 +15,9 @@ export const UmamiLink = ({
     <Link
       {...props}
       onClick={() =>
-        umamiTrack("navigere", {
-          kilde: stegaClean(umamiKilde),
-          url: stegaClean(props.href)!,
+        umamiTrack(Events.NAVIGERE, {
+          lenketekst: stegaClean(umamiKilde),
+          destinasjon: stegaClean(props.href)!,
         })
       }
       className={styles.umamiLink}

--- a/aksel.nav.no/website/app/_ui/video/Video.tsx
+++ b/aksel.nav.no/website/app/_ui/video/Video.tsx
@@ -1,11 +1,8 @@
-"use client";
-
 import { useId } from "react";
-import { Events } from "@navikt/analytics-types";
 import { BodyLong, Box, ReadMore, VStack } from "@navikt/ds-react";
 import { ExtractPortableComponentProps } from "@/app/_sanity/types";
-import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import styles from "./Video.module.css";
+import { VideoPlayer } from "./VideoPlayer";
 
 function Video(props: ExtractPortableComponentProps<"video">) {
   const { webm, fallback, alt, caption, transkripsjon, track } = props.value;
@@ -19,8 +16,8 @@ function Video(props: ExtractPortableComponentProps<"video">) {
   /* https://www.w3.org/WAI/PF/HTML/wiki/Media_Alt_Technologies#1:_Use_.40aria-label_for_the_text_description_of_player */
   return (
     <VStack gap="space-8" data-block-margin="space-28">
-      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-      <video
+      <VideoPlayer
+        alt={alt}
         className={styles.video}
         title={alt}
         playsInline
@@ -29,8 +26,6 @@ function Video(props: ExtractPortableComponentProps<"video">) {
         aria-describedby={transkripsjon ? transcriptId : undefined}
         poster="/images/og/video-poster.png"
         crossOrigin="anonymous" // Needed for the <track>
-        onPlay={() => umamiTrack(Events.VIDEO_START, { tittel: alt })}
-        onPause={() => umamiTrack(Events.VIDEO_STOPP, { tittel: alt })}
       >
         {webm.url && (
           <source src={webm.url} type={`video/${webm?.extension}`} />
@@ -39,7 +34,7 @@ function Video(props: ExtractPortableComponentProps<"video">) {
           <source src={fallback.url} type={`video/${fallback.extension}`} />
         )}
         {track && <track kind="captions" srcLang="no" src={track} />}
-      </video>
+      </VideoPlayer>
       {caption && (
         <Box asChild paddingInline="space-16">
           <BodyLong as="figcaption">{caption}</BodyLong>

--- a/aksel.nav.no/website/app/_ui/video/Video.tsx
+++ b/aksel.nav.no/website/app/_ui/video/Video.tsx
@@ -1,6 +1,10 @@
+"use client";
+
 import { useId } from "react";
+import { Events } from "@navikt/analytics-types";
 import { BodyLong, Box, ReadMore, VStack } from "@navikt/ds-react";
 import { ExtractPortableComponentProps } from "@/app/_sanity/types";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import styles from "./Video.module.css";
 
 function Video(props: ExtractPortableComponentProps<"video">) {
@@ -25,6 +29,8 @@ function Video(props: ExtractPortableComponentProps<"video">) {
         aria-describedby={transkripsjon ? transcriptId : undefined}
         poster="/images/og/video-poster.png"
         crossOrigin="anonymous" // Needed for the <track>
+        onPlay={() => umamiTrack(Events.VIDEO_START, { tittel: alt })}
+        onPause={() => umamiTrack(Events.VIDEO_STOPP, { tittel: alt })}
       >
         {webm.url && (
           <source src={webm.url} type={`video/${webm?.extension}`} />

--- a/aksel.nav.no/website/app/_ui/video/VideoPlayer.tsx
+++ b/aksel.nav.no/website/app/_ui/video/VideoPlayer.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Events } from "@navikt/analytics-types";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
+
+type VideoPlayerProps = React.VideoHTMLAttributes<HTMLVideoElement> & {
+  alt: string;
+};
+
+/**
+ * We need a nested client-component for the video element to be able to track play/pause events with umami, without making the entire Video component a client component.
+ * Reason: If whole component was a client-component and then used inside a nested PortableText it ends up crashing.
+ * - Example: PortableText renders expansioncard -> video inside expansioncard -> crash
+ */
+function VideoPlayer({ alt, children, ...rest }: VideoPlayerProps) {
+  return (
+    // eslint-disable-next-line jsx-a11y/media-has-caption
+    <video
+      {...rest}
+      onPlay={() => umamiTrack(Events.VIDEO_START, { tittel: alt })}
+      onPause={() => umamiTrack(Events.VIDEO_STOPP, { tittel: alt })}
+    >
+      {children}
+    </video>
+  );
+}
+
+export { VideoPlayer };

--- a/aksel.nav.no/website/app/_ui/website-accordion/WebsiteAccordion.item.tsx
+++ b/aksel.nav.no/website/app/_ui/website-accordion/WebsiteAccordion.item.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { Events } from "@navikt/analytics-types";
 import {
   AccordionContent,
   AccordionHeader,
   AccordionItem,
 } from "@navikt/ds-react/Accordion";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 import { useWebsiteAccordion } from "./WebsiteAccordion.provider";
 
 function WebsiteAccordionItem({
@@ -20,7 +22,15 @@ function WebsiteAccordionItem({
   return (
     <AccordionItem
       open={currentOpen.includes(index)}
-      onOpenChange={() => openToggle(index)}
+      onOpenChange={() => {
+        const isOpen = currentOpen.includes(index);
+        openToggle(index);
+        if (isOpen) {
+          umamiTrack(Events.ACCORDION_LUKKET, { tittel: title });
+        } else {
+          umamiTrack(Events.ACCORDION_APNET, { tittel: title });
+        }
+      }}
     >
       <AccordionHeader>{title}</AccordionHeader>
       <AccordionContent>{children}</AccordionContent>

--- a/aksel.nav.no/website/app/_ui/website-expansioncard/WebsiteExpansionCard.tsx
+++ b/aksel.nav.no/website/app/_ui/website-expansioncard/WebsiteExpansionCard.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { PortableTextBlock, stegaClean } from "next-sanity";
+import { Events } from "@navikt/analytics-types";
 import {
   ExpansionCard,
   ExpansionCardContent,
@@ -8,6 +11,7 @@ import {
 } from "@navikt/ds-react/ExpansionCard";
 import { CustomPortableText } from "@/app/CustomPortableText";
 import { ExtractPortableComponentProps } from "@/app/_sanity/types";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
 
 const cardSize = {
   h2: "large",
@@ -29,6 +33,13 @@ function WebsiteExpansionCard(
       id="aksel-expansioncard"
       aria-label={heading}
       data-block-margin="space-28"
+      onToggle={(open) => {
+        if (open) {
+          umamiTrack(Events.UTVIDBART_KORT_APNET, { tittel: heading });
+        } else {
+          umamiTrack(Events.UTVIDBART_KORT_LUKKET, { tittel: heading });
+        }
+      }}
     >
       <ExpansionCardHeader>
         <ExpansionCardTitle

--- a/aksel.nav.no/website/app/_ui/website-expansioncard/WebsiteExpansionCard.tsx
+++ b/aksel.nav.no/website/app/_ui/website-expansioncard/WebsiteExpansionCard.tsx
@@ -1,9 +1,5 @@
-"use client";
-
 import { PortableTextBlock, stegaClean } from "next-sanity";
-import { Events } from "@navikt/analytics-types";
 import {
-  ExpansionCard,
   ExpansionCardContent,
   ExpansionCardDescription,
   ExpansionCardHeader,
@@ -11,7 +7,7 @@ import {
 } from "@navikt/ds-react/ExpansionCard";
 import { CustomPortableText } from "@/app/CustomPortableText";
 import { ExtractPortableComponentProps } from "@/app/_sanity/types";
-import { umamiTrack } from "@/app/_ui/umami/Umami.track";
+import { WebsiteExpansionCardTracked } from "./WebsiteExpansionCardTracked";
 
 const cardSize = {
   h2: "large",
@@ -29,18 +25,7 @@ function WebsiteExpansionCard(
   }
 
   return (
-    <ExpansionCard
-      id="aksel-expansioncard"
-      aria-label={heading}
-      data-block-margin="space-28"
-      onToggle={(open) => {
-        if (open) {
-          umamiTrack(Events.UTVIDBART_KORT_APNET, { tittel: heading });
-        } else {
-          umamiTrack(Events.UTVIDBART_KORT_LUKKET, { tittel: heading });
-        }
-      }}
-    >
+    <WebsiteExpansionCardTracked heading={heading}>
       <ExpansionCardHeader>
         <ExpansionCardTitle
           as={stegaClean(heading_level)}
@@ -55,7 +40,7 @@ function WebsiteExpansionCard(
       <ExpansionCardContent>
         <CustomPortableText value={body as PortableTextBlock[]} />
       </ExpansionCardContent>
-    </ExpansionCard>
+    </WebsiteExpansionCardTracked>
   );
 }
 

--- a/aksel.nav.no/website/app/_ui/website-expansioncard/WebsiteExpansionCardTracked.tsx
+++ b/aksel.nav.no/website/app/_ui/website-expansioncard/WebsiteExpansionCardTracked.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Events } from "@navikt/analytics-types";
+import { ExpansionCard } from "@navikt/ds-react/ExpansionCard";
+import { umamiTrack } from "@/app/_ui/umami/Umami.track";
+
+function WebsiteExpansionCardTracked({
+  heading,
+  children,
+}: {
+  heading: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <ExpansionCard
+      id="aksel-expansioncard"
+      aria-label={heading}
+      data-block-margin="space-28"
+      onToggle={(open) => {
+        if (open) {
+          umamiTrack(Events.UTVIDBART_KORT_APNET, { tittel: heading });
+        } else {
+          umamiTrack(Events.UTVIDBART_KORT_LUKKET, { tittel: heading });
+        }
+      }}
+    >
+      {children}
+    </ExpansionCard>
+  );
+}
+
+export { WebsiteExpansionCardTracked };

--- a/aksel.nav.no/website/next.config.ts
+++ b/aksel.nav.no/website/next.config.ts
@@ -25,7 +25,7 @@ const cspHeader = `
     frame-src 'self' localhost:3000 http://localhost:3000 https://localhost:3000 https://aksel.ansatt.dev.nav.no;
     media-src 'self' ${cdnUrl} cdn.sanity.io;
     img-src 'self' blob: data: cdn.sanity.io ${dekoratorUrl} https://avatars.githubusercontent.com data: ${cdnUrl};
-    connect-src 'self' ${dekoratorUrl} ${cdnUrl} ${tempChromaticRedirect} https://raw.githubusercontent.com/navikt/ https://hnbe3yhs.apicdn.sanity.io wss://hnbe3yhs.api.sanity.io cdn.sanity.io https://sanity-cdn.com *.api.sanity.io https://reops-event-proxy.nav.no https://main--66b4b3beb91603ed0ab5c45e.chromatic.com;
+    connect-src 'self' ${dekoratorUrl} ${cdnUrl} ${tempChromaticRedirect} https://raw.githubusercontent.com/navikt/ https://hnbe3yhs.apicdn.sanity.io wss://hnbe3yhs.api.sanity.io cdn.sanity.io https://sanity-cdn.com *.api.sanity.io https://reops-event-proxy.ekstern.dev.nav.no https://reops-event-proxy.nav.no https://main--66b4b3beb91603ed0ab5c45e.chromatic.com;
     ${isProduction ? "upgrade-insecure-requests;" : ""}
 `;
 
@@ -67,9 +67,6 @@ const nextConfig: NextConfig = {
     UMAMI_TRACKING_ID: isProduction
       ? "fb69e1e9-1bd3-4fd9-b700-9d035cbf44e1"
       : "7b9fb2cd-40f4-4a30-b208-5b4dba026b57",
-    UMAMI_HOST_URL: isProduction
-      ? "https://reops-event-proxy.nav.no"
-      : "https://reops-event-proxy.ekstern.dev.nav.no",
   },
   cacheHandler: require.resolve("./cache-handler.mjs"),
   cacheMaxMemorySize: 0,

--- a/aksel.nav.no/website/next.config.ts
+++ b/aksel.nav.no/website/next.config.ts
@@ -67,6 +67,7 @@ const nextConfig: NextConfig = {
     UMAMI_TRACKING_ID: isProduction
       ? "fb69e1e9-1bd3-4fd9-b700-9d035cbf44e1"
       : "7b9fb2cd-40f4-4a30-b208-5b4dba026b57",
+    PRODUCTION: isProduction ? "true" : "false",
   },
   cacheHandler: require.resolve("./cache-handler.mjs"),
   cacheMaxMemorySize: 0,

--- a/aksel.nav.no/website/package.json
+++ b/aksel.nav.no/website/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@floating-ui/react": "0.27.8",
+    "@navikt/analytics-types": "0.0.7",
     "@navikt/next-logger": "4.4.1",
     "@navikt/oasis": "3.2.1",
     "@neshca/cache-handler": "1.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4856,6 +4856,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@navikt/analytics-types@npm:0.0.7":
+  version: 0.0.7
+  resolution: "@navikt/analytics-types@npm:0.0.7::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fanalytics-types%2F0.0.7%2F5fc7a2c116b8ce4cd8ae8e9cea57788399824c25"
+  checksum: 10/47d228e8dca960bd3fd802fbf39990120b5665240bd3bbaa332702dd384a2e01b495269ff66e8ac9076306fb210ffbf674b542a60bbc57775584a7ae73fa50fd
+  languageName: node
+  linkType: hard
+
 "@navikt/ds-css@npm:*, @navikt/ds-css@npm:^8.9.1, @navikt/ds-css@workspace:@navikt/core/css":
   version: 0.0.0-use.local
   resolution: "@navikt/ds-css@workspace:@navikt/core/css"
@@ -25590,6 +25597,7 @@ __metadata:
     "@babel/parser": "npm:^7.27.5"
     "@babel/traverse": "npm:^7.27.4"
     "@floating-ui/react": "npm:0.27.8"
+    "@navikt/analytics-types": "npm:0.0.7"
     "@navikt/next-logger": "npm:4.4.1"
     "@navikt/oasis": "npm:3.2.1"
     "@neshca/cache-handler": "npm:1.9.0"


### PR DESCRIPTION
some changes to our tracking script setup. Now we have a sporing-dev.js as well as a sporing.js, we want simple hard separation between dev and prod tracking data 🙌

legger også til en commit i samme PR som legger på litt flere custom tracking events + bruke taksonomi pakken vår ^^, disse kan lett revertes, "hoved commit" er den første som bruker sporing-dev scriptet :)

noen av tracking eventene blir renamed da (for å følge taksonomien), om dere bruker disse dataene mye og historikken betyr noe, så kan de gamle beholdes tenker jeg 🤔 (litt dumt å miste tracking data i disse tilfellene uten mye gevinst).

Så blir det spennende å sjekke ut nye custom tracking events her: https://innblikk.ansatt.nav.no/utforsk-hendelser?period=last_28_days&websiteId=fb69e1e9-1bd3-4fd9-b700-9d035cbf44e1&domain=aksel.nav.no&pathOperator=equals&urlPath=%2F 🤩 

også burde da funke for dev (var visst bare en CSP header som hindret trafikk til dev miljøet 😅 ), også i første commit