### PR TITLE
[Stylelint] Misc fixes and cleanup

### DIFF
--- a/.changeset/tiny-spiders-bet.md
+++ b/.changeset/tiny-spiders-bet.md
@@ -1,0 +1,5 @@
+---
+"@navikt/aksel-stylelint": patch
+---
+
+Stylelint: Fixed bug in aksel-no-deprecated-classes rule skipping some classes

--- a/@navikt/aksel-stylelint/package.json
+++ b/@navikt/aksel-stylelint/package.json
@@ -30,7 +30,8 @@
     "./recommended": "./dist/recommended.js"
   },
   "files": [
-    "/dist"
+    "/dist",
+    "!**/*.test.js"
   ],
   "scripts": {
     "test": "yarn build && node --import tsx --test ./dist/**/*.test.js",

--- a/@navikt/aksel-stylelint/src/rules/aksel-no-deprecated-classes/index.test.ts
+++ b/@navikt/aksel-stylelint/src/rules/aksel-no-deprecated-classes/index.test.ts
@@ -51,5 +51,17 @@ testRule({
       column: 3,
       endColumn: 38,
     },
+    {
+      code: ".foo .aksel-read-more__content--closed {}",
+      description: "selector with deprecated read-more closed class",
+      message: messages.unexpected(
+        "aksel-read-more__content--closed",
+        deprecations[2].message,
+      ),
+      line: 1,
+      endLine: 1,
+      column: 7,
+      endColumn: 39,
+    },
   ],
 });

--- a/@navikt/aksel-stylelint/src/rules/aksel-no-deprecated-classes/index.ts
+++ b/@navikt/aksel-stylelint/src/rules/aksel-no-deprecated-classes/index.ts
@@ -26,7 +26,7 @@ const ruleFunction: stylelint.Rule = () => {
               deprecation.deprecatePrefix &&
               !deprecation.classes.some((x) => className.value.startsWith(x))
             ) {
-              return;
+              continue;
             }
             stylelint.utils.report({
               message: messages.unexpected(

--- a/@navikt/aksel-stylelint/src/rules/aksel-no-internal-tokens/index.test.ts
+++ b/@navikt/aksel-stylelint/src/rules/aksel-no-internal-tokens/index.test.ts
@@ -25,7 +25,7 @@ testRule({
       line: 1,
       endLine: 1,
       column: 8,
-      endColumn: 25,
+      endColumn: 19,
     },
     {
       code: ".foo { color: var(--__axc-bar) }",

--- a/@navikt/aksel-stylelint/src/rules/aksel-no-internal-tokens/index.ts
+++ b/@navikt/aksel-stylelint/src/rules/aksel-no-internal-tokens/index.ts
@@ -47,6 +47,7 @@ const ruleFunction: stylelint.Rule = () => {
           node,
           result: postcssResult,
           ruleName,
+          word: node.prop,
         });
       }
     });


### PR DESCRIPTION
### Description

Bug in @navikt/aksel-stylelint/src/rules/aksel-no-deprecated-classes/index.ts caused every deprecation after the one with prefix to be skipped before

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
