### PR TITLE
[Website] Codeblock adjustments

### DIFF
--- a/aksel.nav.no/website/app/_ui/code-block/CodeBlock.module.css
+++ b/aksel.nav.no/website/app/_ui/code-block/CodeBlock.module.css
@@ -12,11 +12,15 @@
 
   border-top: 1px solid var(--ax-border-neutral-subtleA);
   border-bottom: 1px solid var(--ax-border-neutral-subtleA);
-  padding: var(--codeblock-padding);
+  padding: var(--ax-space-12) var(--codeblock-padding);
   font-size: var(--ax-font-size-medium);
-  font-family: var(--aksel-font-mono);
+  font-family: var(--website-font-mono);
   overflow-x: auto;
   overscroll-behavior-x: contain;
+
+  :global(.dark) & {
+    background-color: var(--ax-bg-sunken);
+  }
 
   &:last-child {
     border-bottom: none;
@@ -46,7 +50,7 @@
         text-align: right;
         user-select: none;
         color: var(--ax-text-neutral-subtle);
-        font-family: var(--aksel-font-mono);
+        font-family: var(--website-font-mono);
         font-size: var(--ax-font-size-small);
         display: inline-block;
         position: absolute;
@@ -59,7 +63,7 @@
 }
 
 .codeBlockLine {
-  margin-left: var(--ax-space-20);
+  margin-left: var(--ax-space-12);
 }
 
 .codeBlockHeader {
@@ -75,7 +79,7 @@
 
 .codeBlockHeaderItem {
   min-height: 2rem;
-  padding: var(--ax-space-8) var(--ax-space-16);
+  padding: var(--ax-space-8) var(--ax-space-12);
   color: var(--ax-text-neutral);
 
   /* Optical centering */
@@ -117,7 +121,7 @@
     text-align: left;
     user-select: none;
     color: var(--ax-text-neutral-subtle);
-    font-family: var(--aksel-font-mono);
+    font-family: var(--website-font-mono);
     font-size: var(--ax-font-size-small);
     display: inline-block;
     position: absolute;

--- a/aksel.nav.no/website/app/_ui/code-block/CodeBlock.provider.tsx
+++ b/aksel.nav.no/website/app/_ui/code-block/CodeBlock.provider.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { createContext, useContext, useState } from "react";
+import {
+  createContext,
+  startTransition,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 
 // https://github.com/FormidableLabs/prism-react-renderer/blob/e1c83a468b05df7f452b3ad7e4ae5ab874574d4e/packages/generate-prism-languages/index.ts#L9-L23
 export const languages = [
@@ -73,6 +79,17 @@ function CodeBlockProvider({
       setCurrentCodeSnippet(code);
     }
   };
+
+  useEffect(
+    function syncGivenTabsWithCurrentCodeSnippet() {
+      if (!tabs || tabs.length === 0) {
+        return;
+      }
+
+      startTransition(() => setCurrentCodeSnippet(tabs?.[0]?.code ?? null));
+    },
+    [tabs],
+  );
 
   return (
     <CodeBlockContext.Provider

--- a/aksel.nav.no/website/app/_ui/code-block/CodeBlock.single.tsx
+++ b/aksel.nav.no/website/app/_ui/code-block/CodeBlock.single.tsx
@@ -14,7 +14,7 @@ function SingleCodeBlock(props: ExtractPortableComponentProps<"kode">) {
   const tab: CodeBlockTabsT[number] = {
     code: code.code,
     lang: (code.language as any) ?? "tsx",
-    text: title ?? code.language?.toUpperCase() ?? "Kode",
+    text: title ?? code.language ?? "Kode",
     value: id,
   };
 

--- a/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
+++ b/aksel.nav.no/website/app/_ui/code-block/CodeBlock.tsx
@@ -240,6 +240,7 @@ function ActionButtons() {
   const { codeSnippet, wrapCode } = useCodeBlock();
 
   const titleId = useId();
+  const codeSnippetValue = codeSnippet.current;
 
   return (
     <HStack gap="space-4" align="center" wrap={false}>
@@ -268,9 +269,9 @@ function ActionButtons() {
           </svg>
         }
       />
-      {codeSnippet.current && (
+      {codeSnippetValue && (
         <CopyButton
-          copyText={codeSnippet.current}
+          copyText={codeSnippetValue}
           size="small"
           onClick={() =>
             umamiTrack(Events.TEKST_KOPIERT, { tekst: "kodeblokk" })

--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.iframe.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.iframe.tsx
@@ -64,6 +64,10 @@ function KodeEksemplerIFrame(props: {
     setHasMounted(true); // eslint-disable-line react-hooks/set-state-in-effect
   }, []);
 
+  const getCurrentCode = () => {
+    return (hasJSXSnippet ? current?.kompaktInnhold : current?.innhold) ?? "";
+  };
+
   return (
     <div>
       <div className={styles.kodeExampleContainer}>
@@ -114,9 +118,7 @@ function KodeEksemplerIFrame(props: {
               text: "App.tsx",
               value: "example",
               lang: "tsx",
-              code:
-                (hasJSXSnippet ? current?.kompaktInnhold : current?.innhold) ??
-                "",
+              code: getCurrentCode(),
               extraCode: hasJSXSnippet ? current?.innhold : undefined,
             },
           ]}

--- a/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.iframe.tsx
+++ b/aksel.nav.no/website/app/_ui/kode-eksempler/KodeEksempler.iframe.tsx
@@ -111,7 +111,7 @@ function KodeEksemplerIFrame(props: {
           aria-label={`Kode for ${current?.title}`}
           tabs={[
             {
-              text: "TSX",
+              text: "App.tsx",
               value: "example",
               lang: "tsx",
               code:


### PR DESCRIPTION
### Description

- Updated default titles when only language is provided to lowercase
- sunken bg for editor on darkmode
- fixed fonts
- Better height/padding ration between header and codeeditor. Mostly only noticable when the codeblock is 1 line of code.
- Fixed issue where copybutton did not get correct code in some scenarios when switching between examples.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
