### PR TITLE
[Clean] :bug: Clean up buildinfo-files

### DIFF
--- a/scripts/clean.mts
+++ b/scripts/clean.mts
@@ -24,11 +24,11 @@ for (const globPattern of globPatterns) {
     exclude: ["**/node_modules"],
   });
   dirsAndFiles
-    /* Longest folder-names first, so that nested dirs are removed bottom-up */
+    /* Longest names first, so that nested dirs are removed bottom-up */
     .toSorted((a, b) => b.length - a.length)
-    .forEach((folder) => {
-      console.info(`Deleting folder ${folder}`);
-      rmSync(folder, { recursive: true });
+    .forEach((name) => {
+      console.info(`Deleting ${name}`);
+      rmSync(name, { recursive: true });
     });
 }
 

--- a/scripts/clean.mts
+++ b/scripts/clean.mts
@@ -8,6 +8,7 @@ import { rmSync } from "node:fs";
  */
 const globPatterns = [
   "**/dist",
+  "**/*.tsbuildinfo",
   "./@navikt/**/lib",
   "./@navikt/**/esm",
   "./@navikt/**/cjs",
@@ -19,10 +20,10 @@ const globPatterns = [
 console.group("Cleaning up build artifacts");
 
 for (const globPattern of globPatterns) {
-  const folders = globSync(globPattern, {
+  const dirsAndFiles = globSync(globPattern, {
     exclude: ["**/node_modules"],
   });
-  folders
+  dirsAndFiles
     /* Longest folder-names first, so that nested dirs are removed bottom-up */
     .toSorted((a, b) => b.length - a.length)
     .forEach((folder) => {


### PR DESCRIPTION
### Description

Current clean-script ignores `tsbuildinfo`-files. This sometimes causes some issues where `yarn boot` fails (locally on mac, unsure why but this fixes it)

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
