### PR TITLE
[Website/Sanity] :tada: Added dekoratøren to sanity komponent grouping

### DIFF
--- a/aksel.nav.no/website/app/_sanity/query-types.ts
+++ b/aksel.nav.no/website/app/_sanity/query-types.ts
@@ -1183,6 +1183,7 @@ export type Komponenter_landingsside = {
   overview_pages?: Array<string>;
   ingress_primitives?: string;
   ingress_core?: string;
+  ingress_dekoratoren?: string;
   ingress_legacy?: string;
   seo?: Seo;
 };
@@ -1436,7 +1437,7 @@ export type Komponent_artikkel = {
   updateInfo?: UpdateInfo;
   publishedAt?: string;
   heading?: string;
-  kategori?: "primitives" | "core" | "legacy" | "standalone";
+  kategori?: "primitives" | "core" | "dekoratoren" | "legacy" | "standalone";
   sidebarindex?: number;
   slug?: Slug;
   status?: {
@@ -2077,7 +2078,13 @@ export type DESIGNSYSTEM_SIDEBAR_QUERY_RESULT = Array<
       _type: "komponent_artikkel";
       heading: string | null;
       slug: string | null;
-      kategori: "core" | "legacy" | "primitives" | "standalone" | null;
+      kategori:
+        | "core"
+        | "dekoratoren"
+        | "legacy"
+        | "primitives"
+        | "standalone"
+        | null;
       tag: "beta" | "deprecated" | "new" | "preview" | "ready" | null;
       sidebarindex: number | null;
     }
@@ -2930,6 +2937,7 @@ export type DESIGNSYSTEM_KOMPONENTER_LANDINGPAGE_QUERY_RESULT = {
   overview_pages?: Array<string>;
   ingress_primitives?: string;
   ingress_core?: string;
+  ingress_dekoratoren?: string;
   ingress_legacy?: string;
   seo?: Seo;
 } | null;
@@ -3109,7 +3117,7 @@ export type KOMPONENT_BY_SLUG_QUERY_RESULT = {
   updateInfo?: UpdateInfo;
   publishedAt?: string;
   heading?: string;
-  kategori?: "core" | "legacy" | "primitives" | "standalone";
+  kategori?: "core" | "dekoratoren" | "legacy" | "primitives" | "standalone";
   sidebarindex?: number;
   slug?: Slug;
   status: {
@@ -4301,7 +4309,13 @@ export type DESIGNSYSTEM_OVERVIEW_BY_CATEGORY_QUERY_RESULT = Array<
           _type: "image";
         };
       } | null;
-      kategori: "core" | "legacy" | "primitives" | "standalone" | null;
+      kategori:
+        | "core"
+        | "dekoratoren"
+        | "legacy"
+        | "primitives"
+        | "standalone"
+        | null;
       sidebarindex: number | null;
       description: string | null;
     }
@@ -4387,7 +4401,13 @@ export type DESIGNSYSTEM_OVERVIEW_BY_TYPE_QUERY_RESULT = Array<
           _type: "image";
         };
       } | null;
-      kategori: "core" | "legacy" | "primitives" | "standalone" | null;
+      kategori:
+        | "core"
+        | "dekoratoren"
+        | "legacy"
+        | "primitives"
+        | "standalone"
+        | null;
       sidebarindex: number | null;
     }
   | {
@@ -8813,7 +8833,12 @@ export type LANDINGSSIDE_LATEST_QUERY_RESULT = Array<{
         updateInfo?: UpdateInfo;
         publishedAt?: string;
         heading?: string;
-        kategori?: "core" | "legacy" | "primitives" | "standalone";
+        kategori?:
+          | "core"
+          | "dekoratoren"
+          | "legacy"
+          | "primitives"
+          | "standalone";
         sidebarindex?: number;
         slug: string | null;
         status?: {
@@ -8951,7 +8976,13 @@ export type LANDINGSSIDE_LATEST_QUERY_RESULT = Array<{
               _type: "image";
             };
           } | null;
-          kategori: "core" | "legacy" | "primitives" | "standalone" | null;
+          kategori:
+            | "core"
+            | "dekoratoren"
+            | "legacy"
+            | "primitives"
+            | "standalone"
+            | null;
           _createdAt: string;
           _updatedAt: string;
           publishedAt: string | null;
@@ -11337,7 +11368,7 @@ export type ALL_KOMPONENTS_MARKDOWN_QUERY_RESULT = Array<{
   updateInfo?: UpdateInfo;
   publishedAt?: string;
   heading?: string;
-  kategori?: "core" | "legacy" | "primitives" | "standalone";
+  kategori?: "core" | "dekoratoren" | "legacy" | "primitives" | "standalone";
   sidebarindex?: number;
   slug?: Slug;
   status?: {
@@ -13813,7 +13844,7 @@ export type KOMPONENT_BY_SLUG_MARKDOWN_QUERY_RESULT = {
   updateInfo?: UpdateInfo;
   publishedAt?: string;
   heading?: string;
-  kategori?: "core" | "legacy" | "primitives" | "standalone";
+  kategori?: "core" | "dekoratoren" | "legacy" | "primitives" | "standalone";
   sidebarindex?: number;
   slug?: Slug;
   status?: {
@@ -16301,7 +16332,13 @@ export type ALL_MARKDOWN_ARTICLES_INDEX_QUERY_RESULT = Array<
       _type: "komponent_artikkel";
       heading: string | null;
       slug: string | null;
-      kategori: "core" | "legacy" | "primitives" | "standalone" | null;
+      kategori:
+        | "core"
+        | "dekoratoren"
+        | "legacy"
+        | "primitives"
+        | "standalone"
+        | null;
       tag: "beta" | "deprecated" | "new" | "preview" | "ready" | null;
       sidebarindex: number | null;
     }

--- a/aksel.nav.no/website/sanity/config.ts
+++ b/aksel.nav.no/website/sanity/config.ts
@@ -51,6 +51,7 @@ export const allArticleDocsRef = allArticleDocuments.map((x) => ({ type: x }));
 export const komponentKategorier = [
   { title: "Primitives", value: "primitives" },
   { title: "Komponenter", value: "core" },
+  { title: "Dekoratøren", value: "dekoratoren" },
   { title: "Avviklet", value: "legacy" },
 ] as const;
 

--- a/aksel.nav.no/website/sanity/sanity-schema.json
+++ b/aksel.nav.no/website/sanity/sanity-schema.json
@@ -6651,6 +6651,13 @@
         },
         "optional": true
       },
+      "ingress_dekoratoren": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
       "ingress_legacy": {
         "type": "objectAttribute",
         "value": {
@@ -8290,6 +8297,10 @@
             {
               "type": "string",
               "value": "core"
+            },
+            {
+              "type": "string",
+              "value": "dekoratoren"
             },
             {
               "type": "string",


### PR DESCRIPTION
### Description

https://github.com/navikt/aksel/compare/dekorator-group?expand=1#diff-06793cdb881b2bda6ee43d2cfe3af1832cb6b4fe63737b322b7f25ad6bf93e25R54

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
