### PR TITLE
:bug: Stop className from being fowarded to input-element in radio/checkbox

### DIFF
--- a/.changeset/cuddly-queens-roll.md
+++ b/.changeset/cuddly-queens-roll.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Radio, Checkbox: Fix regression where `className` were mistakenly passed to `input`-element

--- a/.changeset/cuddly-queens-roll.md
+++ b/.changeset/cuddly-queens-roll.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-Radio, Checkbox: Fix regression where `className` were mistakenly passed to `input`-element
+Radio, Checkbox: Fix regression where `className` was mistakenly passed to `input`-element

--- a/@navikt/core/react/src/form/checkbox/Checkbox.tsx
+++ b/@navikt/core/react/src/form/checkbox/Checkbox.tsx
@@ -35,6 +35,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             "indeterminate",
             "errorId",
             "readOnly",
+            "className",
           ])}
           {...omit(inputProps, ["aria-invalid", "aria-describedby"])}
           aria-describedby={

--- a/@navikt/core/react/src/form/radio/Radio.tsx
+++ b/@navikt/core/react/src/form/radio/Radio.tsx
@@ -24,7 +24,13 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
       >
         <RadioInput
           ref={forwardedRef}
-          {...omit(props, ["children", "size", "description", "readOnly"])}
+          {...omit(props, [
+            "children",
+            "size",
+            "description",
+            "readOnly",
+            "className",
+          ])}
           {...omit(inputProps, ["aria-invalid", "aria-describedby"])}
           aria-describedby={
             cl(inputProps["aria-describedby"], {


### PR DESCRIPTION

### Description

Resolves #4836

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
