### PR TITLE
[Timeline] Enhance keyboard navigation, optimize pin interactions, period-scaling

### DIFF
--- a/.changeset/lovely-melons-shake.md
+++ b/.changeset/lovely-melons-shake.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": minor
+---
+
+Timeline: Added keyboard-navigation support between rows and periods

--- a/.changeset/purple-singers-wink.md
+++ b/.changeset/purple-singers-wink.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Timeline: Icons in periods now scale based on avaliable space. No longer clips on smaller periods

--- a/@navikt/core/css/src/timeline.css
+++ b/@navikt/core/css/src/timeline.css
@@ -73,6 +73,7 @@
 }
 
 .aksel-timeline__period {
+  container-type: inline-size;
   height: 100%;
   border-radius: var(--ax-radius-full);
   position: absolute;
@@ -98,7 +99,7 @@
 }
 
 .aksel-timeline__period--inner {
-  margin: 0 var(--ax-space-8);
+  margin: 0 clamp(var(--ax-space-4), 17cqi, var(--ax-space-8));
   overflow: hidden;
   white-space: nowrap;
   text-overflow: clip;
@@ -109,6 +110,12 @@
 
 .aksel-timeline__period--inner svg {
   flex-shrink: 0;
+}
+
+@container (inline-size < 1.5rem) {
+  .aksel-timeline__period--inner svg {
+    display: none;
+  }
 }
 
 .aksel-timeline__period--clickable {

--- a/@navikt/core/css/src/timeline.css
+++ b/@navikt/core/css/src/timeline.css
@@ -109,12 +109,12 @@
 }
 
 .aksel-timeline__period--inner svg {
-  flex-shrink: 0;
+  flex-shrink: 1;
 }
 
-@container (inline-size < 1.5rem) {
-  .aksel-timeline__period--inner svg {
-    display: none;
+@container (inline-size < 1.4rem) {
+  .aksel-timeline__period--inner {
+    margin: 0 10cqi;
   }
 }
 

--- a/@navikt/core/react/src/timeline/Timeline.tests.stories.tsx
+++ b/@navikt/core/react/src/timeline/Timeline.tests.stories.tsx
@@ -1,0 +1,181 @@
+import type { StoryObj } from "@storybook/react-vite";
+import React from "react";
+import { expect, userEvent } from "storybook/test";
+import Timeline from "./Timeline";
+
+export default {
+  title: "ds-react/Timeline/Tests",
+  component: Timeline,
+  parameters: { chromatic: { disable: true } },
+  tags: ["play-fn"],
+};
+
+type Story = StoryObj<typeof Timeline>;
+
+function getPeriodsInRow(canvasElement: HTMLElement, rowIndex: number) {
+  const rows = canvasElement.querySelectorAll<HTMLElement>(
+    "[data-timeline-row]",
+  );
+  return rows[rowIndex].querySelectorAll<HTMLElement>("[data-timeline-period]");
+}
+
+function getAllPins(canvasElement: HTMLElement) {
+  return canvasElement.querySelectorAll<HTMLElement>("[data-timeline-pin]");
+}
+
+function TwoRowTimeline() {
+  return (
+    <div style={{ width: "80vw" }}>
+      <Timeline
+        startDate={new Date("Jan 1 2022")}
+        endDate={new Date("Dec 31 2022")}
+      >
+        <Timeline.Row label="Row 1">
+          <Timeline.Period
+            start={new Date("Jan 1 2022")}
+            end={new Date("Jan 31 2022")}
+            status="success"
+          />
+          <Timeline.Period
+            start={new Date("May 1 2022")}
+            end={new Date("May 31 2022")}
+            status="warning"
+          />
+          <Timeline.Period
+            start={new Date("Sep 1 2022")}
+            end={new Date("Sep 30 2022")}
+            status="danger"
+          />
+        </Timeline.Row>
+        <Timeline.Row label="Row 2">
+          <Timeline.Period
+            start={new Date("Mar 1 2022")}
+            end={new Date("Mar 31 2022")}
+            status="neutral"
+          />
+          <Timeline.Period
+            start={new Date("Jul 1 2022")}
+            end={new Date("Jul 31 2022")}
+            status="info"
+          />
+        </Timeline.Row>
+      </Timeline>
+    </div>
+  );
+}
+
+function TwoRowTimelineWithPins() {
+  return (
+    <div style={{ width: "80vw" }}>
+      <Timeline
+        startDate={new Date("Jan 1 2022")}
+        endDate={new Date("Dec 31 2022")}
+      >
+        <Timeline.Pin date={new Date("Apr 1 2022")}>Pin A</Timeline.Pin>
+        <Timeline.Pin date={new Date("Aug 1 2022")}>Pin B</Timeline.Pin>
+        <Timeline.Row label="Row 1">
+          <Timeline.Period
+            start={new Date("Jan 1 2022")}
+            end={new Date("Jan 31 2022")}
+            status="success"
+          />
+          <Timeline.Period
+            start={new Date("May 1 2022")}
+            end={new Date("May 31 2022")}
+            status="warning"
+          />
+        </Timeline.Row>
+        <Timeline.Row label="Row 2">
+          <Timeline.Period
+            start={new Date("Mar 1 2022")}
+            end={new Date("Mar 31 2022")}
+            status="neutral"
+          />
+        </Timeline.Row>
+      </Timeline>
+    </div>
+  );
+}
+
+export const HorizontalPeriodNavigation: Story = {
+  render: () => <TwoRowTimeline />,
+  play: async ({ canvasElement }) => {
+    const row1 = getPeriodsInRow(canvasElement, 0);
+
+    // ArrowRight traverses forward
+    row1[0].focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(row1[1]).toHaveFocus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(row1[2]).toHaveFocus();
+
+    // ArrowLeft traverses backward
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(row1[1]).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(row1[0]).toHaveFocus();
+
+    // Stops at boundaries
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(row1[0]).toHaveFocus();
+    row1[2].focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(row1[2]).toHaveFocus();
+  },
+};
+
+export const VerticalRowNavigation: Story = {
+  render: () => <TwoRowTimeline />,
+  play: async ({ canvasElement }) => {
+    const row1 = getPeriodsInRow(canvasElement, 0);
+    const row2 = getPeriodsInRow(canvasElement, 1);
+
+    // ArrowDown moves to next row
+    row1[0].focus();
+    await userEvent.keyboard("{ArrowDown}");
+    expect(row2[0]).toHaveFocus();
+
+    // ArrowDown on last row does nothing
+    await userEvent.keyboard("{ArrowDown}");
+    expect(row2[0]).toHaveFocus();
+
+    // ArrowUp moves back to previous row
+    await userEvent.keyboard("{ArrowUp}");
+    expect(row1[0]).toHaveFocus();
+
+    // ArrowUp on first row with no pin does nothing
+    await userEvent.keyboard("{ArrowUp}");
+    expect(row1[0]).toHaveFocus();
+  },
+};
+
+export const PinNavigation: Story = {
+  render: () => <TwoRowTimelineWithPins />,
+  play: async ({ canvasElement }) => {
+    const pins = getAllPins(canvasElement);
+    const row1 = getPeriodsInRow(canvasElement, 0);
+
+    // ArrowRight/Left between pins
+    pins[0].focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(pins[1]).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(pins[0]).toHaveFocus();
+
+    // Stops at pin boundaries
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(pins[0]).toHaveFocus();
+    pins[1].focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(pins[1]).toHaveFocus();
+
+    // ArrowDown from pin focuses first period of row 1
+    pins[0].focus();
+    await userEvent.keyboard("{ArrowDown}");
+    expect(row1[0]).toHaveFocus();
+
+    // ArrowUp from row 1 returns to first pin
+    await userEvent.keyboard("{ArrowUp}");
+    expect(pins[0]).toHaveFocus();
+  },
+};

--- a/@navikt/core/react/src/timeline/Timeline.tsx
+++ b/@navikt/core/react/src/timeline/Timeline.tsx
@@ -133,7 +133,6 @@ export const Timeline = forwardRef<HTMLDivElement, TimelineProps>(
 
     const initialStartDate = startOfDay(useEarliestDate({ startDate, rows }));
     const [start, setStart] = useState(initialStartDate);
-    const [activeRow] = useState<number | null>(null);
     const [endInclusive, setEndInclusive] = useState(
       endOfDay(useLatestDate({ endDate, rows })),
     );
@@ -178,7 +177,6 @@ export const Timeline = forwardRef<HTMLDivElement, TimelineProps>(
           direction,
           setStart: (d) => handleZoomChange(d),
           setEndInclusive: (d) => setEndInclusive(d),
-          activeRow,
         }}
       >
         <TimelineKeyboardNavProvider timelineElement={timelineElement}>

--- a/@navikt/core/react/src/timeline/Timeline.tsx
+++ b/@navikt/core/react/src/timeline/Timeline.tsx
@@ -1,5 +1,6 @@
 import { endOfDay, isSameDay, startOfDay } from "date-fns";
 import React, { forwardRef, useMemo, useState } from "react";
+import { useMergeRefs } from "../utils/hooks";
 import { AxisLabels } from "./AxisLabels";
 import TimelineRow, { TimelineRowType } from "./TimelineRow";
 import { TimelineKeyboardNavProvider } from "./hooks/TimelineKeyboardNavProvider";
@@ -95,6 +96,10 @@ export const Timeline = forwardRef<HTMLDivElement, TimelineProps>(
     },
     ref,
   ) => {
+    const [timelineElement, setTimelineElement] =
+      useState<HTMLDivElement | null>(null);
+
+    const mergedRefs = useMergeRefs(setTimelineElement, ref);
     const isMultipleRows = Array.isArray(children);
 
     if (!isMultipleRows) {
@@ -176,8 +181,8 @@ export const Timeline = forwardRef<HTMLDivElement, TimelineProps>(
           activeRow,
         }}
       >
-        <TimelineKeyboardNavProvider>
-          <div {...rest} ref={ref}>
+        <TimelineKeyboardNavProvider timelineElement={timelineElement}>
+          <div {...rest} ref={mergedRefs}>
             <div className="aksel-timeline">
               <AxisLabels templates={axisLabelTemplates} />
 

--- a/@navikt/core/react/src/timeline/Timeline.tsx
+++ b/@navikt/core/react/src/timeline/Timeline.tsx
@@ -1,6 +1,5 @@
 import { endOfDay, isSameDay, startOfDay } from "date-fns";
 import React, { forwardRef, useMemo, useState } from "react";
-import { useMergeRefs } from "../utils/hooks";
 import { AxisLabels } from "./AxisLabels";
 import TimelineRow, { TimelineRowType } from "./TimelineRow";
 import { TimelineKeyboardNavProvider } from "./hooks/TimelineKeyboardNavProvider";
@@ -94,12 +93,8 @@ export const Timeline = forwardRef<HTMLDivElement, TimelineProps>(
       axisLabelTemplates,
       ...rest
     },
-    ref,
+    forwardedRef,
   ) => {
-    const [timelineElement, setTimelineElement] =
-      useState<HTMLDivElement | null>(null);
-
-    const mergedRefs = useMergeRefs(setTimelineElement, ref);
     const isMultipleRows = Array.isArray(children);
 
     if (!isMultipleRows) {
@@ -179,8 +174,8 @@ export const Timeline = forwardRef<HTMLDivElement, TimelineProps>(
           setEndInclusive: (d) => setEndInclusive(d),
         }}
       >
-        <TimelineKeyboardNavProvider timelineElement={timelineElement}>
-          <div {...rest} ref={mergedRefs}>
+        <TimelineKeyboardNavProvider>
+          <div {...rest} ref={forwardedRef}>
             <div className="aksel-timeline">
               <AxisLabels templates={axisLabelTemplates} />
 

--- a/@navikt/core/react/src/timeline/Timeline.tsx
+++ b/@navikt/core/react/src/timeline/Timeline.tsx
@@ -1,7 +1,8 @@
 import { endOfDay, isSameDay, startOfDay } from "date-fns";
-import React, { forwardRef, useMemo, useRef, useState } from "react";
+import React, { forwardRef, useMemo, useState } from "react";
 import { AxisLabels } from "./AxisLabels";
 import TimelineRow, { TimelineRowType } from "./TimelineRow";
+import { TimelineKeyboardNavProvider } from "./hooks/TimelineKeyboardNavProvider";
 import { RowContext } from "./hooks/useRowContext";
 import { TimelineContext } from "./hooks/useTimelineContext";
 import {
@@ -96,16 +97,15 @@ export const Timeline = forwardRef<HTMLDivElement, TimelineProps>(
   ) => {
     const isMultipleRows = Array.isArray(children);
 
-    const firstFocusabled = useRef<
-      { ref: HTMLButtonElement | null; id: number }[]
-    >([]);
-
     if (!isMultipleRows) {
       children = [children];
     }
-    const rowChildren = React.Children.toArray(children).filter(
-      (c: any) => c?.type?.componentType === "row",
-    );
+
+    const rowChildren = useMemo(() => {
+      return React.Children.toArray(children).filter(
+        (c: any) => c?.type?.componentType === "row",
+      );
+    }, [children]);
 
     const pins = React.Children.toArray(children)
       .filter((c: any) => c?.type?.componentType === "pin")
@@ -128,7 +128,7 @@ export const Timeline = forwardRef<HTMLDivElement, TimelineProps>(
 
     const initialStartDate = startOfDay(useEarliestDate({ startDate, rows }));
     const [start, setStart] = useState(initialStartDate);
-    const [activeRow, setActiveRow] = useState<number | null>(null);
+    const [activeRow] = useState<number | null>(null);
     const [endInclusive, setEndInclusive] = useState(
       endOfDay(useLatestDate({ endDate, rows })),
     );
@@ -165,38 +165,6 @@ export const Timeline = forwardRef<HTMLDivElement, TimelineProps>(
       }
     };
 
-    const handleActiveRowChange = (key: string) => {
-      if (activeRow !== null && key === "ArrowDown") {
-        for (let i = activeRow + 1; i < processedRows.length; i++) {
-          const row = processedRows[i];
-          if (row.periods.find((p) => !!p.children || !!p.onSelectPeriod)) {
-            setActiveRow(i);
-            firstFocusabled.current.find((x) => x.id === i)?.ref?.focus();
-            break;
-          }
-        }
-        return;
-      }
-      if (activeRow !== null && key === "ArrowUp") {
-        for (let i = activeRow - 1; i >= 0; i--) {
-          const row = processedRows[i];
-          if (row.periods.find((p) => !!p.children || !!p.onSelectPeriod)) {
-            setActiveRow(i);
-            firstFocusabled.current.find((x) => x.id === i)?.ref?.focus();
-            break;
-          }
-        }
-        return;
-      }
-    };
-
-    const addFocusable = (btnRef: HTMLButtonElement | null, id: number) => {
-      let items = firstFocusabled.current;
-      items = items.filter((x) => x.id !== id);
-      items.push({ ref: btnRef, id });
-      firstFocusabled.current = items;
-    };
-
     return (
       <TimelineContext.Provider
         value={{
@@ -206,43 +174,41 @@ export const Timeline = forwardRef<HTMLDivElement, TimelineProps>(
           setStart: (d) => handleZoomChange(d),
           setEndInclusive: (d) => setEndInclusive(d),
           activeRow,
-          setActiveRow: (key) => handleActiveRowChange(key),
-          initiate: (i) => setActiveRow(i),
-          addFocusable,
         }}
       >
-        <div {...rest} ref={ref}>
-          <div className="aksel-timeline">
-            <AxisLabels templates={axisLabelTemplates} />
+        <TimelineKeyboardNavProvider>
+          <div {...rest} ref={ref}>
+            <div className="aksel-timeline">
+              <AxisLabels templates={axisLabelTemplates} />
 
-            {pins.map((PinChild, i) => (
-              <PinChild key={`pin-${i}`} />
-            ))}
+              {pins.map((PinChild, i) => (
+                <PinChild key={`pin-${i}`} />
+              ))}
 
-            {processedRows.map((row, i) => {
-              return (
-                <RowContext.Provider
-                  key={`row-${row.id}`}
-                  value={{
-                    periods: row.periods,
-                    id: row.id,
-                    active: activeRow === i,
-                    index: i,
-                  }}
-                >
-                  <TimelineRow
-                    {...row?.restProps}
-                    ref={row?.ref}
-                    label={row.label}
-                    icon={row.icon}
-                    headingTag={row.headingTag}
-                  />
-                </RowContext.Provider>
-              );
-            })}
+              {processedRows.map((row, i) => {
+                return (
+                  <RowContext.Provider
+                    key={`row-${row.id}`}
+                    value={{
+                      periods: row.periods,
+                      id: row.id,
+                      index: i,
+                    }}
+                  >
+                    <TimelineRow
+                      {...row?.restProps}
+                      ref={row?.ref}
+                      label={row.label}
+                      icon={row.icon}
+                      headingTag={row.headingTag}
+                    />
+                  </RowContext.Provider>
+                );
+              })}
+            </div>
+            {zoomComponent}
           </div>
-          {zoomComponent}
-        </div>
+        </TimelineKeyboardNavProvider>
       </TimelineContext.Provider>
     );
   },

--- a/@navikt/core/react/src/timeline/Timeline.tsx
+++ b/@navikt/core/react/src/timeline/Timeline.tsx
@@ -95,36 +95,43 @@ export const Timeline = forwardRef<HTMLDivElement, TimelineProps>(
     },
     forwardedRef,
   ) => {
-    const isMultipleRows = Array.isArray(children);
-
-    if (!isMultipleRows) {
-      children = [children];
-    }
+    const childArray = useMemo(
+      () =>
+        React.Children.toArray(Array.isArray(children) ? children : [children]),
+      [children],
+    );
 
     const rowChildren = useMemo(() => {
-      return React.Children.toArray(children).filter(
-        (c: any) => c?.type?.componentType === "row",
-      );
-    }, [children]);
+      return childArray.filter((c: any) => c?.type?.componentType === "row");
+    }, [childArray]);
 
-    const pins = React.Children.toArray(children)
-      .filter((c: any) => c?.type?.componentType === "pin")
-      .map((x) => () => x);
+    const pins = useMemo(
+      () =>
+        childArray
+          .filter((c: any) => c?.type?.componentType === "pin")
+          .map((x) => () => x),
+      [childArray],
+    );
 
-    const zoomComponent = React.Children.toArray(children).find(
-      (c: any) => c?.type?.componentType === "zoom",
+    const zoomComponent = useMemo(
+      () => childArray.find((c: any) => c?.type?.componentType === "zoom"),
+      [childArray],
     );
 
     const rowsRaw = useMemo(() => {
       return parseRows(rowChildren);
     }, [rowChildren]);
 
-    const rows = rowsRaw.map((r) => {
-      if (r?.periods) {
-        return r.periods;
-      }
-      return [];
-    });
+    const rows = useMemo(
+      () =>
+        rowsRaw.map((r) => {
+          if (r?.periods) {
+            return r.periods;
+          }
+          return [];
+        }),
+      [rowsRaw],
+    );
 
     const initialStartDate = startOfDay(useEarliestDate({ startDate, rows }));
     const [start, setStart] = useState(initialStartDate);

--- a/@navikt/core/react/src/timeline/TimelineRow.tsx
+++ b/@navikt/core/react/src/timeline/TimelineRow.tsx
@@ -85,7 +85,7 @@ export const TimelineRow = forwardRef<HTMLOListElement, TimelineRowProps>(
             <div className="aksel-timeline__row-label">{label}</div>
           ))}
 
-        {/** biome-ignore lint/a11y/noStaticElementInteractions: temp */}
+        {/** biome-ignore lint/a11y/noStaticElementInteractions: onKeyDown just captures events on child-elements here. Regular interaction patterns still works as expected. */}
         <div
           className={cl("aksel-timeline__row", {
             "aksel-timeline__row--active": activeRow === elementRefState,

--- a/@navikt/core/react/src/timeline/TimelineRow.tsx
+++ b/@navikt/core/react/src/timeline/TimelineRow.tsx
@@ -1,11 +1,12 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 import { format } from "date-fns";
 import React, { forwardRef } from "react";
 import { BodyShort } from "../typography/BodyShort";
 import { cl } from "../utils/helpers";
 import { useI18n } from "../utils/i18n/i18n.hooks";
+import { useTimelineKeyboardContext } from "./hooks/TimelineKeyboardNavProvider";
 import { PeriodContext } from "./hooks/usePeriodContext";
 import { useRowContext } from "./hooks/useRowContext";
-import { useTimelineContext } from "./hooks/useTimelineContext";
 import Period from "./period";
 import {
   PositionedPeriod,
@@ -49,9 +50,13 @@ export interface TimelineRowType extends React.ForwardRefExoticComponent<
 
 export const TimelineRow = forwardRef<HTMLOListElement, TimelineRowProps>(
   ({ label, className, headingTag = "h3", icon, ...rest }, ref) => {
-    const { periods, active } = useRowContext();
-    const { setActiveRow } = useTimelineContext();
+    const { periods } = useRowContext();
+    const { updateActiveRow, handleRowKeyDown, activeRow } =
+      useTimelineKeyboardContext();
     const translate = useI18n("Timeline");
+
+    const [elementRefState, setElementRefState] =
+      React.useState<HTMLDivElement | null>(null);
 
     const latest = periods.reduce((a, b) => {
       return a.end > b.end ? a : b;
@@ -60,10 +65,6 @@ export const TimelineRow = forwardRef<HTMLOListElement, TimelineRowProps>(
     const earliest = periods.reduce((a, b) => {
       return a.end < b.end ? a : b;
     }, {} as PositionedPeriod);
-
-    const firstFocusable = periods.find(
-      (p) => !!p.children || !!p.onSelectPeriod,
-    );
 
     return (
       <>
@@ -80,15 +81,20 @@ export const TimelineRow = forwardRef<HTMLOListElement, TimelineRowProps>(
           ) : (
             <div className="aksel-timeline__row-label">{label}</div>
           ))}
+
+        {/** biome-ignore lint/a11y/noStaticElementInteractions: temp */}
         <div
           className={cl("aksel-timeline__row", {
-            "aksel-timeline__row--active": active,
+            "aksel-timeline__row--active": activeRow === elementRefState,
           })}
+          ref={setElementRefState}
+          tabIndex={-1}
+          onFocusCapture={() => updateActiveRow(elementRefState)}
+          onKeyDown={handleRowKeyDown}
+          data-timeline-row
         >
-          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
           <ol
             {...rest}
-            tabIndex={-1}
             ref={ref}
             aria-label={
               periods.length === 0
@@ -99,12 +105,6 @@ export const TimelineRow = forwardRef<HTMLOListElement, TimelineRowProps>(
                   })
             }
             className={cl("aksel-timeline__row-periods", className)}
-            onKeyDown={(e) => {
-              if (e.key === "ArrowDown" || e.key === "ArrowUp") {
-                e.preventDefault();
-                setActiveRow(e.key);
-              }
-            }}
           >
             {periods?.map((period) => {
               return (
@@ -112,7 +112,6 @@ export const TimelineRow = forwardRef<HTMLOListElement, TimelineRowProps>(
                   <PeriodContext.Provider
                     value={{
                       periodId: period.id,
-                      firstFocus: firstFocusable?.id === period.id,
                       restProps: period?.restProps,
                     }}
                   >

--- a/@navikt/core/react/src/timeline/TimelineRow.tsx
+++ b/@navikt/core/react/src/timeline/TimelineRow.tsx
@@ -4,7 +4,10 @@ import React, { forwardRef } from "react";
 import { BodyShort } from "../typography/BodyShort";
 import { cl } from "../utils/helpers";
 import { useI18n } from "../utils/i18n/i18n.hooks";
-import { useTimelineKeyboardContext } from "./hooks/TimelineKeyboardNavProvider";
+import {
+  useTimelineKeyboardActiveRow,
+  useTimelineKeyboardContext,
+} from "./hooks/TimelineKeyboardNavProvider";
 import { PeriodContext } from "./hooks/usePeriodContext";
 import { useRowContext } from "./hooks/useRowContext";
 import Period from "./period";
@@ -51,8 +54,8 @@ export interface TimelineRowType extends React.ForwardRefExoticComponent<
 export const TimelineRow = forwardRef<HTMLOListElement, TimelineRowProps>(
   ({ label, className, headingTag = "h3", icon, ...rest }, ref) => {
     const { periods } = useRowContext();
-    const { updateActiveRow, handleRowKeyDown, activeRow } =
-      useTimelineKeyboardContext();
+    const { updateActiveRow, handleRowKeyDown } = useTimelineKeyboardContext();
+    const { activeRow } = useTimelineKeyboardActiveRow();
     const translate = useI18n("Timeline");
 
     const [elementRefState, setElementRefState] =

--- a/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
+++ b/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
@@ -54,6 +54,11 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
         return;
       }
 
+      /* Skip interaction of focus is inside popover */
+      if (document.activeElement?.closest("[data-timeline-popover]")) {
+        return;
+      }
+
       const { key } = event;
 
       if (key === "ArrowDown" || key === "ArrowUp") {
@@ -133,6 +138,11 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
     (event: React.KeyboardEvent<Element>) => {
       const timelineEl = timelineElementRef.current;
       if (!timelineEl) {
+        return;
+      }
+
+      /* Skip interaction of focus is inside popover */
+      if (document.activeElement?.closest("[data-timeline-popover]")) {
         return;
       }
 

--- a/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
+++ b/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
@@ -33,12 +33,11 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
     }
 
     const { key } = event;
-    if (key === "ArrowDown" || key === "ArrowUp") {
-      console.info({ key, activeRow });
-      // Find next element with `data-timeline-row` attribute
-      const rows =
-        activeRow.parentElement?.querySelectorAll(`[data-timeline-row]`);
 
+    if (key === "ArrowDown" || key === "ArrowUp") {
+      const rows = activeRow.parentElement?.querySelectorAll(
+        "[data-timeline-row]",
+      );
       const firstPin = activeRow.parentElement?.querySelector(
         "[data-timeline-pin]",
       );
@@ -48,41 +47,31 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
       }
 
       const currentIndex = Array.from(rows).indexOf(activeRow);
-      let nextIndex: number;
+      const atBoundary =
+        key === "ArrowDown"
+          ? currentIndex === rows.length - 1
+          : currentIndex === 0;
 
-      if (key === "ArrowDown") {
-        /* If index is the last one, we want to focus first pin */
-        if (currentIndex === rows.length - 1) {
-          if (firstPin) {
-            (firstPin as HTMLElement).focus();
-          }
-          return;
-        }
-        nextIndex = (currentIndex + 1) % rows.length;
-      } else {
-        /* If row is the first one, we instead want to focus first pin */
-        if (currentIndex === 0) {
-          if (firstPin) {
-            (firstPin as HTMLElement).focus();
-          }
-          return;
-        }
-
-        nextIndex = (currentIndex - 1 + rows.length) % rows.length;
-      }
-
-      const nextRow = rows[nextIndex] as HTMLElement;
-
-      if (!nextRow) {
+      if (atBoundary && firstPin) {
+        (firstPin as HTMLElement | null)?.focus();
         return;
       }
 
-      const periods = nextRow.querySelectorAll("[data-timeline-period]");
-      if (periods.length > 0) {
+      /* Next index need to take into account looping */
+      const nextIndex =
+        key === "ArrowDown"
+          ? (currentIndex + 1) % rows.length
+          : (currentIndex - 1 + rows.length) % rows.length;
+
+      const nextRow = rows[nextIndex];
+      const periods = nextRow?.querySelectorAll("[data-timeline-period]");
+
+      if (periods?.length > 0) {
         (periods[0] as HTMLElement).focus();
-      } else {
-        nextRow.focus();
+      } else if (nextRow) {
+        (nextRow as HTMLElement).focus();
       }
+      return;
     }
 
     if (key === "ArrowRight" || key === "ArrowLeft") {
@@ -91,23 +80,15 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
         return;
       }
 
-      const focusedElement = document.activeElement as HTMLElement;
-      const currentIndex = Array.from(periods).indexOf(focusedElement);
-      let nextIndex: number;
+      const currentIndex = Array.from(periods).indexOf(
+        document.activeElement as HTMLElement,
+      );
+      const nextIndex =
+        key === "ArrowRight"
+          ? (currentIndex + 1) % periods.length
+          : (currentIndex - 1 + periods.length) % periods.length;
 
-      if (key === "ArrowRight") {
-        nextIndex = (currentIndex + 1) % periods.length;
-      } else {
-        nextIndex = (currentIndex - 1 + periods.length) % periods.length;
-      }
-
-      const nextPeriod = periods[nextIndex] as HTMLElement;
-
-      if (!nextPeriod) {
-        return;
-      }
-
-      nextPeriod.focus();
+      (periods[nextIndex] as HTMLElement).focus();
     }
   };
 

--- a/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
+++ b/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
@@ -157,7 +157,7 @@ function TimelineKeyboardNavProvider({
         return;
       }
 
-      /* Skip interaction of focus is inside popover */
+      /* Skip interaction if focus is inside popover */
       if (document.activeElement?.closest("[data-timeline-popover]")) {
         return;
       }

--- a/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
+++ b/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
@@ -47,22 +47,6 @@ function TimelineKeyboardNavProvider({
     setActiveRow(element);
   }, []);
 
-  const focusElement = useCallback(
-    (
-      element: HTMLElement | Element | null,
-      event: React.KeyboardEvent<HTMLElement | Element>,
-    ) => {
-      if (!element) {
-        return;
-      }
-
-      event.preventDefault();
-
-      (element as HTMLElement).focus();
-    },
-    [],
-  );
-
   const handleRowKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
       const currentActiveRow = activeRowRef.current;
@@ -147,7 +131,7 @@ function TimelineKeyboardNavProvider({
         focusElement(periods[nextIndex], event);
       }
     },
-    [focusElement],
+    [],
   );
 
   const handlePinKeyDown = useCallback(
@@ -209,7 +193,7 @@ function TimelineKeyboardNavProvider({
         focusElement(pins[nextIndex], event);
       }
     },
-    [focusElement],
+    [],
   );
 
   return (
@@ -223,6 +207,22 @@ function TimelineKeyboardNavProvider({
       </TimelineKeyboardNavActiveRowContextProvider>
     </TimelineKeyboardNavStableContextProvider>
   );
+}
+
+/**
+ * Focuses the given element and prevents default behavior of the event if focus is called.
+ */
+function focusElement(
+  element: HTMLElement | Element | null,
+  event: React.KeyboardEvent<HTMLElement | Element>,
+) {
+  if (!element) {
+    return;
+  }
+
+  event.preventDefault();
+
+  (element as HTMLElement).focus();
 }
 
 export {

--- a/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
+++ b/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { createStrictContext } from "../../utils/helpers";
+
+type TimelineKeyboardNavContextType = {
+  activeRow: HTMLElement | null;
+  updateActiveRow: (element: HTMLElement | null) => void;
+  handleRowKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
+};
+
+const {
+  Provider: TimelineKeyboardNavContextProvider,
+  useContext: useTimelineKeyboardContext,
+} = createStrictContext<TimelineKeyboardNavContextType>({
+  name: "TimelineKeyboardNavContext",
+  errorMessage:
+    "useTimelineKeyboardNavContext must be used within a TimelineKeyboardNavProvider",
+});
+
+type TimelineKeyboardNavProviderProps = {
+  children: React.ReactNode;
+};
+
+function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
+  const [activeRow, setActiveRow] = React.useState<HTMLElement | null>(null);
+
+  const updateActiveRow = (element: HTMLElement | null) => {
+    setActiveRow(element);
+  };
+
+  const handleRowKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (!activeRow) {
+      return;
+    }
+
+    const { key } = event;
+    if (key === "ArrowDown" || key === "ArrowUp") {
+      console.info({ key, activeRow });
+      // Find next element with `data-timeline-row` attribute
+      const rows =
+        activeRow.parentElement?.querySelectorAll(`[data-timeline-row]`);
+
+      const firstPin = activeRow.parentElement?.querySelector(
+        "[data-timeline-pin]",
+      );
+
+      if (!rows || rows.length === 0) {
+        return;
+      }
+
+      const currentIndex = Array.from(rows).indexOf(activeRow);
+      let nextIndex: number;
+
+      if (key === "ArrowDown") {
+        /* If index is the last one, we want to focus first pin */
+        if (currentIndex === rows.length - 1) {
+          if (firstPin) {
+            (firstPin as HTMLElement).focus();
+          }
+          return;
+        }
+        nextIndex = (currentIndex + 1) % rows.length;
+      } else {
+        /* If row is the first one, we instead want to focus first pin */
+        if (currentIndex === 0) {
+          if (firstPin) {
+            (firstPin as HTMLElement).focus();
+          }
+          return;
+        }
+
+        nextIndex = (currentIndex - 1 + rows.length) % rows.length;
+      }
+
+      const nextRow = rows[nextIndex] as HTMLElement;
+
+      if (!nextRow) {
+        return;
+      }
+
+      const periods = nextRow.querySelectorAll("[data-timeline-period]");
+      if (periods.length > 0) {
+        (periods[0] as HTMLElement).focus();
+      } else {
+        nextRow.focus();
+      }
+    }
+
+    if (key === "ArrowRight" || key === "ArrowLeft") {
+      const periods = activeRow.querySelectorAll("[data-timeline-period]");
+      if (periods.length === 0) {
+        return;
+      }
+
+      const focusedElement = document.activeElement as HTMLElement;
+      const currentIndex = Array.from(periods).indexOf(focusedElement);
+      let nextIndex: number;
+
+      if (key === "ArrowRight") {
+        nextIndex = (currentIndex + 1) % periods.length;
+      } else {
+        nextIndex = (currentIndex - 1 + periods.length) % periods.length;
+      }
+
+      const nextPeriod = periods[nextIndex] as HTMLElement;
+
+      if (!nextPeriod) {
+        return;
+      }
+
+      nextPeriod.focus();
+    }
+  };
+
+  return (
+    <TimelineKeyboardNavContextProvider
+      updateActiveRow={updateActiveRow}
+      handleRowKeyDown={handleRowKeyDown}
+      activeRow={activeRow}
+    >
+      {props.children}
+    </TimelineKeyboardNavContextProvider>
+  );
+}
+
+export { TimelineKeyboardNavProvider, useTimelineKeyboardContext };

--- a/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
+++ b/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
@@ -70,7 +70,7 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
         return;
       }
 
-      /* Skip interaction of focus is inside popover */
+      /* Skip interaction if focus is inside popover */
       if (document.activeElement?.closest("[data-timeline-popover]")) {
         return;
       }

--- a/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
+++ b/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
@@ -1,20 +1,32 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { createStrictContext } from "../../utils/helpers";
 
-type TimelineKeyboardNavContextType = {
-  activeRow: HTMLElement | null;
+type TimelineKeyboardNavStableContextType = {
   updateActiveRow: (element: HTMLElement | null) => void;
   handleRowKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
   handlePinKeyDown: (event: React.KeyboardEvent<Element>) => void;
 };
 
+type TimelineKeyboardNavActiveRowContextType = {
+  activeRow: HTMLElement | null;
+};
+
 const {
-  Provider: TimelineKeyboardNavContextProvider,
+  Provider: TimelineKeyboardNavStableContextProvider,
   useContext: useTimelineKeyboardContext,
-} = createStrictContext<TimelineKeyboardNavContextType>({
-  name: "TimelineKeyboardNavContext",
+} = createStrictContext<TimelineKeyboardNavStableContextType>({
+  name: "TimelineKeyboardNavStableContext",
   errorMessage:
-    "useTimelineKeyboardNavContext must be used within a TimelineKeyboardNavProvider",
+    "useTimelineKeyboardContext must be used within a TimelineKeyboardNavProvider",
+});
+
+const {
+  Provider: TimelineKeyboardNavActiveRowContextProvider,
+  useContext: useTimelineKeyboardActiveRow,
+} = createStrictContext<TimelineKeyboardNavActiveRowContextType>({
+  name: "TimelineKeyboardNavActiveRowContext",
+  errorMessage:
+    "useTimelineKeyboardActiveRow must be used within a TimelineKeyboardNavProvider",
 });
 
 type TimelineKeyboardNavProviderProps = {
@@ -26,148 +38,169 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
   const { timelineElement } = props;
 
   const [activeRow, setActiveRow] = React.useState<HTMLElement | null>(null);
+  const activeRowRef = React.useRef<HTMLElement | null>(null);
+  const timelineElementRef = React.useRef<HTMLDivElement | null>(null);
+  timelineElementRef.current = timelineElement;
 
-  const updateActiveRow = (element: HTMLElement | null) => {
+  const updateActiveRow = React.useCallback((element: HTMLElement | null) => {
+    activeRowRef.current = element;
     setActiveRow(element);
-  };
+  }, []);
 
-  const handleRowKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
-    if (!activeRow) {
-      return;
-    }
-
-    const { key } = event;
-
-    if (key === "ArrowDown" || key === "ArrowUp") {
-      event.preventDefault();
-      const rows = activeRow.parentElement?.querySelectorAll(
-        "[data-timeline-row]",
-      );
-      const firstPin = activeRow.parentElement?.querySelector(
-        "[data-timeline-pin]",
-      );
-
-      if (!rows || rows.length === 0) {
+  const handleRowKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      const currentActiveRow = activeRowRef.current;
+      if (!currentActiveRow) {
         return;
       }
 
-      const currentIndex = Array.from(rows).indexOf(activeRow);
-      if (currentIndex === -1) {
-        return;
-      }
+      const { key } = event;
 
-      const atBoundary = currentIndex === 0 && key === "ArrowUp";
+      if (key === "ArrowDown" || key === "ArrowUp") {
+        event.preventDefault();
+        const rows = currentActiveRow.parentElement?.querySelectorAll(
+          "[data-timeline-row]",
+        );
+        const firstPin = currentActiveRow.parentElement?.querySelector(
+          "[data-timeline-pin]",
+        );
 
-      if (atBoundary && firstPin) {
-        (firstPin as HTMLElement | null)?.focus();
-        return;
-      }
+        if (!rows || rows.length === 0) {
+          return;
+        }
 
-      /* Next index need to take into account looping */
-      const nextIndex =
-        key === "ArrowDown" ? currentIndex + 1 : currentIndex - 1;
+        const currentIndex = Array.from(rows).indexOf(currentActiveRow);
+        if (currentIndex === -1) {
+          return;
+        }
 
-      if (nextIndex < 0 || nextIndex >= rows.length) {
-        return;
-      }
+        const atBoundary = currentIndex === 0 && key === "ArrowUp";
 
-      const nextRow = rows[nextIndex];
-      const periods = nextRow?.querySelectorAll("[data-timeline-period]");
+        if (atBoundary && firstPin) {
+          (firstPin as HTMLElement | null)?.focus();
+          return;
+        }
 
-      if (periods?.length > 0) {
-        (periods[0] as HTMLElement).focus();
-      } else if (nextRow) {
-        (nextRow as HTMLElement).focus();
-      }
-      return;
-    }
+        /* Next index need to take into account looping */
+        const nextIndex =
+          key === "ArrowDown" ? currentIndex + 1 : currentIndex - 1;
 
-    if (key === "ArrowRight" || key === "ArrowLeft") {
-      event.preventDefault();
-      const periods = activeRow.querySelectorAll("[data-timeline-period]");
-      if (periods.length === 0) {
-        return;
-      }
+        if (nextIndex < 0 || nextIndex >= rows.length) {
+          return;
+        }
 
-      const currentIndex = Array.from(periods).indexOf(
-        document.activeElement as HTMLElement,
-      );
-      if (currentIndex === -1) {
-        return;
-      }
-
-      const nextIndex =
-        key === "ArrowRight" ? currentIndex + 1 : currentIndex - 1;
-
-      if (nextIndex < 0 || nextIndex >= periods.length) {
-        return;
-      }
-
-      (periods[nextIndex] as HTMLElement).focus();
-    }
-  };
-
-  const handlePinKeyDown = (event: React.KeyboardEvent<Element>) => {
-    if (!timelineElement) {
-      return;
-    }
-
-    const { key } = event;
-
-    if (key === "ArrowDown") {
-      event.preventDefault();
-      const rows = timelineElement.querySelectorAll("[data-timeline-row]");
-      if (rows.length === 0) {
-        return;
-      }
-      const rowToFocus = rows[0] as HTMLElement | null;
-
-      if (rowToFocus) {
-        const periods = rowToFocus?.querySelectorAll("[data-timeline-period]");
+        const nextRow = rows[nextIndex];
+        const periods = nextRow?.querySelectorAll("[data-timeline-period]");
 
         if (periods?.length > 0) {
           (periods[0] as HTMLElement).focus();
-        } else if (rowToFocus) {
-          (rowToFocus as HTMLElement).focus();
+        } else if (nextRow) {
+          (nextRow as HTMLElement).focus();
+        }
+        return;
+      }
+
+      if (key === "ArrowRight" || key === "ArrowLeft") {
+        event.preventDefault();
+        const periods = currentActiveRow.querySelectorAll(
+          "[data-timeline-period]",
+        );
+        if (periods.length === 0) {
+          return;
+        }
+
+        const currentIndex = Array.from(periods).indexOf(
+          document.activeElement as HTMLElement,
+        );
+        if (currentIndex === -1) {
+          return;
+        }
+
+        const nextIndex =
+          key === "ArrowRight" ? currentIndex + 1 : currentIndex - 1;
+
+        if (nextIndex < 0 || nextIndex >= periods.length) {
+          return;
+        }
+
+        (periods[nextIndex] as HTMLElement).focus();
+      }
+    },
+    [],
+  );
+
+  const handlePinKeyDown = useCallback(
+    (event: React.KeyboardEvent<Element>) => {
+      const timelineEl = timelineElementRef.current;
+      if (!timelineEl) {
+        return;
+      }
+
+      const { key } = event;
+
+      if (key === "ArrowDown") {
+        event.preventDefault();
+        const rows = timelineEl.querySelectorAll("[data-timeline-row]");
+        if (rows.length === 0) {
+          return;
+        }
+        const rowToFocus = rows[0] as HTMLElement | null;
+
+        if (rowToFocus) {
+          const periods = rowToFocus?.querySelectorAll(
+            "[data-timeline-period]",
+          );
+
+          if (periods?.length > 0) {
+            (periods[0] as HTMLElement).focus();
+          } else if (rowToFocus) {
+            (rowToFocus as HTMLElement).focus();
+          }
         }
       }
-    }
 
-    if (key === "ArrowRight" || key === "ArrowLeft") {
-      event.preventDefault();
-      const pins = timelineElement.querySelectorAll("[data-timeline-pin]");
-      if (pins.length === 0) {
-        return;
+      if (key === "ArrowRight" || key === "ArrowLeft") {
+        event.preventDefault();
+        const pins = timelineEl.querySelectorAll("[data-timeline-pin]");
+        if (pins.length === 0) {
+          return;
+        }
+
+        const currentIndex = Array.from(pins).indexOf(
+          document.activeElement as HTMLElement,
+        );
+        if (currentIndex === -1) {
+          return;
+        }
+
+        const nextIndex =
+          key === "ArrowRight" ? currentIndex + 1 : currentIndex - 1;
+
+        if (nextIndex < 0 || nextIndex >= pins.length) {
+          return;
+        }
+
+        (pins[nextIndex] as HTMLElement).focus();
       }
-
-      const currentIndex = Array.from(pins).indexOf(
-        document.activeElement as HTMLElement,
-      );
-      if (currentIndex === -1) {
-        return;
-      }
-
-      const nextIndex =
-        key === "ArrowRight" ? currentIndex + 1 : currentIndex - 1;
-
-      if (nextIndex < 0 || nextIndex >= pins.length) {
-        return;
-      }
-
-      (pins[nextIndex] as HTMLElement).focus();
-    }
-  };
+    },
+    [],
+  );
 
   return (
-    <TimelineKeyboardNavContextProvider
+    <TimelineKeyboardNavStableContextProvider
       updateActiveRow={updateActiveRow}
       handleRowKeyDown={handleRowKeyDown}
-      activeRow={activeRow}
       handlePinKeyDown={handlePinKeyDown}
     >
-      {props.children}
-    </TimelineKeyboardNavContextProvider>
+      <TimelineKeyboardNavActiveRowContextProvider activeRow={activeRow}>
+        {props.children}
+      </TimelineKeyboardNavActiveRowContextProvider>
+    </TimelineKeyboardNavStableContextProvider>
   );
 }
 
-export { TimelineKeyboardNavProvider, useTimelineKeyboardContext };
+export {
+  TimelineKeyboardNavProvider,
+  useTimelineKeyboardContext,
+  useTimelineKeyboardActiveRow,
+};

--- a/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
+++ b/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
@@ -5,6 +5,7 @@ type TimelineKeyboardNavContextType = {
   activeRow: HTMLElement | null;
   updateActiveRow: (element: HTMLElement | null) => void;
   handleRowKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
+  handlePinKeyDown: (event: React.KeyboardEvent<Element>) => void;
 };
 
 const {
@@ -47,10 +48,7 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
       }
 
       const currentIndex = Array.from(rows).indexOf(activeRow);
-      const atBoundary =
-        key === "ArrowDown"
-          ? currentIndex === rows.length - 1
-          : currentIndex === 0;
+      const atBoundary = currentIndex === 0 && key === "ArrowUp";
 
       if (atBoundary && firstPin) {
         (firstPin as HTMLElement | null)?.focus();
@@ -59,9 +57,11 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
 
       /* Next index need to take into account looping */
       const nextIndex =
-        key === "ArrowDown"
-          ? (currentIndex + 1) % rows.length
-          : (currentIndex - 1 + rows.length) % rows.length;
+        key === "ArrowDown" ? currentIndex + 1 : currentIndex - 1;
+
+      if (nextIndex < 0 || nextIndex >= rows.length) {
+        return;
+      }
 
       const nextRow = rows[nextIndex];
       const periods = nextRow?.querySelectorAll("[data-timeline-period]");
@@ -84,11 +84,54 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
         document.activeElement as HTMLElement,
       );
       const nextIndex =
-        key === "ArrowRight"
-          ? (currentIndex + 1) % periods.length
-          : (currentIndex - 1 + periods.length) % periods.length;
+        key === "ArrowRight" ? currentIndex + 1 : currentIndex - 1;
+
+      if (nextIndex < 0 || nextIndex >= periods.length) {
+        return;
+      }
 
       (periods[nextIndex] as HTMLElement).focus();
+    }
+  };
+
+  const handlePinKeyDown = (event: React.KeyboardEvent<Element>) => {
+    const { key } = event;
+
+    if (key === "ArrowDown") {
+      const rows = document.querySelectorAll("[data-timeline-row]");
+      if (rows.length === 0) {
+        return;
+      }
+      const rowToFocus = rows[0] as HTMLElement | null;
+
+      if (rowToFocus) {
+        const periods = rowToFocus?.querySelectorAll("[data-timeline-period]");
+
+        if (periods?.length > 0) {
+          (periods[0] as HTMLElement).focus();
+        } else if (rowToFocus) {
+          (rowToFocus as HTMLElement).focus();
+        }
+      }
+    }
+
+    if (key === "ArrowRight" || key === "ArrowLeft") {
+      const pins = document.querySelectorAll("[data-timeline-pin]");
+      if (pins.length === 0) {
+        return;
+      }
+
+      const currentIndex = Array.from(pins).indexOf(
+        document.activeElement as HTMLElement,
+      );
+      const nextIndex =
+        key === "ArrowRight" ? currentIndex + 1 : currentIndex - 1;
+
+      if (nextIndex < 0 || nextIndex >= pins.length) {
+        return;
+      }
+
+      (pins[nextIndex] as HTMLElement).focus();
     }
   };
 
@@ -97,6 +140,7 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
       updateActiveRow={updateActiveRow}
       handleRowKeyDown={handleRowKeyDown}
       activeRow={activeRow}
+      handlePinKeyDown={handlePinKeyDown}
     >
       {props.children}
     </TimelineKeyboardNavContextProvider>

--- a/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
+++ b/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useRef } from "react";
+import { Slot } from "../../utils/components/slot/Slot";
 import { createStrictContext } from "../../utils/helpers";
 
 type TimelineKeyboardNavStableContextType = {
@@ -30,17 +31,16 @@ const {
 });
 
 type TimelineKeyboardNavProviderProps = {
-  children: React.ReactNode;
-  timelineElement: HTMLDivElement | null;
+  children: React.ReactElement;
 };
 
-function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
-  const { timelineElement } = props;
-
+function TimelineKeyboardNavProvider({
+  children,
+}: TimelineKeyboardNavProviderProps) {
   const [activeRow, setActiveRow] = React.useState<HTMLElement | null>(null);
   const activeRowRef = React.useRef<HTMLElement | null>(null);
-  const timelineElementRef = React.useRef<HTMLDivElement | null>(null);
-  timelineElementRef.current = timelineElement;
+
+  const timelineElementRef = useRef<HTMLTableElement>(null);
 
   const updateActiveRow = React.useCallback((element: HTMLElement | null) => {
     activeRowRef.current = element;
@@ -101,10 +101,10 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
           return;
         }
 
-        /* Next index need to take into account looping */
         const nextIndex =
           key === "ArrowDown" ? currentIndex + 1 : currentIndex - 1;
 
+        /* We want to avoid looping */
         if (nextIndex < 0 || nextIndex >= rows.length) {
           return;
         }
@@ -139,6 +139,7 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
         const nextIndex =
           key === "ArrowRight" ? currentIndex + 1 : currentIndex - 1;
 
+        /* We want to avoid looping */
         if (nextIndex < 0 || nextIndex >= periods.length) {
           return;
         }
@@ -151,8 +152,8 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
 
   const handlePinKeyDown = useCallback(
     (event: React.KeyboardEvent<Element>) => {
-      const timelineEl = timelineElementRef.current;
-      if (!timelineEl) {
+      const timelineElement = timelineElementRef.current;
+      if (!timelineElement) {
         return;
       }
 
@@ -164,7 +165,7 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
       const { key } = event;
 
       if (key === "ArrowDown") {
-        const rows = timelineEl.querySelectorAll("[data-timeline-row]");
+        const rows = timelineElement.querySelectorAll("[data-timeline-row]");
         if (rows.length === 0) {
           return;
         }
@@ -185,7 +186,7 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
 
       if (key === "ArrowRight" || key === "ArrowLeft") {
         event.preventDefault();
-        const pins = timelineEl.querySelectorAll("[data-timeline-pin]");
+        const pins = timelineElement.querySelectorAll("[data-timeline-pin]");
         if (pins.length === 0) {
           return;
         }
@@ -200,6 +201,7 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
         const nextIndex =
           key === "ArrowRight" ? currentIndex + 1 : currentIndex - 1;
 
+        /* We want to avoid looping */
         if (nextIndex < 0 || nextIndex >= pins.length) {
           return;
         }
@@ -217,7 +219,7 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
       handlePinKeyDown={handlePinKeyDown}
     >
       <TimelineKeyboardNavActiveRowContextProvider activeRow={activeRow}>
-        {props.children}
+        <Slot ref={timelineElementRef}>{children}</Slot>
       </TimelineKeyboardNavActiveRowContextProvider>
     </TimelineKeyboardNavStableContextProvider>
   );

--- a/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
+++ b/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
@@ -47,6 +47,22 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
     setActiveRow(element);
   }, []);
 
+  const focusElement = useCallback(
+    (
+      element: HTMLElement | Element | null,
+      event: React.KeyboardEvent<HTMLElement | Element>,
+    ) => {
+      if (!element) {
+        return;
+      }
+
+      event.preventDefault();
+
+      (element as HTMLElement).focus();
+    },
+    [],
+  );
+
   const handleRowKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
       const currentActiveRow = activeRowRef.current;
@@ -62,7 +78,6 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
       const { key } = event;
 
       if (key === "ArrowDown" || key === "ArrowUp") {
-        event.preventDefault();
         const rows = currentActiveRow.parentElement?.querySelectorAll(
           "[data-timeline-row]",
         );
@@ -82,7 +97,7 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
         const atBoundary = currentIndex === 0 && key === "ArrowUp";
 
         if (atBoundary && firstPin) {
-          (firstPin as HTMLElement | null)?.focus();
+          focusElement(firstPin, event);
           return;
         }
 
@@ -98,9 +113,9 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
         const periods = nextRow?.querySelectorAll("[data-timeline-period]");
 
         if (periods?.length > 0) {
-          (periods[0] as HTMLElement).focus();
+          focusElement(periods[0], event);
         } else if (nextRow) {
-          (nextRow as HTMLElement).focus();
+          focusElement(nextRow, event);
         }
         return;
       }
@@ -128,10 +143,10 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
           return;
         }
 
-        (periods[nextIndex] as HTMLElement).focus();
+        focusElement(periods[nextIndex], event);
       }
     },
-    [],
+    [focusElement],
   );
 
   const handlePinKeyDown = useCallback(
@@ -149,7 +164,6 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
       const { key } = event;
 
       if (key === "ArrowDown") {
-        event.preventDefault();
         const rows = timelineEl.querySelectorAll("[data-timeline-row]");
         if (rows.length === 0) {
           return;
@@ -162,9 +176,9 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
           );
 
           if (periods?.length > 0) {
-            (periods[0] as HTMLElement).focus();
+            focusElement(periods[0], event);
           } else if (rowToFocus) {
-            (rowToFocus as HTMLElement).focus();
+            focusElement(rowToFocus, event);
           }
         }
       }
@@ -190,10 +204,10 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
           return;
         }
 
-        (pins[nextIndex] as HTMLElement).focus();
+        focusElement(pins[nextIndex], event);
       }
     },
-    [],
+    [focusElement],
   );
 
   return (

--- a/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
+++ b/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
@@ -19,9 +19,12 @@ const {
 
 type TimelineKeyboardNavProviderProps = {
   children: React.ReactNode;
+  timelineElement: HTMLDivElement | null;
 };
 
 function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
+  const { timelineElement } = props;
+
   const [activeRow, setActiveRow] = React.useState<HTMLElement | null>(null);
 
   const updateActiveRow = (element: HTMLElement | null) => {
@@ -36,6 +39,7 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
     const { key } = event;
 
     if (key === "ArrowDown" || key === "ArrowUp") {
+      event.preventDefault();
       const rows = activeRow.parentElement?.querySelectorAll(
         "[data-timeline-row]",
       );
@@ -48,6 +52,10 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
       }
 
       const currentIndex = Array.from(rows).indexOf(activeRow);
+      if (currentIndex === -1) {
+        return;
+      }
+
       const atBoundary = currentIndex === 0 && key === "ArrowUp";
 
       if (atBoundary && firstPin) {
@@ -75,6 +83,7 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
     }
 
     if (key === "ArrowRight" || key === "ArrowLeft") {
+      event.preventDefault();
       const periods = activeRow.querySelectorAll("[data-timeline-period]");
       if (periods.length === 0) {
         return;
@@ -83,6 +92,10 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
       const currentIndex = Array.from(periods).indexOf(
         document.activeElement as HTMLElement,
       );
+      if (currentIndex === -1) {
+        return;
+      }
+
       const nextIndex =
         key === "ArrowRight" ? currentIndex + 1 : currentIndex - 1;
 
@@ -95,10 +108,15 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
   };
 
   const handlePinKeyDown = (event: React.KeyboardEvent<Element>) => {
+    if (!timelineElement) {
+      return;
+    }
+
     const { key } = event;
 
     if (key === "ArrowDown") {
-      const rows = document.querySelectorAll("[data-timeline-row]");
+      event.preventDefault();
+      const rows = timelineElement.querySelectorAll("[data-timeline-row]");
       if (rows.length === 0) {
         return;
       }
@@ -116,7 +134,8 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
     }
 
     if (key === "ArrowRight" || key === "ArrowLeft") {
-      const pins = document.querySelectorAll("[data-timeline-pin]");
+      event.preventDefault();
+      const pins = timelineElement.querySelectorAll("[data-timeline-pin]");
       if (pins.length === 0) {
         return;
       }
@@ -124,6 +143,10 @@ function TimelineKeyboardNavProvider(props: TimelineKeyboardNavProviderProps) {
       const currentIndex = Array.from(pins).indexOf(
         document.activeElement as HTMLElement,
       );
+      if (currentIndex === -1) {
+        return;
+      }
+
       const nextIndex =
         key === "ArrowRight" ? currentIndex + 1 : currentIndex - 1;
 

--- a/@navikt/core/react/src/timeline/hooks/usePeriodContext.tsx
+++ b/@navikt/core/react/src/timeline/hooks/usePeriodContext.tsx
@@ -2,13 +2,11 @@ import { createContext, useContext } from "react";
 
 interface PeriodContextProps {
   periodId: string;
-  firstFocus: boolean;
   restProps?: any;
 }
 
 export const PeriodContext = createContext<PeriodContextProps>({
   periodId: "",
-  firstFocus: false,
 });
 
 export const usePeriodContext = () => {

--- a/@navikt/core/react/src/timeline/hooks/useRowContext.tsx
+++ b/@navikt/core/react/src/timeline/hooks/useRowContext.tsx
@@ -4,14 +4,12 @@ import { PositionedPeriod } from "../utils/types.internal";
 interface RowContextProps {
   periods: PositionedPeriod[];
   id: string;
-  active: boolean;
   index: number;
 }
 
 export const RowContext = createContext<RowContextProps>({
   periods: [],
   id: "",
-  active: false,
   index: 0,
 });
 

--- a/@navikt/core/react/src/timeline/hooks/useTimelineContext.tsx
+++ b/@navikt/core/react/src/timeline/hooks/useTimelineContext.tsx
@@ -7,9 +7,6 @@ interface TimelineContextProps {
   setStart: (d: Date) => void;
   setEndInclusive: (d: Date) => void;
   activeRow: number | null;
-  setActiveRow: (i: string) => void;
-  initiate: (i: number) => void;
-  addFocusable: (ref: HTMLButtonElement | null, id: number) => void;
 }
 
 export const TimelineContext = createContext<TimelineContextProps>({
@@ -19,9 +16,6 @@ export const TimelineContext = createContext<TimelineContextProps>({
   setStart: () => null,
   setEndInclusive: () => null,
   activeRow: 0,
-  setActiveRow: () => null,
-  initiate: () => null,
-  addFocusable: () => null,
 });
 
 export const useTimelineContext = () => {

--- a/@navikt/core/react/src/timeline/hooks/useTimelineContext.tsx
+++ b/@navikt/core/react/src/timeline/hooks/useTimelineContext.tsx
@@ -6,7 +6,6 @@ interface TimelineContextProps {
   direction: "left" | "right";
   setStart: (d: Date) => void;
   setEndInclusive: (d: Date) => void;
-  activeRow: number | null;
 }
 
 export const TimelineContext = createContext<TimelineContextProps>({
@@ -15,7 +14,6 @@ export const TimelineContext = createContext<TimelineContextProps>({
   direction: "left",
   setStart: () => null,
   setEndInclusive: () => null,
-  activeRow: 0,
 });
 
 export const useTimelineContext = () => {

--- a/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
@@ -16,9 +16,6 @@ import React, { useState } from "react";
 import { cl } from "../../utils/helpers";
 import { useMergeRefs } from "../../utils/hooks";
 import { useI18n } from "../../utils/i18n/i18n.hooks";
-import { usePeriodContext } from "../hooks/usePeriodContext";
-import { useRowContext } from "../hooks/useRowContext";
-import { useTimelineContext } from "../hooks/useTimelineContext";
 import { ariaLabel, getConditionalClasses } from "../utils/period";
 import type { PeriodProps } from "./types";
 
@@ -53,9 +50,6 @@ const ClickablePeriod = React.memo(
     periodRef,
   }: TimelineClickablePeriodProps) => {
     const [open, setOpen] = useState(false);
-    const { index } = useRowContext();
-    const { firstFocus } = usePeriodContext();
-    const { initiate, addFocusable } = useTimelineContext();
 
     const translate = useI18n("Timeline");
 
@@ -95,13 +89,11 @@ const ClickablePeriod = React.memo(
     return (
       <>
         <button
+          data-timeline-period
           {...restProps}
           data-color={restProps?.["data-color"] ?? status}
           type="button"
-          ref={(r) => {
-            firstFocus && addFocusable(r, index);
-            mergedRef?.(r);
-          }}
+          ref={mergedRef}
           aria-label={label}
           className={cl(
             "aksel-timeline__period--clickable",
@@ -114,9 +106,6 @@ const ClickablePeriod = React.memo(
           aria-expanded={children ? open : undefined}
           aria-current={isActive || undefined}
           {...getReferenceProps({
-            onFocus: () => {
-              initiate(index);
-            },
             onKeyDown: (e) => {
               restProps?.onKeydown?.(e);
               if (e.key === " ") {

--- a/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
@@ -136,6 +136,7 @@ const ClickablePeriod = React.memo(
           >
             <div
               className="aksel-timeline__popover"
+              data-timeline-popover
               data-placement={placement}
               ref={refs.setFloating}
               role="dialog"

--- a/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
@@ -132,7 +132,7 @@ const ClickablePeriod = React.memo(
             context={context}
             modal={false}
             initialFocus={-1}
-            returnFocus={false}
+            returnFocus
           >
             <div
               className="aksel-timeline__popover"

--- a/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
@@ -107,7 +107,7 @@ const ClickablePeriod = React.memo(
           aria-current={isActive || undefined}
           {...getReferenceProps({
             onKeyDown: (e) => {
-              restProps?.onKeydown?.(e);
+              restProps?.onKeyDown?.(e);
               if (e.key === " ") {
                 onSelectPeriod?.(e);
               }

--- a/@navikt/core/react/src/timeline/period/NonClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/NonClickablePeriod.tsx
@@ -25,7 +25,9 @@ const NonClickablePeriod = ({
 
   return (
     <div
+      data-timeline-period
       ref={periodRef}
+      tabIndex={-1}
       {...restProps}
       data-color={restProps?.["data-color"] ?? status}
       className={cl(

--- a/@navikt/core/react/src/timeline/pin/PinInternal.tsx
+++ b/@navikt/core/react/src/timeline/pin/PinInternal.tsx
@@ -91,11 +91,6 @@ export const PinInternal = forwardRef<HTMLButtonElement, TimelinePinProps>(
             {...getReferenceProps({
               onKeyDown: (e) => {
                 rest?.onKeyDown?.(e as React.KeyboardEvent<HTMLButtonElement>);
-                if (e.key === "Enter") {
-                  setOpen((prev) => !prev);
-                } else if (e.key === " ") {
-                  setOpen(false);
-                }
                 handlePinKeyDown(e);
               },
             })}

--- a/@navikt/core/react/src/timeline/pin/PinInternal.tsx
+++ b/@navikt/core/react/src/timeline/pin/PinInternal.tsx
@@ -101,7 +101,7 @@ export const PinInternal = forwardRef<HTMLButtonElement, TimelinePinProps>(
             context={context}
             modal={false}
             initialFocus={-1}
-            returnFocus={false}
+            returnFocus
           >
             <div
               className="aksel-timeline__popover"

--- a/@navikt/core/react/src/timeline/pin/PinInternal.tsx
+++ b/@navikt/core/react/src/timeline/pin/PinInternal.tsx
@@ -16,6 +16,7 @@ import { format } from "date-fns";
 import React, { forwardRef, useState } from "react";
 import { useMergeRefs } from "../../utils/hooks";
 import { useI18n } from "../../utils/i18n/i18n.hooks";
+import { useTimelineKeyboardContext } from "../hooks/TimelineKeyboardNavProvider";
 import { useTimelineContext } from "../hooks/useTimelineContext";
 import { position } from "../utils/calc";
 
@@ -33,6 +34,7 @@ export interface TimelinePinProps extends React.HTMLAttributes<HTMLButtonElement
 export const PinInternal = forwardRef<HTMLButtonElement, TimelinePinProps>(
   ({ date, children, ...rest }, ref) => {
     const { startDate, endDate, direction } = useTimelineContext();
+    const { handlePinKeyDown } = useTimelineKeyboardContext();
     const [open, setOpen] = useState(false);
 
     const translate = useI18n("Timeline");
@@ -94,6 +96,7 @@ export const PinInternal = forwardRef<HTMLButtonElement, TimelinePinProps>(
                 } else if (e.key === " ") {
                   setOpen(false);
                 }
+                handlePinKeyDown(e);
               },
             })}
           />

--- a/@navikt/core/react/src/timeline/pin/PinInternal.tsx
+++ b/@navikt/core/react/src/timeline/pin/PinInternal.tsx
@@ -79,6 +79,7 @@ export const PinInternal = forwardRef<HTMLButtonElement, TimelinePinProps>(
           style={{ [direction]: `${position(date, startDate, endDate)}%` }}
         >
           <button
+            data-timeline-pin
             {...rest}
             ref={mergedRef}
             className="aksel-timeline__pin-button"

--- a/@navikt/core/react/src/timeline/pin/PinInternal.tsx
+++ b/@navikt/core/react/src/timeline/pin/PinInternal.tsx
@@ -105,6 +105,7 @@ export const PinInternal = forwardRef<HTMLButtonElement, TimelinePinProps>(
           >
             <div
               className="aksel-timeline__popover"
+              data-timeline-popover
               data-placement={placement}
               ref={refs.setFloating}
               role="dialog"

--- a/@navikt/core/react/src/timeline/pin/PinInternal.tsx
+++ b/@navikt/core/react/src/timeline/pin/PinInternal.tsx
@@ -5,6 +5,7 @@ import {
   offset,
   safePolygon,
   shift,
+  useClick,
   useDismiss,
   useFloating,
   useFocus,
@@ -56,8 +57,10 @@ export const PinInternal = forwardRef<HTMLButtonElement, TimelinePinProps>(
     });
     const focus = useFocus(context);
     const dismiss = useDismiss(context);
+    const click = useClick(context);
 
     const { getFloatingProps, getReferenceProps } = useInteractions([
+      click,
       hover,
       focus,
       dismiss,


### PR DESCRIPTION
### Description

Added built-in keyboard-nav for timeline
- ArrowLeft/ArrowRight: Navigates between periods and pins
- ArrowUp/ArrowDown: Navigates between rows or up to pins.


Added dynamic scaling for period-icons based on container size
- This avoid the clipping for smaller periods today

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
