### PR TITLE
Storybook: improved types in main and preview config

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,4 @@
-import { StorybookConfig } from "@storybook/react-vite";
+import { defineMain } from "@storybook/react-vite/node";
 import FG from "fast-glob";
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
@@ -17,7 +17,7 @@ const includeWebsiteStories = process.env.WITH_WEBSITE === "true";
 
 const indexRegex = /export const args = {\s+index: (\d+),/;
 
-export default {
+export default defineMain({
   experimental_indexers: (indexers) => {
     // Changes here might need to be reflected in aksel.nav.no/website/.storybook/main.ts
     const customIndexer = async (fileName: string, opts: any) => {
@@ -126,9 +126,9 @@ export default {
   features: {
     actions: false,
   },
-} satisfies StorybookConfig;
+});
 
-function getAbsolutePath(value: string): any {
+function getAbsolutePath(value: string) {
   return dirname(require.resolve(join(value, "package.json")));
 }
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,7 @@
-import { withThemeByClassName } from "@storybook/addon-themes";
+import addonA11y from "@storybook/addon-a11y";
+import addonDocs from "@storybook/addon-docs";
+import addonThemes, { withThemeByClassName } from "@storybook/addon-themes";
+import addonVitest from "@storybook/addon-vitest";
 import { definePreview } from "@storybook/react-vite";
 import React, { useEffect } from "react";
 import "../@navikt/core/css/src/data-table.css";
@@ -56,6 +59,7 @@ const TypoDecorator = ({
 };
 
 export default definePreview({
+  addons: [addonA11y(), addonThemes(), addonDocs(), addonVitest()],
   parameters: {
     options: {
       storySort: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,8 @@
-import { withThemeByClassName } from "@storybook/addon-themes";
-import { Preview } from "@storybook/react-vite";
+import addonA11y from "@storybook/addon-a11y";
+import addonDocs from "@storybook/addon-docs";
+import addonThemes, { withThemeByClassName } from "@storybook/addon-themes";
+import addonVitest from "@storybook/addon-vitest";
+import { definePreview } from "@storybook/react-vite";
 import React, { useEffect } from "react";
 import "../@navikt/core/css/src/data-table.css";
 import "../@navikt/core/css/src/data-token-filter.css";
@@ -55,7 +58,8 @@ const TypoDecorator = ({
   return <>{children}</>;
 };
 
-export default {
+export default definePreview({
+  addons: [addonA11y(), addonThemes(), addonDocs(), addonVitest()],
   parameters: {
     options: {
       storySort: {
@@ -132,4 +136,4 @@ export default {
       defaultTheme: "light",
     }),
   ],
-} satisfies Preview;
+});

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,7 +1,4 @@
-import addonA11y from "@storybook/addon-a11y";
-import addonDocs from "@storybook/addon-docs";
-import addonThemes, { withThemeByClassName } from "@storybook/addon-themes";
-import addonVitest from "@storybook/addon-vitest";
+import { withThemeByClassName } from "@storybook/addon-themes";
 import { definePreview } from "@storybook/react-vite";
 import React, { useEffect } from "react";
 import "../@navikt/core/css/src/data-table.css";
@@ -59,7 +56,6 @@ const TypoDecorator = ({
 };
 
 export default definePreview({
-  addons: [addonA11y(), addonThemes(), addonDocs(), addonVitest()],
   parameters: {
     options: {
       storySort: {

--- a/aksel.nav.no/website/.storybook/main.ts
+++ b/aksel.nav.no/website/.storybook/main.ts
@@ -1,4 +1,4 @@
-import type { StorybookConfig } from "@storybook/nextjs-vite";
+import { defineMain } from "@storybook/nextjs-vite/node";
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
@@ -13,7 +13,7 @@ const require = createRequire(import.meta.url);
 
 const indexRegex = /export const args = {\s+index: (\d+),/;
 
-const sbConfig: StorybookConfig = {
+export default defineMain({
   experimental_indexers: (indexers) => {
     // Changes here might need to be reflected in .storybook/main.ts
     const customIndexer = async (fileName: string, opts: any) => {
@@ -86,8 +86,7 @@ const sbConfig: StorybookConfig = {
       ],
     });
   },
-};
-export default sbConfig;
+});
 
 function getAbsolutePath(value: string): any {
   return dirname(require.resolve(join(value, "package.json")));

--- a/aksel.nav.no/website/.storybook/main.ts
+++ b/aksel.nav.no/website/.storybook/main.ts
@@ -88,6 +88,6 @@ export default defineMain({
   },
 });
 
-function getAbsolutePath(value: string): any {
+function getAbsolutePath(value: string) {
   return dirname(require.resolve(join(value, "package.json")));
 }

--- a/aksel.nav.no/website/.storybook/preview.tsx
+++ b/aksel.nav.no/website/.storybook/preview.tsx
@@ -1,5 +1,8 @@
-import { withThemeByClassName } from "@storybook/addon-themes";
-import type { Preview } from "@storybook/nextjs-vite";
+import a11yAddon from "@storybook/addon-a11y";
+import docsAddon from "@storybook/addon-docs";
+import themesAddon, { withThemeByClassName } from "@storybook/addon-themes";
+import { definePreview } from "@storybook/nextjs-vite";
+import type { JSX } from "react";
 import { Box, Theme } from "@navikt/ds-react";
 import "./aksel-storybook.css";
 
@@ -13,7 +16,8 @@ const withTheme = (Story: () => JSX.Element) => {
   );
 };
 
-const preview: Preview = {
+const preview = definePreview({
+  addons: [a11yAddon(), themesAddon(), docsAddon()],
   parameters: {
     options: {
       // The `a` and `b` arguments in this function have a type of `import('storybook/internal/types').IndexEntry`.
@@ -42,6 +46,6 @@ const preview: Preview = {
       defaultTheme: "light",
     }),
   ],
-};
+});
 
 export default preview;

--- a/aksel.nav.no/website/.storybook/preview.tsx
+++ b/aksel.nav.no/website/.storybook/preview.tsx
@@ -1,4 +1,6 @@
-import { withThemeByClassName } from "@storybook/addon-themes";
+import a11yAddon from "@storybook/addon-a11y";
+import docsAddon from "@storybook/addon-docs";
+import themesAddon, { withThemeByClassName } from "@storybook/addon-themes";
 import { definePreview } from "@storybook/nextjs-vite";
 import type { JSX } from "react";
 import { Box, Theme } from "@navikt/ds-react";
@@ -15,6 +17,7 @@ const withTheme = (Story: () => JSX.Element) => {
 };
 
 const preview = definePreview({
+  addons: [a11yAddon(), themesAddon(), docsAddon()],
   parameters: {
     options: {
       // The `a` and `b` arguments in this function have a type of `import('storybook/internal/types').IndexEntry`.

--- a/aksel.nav.no/website/.storybook/preview.tsx
+++ b/aksel.nav.no/website/.storybook/preview.tsx
@@ -1,6 +1,4 @@
-import a11yAddon from "@storybook/addon-a11y";
-import docsAddon from "@storybook/addon-docs";
-import themesAddon, { withThemeByClassName } from "@storybook/addon-themes";
+import { withThemeByClassName } from "@storybook/addon-themes";
 import { definePreview } from "@storybook/nextjs-vite";
 import type { JSX } from "react";
 import { Box, Theme } from "@navikt/ds-react";
@@ -17,7 +15,6 @@ const withTheme = (Story: () => JSX.Element) => {
 };
 
 const preview = definePreview({
-  addons: [a11yAddon(), themesAddon(), docsAddon()],
   parameters: {
     options: {
       // The `a` and `b` arguments in this function have a type of `import('storybook/internal/types').IndexEntry`.


### PR DESCRIPTION
This will be needed in order to use the new [Component Story Format](https://storybook.js.org/docs/api/csf/csf-next?renderer=react).

I tested to use the new format in a story file, but it required too much refactoring for now. The main benefit with the new format, as I understand it, is that the `parameters` property is now better typed. Maybe other props too.