### PR TITLE
[DataGrid] :bug: Loadingbar now follows sticky header properly

### DIFF
--- a/.changeset/dry-rockets-study.md
+++ b/.changeset/dry-rockets-study.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+DataGrid: Loading-bar now stays stuck to sticky-header.

--- a/@navikt/core/css/src/data-grid-preview.css
+++ b/@navikt/core/css/src/data-grid-preview.css
@@ -78,6 +78,12 @@
     animation: animateDataTableLoading 1s linear infinite;
     z-index: 11;
   }
+
+  &[data-sticky="true"] {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+  }
 }
 
 .aksel-data-table__tbody {
@@ -101,8 +107,6 @@
     transition: opacity 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
     z-index: 10;
     opacity: 0.2;
-
-    /* iOS 26+: Ensure the backdrop covers the entire visible viewport. */
 
     @starting-style {
       opacity: 0.001;

--- a/@navikt/core/css/src/data-grid-preview.css
+++ b/@navikt/core/css/src/data-grid-preview.css
@@ -20,6 +20,11 @@
   width: 100%;
   position: relative;
   scroll-timeline: --horizontal-table-scroll inline;
+
+  /* Avoids overlay-bug in Safari when scrolling */
+  &:has([data-loading="true"]) {
+    overflow-y: hidden;
+  }
 }
 
 .aksel-data-table {
@@ -68,12 +73,13 @@
 
 .aksel-data-table__thead {
   background-color: var(--ax-bg-raised);
+  position: relative; /* Shadow ends up behind loading/empty-state without, consider after-element instead like with sticky */
+  box-shadow: 0 1px 0 0 var(--ax-border-neutral-subtle);
 
   .aksel-data-table[data-loading="true"] &::after {
     content: "";
     position: absolute;
     block-size: 2px;
-    inset-block-end: -2px;
     background-color: var(--ax-bg-strong);
     animation: animateDataTableLoading 1s linear infinite;
     z-index: 11;
@@ -91,12 +97,7 @@
   position: relative;
 
   &[inert] {
-    transition: opacity 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
     opacity: var(--ax-opacity-disabled);
-
-    @starting-style {
-      opacity: 0.001;
-    }
   }
 
   &[inert]::after {
@@ -104,36 +105,14 @@
     position: absolute;
     inset: 0;
     background-color: var(--ax-bg-overlay);
-    transition: opacity 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
-    z-index: 10;
+    z-index: 2;
     opacity: 0.2;
-
-    @starting-style {
-      opacity: 0.001;
-    }
   }
 }
 
 .aksel-data-table__tr {
   &[data-selected="true"] {
     background-color: var(--ax-bg-softA);
-  }
-
-  .aksel-data-table__thead &[data-sticky="true"] {
-    position: sticky;
-    top: 0;
-    z-index: 3;
-    box-shadow: 1px 1px 0 0 var(--ax-border-neutral-subtle);
-
-    /* This breaks filler-cells ⬇️. Trying box-shadow instead ⬆️ */
-    /* &::after {
-      content: "";
-      position: absolute;
-      inset-inline: 0;
-      bottom: -1px;
-      pointer-events: none;
-      border-bottom: 1px solid var(--ax-border-neutral-subtle);
-    } */
   }
 }
 
@@ -160,11 +139,6 @@
   border-spacing: 0;
   border-right: 1px solid var(--ax-border-neutral-subtle);
   border-bottom: 1px solid var(--ax-border-neutral-subtle);
-}
-
-.aksel-data-table__thead {
-  position: relative; /* Shadow ends up behind loading/empty-state without, consider after-element instead like with sticky */
-  box-shadow: 0 1px 0 0 var(--ax-border-neutral-subtle);
 }
 
 @keyframes scroll-shadow-fade-start {

--- a/@navikt/core/css/src/data-grid-preview.css
+++ b/@navikt/core/css/src/data-grid-preview.css
@@ -20,11 +20,6 @@
   width: 100%;
   position: relative;
   scroll-timeline: --horizontal-table-scroll inline;
-
-  /* Avoids overlay-bug in Safari when scrolling */
-  &:has([data-loading="true"]) {
-    overflow-y: hidden;
-  }
 }
 
 .aksel-data-table {

--- a/@navikt/core/react/src/data/stories/Data.data-prop.stories.tsx
+++ b/@navikt/core/react/src/data/stories/Data.data-prop.stories.tsx
@@ -359,7 +359,7 @@ export const LoadingWhileKeepingDataNoPlaceholders: Story = {
   render: () => {
     const [isLoading, setIsLoading] = useState(true);
     return (
-      <VStack gap="space-12">
+      <VStack gap="space-12" maxHeight="220px">
         <Button onClick={() => setIsLoading((prev) => !prev)}>
           Toggle loading
         </Button>

--- a/@navikt/core/react/src/data/table/helpers/table-focus.ts
+++ b/@navikt/core/react/src/data/table/helpers/table-focus.ts
@@ -137,7 +137,7 @@ function getStickyOffsets(element: HTMLElement): {
   }
 
   const stickyHeader = table.querySelector<HTMLElement>(
-    `.aksel-data-table__tr[data-sticky="true"]`,
+    `.aksel-data-table__thead[data-sticky="true"]`,
   );
 
   const stickyNodesStart = table.querySelectorAll<HTMLElement>(

--- a/@navikt/core/react/src/data/table/root/DataGridTableRoot.tsx
+++ b/@navikt/core/react/src/data/table/root/DataGridTableRoot.tsx
@@ -239,7 +239,7 @@ const DataGridTableInternal = forwardRef<
             aria-busy={isLoading || undefined}
           >
             <DataTableDetailsPanelProvider detailsPanel={detailsPanel}>
-              <DataTableThead>
+              <DataTableThead data-sticky={stickyHeader || undefined}>
                 <DataTableTr>
                   {columns.map(
                     ({ isSticky, isStickyLast, stickyLeftOffset, colDef }) => {

--- a/@navikt/core/react/src/data/table/tr/DataTableTr.tsx
+++ b/@navikt/core/react/src/data/table/tr/DataTableTr.tsx
@@ -51,10 +51,9 @@ const DataTableTr = forwardRef<HTMLTableRowElement, DataTableTrProps>(
     },
     forwardedRef,
   ) => {
-    const { layout, stickyHeader, selectionState, onRowAction } =
+    const { layout, stickyHeader, selectionState, onRowAction, tableItems } =
       useDataTableContext();
     const { location } = useDataTableLocation();
-    const { tableItems } = useDataTableContext();
 
     const renderFillerCell = layout === "fixed" && children;
 

--- a/@navikt/core/react/src/data/table/tr/DataTableTr.tsx
+++ b/@navikt/core/react/src/data/table/tr/DataTableTr.tsx
@@ -51,7 +51,7 @@ const DataTableTr = forwardRef<HTMLTableRowElement, DataTableTrProps>(
     },
     forwardedRef,
   ) => {
-    const { layout, stickyHeader, selectionState, onRowAction, tableItems } =
+    const { layout, selectionState, onRowAction, tableItems } =
       useDataTableContext();
     const { location } = useDataTableLocation();
 
@@ -59,8 +59,6 @@ const DataTableTr = forwardRef<HTMLTableRowElement, DataTableTrProps>(
 
     const selected =
       selectionState.selection.isRowSelected(rowId ?? "") ?? selectedProp;
-
-    const isSticky = location === "thead" && stickyHeader;
 
     const handleClick =
       location === "tbody" &&
@@ -130,7 +128,6 @@ const DataTableTr = forwardRef<HTMLTableRowElement, DataTableTrProps>(
         ref={forwardedRef}
         className={cl("aksel-data-table__tr", className)}
         data-selected={selected}
-        data-sticky={isSticky || undefined}
       >
         <RowExpansionCell rowId={rowId} />
         <RowSelectionCell rowId={rowId} />


### PR DESCRIPTION
### Description

<img width="953" height="225" alt="Screenshot 2026-05-22 at 13 59 52" src="https://github.com/user-attachments/assets/e924170c-2ab9-45ee-96b6-760b1f210a85" />


### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
