### PR TITLE
DataGrid.Table: Fix auto-width for col with "show nested rows" button

### DIFF
--- a/.changeset/major-carpets-talk.md
+++ b/.changeset/major-carpets-talk.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+DataGrid.Table: Fix auto-width for col with "show nested rows" button

--- a/@navikt/core/react/src/data/stories/Data.resize.stories.tsx
+++ b/@navikt/core/react/src/data/stories/Data.resize.stories.tsx
@@ -177,6 +177,15 @@ export const ResizeAuto: Story = {
     data: testData,
     columns: [
       {
+        id: "nested",
+        header: "Nested",
+        width: {
+          defaultValue: 200,
+          autoResizeOnce: true,
+        },
+        bodyCell: () => "Nested",
+      },
+      {
         id: "left",
         header: "L",
         align: "left",
@@ -225,13 +234,36 @@ export const ResizeAuto: Story = {
         isSortable: true,
         bodyCell: () => "Test",
       },
+      {
+        id: "blockContent",
+        header: "Block content",
+        width: {
+          defaultValue: 300,
+          autoResizeOnce: true,
+        },
+        bodyCell: () => <div>This is inside a div</div>,
+      },
     ],
+    getRowId: (row) => row.left,
   },
   render: (props) => {
     const [showTable, setShowTable] = React.useState(false);
     return showTable ? (
       <DataGrid {...props}>
-        <DataGrid.Table />
+        <DataGrid.Table<Row>
+          subRows={{
+            getRows: (row) =>
+              row.left.includes(".")
+                ? []
+                : [
+                    {
+                      left: `${row.left}.1`,
+                      center: "Yes",
+                      right: "100",
+                    },
+                  ],
+          }}
+        />
       </DataGrid>
     ) : (
       <button onClick={() => setShowTable(true)}>Show table</button>
@@ -244,11 +276,13 @@ export const ResizeAuto: Story = {
     button.click();
     await new Promise((r) => setTimeout(r, 100)); // Make sure auto resize has happened
     const headers = canvas.getAllByRole("columnheader");
-    expect(headers.length).toBe(5);
-    expect(headers[0]).toHaveStyle({ width: "80px" });
-    expect(headers[1]).toHaveStyle({ width: "82px" });
-    expect(headers[2]).toHaveStyle({ width: "103px" });
-    expect(headers[3]).toHaveStyle({ width: "168px" });
-    expect(headers[4]).toHaveStyle({ width: "248px" });
+    expect(headers.length).toBe(7);
+    expect(headers[0]).toHaveStyle({ width: "126px" });
+    expect(headers[1]).toHaveStyle({ width: "80px" });
+    expect(headers[2]).toHaveStyle({ width: "82px" });
+    expect(headers[3]).toHaveStyle({ width: "103px" });
+    expect(headers[4]).toHaveStyle({ width: "168px" });
+    expect(headers[5]).toHaveStyle({ width: "248px" });
+    expect(headers[6]).toHaveStyle({ width: "168px" });
   },
 };

--- a/@navikt/core/react/src/data/table/column-header/useTableColumnResize.ts
+++ b/@navikt/core/react/src/data/table/column-header/useTableColumnResize.ts
@@ -26,8 +26,6 @@ type ResizeProps = {
    * consider using `layout="auto"` on the root instead for better performance.
    *
    * **NB:** This can cause a layout shift. Set a good initial width with `width` or `defaultWidth` to mitigate this.
-   *
-   * **NB:** Does not work with block content.
    */
   autoResizeOnce?: boolean;
   /**
@@ -292,7 +290,6 @@ function useTableColumnResize({
 
 /**
  * Figures out how wide the column needs to be to fit all the content without truncation.
- * NB: Does not work with block content!
  */
 function getAutoColumnWidth(
   thRef: React.RefObject<HTMLTableCellElement | null>,
@@ -353,7 +350,13 @@ function getAutoColumnWidth(
     cellContent.style.width = "fit-content";
     const cellContentWidth = cellContent.scrollWidth;
     cellContent.style.removeProperty("width");
-    const widthNeededForThisCell = (cellContentWidth + 1) / cell.colSpan;
+    let marginLeft = 0;
+    if (cell.dataset.nested === "true") {
+      const contentElStyle = window.getComputedStyle(cellContent);
+      marginLeft = parseInt(contentElStyle.marginLeft, 10);
+    }
+    const widthNeededForThisCell =
+      (cellContentWidth + marginLeft + 1) / cell.colSpan;
     if (widthNeededForThisCell > newColumnWidth) {
       newColumnWidth = Math.ceil(widthNeededForThisCell);
     }


### PR DESCRIPTION
Forgot to take into account margin. Also removed comments about not supporting block content, and added test cases.

### Component Checklist 📝

- [x] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [x] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [x] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
