### PR TITLE
[DataGrid] Column display-prop

### DIFF
--- a/.changeset/lucky-moose-stand.md
+++ b/.changeset/lucky-moose-stand.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+DataGrid: Added `columnDisplay` value to settings

--- a/@navikt/core/react/src/data-grid/root/DataGrid.types.ts
+++ b/@navikt/core/react/src/data-grid/root/DataGrid.types.ts
@@ -31,6 +31,13 @@ type DataGridSettings = {
    * @default "medium"
    */
   textSize?: "small" | "medium";
+  /**
+   * Optional configuration for column display settings.
+   * If provided:
+   * - Order of columns will be determined by the order of this array, not the `columns` prop.
+   * - Visible-boolean will determine if the column is rendered or not.
+   */
+  columnDisplay?: { id: string; visible: boolean }[];
 };
 
 export type { DataGridSettings };

--- a/@navikt/core/react/src/data-grid/root/DataGrid.types.ts
+++ b/@navikt/core/react/src/data-grid/root/DataGrid.types.ts
@@ -32,10 +32,13 @@ type DataGridSettings = {
    */
   textSize?: "small" | "medium";
   /**
-   * Optional configuration for column display settings.
-   * If provided:
-   * - Order of columns will be determined by the order of this array, not the `columns` prop.
-   * - Visible-boolean will determine if the column is rendered or not.
+   * Optional configuration for column order and visibility.
+   *
+   * If provided, only columns listed here are rendered, and the array order
+   * determines the rendered column order.
+   *
+   * Set `visible: false` to hide a column without removing it from the list.
+   * Each `id` must be unique and match a column `id` in the `columns` prop.
    */
   columnDisplay?: { id: string; visible: boolean }[];
 };

--- a/@navikt/core/react/src/data-grid/root/DataGridRoot.tsx
+++ b/@navikt/core/react/src/data-grid/root/DataGridRoot.tsx
@@ -97,6 +97,7 @@ const DataGridInternal = forwardRef<HTMLDivElement, DataGridProps<any>>(
         truncateContent: settings?.truncateContent,
         stickyColumns: settings?.stickyColumns ?? {},
         textSize: settings?.textSize ?? "medium",
+        columnDisplay: settings?.columnDisplay,
       }),
       [
         settings?.rowDensity,
@@ -104,6 +105,7 @@ const DataGridInternal = forwardRef<HTMLDivElement, DataGridProps<any>>(
         settings?.truncateContent,
         settings?.stickyColumns,
         settings?.textSize,
+        settings?.columnDisplay,
       ],
     );
 

--- a/@navikt/core/react/src/data/stories/Data.data-prop.stories.tsx
+++ b/@navikt/core/react/src/data/stories/Data.data-prop.stories.tsx
@@ -1091,8 +1091,7 @@ export const ColumnDisplay: Story = {
             });
           }}
         >
