### PR TITLE
[website] Use ShowMore in Preview note

### DIFF
--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/LogEntry.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/grunnleggende/endringslogg/_ui/LogEntry.tsx
@@ -161,7 +161,7 @@ export default function LogEntry({
                 <ShowMore.Button>
                   <Button
                     size="small"
-                    variant="secondary-neutral"
+                    variant="secondary"
                     className={
                       fremhevet ? styles.showMoreButtonFremhevet : undefined
                     }

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/komponenter/[category]/_ui/KomponenterPage.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/komponenter/[category]/_ui/KomponenterPage.tsx
@@ -1,12 +1,5 @@
 import { PortableTextBlock } from "next-sanity";
 import { notFound } from "next/navigation";
-import { TestFlaskIcon } from "@navikt/aksel-icons";
-import {
-  InfoCard,
-  InfoCardContent,
-  InfoCardHeader,
-  InfoCardTitle,
-} from "@navikt/ds-react/InfoCard";
 import { DesignsystemetKomponentIntro } from "@/app/(routes)/(designsystemet)/_ui/Designsystemet.intro";
 import {
   DesignsystemetPageHeader,
@@ -20,6 +13,7 @@ import {
 import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
 import { SystemPanel } from "@/app/_ui/system-panel/SystemPanel";
 import { TableOfContents } from "@/app/_ui/toc/TableOfContents";
+import { PreviewNote } from "./PreviewNote";
 
 async function KomponenterPage({ slug }: { slug: string }) {
   const [{ data: pageData }, { data: toc = [] }] = await Promise.all([
@@ -59,16 +53,9 @@ async function KomponenterPage({ slug }: { slug: string }) {
         )}
 
         {renderPreviewNote && (
-          <InfoCard data-block-margin="space-28" data-color="meta-purple">
-            <InfoCardHeader icon={<TestFlaskIcon aria-hidden />}>
-              <InfoCardTitle>Preview</InfoCardTitle>
-            </InfoCardHeader>
-            <InfoCardContent>
-              <CustomPortableText
-                value={pageData.status?.preview_note as PortableTextBlock[]}
-              />
-            </InfoCardContent>
-          </InfoCard>
+          <PreviewNote
+            content={pageData.status?.preview_note as PortableTextBlock[]}
+          />
         )}
         <DesignsystemetKomponentIntro data={pageData} />
         <CustomPortableText value={pageData.content as PortableTextBlock[]} />

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/komponenter/[category]/_ui/PreviewNote.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/komponenter/[category]/_ui/PreviewNote.tsx
@@ -30,7 +30,7 @@ export const PreviewNote = ({ content }: { content: PortableTextBlock[] }) => {
         <InfoCardTitle>Preview</InfoCardTitle>
       </InfoCardHeader>
       <InfoCardContent>
-        <ShowMore as="div" scrollBackOnCollapse={true} scrollTargetRef={ref}>
+        <ShowMore as="div" scrollTargetRef={ref}>
           <ShowMore.Content collapsedHeight="16rem">
             <CustomPortableText value={content} />
           </ShowMore.Content>

--- a/aksel.nav.no/website/app/(routes)/(designsystemet)/komponenter/[category]/_ui/PreviewNote.tsx
+++ b/aksel.nav.no/website/app/(routes)/(designsystemet)/komponenter/[category]/_ui/PreviewNote.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { PortableTextBlock } from "next-sanity";
+import { useRef } from "react";
+import { TestFlaskIcon } from "@navikt/aksel-icons";
+import { Button } from "@navikt/ds-react";
+import {
+  InfoCard,
+  InfoCardContent,
+  InfoCardHeader,
+  InfoCardTitle,
+} from "@navikt/ds-react/InfoCard";
+import { CustomPortableText } from "@/app/_ui/portable-text/CustomPortableText";
+import ShowMore from "../../../grunnleggende/endringslogg/_ui/ShowMore";
+
+export const PreviewNote = ({ content }: { content: PortableTextBlock[] }) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  return (
+    <InfoCard
+      ref={ref}
+      data-block-margin="space-28"
+      data-color="meta-purple"
+      style={{
+        position: "relative",
+        scrollMarginTop: "var(--website-header-sticky-height)",
+      }}
+    >
+      <InfoCardHeader icon={<TestFlaskIcon aria-hidden />}>
+        <InfoCardTitle>Preview</InfoCardTitle>
+      </InfoCardHeader>
+      <InfoCardContent>
+        <ShowMore as="div" scrollBackOnCollapse={true} scrollTargetRef={ref}>
+          <ShowMore.Content collapsedHeight="16rem">
+            <CustomPortableText value={content} />
+          </ShowMore.Content>
+          <ShowMore.Button>
+            <Button
+              size="small"
+              variant="secondary"
+              data-color="neutral"
+              style={{ bottom: "var(--ax-space-20)" }}
+            />
+          </ShowMore.Button>
+        </ShowMore>
+      </InfoCardContent>
+    </InfoCard>
+  );
+};


### PR DESCRIPTION
We might want to make the ReadMore optional via toggle in Sanity (and maybe be able to adjust collapsedHeight), but let's just focus on the needs for DataGrid for now.

<img width="1020" height="477" alt="image" src="https://github.com/user-attachments/assets/dc7a6f42-680f-4f56-ad54-cfd920d3711b" />