### PR TITLE
[Timeline] Fix Axislabel calculation

### DIFF
--- a/.changeset/real-cobras-lead.md
+++ b/.changeset/real-cobras-lead.md
@@ -1,0 +1,6 @@
+---
+"@navikt/ds-react": patch
+"@navikt/ds-css": patch
+---
+
+Timeline: Update AxisLabel width calculation

--- a/@navikt/core/css/src/timeline.css
+++ b/@navikt/core/css/src/timeline.css
@@ -34,11 +34,7 @@
   position: absolute;
   color: var(--ax-text-neutral-subtle);
   white-space: nowrap;
-
-  .aksel-timeline__axislabels[data-direction="left"] > &:first-of-type,
-  .aksel-timeline__axislabels[data-direction="right"] > &:last-of-type {
-    overflow-x: clip;
-  }
+  overflow-x: clip;
 }
 
 .aksel-timeline__row {

--- a/@navikt/core/css/src/timeline.css
+++ b/@navikt/core/css/src/timeline.css
@@ -35,8 +35,8 @@
   color: var(--ax-text-neutral-subtle);
   white-space: nowrap;
 
-  &:first-of-type,
-  &:last-of-type {
+  .aksel-timeline__axislabels[data-direction="left"] > &:first-of-type,
+  .aksel-timeline__axislabels[data-direction="right"] > &:last-of-type {
     overflow-x: clip;
   }
 }

--- a/@navikt/core/react/src/timeline/AxisLabels.tsx
+++ b/@navikt/core/react/src/timeline/AxisLabels.tsx
@@ -147,19 +147,42 @@ export const AxisLabels = ({
   });
   const locale = useDateLocale();
 
-  const labels = getLabels(startDate, endDate, direction, locale, translate);
+  const labels = getLabels(
+    startDate,
+    endDate,
+    direction,
+    locale,
+    translate,
+  ).filter(isVisible);
+
+  const getLabelWidth = (calculatedWidth: number, index: number) => {
+    let comparator = 0;
+    if (direction === "right") {
+      comparator = labels.length - 1;
+    }
+
+    if (index === comparator) {
+      return undefined;
+    }
+
+    return `${calculatedWidth.toFixed(3)}%`;
+  };
 
   return (
-    <div className="aksel-timeline__axislabels" aria-hidden="true">
-      {labels.filter(isVisible).map((etikett) => (
+    <div
+      className="aksel-timeline__axislabels"
+      aria-hidden="true"
+      data-direction={direction}
+    >
+      {labels.map((etikett, index) => (
         <Detail
           className="aksel-timeline__axislabels-label"
           as="div"
           key={etikett.label}
           style={{
             justifyContent: direction === "left" ? "flex-start" : "flex-end",
-            [direction]: `${etikett.horizontalPosition}%`,
-            width: `${etikett.width}%`,
+            [direction]: `${etikett.horizontalPosition.toFixed(3)}%`,
+            width: getLabelWidth(etikett.width, index),
           }}
         >
           {etikett.label}

--- a/@navikt/core/react/src/timeline/AxisLabels.tsx
+++ b/@navikt/core/react/src/timeline/AxisLabels.tsx
@@ -14,7 +14,7 @@ import {
   startOfYear,
   subDays,
 } from "date-fns";
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import { Detail } from "../typography/Detail";
 import { useDateLocale, useI18n } from "../utils/i18n/i18n.hooks";
 import { TFunction } from "../utils/i18n/i18n.types";
@@ -147,26 +147,24 @@ export const AxisLabels = ({
   });
   const locale = useDateLocale();
 
-  const labels = getLabels(
-    startDate,
-    endDate,
-    direction,
-    locale,
-    translate,
-  ).filter(isVisible);
+  const labels = useMemo(
+    () =>
+      getLabels(startDate, endDate, direction, locale, translate).filter(
+        isVisible,
+      ),
+    [startDate, endDate, direction, locale, translate],
+  );
 
-  const getLabelWidth = (calculatedWidth: number, index: number) => {
-    let comparator = 0;
-    if (direction === "right") {
-      comparator = labels.length - 1;
-    }
-
-    if (index === comparator) {
-      return undefined;
-    }
-
-    return `${calculatedWidth.toFixed(3)}%`;
-  };
+  const getLabelWidth = useCallback(
+    (calculatedWidth: number, index: number) => {
+      const comparator = direction === "right" ? labels.length - 1 : 0;
+      if (index === comparator) {
+        return undefined;
+      }
+      return `${calculatedWidth.toFixed(3)}%`;
+    },
+    [direction, labels.length],
+  );
 
   return (
     <div

--- a/@navikt/core/react/src/timeline/AxisLabels.tsx
+++ b/@navikt/core/react/src/timeline/AxisLabels.tsx
@@ -146,31 +146,25 @@ export const AxisLabels = ({
 
   const labels = useMemo(
     () =>
-      getLabels(startDate, endDate, direction, locale, translate).filter(
-        isVisible,
-      ),
+      getLabels(startDate, endDate, direction, locale, translate)
+        .filter(isVisible)
+        .sort((a, b) => a.horizontalPosition - b.horizontalPosition),
     [startDate, endDate, direction, locale, translate],
   );
 
   const getLabelWidth = useCallback(
-    (calculatedWidth: number, index: number) => {
-      const comparator = direction === "right" ? labels.length - 1 : 0;
-      if (index === comparator) {
-        return undefined;
-      }
-      return `${calculatedWidth.toFixed(3)}%`;
+    (index: number): string => {
+      const next = labels[index + 1];
+      const bound = next ? next.horizontalPosition : 100;
+      return `${(bound - labels[index].horizontalPosition).toFixed(3)}%`;
     },
-    [direction, labels.length],
+    [labels],
   );
 
   const justifyContent = direction === "left" ? "flex-start" : "flex-end";
 
   return (
-    <div
-      className="aksel-timeline__axislabels"
-      aria-hidden="true"
-      data-direction={direction}
-    >
+    <div className="aksel-timeline__axislabels" aria-hidden="true">
       {labels.map((etikett, index) => (
         <Detail
           className="aksel-timeline__axislabels-label"
@@ -179,7 +173,7 @@ export const AxisLabels = ({
           style={{
             justifyContent,
             [direction]: `${etikett.horizontalPosition.toFixed(3)}%`,
-            width: getLabelWidth(etikett.width, index),
+            width: getLabelWidth(index),
           }}
         >
           {etikett.label}

--- a/@navikt/core/react/src/timeline/AxisLabels.tsx
+++ b/@navikt/core/react/src/timeline/AxisLabels.tsx
@@ -116,6 +116,12 @@ const getLabels = (
   translate: TFunction<"Timeline">,
 ): AxisLabel[] => {
   const totalDays = differenceInDays(end, start);
+
+  /* Zero or negative total days can break further calculations */
+  if (totalDays <= 0) {
+    return [];
+  }
+
   if (totalDays < 40) {
     const dayTemplate = translate("dayFormat");
     return dayLabels(start, end, totalDays, direction, dayTemplate, locale);

--- a/@navikt/core/react/src/timeline/AxisLabels.tsx
+++ b/@navikt/core/react/src/timeline/AxisLabels.tsx
@@ -33,26 +33,23 @@ export const dayLabels = (
 ): AxisLabel[] => {
   const increment = Math.ceil(totalDays / 10);
   const lastDay = startOfDay(end);
-  return new Array(totalDays)
-    .fill(lastDay)
-    .map((thisDay, i) => {
-      if (i % increment !== 0) return null;
-      const day: Date = subDays(thisDay, i);
-      const { horizontalPosition, width } = horizontalPositionAndWidth(
-        day,
-        addDays(day, 1),
-        start,
-        end,
-      );
-      return {
-        direction,
-        horizontalPosition,
-        label: format(day, template, { locale }),
-        date: day,
-        width,
-      };
-    })
-    .filter((label) => label !== null) as AxisLabel[];
+  const count = Math.ceil(totalDays / increment);
+  return Array.from({ length: count }, (_, i) => {
+    const day: Date = subDays(lastDay, i * increment);
+    const { horizontalPosition, width } = horizontalPositionAndWidth(
+      day,
+      addDays(day, 1),
+      start,
+      end,
+    );
+    return {
+      direction,
+      horizontalPosition,
+      label: format(day, template, { locale }),
+      date: day,
+      width,
+    };
+  });
 };
 
 export const monthLabels = (
@@ -65,8 +62,8 @@ export const monthLabels = (
   const startMonth = startOfMonth(start);
   const endMonth = endOfMonth(end);
   const numberOfMonths = differenceInMonths(endMonth, startMonth) + 1;
-  return new Array(numberOfMonths).fill(startMonth).map((thisMonth, i) => {
-    const month: Date = addMonths(thisMonth, i);
+  return Array.from({ length: numberOfMonths }, (_, i) => {
+    const month: Date = addMonths(startMonth, i);
     const { horizontalPosition, width } = horizontalPositionAndWidth(
       month,
       addMonths(month, 1),
@@ -93,8 +90,8 @@ export const yearLabels = (
   const firstYear = startOfYear(start);
   const lastYear = endOfYear(end);
   const yearCount = differenceInYears(lastYear, start) + 1;
-  return new Array(yearCount).fill(firstYear).map((thisYear, i) => {
-    const year: Date = addYears(thisYear, i);
+  return Array.from({ length: yearCount }, (_, i) => {
+    const year: Date = addYears(firstYear, i);
     const { horizontalPosition, width } = horizontalPositionAndWidth(
       year,
       addYears(year, 1),
@@ -166,6 +163,8 @@ export const AxisLabels = ({
     [direction, labels.length],
   );
 
+  const justifyContent = direction === "left" ? "flex-start" : "flex-end";
+
   return (
     <div
       className="aksel-timeline__axislabels"
@@ -178,7 +177,7 @@ export const AxisLabels = ({
           as="div"
           key={etikett.label}
           style={{
-            justifyContent: direction === "left" ? "flex-start" : "flex-end",
+            justifyContent,
             [direction]: `${etikett.horizontalPosition.toFixed(3)}%`,
             width: getLabelWidth(etikett.width, index),
           }}

--- a/@navikt/core/react/src/timeline/Timeline.stories.tsx
+++ b/@navikt/core/react/src/timeline/Timeline.stories.tsx
@@ -601,8 +601,8 @@ export const OverflowingAxisLabels: StoryFn = () => {
   return (
     <div style={{ width: "800px" }}>
       <Timeline
-        startDate={new Date("2025-06-08")}
-        endDate={new Date("2026-04-08")}
+        startDate={new Date("2026-05-04")}
+        endDate={new Date("2026-05-31")}
       >
         <Timeline.Row label="Row">
           {row1.map((p) => {

--- a/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
@@ -90,7 +90,7 @@ const ClickablePeriod = React.memo(
       return null;
     }
 
-    if (left === 0 || !Number.isFinite(left)) {
+    if (!Number.isFinite(left)) {
       return null;
     }
 

--- a/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
@@ -113,8 +113,8 @@ const ClickablePeriod = React.memo(
               }
             },
             style: {
-              width: `${width}%`,
-              [direction]: `${left}%`,
+              width: `${width.toFixed(3)}%`,
+              [direction]: `${left.toFixed(3)}%`,
             },
             onClick: (e) => {
               restProps?.onClick?.(e);

--- a/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/ClickablePeriod.tsx
@@ -86,6 +86,14 @@ const ClickablePeriod = React.memo(
 
     const label = ariaLabel(start, end, status, statusLabel, translate);
 
+    if (width === 0 || !Number.isFinite(width)) {
+      return null;
+    }
+
+    if (left === 0 || !Number.isFinite(left)) {
+      return null;
+    }
+
     return (
       <>
         <button

--- a/@navikt/core/react/src/timeline/period/NonClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/NonClickablePeriod.tsx
@@ -27,7 +27,7 @@ const NonClickablePeriod = ({
     return null;
   }
 
-  if (left === 0 || !Number.isFinite(left)) {
+  if (!Number.isFinite(left)) {
     return null;
   }
 

--- a/@navikt/core/react/src/timeline/period/NonClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/NonClickablePeriod.tsx
@@ -23,6 +23,14 @@ const NonClickablePeriod = ({
 }: TimelineNonClickablePeriodProps) => {
   const translate = useI18n("Timeline");
 
+  if (width === 0 || !Number.isFinite(width)) {
+    return null;
+  }
+
+  if (left === 0 || !Number.isFinite(left)) {
+    return null;
+  }
+
   return (
     <div
       data-timeline-period

--- a/@navikt/core/react/src/timeline/period/NonClickablePeriod.tsx
+++ b/@navikt/core/react/src/timeline/period/NonClickablePeriod.tsx
@@ -35,8 +35,8 @@ const NonClickablePeriod = ({
         restProps?.className,
       )}
       style={{
-        width: `${width}%`,
-        [direction]: `${left}%`,
+        width: `${width.toFixed(3)}%`,
+        [direction]: `${left.toFixed(3)}%`,
       }}
     >
       <span className="aksel-timeline__period--inner">

--- a/@navikt/core/react/src/timeline/pin/PinInternal.tsx
+++ b/@navikt/core/react/src/timeline/pin/PinInternal.tsx
@@ -78,7 +78,9 @@ export const PinInternal = forwardRef<HTMLButtonElement, TimelinePinProps>(
       <>
         <div
           className="aksel-timeline__pin-wrapper"
-          style={{ [direction]: `${position(date, startDate, endDate)}%` }}
+          style={{
+            [direction]: `${position(date, startDate, endDate).toFixed(3)}%`,
+          }}
         >
           <button
             data-timeline-pin

--- a/@navikt/core/react/src/timeline/pin/PinInternal.tsx
+++ b/@navikt/core/react/src/timeline/pin/PinInternal.tsx
@@ -13,7 +13,7 @@ import {
   useInteractions,
 } from "@floating-ui/react";
 import { format } from "date-fns";
-import React, { forwardRef, useState } from "react";
+import React, { forwardRef, useMemo, useState } from "react";
 import { useMergeRefs } from "../../utils/hooks";
 import { useI18n } from "../../utils/i18n/i18n.hooks";
 import { useTimelineKeyboardContext } from "../hooks/TimelineKeyboardNavProvider";
@@ -74,13 +74,16 @@ export const PinInternal = forwardRef<HTMLButtonElement, TimelinePinProps>(
       date: format(date, translate("dateFormat")),
     });
 
+    const pinPositionStyle = useMemo(() => {
+      const pinPosition = position(date, startDate, endDate);
+      return Number.isFinite(pinPosition) ? `${pinPosition.toFixed(3)}%` : "0%";
+    }, [date, endDate, startDate]);
+
     return (
       <>
         <div
           className="aksel-timeline__pin-wrapper"
-          style={{
-            [direction]: `${position(date, startDate, endDate).toFixed(3)}%`,
-          }}
+          style={{ [direction]: pinPositionStyle }}
         >
           <button
             data-timeline-pin


### PR DESCRIPTION
### Description

- `overflow-x: clip;` can now always be set since each labels width is all avaliable space up-to next label. Stops at 100%, so last label will overflow if larger than timeline itself
- `.sort((a, b) => a.horizontalPosition - b.horizontalPosition)`: Labels now correct order in DOM
- Added toFixed to avoid some hydration errors here server/client calculated different level of precision


https://nav-it.slack.com/archives/C7NE7A8UF/p1781245692299409?thread_ts=1780917776.231279&cid=C7NE7A8UF

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
