### PR TITLE
ActionMenu: Fix reference to wrong component in size example description

### DIFF
--- a/aksel.nav.no/website/pages/eksempler/actionmenu/size.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/size.tsx
@@ -126,5 +126,5 @@ export const Demo = {
 
 export const args = {
   index: 12,
-  desc: "Du kan endre størrelsen på ActionMenu ved å bruke `size`-prop på `ActionMenu.Root`. Standardstørrelsen er `small`",
+  desc: "Du kan endre størrelsen ved å bruke `size`-prop på `ActionMenu`. Standardstørrelsen er `small`",
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/size.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/size.tsx
@@ -126,5 +126,5 @@ export const Demo = {
 
 export const args = {
   index: 12,
-  desc: "Du kan endre størrelsen på ActionMenu ved å bruke `size`-prop på `ActionMenu.Content`. Standardstørrelsen er `small`",
+  desc: "Du kan endre størrelsen på ActionMenu ved å bruke `size`-prop på `ActionMenu.Root`. Standardstørrelsen er `small`",
 };


### PR DESCRIPTION
### Description

<!-- PR description/motivation, summary of changes, links to issue/slack discussion etc. -->

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
