### PR TITLE
[Dismissablelayer] Focus edgecase

### DIFF
--- a/.changeset/fast-donuts-notice.md
+++ b/.changeset/fast-donuts-notice.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+Popover: Fixed issue where clicking inside container sometimes could lead to Popover closing

--- a/@navikt/core/react/src/help-text/HelpText.stories.tsx
+++ b/@navikt/core/react/src/help-text/HelpText.stories.tsx
@@ -116,6 +116,18 @@ export const ColorRole: StoryFn = () => {
   );
 };
 
+export const InsideFocusableContainer: StoryFn<typeof HelpText> = (props) => {
+  return (
+    <div tabIndex={-1}>
+      <HelpText {...props}>
+        Id ullamco excepteur elit fugiat labore. Incididunt laborum eiusmod
+        ullamco id aliquip officia ex irure aliqua laboris id ea do nisi. Ex
+        esse ad duis culpa non aliquip exercitation eu culpa cupidatat nisi.
+      </HelpText>
+    </div>
+  );
+};
+
 export const Chromatic = renderStoriesForChromatic({
   Default,
   Open,

--- a/@navikt/core/react/src/utils/components/dismissablelayer/DismissableLayer.tests.stories.tsx
+++ b/@navikt/core/react/src/utils/components/dismissablelayer/DismissableLayer.tests.stories.tsx
@@ -85,6 +85,37 @@ export const PointerDownOutside: Story = {
   },
 };
 
+/**
+ * Tabindex on parent element causes focusin-event to be triggered on the parent when clicking inside the child, which again causes `onFocusOutside` to be called.
+ * This test ensures that clicking inside the element does not trigger `onFocusOutside` or `onDismiss`, even with a tabindex on the parent.
+ */
+export const PointerDownInside: Story = {
+  render: (props) => {
+    return (
+      <div tabIndex={-1}>
+        <DismissableLayer asChild {...props} onDismiss={console.log}>
+          <div
+            data-testid="inside-element"
+            style={{ background: "red", padding: "2rem" }}
+          />
+        </DismissableLayer>
+      </div>
+    );
+  },
+  play: async ({ args }) => {
+    const canvas = within(document.body);
+    const insideElement = canvas.getByTestId("inside-element");
+    await userEvent.click(insideElement);
+
+    expect(args.onFocusOutside).not.toHaveBeenCalled();
+    expect(args.onDismiss).not.toHaveBeenCalled();
+  },
+  args: {
+    onDismiss: fn(),
+    onFocusOutside: fn(),
+  },
+};
+
 export const InteractOutside: Story = {
   render: (props) => {
     return (

--- a/@navikt/core/react/src/utils/components/dismissablelayer/DismissableLayer.tsx
+++ b/@navikt/core/react/src/utils/components/dismissablelayer/DismissableLayer.tsx
@@ -460,6 +460,7 @@ const DismissableLayer = forwardRef<HTMLDivElement, DismissableLayerProps>(
             () => {
               pointerDownOutside.onPointerDownCapture();
               pointerUpOutside.onPointerDownCapture();
+              focusOutside.onPointerDownCapture();
             },
           )}
           onPointerUpCapture={composeEventHandlers(

--- a/@navikt/core/react/src/utils/components/dismissablelayer/util/useFocusOutside.ts
+++ b/@navikt/core/react/src/utils/components/dismissablelayer/util/useFocusOutside.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useEventCallback } from "../../../hooks";
+import { useEventCallback, useTimeout } from "../../../hooks";
 import {
   CUSTOM_EVENTS,
   CustomFocusEvent,
@@ -16,6 +16,8 @@ export function useFocusOutside(
 ) {
   const handleFocusOutside = useEventCallback(callback) as EventListener;
   const isFocusInsideReactTreeRef = useRef(false);
+  const skipFocusCheckRef = useRef(false);
+  const timeout = useTimeout();
 
   useEffect(() => {
     if (!enabled) {
@@ -23,7 +25,11 @@ export function useFocusOutside(
     }
 
     const handleFocus = (event: FocusEvent) => {
-      if (event.target && !isFocusInsideReactTreeRef.current) {
+      if (
+        event.target &&
+        !isFocusInsideReactTreeRef.current &&
+        !skipFocusCheckRef.current
+      ) {
         const eventDetail = { originalEvent: event };
 
         /**
@@ -58,6 +64,12 @@ export function useFocusOutside(
     },
     onBlurCapture: () => {
       isFocusInsideReactTreeRef.current = false;
+    },
+    onPointerDownCapture: () => {
+      skipFocusCheckRef.current = true;
+      timeout.start(0, () => {
+        skipFocusCheckRef.current = false;
+      });
     },
   };
 }


### PR DESCRIPTION
### Description

- If parent-node has tabIndex or is clickable, since Helptext (Popover) container is inside this container, clicking container focuses parent-node thus triggering focus-outside event and closes container
- Could be resolved by moving Popover/Helptext into a Portal, but that could be breaking
- Fixed by listening on pointerdown-events on container. If user has used pointerdown on it, for 1 frame we ignore focus-events.

Resolves #4901

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
