### PR TITLE
[website] Fix alignment of CopyButton in ExampleText

### DIFF
--- a/aksel.nav.no/website/app/_ui/example-text/ExampleText.tsx
+++ b/aksel.nav.no/website/app/_ui/example-text/ExampleText.tsx
@@ -1,5 +1,5 @@
 import { FileTextIcon } from "@navikt/aksel-icons";
-import { BodyLong, CopyButton, Spacer, VStack } from "@navikt/ds-react";
+import { BodyLong, Box, CopyButton, Spacer, VStack } from "@navikt/ds-react";
 import {
   InfoCard,
   InfoCardContent,
@@ -22,7 +22,9 @@ function ExampleText(
       <InfoCardHeader icon={<FileTextIcon aria-hidden fontSize="1.5rem" />}>
         <InfoCardTitle as="div">{title}</InfoCardTitle>
         <Spacer />
-        <CopyButton size="small" copyText={text} />
+        <Box asChild marginBlock="space-4 space-0">
+          <CopyButton size="small" copyText={text} />
+        </Box>
       </InfoCardHeader>
       <InfoCardContent>
         <VStack gap="space-24">{formatText(text)}</VStack>


### PR DESCRIPTION
### Description

Alternatively, we could remove `align-items: flex-start` on `.aksel-base-alert__header`, unless it breaks something else. It will cause the button to vertically center (might be less desirable if heading breaks to multiple lines).

Before:
<img width="906" height="189" alt="image" src="https://github.com/user-attachments/assets/9571a19e-ee1c-4fa9-8970-62367e8bc9b9" />

After:
<img width="907" height="189" alt="image" src="https://github.com/user-attachments/assets/ad69c36a-8a8f-4455-bd4d-fdb85643e150" />

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
