### PR TITLE
:lipstick: Dialog now bottom-aligns on smaller breakpoint

### DIFF
--- a/.changeset/tender-beers-chew.md
+++ b/.changeset/tender-beers-chew.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Dialog: Now aligns to bottom when centered at 480px instead of 768px screen width

--- a/@navikt/core/css/src/dialog.css
+++ b/@navikt/core/css/src/dialog.css
@@ -96,7 +96,7 @@
       transform: translateY(calc(1rem * var(--__axc-nested-level) * -1)) scale(calc(1 - 0.02 * var(--__axc-nested-level)));
     }
 
-    @media (max-width: 768px) or (max-height: 479px) {
+    @media (max-width: 480px) or (max-height: 479px) {
       --__axc-dialog-transform: translateY(35%);
 
       max-height: calc(100dvh - max(16px, 10dvh));


### PR DESCRIPTION
### Description

https://nav-it.slack.com/archives/C7NE7A8UF/p1776927786728509

Resolves #4729

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
