### PR TITLE
Pagination: Fix selected-styling in forced-colors mode

### DIFF
--- a/.changeset/funky-bats-wink.md
+++ b/.changeset/funky-bats-wink.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Pagination: Fix selected-styling in forced-colors mode

--- a/@navikt/core/css/src/button.css
+++ b/@navikt/core/css/src/button.css
@@ -247,6 +247,15 @@
       color: highlight;
       box-shadow: none;
     }
+
+    &[data-variant="tertiary"][data-pressed="true"] {
+      background-color: selecteditem;
+      color: selecteditemtext;
+
+      & span {
+        forced-color-adjust: none;
+      }
+    }
   }
 
   .aksel-button:not(:disabled):hover span {


### PR DESCRIPTION
### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