-          Scrable order
-        </Button>
+          Scramble order
         <Button
           onClick={() => {
             setColumnDisplay((prev) => {

--- a/@navikt/core/react/src/data/stories/Data.data-prop.stories.tsx
+++ b/@navikt/core/react/src/data/stories/Data.data-prop.stories.tsx
@@ -1091,7 +1091,7 @@ export const ColumnDisplay: Story = {
             });
           }}
         >
-          Scramble order
+          Move first column to the end
         </Button>
         <Button
           onClick={() => {

--- a/@navikt/core/react/src/data/stories/Data.data-prop.stories.tsx
+++ b/@navikt/core/react/src/data/stories/Data.data-prop.stories.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { expect, fn, userEvent, within } from "storybook/test";
 import { Button } from "../../button";
 import { DataGrid } from "../../data-grid";
+import { HGrid } from "../../primitives/grid";
 import { VStack } from "../../primitives/stack";
 import { Tag } from "../../tag";
 import type {
@@ -1068,4 +1069,51 @@ export const NestedRowsWithMasterDetail: Story = {
     ).toBeInTheDocument();
   }, */
   ...selectionControls,
+};
+
+export const ColumnDisplay: Story = {
+  render: () => {
+    const [columnDisplay, setColumnDisplay] = useState(
+      userColumnDef.map((col) => ({
+        id: col.id,
+        visible: col.id !== "bar",
+      })),
+    );
+    return (
+      <HGrid gap="space-8 space-16" columns="1fr">
+        <Button
+          onClick={() => {
+            setColumnDisplay((prev) => {
+              const next = [...prev];
+              const moved = next.splice(0, 1)[0];
+              next.push(moved);
+              return next;
+            });
+          }}
+        >
+          Scrable order
+        </Button>
+        <Button
+          onClick={() => {
+            setColumnDisplay((prev) => {
+              return prev.map((col) =>
+                col.id === "bar" ? { ...col, visible: !col.visible } : col,
+              );
+            });
+          }}
+        >
+          Toggle Bar column
+        </Button>
+        <DataGrid
+          columns={userColumnDef}
+          data={userData}
+          settings={{
+            columnDisplay,
+          }}
+        >
+          <DataGrid.Table />
+        </DataGrid>
+      </HGrid>
+    );
+  },
 };

--- a/@navikt/core/react/src/data/stories/Data.data-prop.stories.tsx
+++ b/@navikt/core/react/src/data/stories/Data.data-prop.stories.tsx
@@ -1084,10 +1084,8 @@ export const ColumnDisplay: Story = {
         <Button
           onClick={() => {
             setColumnDisplay((prev) => {
-              const next = [...prev];
-              const moved = next.splice(0, 1)[0];
-              next.push(moved);
-              return next;
+              const [first, ...rest] = prev;
+              return [...rest, first];
             });
           }}
         >

--- a/@navikt/core/react/src/data/stories/Data.data-prop.stories.tsx
+++ b/@navikt/core/react/src/data/stories/Data.data-prop.stories.tsx
@@ -1092,6 +1092,7 @@ export const ColumnDisplay: Story = {
           }}
         >
           Scramble order
+        </Button>
         <Button
           onClick={() => {
             setColumnDisplay((prev) => {

--- a/@navikt/core/react/src/data/table/hooks/useColumnOptions.ts
+++ b/@navikt/core/react/src/data/table/hooks/useColumnOptions.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { consoleWarning } from "../../../utils/helpers/consoleWarning";
 import type {
   ColumnDefinition,
   ColumnDefinitions,
@@ -112,6 +113,13 @@ function orderColumnsAndFilterByVisibility<T>(
 
   return columnDisplay.reduce<ColumnDefinition<T>[]>((acc, { id, visible }) => {
     const col = columnMap.get(id);
+
+    if (!col) {
+      consoleWarning(
+        `DataGrid: Column with id "${id}" not found in column definitions. Please check your columnDisplay configuration.`,
+      );
+    }
+
     if (col && visible) {
       acc.push(col);
     }

--- a/@navikt/core/react/src/data/table/hooks/useColumnOptions.ts
+++ b/@navikt/core/react/src/data/table/hooks/useColumnOptions.ts
@@ -13,6 +13,10 @@ type UseColumnOptions = {
   hasSelection: boolean;
   hasDetailsPanel: boolean;
   layout: "fixed" | "auto";
+  columnDisplay?: {
+    id: string;
+    visible: boolean;
+  }[];
 };
 
 type StickyStartState = {
@@ -37,7 +41,13 @@ function useColumnOptions<T>(
   columnDefinitions: ColumnDefinitions<T>,
   options: UseColumnOptions,
 ): UseColumnOptionsResult<T> {
-  const { stickyColumns, hasSelection, hasDetailsPanel, layout } = options;
+  const {
+    stickyColumns,
+    hasSelection,
+    hasDetailsPanel,
+    layout,
+    columnDisplay,
+  } = options;
 
   const hasStickyStart = stickyColumns?.start === 1;
 
@@ -49,11 +59,15 @@ function useColumnOptions<T>(
     (stickyExpansion ? ACTION_CELL_WIDTH : 0) +
     (stickySelection ? ACTION_CELL_WIDTH : 0);
 
+  const visibleColumns = useMemo(() => {
+    return orderColumnsAndFilterByVisibility(columnDefinitions, columnDisplay);
+  }, [columnDefinitions, columnDisplay]);
+
   const columns = useMemo(() => {
-    return columnDefinitions.map((colDef, index) => {
+    return visibleColumns.map((colDef, index) => {
       const isFirstSticky = hasStickyStart && index === 0;
       const isLastSticky =
-        stickyColumns?.end === 1 && index === columnDefinitions.length - 1;
+        stickyColumns?.end === 1 && index === visibleColumns.length - 1;
 
       return {
         isSticky: isFirstSticky
@@ -66,12 +80,7 @@ function useColumnOptions<T>(
         colDef,
       };
     });
-  }, [
-    columnDefinitions,
-    hasStickyStart,
-    stickyColumns,
-    stickyFirstColumnOffset,
-  ]);
+  }, [visibleColumns, hasStickyStart, stickyColumns, stickyFirstColumnOffset]);
 
   const totalColSpan =
     columns.length +
@@ -91,6 +100,24 @@ function useColumnOptions<T>(
   };
 }
 
+function orderColumnsAndFilterByVisibility<T>(
+  columns: ColumnDefinition<T>[],
+  columnDisplay?: { id: string; visible: boolean }[],
+): ColumnDefinition<T>[] {
+  if (!columnDisplay) {
+    return columns;
+  }
+
+  const columnMap = new Map(columns.map((col) => [col.id, col]));
+
+  return columnDisplay.reduce<ColumnDefinition<T>[]>((acc, { id, visible }) => {
+    const col = columnMap.get(id);
+    if (col && visible) {
+      acc.push(col);
+    }
+    return acc;
+  }, []);
+}
+
 export { useColumnOptions };
-export type { StickyStartState };
-export type { UseColumnOptionsResult };
+export type { StickyStartState, UseColumnOptionsResult };

--- a/@navikt/core/react/src/data/table/root/DataGridTableRoot.tsx
+++ b/@navikt/core/react/src/data/table/root/DataGridTableRoot.tsx
@@ -195,6 +195,7 @@ const DataGridTableInternal = forwardRef<
         hasSelection: tableSelectionState.selection.mode !== "none",
         hasDetailsPanel: !!detailsPanel?.getContent,
         layout,
+        columnDisplay: tableSettings?.columnDisplay,
       },
     );
 


### PR DESCRIPTION
### Description

Used to set visibility of columns, and array-order determines column-order

### Connecting with DataGrid.Settings
- `columnDisplay` is a key on the settings-object.
- DataGrid.Settings uses `columnDefinition` to render the DnD-list, and editing visibility/order will update `columnDisplay`
- Might need to add a `enableHiding`-value on `columnDefinition` that "locks" visibility-switch on settings

### Testing with resizing
Since columns are rendered with the column-id as the key, the resized width etc is preserved when using only local state.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
