### PR TITLE
[website] Improvements in props-section

### DIFF
--- a/aksel.nav.no/website/app/_ui/props-seksjon/PropsSeksjon.decription.tsx
+++ b/aksel.nav.no/website/app/_ui/props-seksjon/PropsSeksjon.decription.tsx
@@ -7,9 +7,11 @@ import styles from "./PropsSeksjon.module.css";
 function PropsSeksjonDescription({
   description,
   params,
+  returnVal,
 }: {
-  description?: string;
-  params?: string[];
+  description: string | undefined;
+  params: string[] | undefined;
+  returnVal: string | undefined;
 }) {
   if (!description) {
     return null;
@@ -30,20 +32,26 @@ function PropsSeksjonDescription({
           >
             {description}
           </Markdown>
+          {params && (
+            <ul>
+              {params.map((param) => {
+                const [name, ...desc] = param.split(" ");
+                return (
+                  <li key={param}>
+                    <strong>{name}: </strong>
+                    {desc.join(" ")}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          {returnVal && (
+            <div>
+              <strong>Return: </strong>
+              {returnVal}
+            </div>
+          )}
         </VStack>
-        {params && (
-          <ul>
-            {params.map((param) => {
-              const [name, ...desc] = param.split(" ");
-              return (
-                <li key={param}>
-                  <strong>{name}: </strong>
-                  {desc.join(" ")}
-                </li>
-              );
-            })}
-          </ul>
-        )}
       </div>
     </li>
   );

--- a/aksel.nav.no/website/app/_ui/props-seksjon/PropsSeksjon.tsx
+++ b/aksel.nav.no/website/app/_ui/props-seksjon/PropsSeksjon.tsx
@@ -86,55 +86,22 @@ const PropEntry = ({
     NonNullable<PropsSeksjonComponentT["propref"]>["proplist"]
   >[0];
 }) => {
-  if (prop.deprecated) {
-    return (
-      <>
-        <Box
-          as="dt"
-          paddingBlock="space-8 space-0"
-          paddingInline="space-8"
-          className="inline-block"
-        >
-          <Code as="h4" className="mr-2" strikethrough highlighted>{`${
-            prop.name
-          }${prop?.required ? "" : "?"}`}</Code>
-        </Box>
-        <BodyShort as="dd">
-          <Box as="ul" overflowX="auto">
-            <PropsSeksjonDeprecation text={prop.deprecated} />
-            <PropsSeksjonCode code={prop.type} title="Type" wrap />
-            <PropsSeksjonCode
-              /* We assume that if type starts with ", its an union-type */
-              code={prop.defaultValue}
-              title="Default"
-              wrap
-            />
-            <PropsSeksjonDescription
-              description={prop.description}
-              params={prop.params}
-            />
-            <PropsSeksjonCode code={prop.example} title="Example" />
-          </Box>
-        </BodyShort>
-      </>
-    );
-  }
-
-  let type = prop.type;
-
-  if (prop.type === "AkselColor") {
-    type = unpackAkselColorType();
-  }
+  const type = prop.type === "AkselColor" ? unpackedAkselColorType : prop.type;
 
   return (
     <>
       <Box as="dt" paddingBlock="space-8 space-0" paddingInline="space-8">
-        <Code as="h4" highlighted>{`${prop.name}${
-          prop?.required ? "" : "?"
-        }`}</Code>
+        <Code
+          as="h4"
+          highlighted
+          strikethrough={!!prop.deprecated}
+        >{`${prop.name}${prop?.required ? "" : "?"}`}</Code>
       </Box>
       <BodyShort as="dd">
         <Box as="ul" overflowX="auto">
+          {prop.deprecated && (
+            <PropsSeksjonDeprecation text={prop.deprecated} />
+          )}
           <PropsSeksjonCode code={type} title="Type" wrap />
           <PropsSeksjonCode
             /* We assume that if type starts with ", its an union-type */
@@ -145,6 +112,7 @@ const PropEntry = ({
           <PropsSeksjonDescription
             description={prop.description}
             params={prop.params}
+            returnVal={prop.return}
           />
           <PropsSeksjonCode code={prop.example} title="Example" />
         </Box>
@@ -167,10 +135,8 @@ const colors: Record<AkselColorRole, boolean> = {
   "brand-magenta": true,
 };
 
-function unpackAkselColorType() {
-  return Object.keys(colors)
-    .map((key) => `"${key}"`)
-    .join(" | ");
-}
+const unpackedAkselColorType = Object.keys(colors)
+  .map((key) => `"${key}"`)
+  .join(" | ");
 
 export { PropsSeksjon };


### PR DESCRIPTION
Before:
<img width="639" height="195" alt="image" src="https://github.com/user-attachments/assets/02699a55-47b1-42f9-a00d-c8cf2f971d1f" />

After:
<img width="647" height="203" alt="image" src="https://github.com/user-attachments/assets/5055184e-14b1-40cf-82de-737195f0ea22" />

Before:
<img width="631" height="145" alt="image" src="https://github.com/user-attachments/assets/f9437898-a8e7-4529-9c0f-7c9a3c82a180" />

After:
<img width="684" height="181" alt="image" src="https://github.com/user-attachments/assets/7b772314-d0a2-40ad-af0a-b7b36e942eab" />
