### PR TITLE
useControllableState: The setter can have narrower type than the state

### DIFF
--- a/@navikt/core/react/src/data/table/column-header/useTableColumnResize.ts
+++ b/@navikt/core/react/src/data/table/column-header/useTableColumnResize.ts
@@ -58,7 +58,7 @@ type ResizeProps = {
    * Called when the column width changes.
    * @param width New width in pixels.
    */
-  onWidthChange?: (width: number | string) => void;
+  onWidthChange?: (width: number) => void;
   /**
    * Forwarded styles
    */

--- a/@navikt/core/react/src/utils/hooks/useControllableState.ts
+++ b/@navikt/core/react/src/utils/hooks/useControllableState.ts
@@ -2,28 +2,31 @@
 import { useState } from "react";
 import { useEventCallback } from "./useEventCallback";
 
-export interface UseControllableStateProps<T> {
-  value?: T;
-  defaultValue: T | (() => T);
-  onChange?: (value: T) => void;
+export interface UseControllableStateProps<
+  StateT,
+  ChangeT extends StateT = StateT,
+> {
+  value?: StateT;
+  defaultValue: StateT | (() => StateT);
+  onChange?: (value: ChangeT) => void;
 }
 
 /**
  * `useControllableState` returns the state and function that updates the state, just like React.useState does.
  */
-export function useControllableState<T>({
+export function useControllableState<StateT, ChangeT extends StateT = StateT>({
   value: valueProp,
   defaultValue,
   onChange,
-}: UseControllableStateProps<T>) {
+}: UseControllableStateProps<StateT, ChangeT>) {
   const onChangeProp = useEventCallback(onChange);
 
   const [uncontrolledState, setUncontrolledState] = useState(defaultValue);
   const controlled = valueProp !== undefined;
   const value = controlled ? valueProp : uncontrolledState;
 
-  const setValue = useEventCallback((next: React.SetStateAction<T>) => {
-    const setter = next as (prevState?: T) => T;
+  const setValue = useEventCallback((next: React.SetStateAction<ChangeT>) => {
+    const setter = next as (prevState?: StateT) => ChangeT;
     const nextValue = typeof next === "function" ? setter(value) : next;
 
     if (!controlled) {


### PR DESCRIPTION
### Description

Adjust the types in `useControllableState()` to allow `value` in `onChange` to be a subset of the state type.

Used in `useTableColumnResize()`.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
