### PR TITLE
[Endringslogg] Publiseringsflyt og templates

### DIFF
--- a/aksel.nav.no/website/sanity.blueprint.ts
+++ b/aksel.nav.no/website/sanity.blueprint.ts
@@ -5,6 +5,7 @@ const allPublishedAtDocuments = `[${allArticleDocuments.map((t) => `"${t}"`).joi
 const allVerifiedDocuments = `[${[
   "komponent_artikkel",
   "ds_artikkel",
+  "templates_artikkel",
   "aksel_artikkel",
 ]
   .map((t) => `"${t}"`)

--- a/aksel.nav.no/website/sanity/plugins/publication-flow/actions/lastVerified.tsx
+++ b/aksel.nav.no/website/sanity/plugins/publication-flow/actions/lastVerified.tsx
@@ -198,7 +198,7 @@ function StepTwo(props: StepTwoProps) {
             });
           }}
         >
-          Oppdatert godkjenningsdato
+          Oppdater godkjenningsdato
         </Checkbox>
         <Box marginInline="space-24 space-0">
           <Checkbox

--- a/aksel.nav.no/website/sanity/plugins/publication-flow/actions/lastVerified.tsx
+++ b/aksel.nav.no/website/sanity/plugins/publication-flow/actions/lastVerified.tsx
@@ -157,8 +157,8 @@ type StepTwoProps = {
 function StepTwo(props: StepTwoProps) {
   const { onPublish, lastVerified } = props;
   const [formState, setFormState] = useState({
-    updateDate: true,
-    newChangeLog: true,
+    updateDate: props.docType === "aksel-artikkel",
+    newChangeLog: props.docType === "aksel-artikkel",
   });
 
   const publishWithChangelog = formState.updateDate && formState.newChangeLog;

--- a/aksel.nav.no/website/sanity/plugins/publication-flow/actions/lastVerified.tsx
+++ b/aksel.nav.no/website/sanity/plugins/publication-flow/actions/lastVerified.tsx
@@ -192,17 +192,10 @@ function StepTwo(props: StepTwoProps) {
           value="update-date"
           checked={formState.updateDate}
           onChange={() => {
-            if (formState.updateDate) {
-              setFormState({
-                updateDate: false,
-                newChangeLog: false,
-              });
-            } else {
-              setFormState({
-                updateDate: true,
-                newChangeLog: true,
-              });
-            }
+            setFormState({
+              updateDate: !formState.updateDate,
+              newChangeLog: !formState.updateDate,
+            });
           }}
         >
           Oppdatert godkjenningsdato

--- a/aksel.nav.no/website/sanity/plugins/publication-flow/actions/lastVerified.tsx
+++ b/aksel.nav.no/website/sanity/plugins/publication-flow/actions/lastVerified.tsx
@@ -6,13 +6,16 @@ import { DocumentActionComponent, useDocumentOperation } from "sanity";
 import { ChevronRightIcon } from "@navikt/aksel-icons";
 import {
   BodyLong,
+  Box,
   Button,
+  Checkbox,
   HGrid,
   HStack,
   Heading,
   List,
   VStack,
 } from "@navikt/ds-react";
+import { ListItem } from "@navikt/ds-react/List";
 
 type Steps = "1" | "2";
 
@@ -33,7 +36,11 @@ export function setLastVerified(
       setCurrentStep("1");
     };
 
-    const publishDocument = (withNewVerify: boolean = false) => {
+    const publishDocument = ({
+      withNewVerify = false,
+      createChangeLog = false,
+    }: { withNewVerify?: boolean; createChangeLog?: boolean } = {}) => {
+      console.info(createChangeLog);
       closeDialog();
       if (withNewVerify) {
         patch.execute([
@@ -52,7 +59,7 @@ export function setLastVerified(
         setCurrentStep("2");
       } else {
         /* Sanity functions handles initial lastVerified timestamp creation */
-        publishDocument(false);
+        publishDocument({ withNewVerify: false });
       }
     };
 
@@ -140,22 +147,35 @@ function StepOne(props: StepOneProps) {
 }
 
 type StepTwoProps = {
-  onPublish: (withNewVerify: boolean) => void;
+  onPublish: (options?: {
+    withNewVerify?: boolean;
+    createChangeLog?: boolean;
+  }) => void;
   lastVerified?: string;
 };
 
 function StepTwo(props: StepTwoProps) {
   const { onPublish, lastVerified } = props;
+  const [formState, setFormState] = useState({
+    updateDate: true,
+    newChangeLog: true,
+  });
 
   return (
     <div>
-      <VStack gap="space-8">
+      <VStack gap="space-16">
         <BodyLong>
-          Hvis innholdet fortsatt er relevant og oppdatert, kan du velge å
-          publisere med oppdatert godkjenningsdato. Hvis du derimot mener at
-          innholdet trenger en gjennomgang, kan du publisere uten å oppdatere
-          godkjenningsdatoen.
+          Dersom artikkelen inneholder betydelige endringer, bør du vurdere om
+          disse skal beskrives i endringsloggen. Det gjelder blant annet:
         </BodyLong>
+        <List>
+          <ListItem>
+            endringer i praksis / komponent som brukerne bør informeres om
+          </ListItem>
+          <ListItem>
+            endringer som er nyttige å loggføre for vår egen oversikt
+          </ListItem>
+        </List>
         {lastVerified && (
           <BodyLong>
             Nåværende godkjenningsdato:{" "}
@@ -165,12 +185,54 @@ function StepTwo(props: StepTwoProps) {
           </BodyLong>
         )}
       </VStack>
-      <HGrid gap="space-8" marginBlock="space-16 space-0">
-        <Button variant="secondary" onClick={() => onPublish(false)}>
-          Bruk eksisterende godkjenningsdato
-        </Button>
-        <Button onClick={() => onPublish(true)}>
-          Oppdater godkjenningsdato
+      <VStack marginBlock="space-16">
+        <Checkbox
+          value="update-date"
+          checked={formState.updateDate}
+          onChange={() => {
+            if (formState.updateDate) {
+              setFormState({
+                updateDate: false,
+                newChangeLog: false,
+              });
+            } else {
+              setFormState({
+                updateDate: true,
+                newChangeLog: true,
+              });
+            }
+          }}
+        >
+          Oppdatert godkjenningsdato
+        </Checkbox>
+        <Box marginInline="space-24 space-0">
+          <Checkbox
+            value="new-change-log"
+            checked={formState.newChangeLog}
+            disabled={!formState.updateDate}
+            onChange={() =>
+              setFormState({
+                ...formState,
+                newChangeLog: !formState.newChangeLog,
+              })
+            }
+          >
+            Lag nytt endringsinnlegg ved publisering
+          </Checkbox>
+        </Box>
+      </VStack>
+      <HGrid marginBlock="space-16 space-0">
+        <Button
+          onClick={() =>
+            onPublish({
+              withNewVerify: formState.updateDate,
+              createChangeLog: formState.updateDate
+                ? formState.newChangeLog
+                : false,
+            })
+          }
+        >
+          Publiser
         </Button>
       </HGrid>
     </div>

--- a/aksel.nav.no/website/sanity/plugins/publication-flow/actions/lastVerified.tsx
+++ b/aksel.nav.no/website/sanity/plugins/publication-flow/actions/lastVerified.tsx
@@ -93,6 +93,7 @@ export function setLastVerified(
                 (props.published as any)?.updateInfo?.lastVerified
               }
               id={props.id}
+              docType={props.type}
             />
           ),
       },
@@ -150,6 +151,7 @@ type StepTwoProps = {
   onPublish: (options?: { withNewVerify?: boolean }) => void;
   lastVerified?: string;
   id: string;
+  docType: string;
 };
 
 function StepTwo(props: StepTwoProps) {
@@ -225,6 +227,7 @@ function StepTwo(props: StepTwoProps) {
         {publishWithChangelog ? (
           <PublishAndCreateChangelog
             id={props.id}
+            docType={props.docType}
             onClick={() =>
               onPublish({
                 withNewVerify: formState.updateDate,
@@ -247,16 +250,20 @@ function StepTwo(props: StepTwoProps) {
   );
 }
 
+type PublishAndCreateChangelogProps = {
+  id: string;
+  onClick?: () => void;
+  docType: string;
+};
+
 /**
  * Note that we need to open in new tab so that original document finishes publishing.
  */
 function PublishAndCreateChangelog({
   id,
   onClick: onClickProp,
-}: {
-  id: string;
-  onClick?: () => void;
-}) {
+  docType,
+}: PublishAndCreateChangelogProps) {
   const cleanedId = useMemo(() => {
     const split = id.split(".");
     return split[split.length - 1];
@@ -264,13 +271,7 @@ function PublishAndCreateChangelog({
 
   const { href, onClick } = useIntentLink({
     intent: "create",
-    params: [
-      {
-        type: "gp_endringslogg_artikkel",
-        template: "gp.changelog.with.reference",
-      },
-      { id: cleanedId },
-    ],
+    params: [getIntentFromDocType(docType), { id: cleanedId }],
     target: "_blank",
     onClick: onClickProp,
   });
@@ -286,4 +287,21 @@ function PublishAndCreateChangelog({
       Publiser
     </Button>
   );
+}
+
+function getIntentFromDocType(docType: string) {
+  switch (docType) {
+    case "ds_artikkel":
+    case "komponent_artikkel":
+    case "templates_artikkel":
+      return {
+        type: "ds_endringslogg_artikkel",
+        template: "ds.changelog.with.reference",
+      };
+    default:
+      return {
+        type: "gp_endringslogg_artikkel",
+        template: "gp.changelog.with.reference",
+      };
+  }
 }

--- a/aksel.nav.no/website/sanity/plugins/publication-flow/actions/lastVerified.tsx
+++ b/aksel.nav.no/website/sanity/plugins/publication-flow/actions/lastVerified.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { format } from "date-fns";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { DocumentActionComponent, useDocumentOperation } from "sanity";
+import { useIntentLink } from "sanity/router";
 import { ChevronRightIcon } from "@navikt/aksel-icons";
 import {
   BodyLong,
@@ -38,9 +39,7 @@ export function setLastVerified(
 
     const publishDocument = ({
       withNewVerify = false,
-      createChangeLog = false,
-    }: { withNewVerify?: boolean; createChangeLog?: boolean } = {}) => {
-      console.info(createChangeLog);
+    }: { withNewVerify?: boolean } = {}) => {
       closeDialog();
       if (withNewVerify) {
         patch.execute([
@@ -93,6 +92,7 @@ export function setLastVerified(
                 (props.draft as any)?.updateInfo?.lastVerified ??
                 (props.published as any)?.updateInfo?.lastVerified
               }
+              id={props.id}
             />
           ),
       },
@@ -147,11 +147,9 @@ function StepOne(props: StepOneProps) {
 }
 
 type StepTwoProps = {
-  onPublish: (options?: {
-    withNewVerify?: boolean;
-    createChangeLog?: boolean;
-  }) => void;
+  onPublish: (options?: { withNewVerify?: boolean }) => void;
   lastVerified?: string;
+  id: string;
 };
 
 function StepTwo(props: StepTwoProps) {
@@ -160,6 +158,8 @@ function StepTwo(props: StepTwoProps) {
     updateDate: true,
     newChangeLog: true,
   });
+
+  const publishWithChangelog = formState.updateDate && formState.newChangeLog;
 
   return (
     <div>
@@ -222,19 +222,68 @@ function StepTwo(props: StepTwoProps) {
         </Box>
       </VStack>
       <HGrid marginBlock="space-16 space-0">
-        <Button
-          onClick={() =>
-            onPublish({
-              withNewVerify: formState.updateDate,
-              createChangeLog: formState.updateDate
-                ? formState.newChangeLog
-                : false,
-            })
-          }
-        >
-          Publiser
-        </Button>
+        {publishWithChangelog ? (
+          <PublishAndCreateChangelog
+            id={props.id}
+            onClick={() =>
+              onPublish({
+                withNewVerify: formState.updateDate,
+              })
+            }
+          />
+        ) : (
+          <Button
+            onClick={() =>
+              onPublish({
+                withNewVerify: formState.updateDate,
+              })
+            }
+          >
+            Publiser
+          </Button>
+        )}
       </HGrid>
     </div>
+  );
+}
+
+/**
+ * Note that we need to open in new tab so that original document finishes publishing.
+ */
+function PublishAndCreateChangelog({
+  id,
+  onClick: onClickProp,
+}: {
+  id: string;
+  onClick?: () => void;
+}) {
+  const cleanedId = useMemo(() => {
+    const split = id.split(".");
+    return split[split.length - 1];
+  }, [id]);
+
+  const { href, onClick } = useIntentLink({
+    intent: "create",
+    params: [
+      {
+        type: "gp_endringslogg_artikkel",
+        template: "gp.changelog.with.reference",
+      },
+      { id: cleanedId },
+    ],
+    target: "_blank",
+    onClick: onClickProp,
+  });
+
+  return (
+    <Button
+      as="a"
+      href={href}
+      onClick={onClick}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Publiser
+    </Button>
   );
 }

--- a/aksel.nav.no/website/sanity/plugins/publication-flow/index.ts
+++ b/aksel.nav.no/website/sanity/plugins/publication-flow/index.ts
@@ -16,6 +16,7 @@ export const publicationFlow = definePlugin(() => {
         const shouldUseQualityControl = [
           "komponent_artikkel",
           "ds_artikkel",
+          "templates_artikkel",
           "aksel_artikkel",
         ].some((docType) => docType === context.schemaType);
 

--- a/aksel.nav.no/website/sanity/schema/documents/grunnleggende/endringsloggartikkel.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/grunnleggende/endringsloggartikkel.tsx
@@ -94,8 +94,8 @@ export const EndringsloggArtikkel = defineType({
       ],
       hidden: true,
       deprecated: {
-        reason: "Endringslogger skal ikke lengre kunne være fremhevet.",
-      },
+        reason: "Endringslogger skal ikke lenger kunne være fremhevet.",
+      }
     }),
     defineField({
       title: "Innhold",

--- a/aksel.nav.no/website/sanity/schema/documents/grunnleggende/endringsloggartikkel.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/grunnleggende/endringsloggartikkel.tsx
@@ -53,21 +53,17 @@ export const EndringsloggArtikkel = defineType({
         "Dette valget legger på styling på oppdateringen som gjør at den tiltrekker seg mer oppmerksomhet.",
       type: "boolean",
       initialValue: false,
+      hidden: true,
+      deprecated: {
+        reason: "Endringslogger skal ikke lengre kunne være fremhevet.",
+      },
     }),
     defineField({
-      hidden: ({ document }) => !document?.fremhevet,
       title: "Fremhevet herobilde",
       name: "herobilde",
       description:
         "Bildet vises øverst på kortet/siden og blir brukt som OG-bilde. Anbefalt størrelse er 1200x630px.",
       type: "image",
-      validation: (Rule) =>
-        Rule.custom((value, { document }) => {
-          if (document?.fremhevet && !value?.asset?._ref) {
-            return "En fremhevet oppdatering må ha et herobilde";
-          }
-          return true;
-        }),
       fields: [
         defineField({
           name: "dekorativt",
@@ -96,6 +92,10 @@ export const EndringsloggArtikkel = defineType({
             }),
         }),
       ],
+      hidden: true,
+      deprecated: {
+        reason: "Endringslogger skal ikke lengre kunne være fremhevet.",
+      },
     }),
     defineField({
       title: "Innhold",
@@ -113,6 +113,29 @@ export const EndringsloggArtikkel = defineType({
         'Skjuler deler av innholdet bak en "Vis mer"-knapp. OBS: Dobbeltsjekk at det er nok innhold til at det gir mening å bruke denne.',
       type: "boolean",
       initialValue: false,
+    }),
+    defineField({
+      title: "Artikler",
+      name: "artikler",
+      group: "innhold",
+      description: "Artikler denne oppdateringen gjelder.",
+      type: "array",
+      options: {
+        sortable: false,
+      },
+      of: [
+        {
+          type: "reference",
+          to: [
+            { type: "ds_artikkel" },
+            { type: "komponent_artikkel" },
+            { type: "templates_artikkel" },
+          ],
+          options: {
+            disableNew: true,
+          },
+        },
+      ],
     }),
     BaseSEOPreset,
   ],

--- a/aksel.nav.no/website/sanity/schema/documents/grunnleggende/endringsloggartikkel.tsx
+++ b/aksel.nav.no/website/sanity/schema/documents/grunnleggende/endringsloggartikkel.tsx
@@ -55,8 +55,8 @@ export const EndringsloggArtikkel = defineType({
       initialValue: false,
       hidden: true,
       deprecated: {
-        reason: "Endringslogger skal ikke lengre kunne være fremhevet.",
-      },
+        reason: "Endringslogger skal ikke lenger kunne være fremhevet.",
+      }
     }),
     defineField({
       title: "Fremhevet herobilde",

--- a/aksel.nav.no/website/sanity/schema/index.ts
+++ b/aksel.nav.no/website/sanity/schema/index.ts
@@ -103,7 +103,7 @@ export const schema: SchemaPluginOptions = {
     },
     {
       id: "gp.artikkel.by.undertema",
-      title: "God praksis aritkkel med undertema",
+      title: "God praksis artikkel med undertema",
       schemaType: "aksel_artikkel",
       parameters: [{ name: "undertema_id", type: "string" }],
       value: (params) => ({
@@ -112,11 +112,20 @@ export const schema: SchemaPluginOptions = {
     },
     {
       id: "gp.artikkel.by.innholdstype",
-      title: "God praksis aritkkel med innholdstype",
+      title: "God praksis artikkel med innholdstype",
       schemaType: "aksel_artikkel",
       parameters: [{ name: "id", type: "string" }],
       value: (params) => ({
         innholdstype: { _type: "reference", _ref: params.id },
+      }),
+    },
+    {
+      id: "gp.changelog.with.reference",
+      title: "Endringsloggartikkel med referanse",
+      schemaType: "gp_endringslogg_artikkel",
+      parameters: [{ name: "id", type: "string" }],
+      value: (params) => ({
+        artikler: [{ _type: "reference", _ref: params.id }],
       }),
     },
   ],

--- a/aksel.nav.no/website/sanity/schema/index.ts
+++ b/aksel.nav.no/website/sanity/schema/index.ts
@@ -128,5 +128,16 @@ export const schema: SchemaPluginOptions = {
         artikler: [{ _type: "reference", _ref: params.id }],
       }),
     },
+    {
+      id: "ds.changelog.with.reference",
+      title: "Endringsloggartikkel med referanse",
+      schemaType: "ds_endringslogg_artikkel",
+      parameters: [{ name: "id", type: "string" }],
+      value: (params) => ({
+        artikler: [{ _type: "reference", _ref: params.id }],
+        endringsdato: new Date().toISOString(),
+        endringstype: "dokumentasjon",
+      }),
+    },
   ],
 };


### PR DESCRIPTION
### Description

Ved publisering + checked "med endringsinnlegg" satt vil det nå åpnes en ny tab med endringslogg-artikkel som er pre-utfylt med noe innhold


https://github.com/user-attachments/assets/6efa666f-c6cf-4c3f-82dc-00b3f75a054d



### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
