### PR TITLE
[Timeline] When row has focus, focus first or last period based on arrow-keys

### DIFF
--- a/@navikt/core/css/src/timeline.css
+++ b/@navikt/core/css/src/timeline.css
@@ -41,6 +41,17 @@
   background: var(--ax-bg-neutral-softA);
   margin: var(--ax-space-16) 0;
   grid-column: 2;
+
+  &:focus {
+    outline: none;
+  }
+
+  @media (forced-colors: active) {
+    &:focus {
+      outline: 1px solid highlight;
+      outline-offset: -1px;
+    }
+  }
 }
 
 .aksel-timeline__row--active {

--- a/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
+++ b/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
@@ -117,6 +117,11 @@ function TimelineKeyboardNavProvider({
           document.activeElement as HTMLElement,
         );
         if (currentIndex === -1) {
+          /* Of just the row has focus, we want to focus either the first or last period inside based on key */
+          focusElement(
+            periods[key === "ArrowRight" ? 0 : periods.length - 1],
+            event,
+          );
           return;
         }
 

--- a/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
+++ b/@navikt/core/react/src/timeline/hooks/TimelineKeyboardNavProvider.tsx
@@ -117,7 +117,7 @@ function TimelineKeyboardNavProvider({
           document.activeElement as HTMLElement,
         );
         if (currentIndex === -1) {
-          /* Of just the row has focus, we want to focus either the first or last period inside based on key */
+          /* If just the row has focus, we want to focus either the first or last period inside based on key */
           focusElement(
             periods[key === "ArrowRight" ? 0 : periods.length - 1],
             event,


### PR DESCRIPTION
### Description

Also added high-contrast border when row has focus.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
