### PR TITLE
Remove Storybook+Vitest setup file

### DIFF
--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -1,7 +1,0 @@
-import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
-import { setProjectAnnotations } from "@storybook/react-vite";
-import * as projectAnnotations from "./preview";
-
-// This is an important step to apply the right configuration when testing your stories.
-// More info at: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations
-setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,7 +25,6 @@ export default defineConfig({
             provider: playwright(),
             instances: [{ browser: "firefox" }],
           },
-          setupFiles: [".storybook/vitest.setup.ts"],
         },
       },
     ],


### PR DESCRIPTION
This comes up when running `yarn storybook:test`

> Found a setup file with "setProjectAnnotations". Skipping automatic provisioning of preview annotations to avoid conflicts. Since Storybook 10.3, "@storybook/addon-vitest" applies these automatically. You can safely remove the "setProjectAnnotations" call from your setup file, or remove the file entirely if you don't have custom code there.