### PR TITLE
:bug: Make sure text-variant for Skeleton has properly rounded edges

### DIFF
--- a/.changeset/forty-views-pull.md
+++ b/.changeset/forty-views-pull.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Skeleton: Text-variant now has properly rounded edges

--- a/@navikt/core/css/src/skeleton.css
+++ b/@navikt/core/css/src/skeleton.css
@@ -27,9 +27,7 @@
 
 .aksel-skeleton--text {
   height: auto;
-  transform-origin: 0 55%;
-  transform: scale(1, 0.6);
-  border-radius: var(--ax-radius-8);
+  clip-path: inset(20% 0 round var(--ax-radius-4));
 
   &:empty::before {
     content: "\00a0";


### PR DESCRIPTION
### Description

Before and after
<img width="143" height="181" alt="Screenshot 2026-04-14 at 14 39 16" src="https://github.com/user-attachments/assets/0c860d56-b518-49a9-877c-c55ff0022f56" />
<img width="97" height="165" alt="Screenshot 2026-04-14 at 14 39 23" src="https://github.com/user-attachments/assets/66d513ed-451d-4241-8f10-e90ae1c75070" />


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
