### PR TITLE
[MCP] Search improvements

### DIFF
--- a/mcp-server/REVIEW.md
+++ b/mcp-server/REVIEW.md
@@ -11,6 +11,8 @@ Derived from the 13 manual testing sessions. Findings are taken at face value: e
 
 > Several capabilities that sessions reported as "missing" already exist **as MCP resources** (`aksel-migrations://catalog`, `aksel-tokens://catalog`) and `aksel_get_token_details` already returns "did you mean" suggestions. MCP clients rarely auto-invoke resources — agents reliably call **tools**, not resources. So most of this review is about **findability and descriptions**, not net-new capability.
 
+> **Update (revised approach for T3/T4/T5):** Instead of adding separate `aksel_find_migrations` / `aksel_find_tokens` tools, the migration and token catalogs are now exposed through a `kind` selector on the existing `aksel_find_docs` tool: `kind: 'docs' | 'migrations' | 'tokens'` (default `'docs'`). This keeps a single discoverable entry point and lets the planned Aksel **skill** drive routing by instructing the LLM to call `aksel_find_docs` with `kind:'migrations'` or `kind:'tokens'`. **Skill TODO:** teach this routing (migrations → `kind:'migrations'`; token browse → `kind:'tokens'`; token details → `aksel_get_token_details`).
+
 ---
 
 ## 1. Executive summary
@@ -21,23 +23,23 @@ The second theme is **routing**: token and migration questions get sent to `akse
 
 ### Scored backlog (overview)
 
-| #   | Theme                                                           | Sessions         | Impact | Effort | Primary owner               |
-| --- | --------------------------------------------------------------- | ---------------- | ------ | ------ | --------------------------- |
-| T1  | `find_docs` low recall (multi-word / conceptual / migration)    | 1,2,3,4,5,8,9,13 | High   | Med    | `[MCP-TOOL]`                |
-| T2  | English vs Norwegian query mismatch                             | 1,3,4,5          | High   | Med    | `[MCP-TOOL]`                |
-| T3  | Token questions mis-routed to docs search                       | 10,11,12,13      | High   | Low    | `[MCP-DESC]` + `[MCP-TOOL]` |
-| T4  | Migration/codemod discovery (catalog is a resource, not a tool) | 7,8,9,13         | High   | Low    | `[MCP-TOOL]`                |
-| T5  | No token browse/list tool (catalog is a resource)               | 13               | Med    | Low    | `[MCP-TOOL]`                |
-| T6  | Component existence / closest-alternative signaling             | 1                | Med    | Med    | `[MCP-TOOL]`                |
-| T7  | Icon name aliases / "did you mean"                              | 1                | Med    | Low    | `[MCP-TOOL]`                |
-| T8  | 0-result fallback strategy not documented                       | 4,5,13           | High   | Low    | `[SKILL]`                   |
-| T9  | Tool-selection routing heuristics (token vs docs vs component)  | 4,5,10,11        | Med    | Low    | `[SKILL]`                   |
-| T10 | Detect library context early / auto-validate after install      | 4                | Med    | —      | `[SKILL]`                   |
-| T11 | Breaking-change vs deprecation not distinguished                | 9                | Med    | Low    | `[DOCS]` + `[SKILL]`        |
-| T12 | Version-specific setup (Tailwind v3 vs v4)                      | 2                | Med    | —      | `[SKILL]` + `[DOCS]`        |
-| T13 | Large doc payload `%20` path failure                            | 2                | Low    | —      | Client-side (not MCP)       |
-| T14 | Speculative / unnecessary tool calls                            | 5                | Low    | —      | `[SKILL]`                   |
-| T15 | Migration docs not indexed/sectioned on site                    | 8,13             | Med    | Med    | `[DOCS]`                    |
+| #   | Theme                                                           | Sessions         | Impact | Effort | Primary owner                                        |
+| --- | --------------------------------------------------------------- | ---------------- | ------ | ------ | ---------------------------------------------------- |
+| T1  | `find_docs` low recall (multi-word / conceptual / migration)    | 1,2,3,4,5,8,9,13 | High   | Med    | `[MCP-TOOL]`                                         |
+| T2  | English vs Norwegian query mismatch                             | 1,3,4,5          | High   | Med    | `[MCP-TOOL]`                                         |
+| T3  | Token questions mis-routed to docs search                       | 10,11,12,13      | High   | Low    | `[MCP-DESC]` + `[MCP-TOOL]` ✅ done                  |
+| T4  | Migration/codemod discovery (catalog is a resource, not a tool) | 7,8,9,13         | High   | Low    | `[MCP-TOOL]` ✅ done (`find_docs kind:'migrations'`) |
+| T5  | No token browse/list tool (catalog is a resource)               | 13               | Med    | Low    | `[MCP-TOOL]` ✅ done (`find_docs kind:'tokens'`)     |
+| T6  | Component existence / closest-alternative signaling             | 1                | Med    | Med    | `[MCP-TOOL]`                                         |
+| T7  | Icon name aliases / "did you mean"                              | 1                | Med    | Low    | `[MCP-TOOL]`                                         |
+| T8  | 0-result fallback strategy not documented                       | 4,5,13           | High   | Low    | `[SKILL]`                                            |
+| T9  | Tool-selection routing heuristics (token vs docs vs component)  | 4,5,10,11        | Med    | Low    | `[SKILL]`                                            |
+| T10 | Detect library context early / auto-validate after install      | 4                | Med    | —      | `[SKILL]`                                            |
+| T11 | Breaking-change vs deprecation not distinguished                | 9                | Med    | Low    | `[DOCS]` + `[SKILL]`                                 |
+| T12 | Version-specific setup (Tailwind v3 vs v4)                      | 2                | Med    | —      | `[SKILL]` + `[DOCS]`                                 |
+| T13 | Large doc payload `%20` path failure                            | 2                | Low    | —      | Client-side (not MCP)                                |
+| T14 | Speculative / unnecessary tool calls                            | 5                | Low    | —      | `[SKILL]`                                            |
+| T15 | Migration docs not indexed/sectioned on site                    | 8,13             | Med    | Med    | `[DOCS]`                                             |
 
 ---
 
@@ -174,49 +176,43 @@ Make the hint actionable and route to the right tool/resource:
 
 **Recommendations:**
 
-`[MCP-DESC]` **Make this the obvious entry point for token questions** (it currently reads as "details for a token you already know"):
+`[MCP-DESC]` **Make this the obvious entry point for token questions** (it currently reads as "details for a token you already know"). ✅ **Done** — shipped description:
 
-> "Look up an Aksel design token by name and get its value, accessors (CSS/SCSS/LESS/JS), semantics, and usage. THIS is the right tool for any token/color question — do not use `aksel_find_docs` for tokens. Unknown or outdated names (e.g. v7 `text-action`) return the closest existing tokens. To browse all tokens use `aksel_find_tokens` / `aksel-tokens://catalog`."
+> "Look up an Aksel design token by name and get its value, accessors (CSS/SCSS/LESS/JS), semantics, and usage. THIS is the right tool for any token/color question — do not use `aksel_find_docs` (kind='docs') for tokens. Unknown or outdated names (e.g. v7 `text-action`) return the closest existing tokens. To browse all tokens, call `aksel_find_docs` with kind='tokens'."
 
-`[MCP-DESC]` Add a token-name pattern hint to the param so agents can construct names:
+`[MCP-DESC]` Add a token-name pattern hint to the param so agents can construct names. ✅ **Done** — shipped param:
 
-> "Token name, e.g. 'bg-neutral-moderate', 'text-danger', 'shadow-dialog'. Tokens follow `<role>-<tone>-<emphasis>` patterns. To discover names use `aksel_find_tokens` or the catalog."
+> "Token name, e.g. 'bg-neutral-moderate', 'text-danger', 'shadow-dialog'. Tokens follow `<role>-<tone>-<emphasis>` patterns. To discover names, browse with `aksel_find_docs` using kind='tokens'."
 
-See §4.2 for the new browse tool that closes the discovery gap (T5).
+See §4.2 for how the discovery gap (T5) is closed via `aksel_find_docs` kind='tokens'.
 
 ---
 
 ## 4. Findability gaps — convert resources to tools
 
-MCP clients reliably call **tools** but rarely auto-load **resources**. Two high-value capabilities are currently locked inside resources, which is exactly why sessions reported them as "missing."
+MCP clients reliably call **tools** but rarely auto-load **resources**. Two high-value capabilities were locked inside resources, which is why sessions reported them as "missing."
 
-### 4.1 `aksel_find_migrations` (new tool wrapping `aksel-migrations://catalog`) — T4
+> **Revised & shipped:** rather than two new tools, both capabilities are exposed via a `kind` selector on `aksel_find_docs` (`kind: 'docs' | 'migrations' | 'tokens'`, default `'docs'`). The catalogs/resources remain unchanged; the tool reads the same data sources. A single, already-discoverable tool now covers all three. The planned skill teaches when to pass each `kind`.
+
+### 4.1 ~~`aksel_find_migrations` (new tool)~~ → `aksel_find_docs` kind='migrations' — T4 ✅ done
 
 **Sessions:** S7 (couldn't find any codemods at all), S8 (couldn't find the v6 codemod command), S9 (didn't use MCP for breaking changes), S13 (no direct path to migration info → fell back to Explore).
 
-`[MCP-TOOL]` Add a tool that surfaces the already-existing migrations catalog so agents discover it without knowing the resource URI. Proposed shape:
+`[MCP-TOOL]` ✅ **Done** — `aksel_find_docs` with `kind:'migrations'` surfaces the migrations catalog without needing the resource URI.
 
-- Input: optional `version` (e.g. `"v8"`, `"7"`, or `"7->8"`).
-- Output: matching codemods with `name`, `description`, `warning`, plus the `runCommand` (`npx @navikt/aksel codemod <name>`) and `cliVersion` already in the catalog.
-
-**Proposed description:**
-
-> "List Aksel codemods/migrations for upgrading between major versions. Use for any 'how do I migrate / upgrade / codemod / breaking changes' question (e.g. v6→v7, v7→v8). Returns codemod names, descriptions, warnings, and the exact `npx @navikt/aksel codemod <name>` command."
+- Input: optional `query` matching a version (`"v8"`, `"8"`, `"7->8"`) or a codemod keyword; omit to list all.
+- Output: matching codemods with `name`, `description`, `version`, optional `warning`, plus `runCommand` (`npx @navikt/aksel codemod <name>`) and `cliVersion`. Unknown query → `message` + `availableVersions`.
 
 This directly closes S7/S8/S13's dead ends and gives S9 a structured source for "what changed."
 
-### 4.2 `aksel_find_tokens` (new tool wrapping `aksel-tokens://catalog`) — T5
+### 4.2 ~~`aksel_find_tokens` (new tool)~~ → `aksel_find_docs` kind='tokens' — T5 ✅ done
 
 **Sessions:** S13 — "Unable to systematically browse token catalog (only works with exact names)"; trial-and-error via build errors.
 
-`[MCP-TOOL]` Add a browse/filter tool over the existing tokens catalog:
+`[MCP-TOOL]` ✅ **Done** — `aksel_find_docs` with `kind:'tokens'` browses/filters the tokens catalog:
 
-- Input: optional `query`/`keyword`, `category`, `type`, `role` (e.g. `neutral`, `danger`), `limit`.
-- Output: lightweight `{ name, comment, category, type }` rows (same shape as the catalog), so agents can discover names then drill in with `aksel_get_token_details`.
-
-**Proposed description:**
-
-> "Browse and filter Aksel design tokens by keyword, category, type, or semantic role (e.g. 'danger', 'neutral'). Use this to discover token names, then call `aksel_get_token_details` for full metadata. Prefer this over `aksel_find_docs` for any token question."
+- Input: optional `query` (keyword matched against name/category/comment), `limit`; omit `query` to browse.
+- Output: lightweight `{ name, comment, category, type }` rows (same shape as the catalog), so agents discover names then drill in with `aksel_get_token_details`.
 
 ### 4.3 Reference resources from tool descriptions
 
@@ -236,8 +232,8 @@ This directly closes S7/S8/S13's dead ends and gives S9 a structured source for 
 
 These cannot be fixed by the MCP server alone and belong in the dedicated "how to use Aksel" skill. Flagged per the brief — not drafted here.
 
-- `[SKILL]` **T8 — 0-result fallback strategy.** What to do when `aksel_find_docs` returns nothing (retry with a single keyword/component name; for tokens go to token tools; for migrations go to migrations tool). (S4, S5, S13)
-- `[SKILL]` **T9 — tool-selection routing.** When to use docs search vs `aksel_get_component_info` vs `aksel_get_token_details` vs `aksel_find_migrations`. Token/color → token tool; version/upgrade → migrations tool; component API/props → component info; concepts/guides → docs search. (S10, S11, S12, S13)
+- `[SKILL]` **T8 — 0-result fallback strategy.** What to do when `aksel_find_docs` returns nothing (retry with a single keyword/component name; for tokens retry with `kind:'tokens'` or call `aksel_get_token_details`; for migrations retry with `kind:'migrations'`). (S4, S5, S13)
+- `[SKILL]` **T9 — tool-selection routing.** When to use `aksel_find_docs` (with the right `kind`) vs `aksel_get_component_info` vs `aksel_get_token_details`. Token/color → `aksel_get_token_details` (browse via `aksel_find_docs kind:'tokens'`); version/upgrade/codemod → `aksel_find_docs kind:'migrations'`; component API/props → component info; concepts/guides → `aksel_find_docs kind:'docs'`. **NEW: the skill must teach the `kind` selector explicitly.** (S10, S11, S12, S13)
 - `[SKILL]` **T10 — detect Aksel context early & auto-validate after install.** Anchor answers to the Aksel library when the workspace uses it, and run a quick post-install check (versions, imports, basic API) against component info without waiting to be asked. (S4)
 - `[SKILL]` **T11 — breaking vs deprecation discipline.** When enumerating changes, separate strict breaking changes from deprecations/future removals. (S9)
 - `[SKILL]` **T12 — version-aware setup.** Detect Tailwind v3 vs v4 (and Aksel major) and apply the version-specific template rather than generic directives. (S2)
@@ -300,8 +296,8 @@ These need changes to the underlying docs/index, beyond MCP wiring.
 ## 9. Suggested implementation order
 
 1. **`aksel_find_docs` recall** (T1, T2): EN↔NO synonym/alias map + actionable zero-result routing. _(Unblocks the most sessions.)_
-2. **Expose migrations & token catalogs as tools** (T4, T5): `aksel_find_migrations`, `aksel_find_tokens`. _(Low effort, converts "missing" → discoverable.)_
-3. **Description rewrites** (T3, T6, T7 wording; token/component/icon tools): cheap, high routing impact.
+2. ✅ **Done — expose migrations & token catalogs via `aksel_find_docs` `kind` selector** (T4, T5): `kind:'migrations'` and `kind:'tokens'` instead of separate tools. _(Low effort, converts "missing" → discoverable.)_
+3. ✅ **Done (token) — description rewrites** (T3 token tool + param; docs zero-result routing to `kind:'tokens'` / `kind:'migrations'`). Remaining: T6, T7 wording.
 4. **Closest-alternative on `get_component_info` 404** (T6) and **icon aliases** (T7): reuse the token tool's did-you-mean pattern.
 5. **Shared search/normalization helper + consistent zero-result contract** (§5): consolidate behavior.
 6. Hand off `[SKILL]` and `[DOCS]` items (§6, §7) to the Aksel skill and docs owners.

--- a/mcp-server/src/helpers/search-icons.test.ts
+++ b/mcp-server/src/helpers/search-icons.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+import { searchIcons } from "./search-icons.js";
+
+describe("searchIcons", () => {
+  test("fuzzy-matches icon names/keywords", () => {
+    const results = searchIcons("house");
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]).toHaveProperty("id");
+    expect(results[0]).toHaveProperty("name");
+  });
+
+  test("returns ranked results (best match first)", () => {
+    const results = searchIcons("house");
+    const names = results.map((icon) => icon.name.toLowerCase());
+
+    expect(names.some((name) => name.includes("house"))).toBe(true);
+  });
+
+  test("returns empty for gibberish", () => {
+    expect(searchIcons("zzzqqxnonexistent")).toEqual([]);
+  });
+});

--- a/mcp-server/src/helpers/search-icons.ts
+++ b/mcp-server/src/helpers/search-icons.ts
@@ -1,0 +1,35 @@
+import Fuse, { type IFuseOptions } from "fuse.js";
+import type { AkselIcon } from "@navikt/aksel-icons/metadata";
+import { metadata } from "../resources/icons-catalog.js";
+
+const icons = Object.values(metadata);
+
+const fuseKeys: NonNullable<IFuseOptions<AkselIcon>["keys"]> = [
+  { name: "name", weight: 100 },
+  { name: "keywords", weight: 60 },
+  { name: "sub_category", weight: 20 },
+];
+
+const fuseOptions: IFuseOptions<AkselIcon> = {
+  keys: fuseKeys,
+  includeScore: true,
+  shouldSort: true,
+  minMatchCharLength: 2,
+  ignoreLocation: true,
+  threshold: 0.3,
+  distance: 50,
+  useTokenSearch: true,
+  ignoreDiacritics: true,
+};
+
+const fuse = new Fuse(icons, fuseOptions);
+
+/**
+ * Fuzzy-matches icons against name/keywords/sub_category, ordered by relevance.
+ * Returns the full ranked match list; callers apply their own filters/limit.
+ */
+function searchIcons(query: string): AkselIcon[] {
+  return fuse.search(query.trim()).map(({ item }) => item);
+}
+
+export { searchIcons };

--- a/mcp-server/src/helpers/search-icons.ts
+++ b/mcp-server/src/helpers/search-icons.ts
@@ -12,11 +12,11 @@ const fuseKeys: NonNullable<IFuseOptions<AkselIcon>["keys"]> = [
 
 const fuseOptions: IFuseOptions<AkselIcon> = {
   keys: fuseKeys,
-  includeScore: true,
+  includeScore: false,
   shouldSort: true,
-  minMatchCharLength: 2,
-  ignoreLocation: true,
-  threshold: 0.3,
+  minMatchCharLength: 3,
+  ignoreLocation: false,
+  threshold: 0.2,
   distance: 50,
   useTokenSearch: true,
   ignoreDiacritics: true,

--- a/mcp-server/src/helpers/search-migrations.test.ts
+++ b/mcp-server/src/helpers/search-migrations.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import { getAvailableVersions, searchMigrations } from "./search-migrations.js";
+
+describe("searchMigrations", () => {
+  test("returns all migrations when no query", () => {
+    const all = searchMigrations();
+
+    expect(all.length).toBeGreaterThan(0);
+    expect(all[0]).toHaveProperty("name");
+    expect(all[0]).toHaveProperty("description");
+    expect(all[0]).toHaveProperty("version");
+  });
+
+  test("filters to exact version for version-shaped queries", () => {
+    const v8 = searchMigrations("v8");
+
+    expect(v8.length).toBeGreaterThan(0);
+    expect(v8.every((m) => m.version === "v8")).toBe(true);
+  });
+
+  test("normalizes bare numbers to version keys", () => {
+    const withV = searchMigrations("v8");
+    const withoutV = searchMigrations("8");
+
+    expect(withoutV).toEqual(withV);
+  });
+
+  test("does not fuzzy-fall-back for unknown versions", () => {
+    expect(searchMigrations("v99")).toEqual([]);
+  });
+
+  test("fuzzy-matches codemod names/descriptions", () => {
+    const results = searchMigrations("box");
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(
+      results.some(
+        (m) =>
+          m.name.toLowerCase().includes("box") ||
+          m.description.toLowerCase().includes("box"),
+      ),
+    ).toBe(true);
+  });
+
+  test("getAvailableVersions returns version keys", () => {
+    const versions = getAvailableVersions();
+
+    expect(versions.length).toBeGreaterThan(0);
+    expect(versions).toContain("v8");
+  });
+});

--- a/mcp-server/src/helpers/search-migrations.ts
+++ b/mcp-server/src/helpers/search-migrations.ts
@@ -1,0 +1,76 @@
+import Fuse, { type IFuseOptions } from "fuse.js";
+import { migrations } from "@navikt/aksel/migrations";
+
+type MigrationResult = {
+  name: string;
+  description: string;
+  version: string;
+  warning?: string;
+};
+
+const allMigrations: MigrationResult[] = Object.entries(migrations).flatMap(
+  ([version, entries]) =>
+    entries.map((m) => ({
+      name: m.value,
+      description: m.description,
+      version,
+      ...(m.warning ? { warning: m.warning } : {}),
+    })),
+);
+
+const fuseKeys: NonNullable<IFuseOptions<MigrationResult>["keys"]> = [
+  { name: "name", weight: 100 },
+  { name: "version", weight: 60 },
+  { name: "description", weight: 30 },
+];
+
+const fuseOptions: IFuseOptions<MigrationResult> = {
+  keys: fuseKeys,
+  includeScore: true,
+  shouldSort: true,
+  minMatchCharLength: 2,
+  ignoreLocation: true,
+  threshold: 0.3,
+  distance: 50,
+  useTokenSearch: true,
+  ignoreDiacritics: true,
+};
+
+const fuse = new Fuse(allMigrations, fuseOptions);
+
+function getAvailableVersions(): string[] {
+  return Object.keys(migrations);
+}
+
+/**
+ * Searches migrations/codemods. When the query references one or more version
+ * keys (e.g. "v8", "8", "7->8") only exact version matches are returned;
+ * otherwise the query is fuzzy-matched against name/description/version.
+ */
+function searchMigrations(query?: string): MigrationResult[] {
+  if (!query) {
+    return allMigrations;
+  }
+
+  const normalized = query.toLowerCase().trim();
+
+  /* Match version tokens like "v8", "8", or "7->8" against version keys. */
+  const requestedVersions = new Set(
+    (normalized.match(/v?\d+/g) ?? []).map((match) =>
+      match.startsWith("v") ? match : `v${match}`,
+    ),
+  );
+
+  /**
+   * A version-shaped query is an explicit version filter — don't fall back to
+   * fuzzy matching (which would noisily match "migration" in descriptions).
+   */
+  if (requestedVersions.size > 0) {
+    return allMigrations.filter((m) => requestedVersions.has(m.version));
+  }
+
+  return fuse.search(normalized).map(({ item }) => item);
+}
+
+export { searchMigrations, getAvailableVersions };
+export type { MigrationResult };

--- a/mcp-server/src/helpers/search-migrations.ts
+++ b/mcp-server/src/helpers/search-migrations.ts
@@ -47,7 +47,7 @@ function getAvailableVersions(): string[] {
  * keys (e.g. "v8", "8", "7->8") only exact version matches are returned;
  * otherwise the query is fuzzy-matched against name/description/version.
  */
-function searchMigrations(query?: string): MigrationResult[] {
+function searchMigrations(query?: string, limit?: number): MigrationResult[] {
   if (!query) {
     return allMigrations;
   }
@@ -69,7 +69,7 @@ function searchMigrations(query?: string): MigrationResult[] {
     return allMigrations.filter((m) => requestedVersions.has(m.version));
   }
 
-  return fuse.search(normalized).map(({ item }) => item);
+  return fuse.search(normalized, { limit }).map(({ item }) => item);
 }
 
 export { searchMigrations, getAvailableVersions };

--- a/mcp-server/src/helpers/search-tokens.test.ts
+++ b/mcp-server/src/helpers/search-tokens.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { searchTokens } from "./search-tokens.js";
+
+describe("searchTokens", () => {
+  test("returns first `limit` tokens when no query", () => {
+    const results = searchTokens(undefined, 5);
+
+    expect(results).toHaveLength(5);
+    expect(results[0]).toHaveProperty("name");
+    expect(results[0]).toHaveProperty("category");
+  });
+
+  test("returns lightweight summary shape only", () => {
+    const [first] = searchTokens(undefined, 1);
+
+    expect(first).toHaveProperty("name");
+    expect(first).toHaveProperty("comment");
+    expect(first).toHaveProperty("category");
+    expect(first).toHaveProperty("type");
+    expect(first).not.toHaveProperty("rawValue");
+    expect(first).not.toHaveProperty("jsValue");
+  });
+
+  test("respects the limit when filtering", () => {
+    const results = searchTokens("bg", 3);
+
+    expect(results.length).toBeLessThanOrEqual(3);
+  });
+
+  test("fuzzy-matches token names", () => {
+    const results = searchTokens("shadow", 10);
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((t) => t.name.toLowerCase().includes("shadow"))).toBe(
+      true,
+    );
+  });
+});

--- a/mcp-server/src/helpers/search-tokens.ts
+++ b/mcp-server/src/helpers/search-tokens.ts
@@ -1,19 +1,8 @@
 import Fuse, { type IFuseOptions } from "fuse.js";
-import { tokens } from "../resources/tokens-catalog.js";
-
-type TokenSummary = {
-  name: string;
-  comment?: string;
-  category: string;
-  type: string;
-};
-
-const tokenSummaries: TokenSummary[] = tokens.map((token) => ({
-  name: token.name,
-  comment: token.comment,
-  category: token.category,
-  type: token.type,
-}));
+import {
+  type TokenSummary,
+  tokenSummary as tokenSummaries,
+} from "../resources/tokens-catalog.js";
 
 const fuseKeys: NonNullable<IFuseOptions<TokenSummary>["keys"]> = [
   { name: "name", weight: 100 },
@@ -51,4 +40,3 @@ function searchTokens(
 }
 
 export { searchTokens };
-export type { TokenSummary };

--- a/mcp-server/src/helpers/search-tokens.ts
+++ b/mcp-server/src/helpers/search-tokens.ts
@@ -1,0 +1,54 @@
+import Fuse, { type IFuseOptions } from "fuse.js";
+import { tokens } from "../resources/tokens-catalog.js";
+
+type TokenSummary = {
+  name: string;
+  comment?: string;
+  category: string;
+  type: string;
+};
+
+const tokenSummaries: TokenSummary[] = tokens.map((token) => ({
+  name: token.name,
+  comment: token.comment,
+  category: token.category,
+  type: token.type,
+}));
+
+const fuseKeys: NonNullable<IFuseOptions<TokenSummary>["keys"]> = [
+  { name: "name", weight: 100 },
+  { name: "category", weight: 40 },
+  { name: "comment", weight: 20 },
+];
+
+const fuseOptions: IFuseOptions<TokenSummary> = {
+  keys: fuseKeys,
+  includeScore: true,
+  shouldSort: true,
+  minMatchCharLength: 2,
+  ignoreLocation: true,
+  threshold: 0.3,
+  distance: 50,
+  useTokenSearch: true,
+  ignoreDiacritics: true,
+};
+
+const fuse = new Fuse(tokenSummaries, fuseOptions);
+
+/**
+ * Browses/filters the token catalog. With no query the first `limit` tokens are
+ * returned; otherwise the query is fuzzy-matched against name/category/comment.
+ */
+function searchTokens(
+  query: string | undefined,
+  limit: number,
+): TokenSummary[] {
+  if (!query) {
+    return tokenSummaries.slice(0, limit);
+  }
+
+  return fuse.search(query.trim(), { limit }).map(({ item }) => item);
+}
+
+export { searchTokens };
+export type { TokenSummary };

--- a/mcp-server/src/resources/tokens-catalog.ts
+++ b/mcp-server/src/resources/tokens-catalog.ts
@@ -4,7 +4,14 @@ import type { McpResource } from "../types.js";
 const URI = "aksel-tokens://catalog";
 const MIME_TYPE = "application/json";
 
-const tokenSummary = tokens.map((token) => ({
+type TokenSummary = {
+  name: string;
+  comment?: string;
+  category: string;
+  type: string;
+};
+
+const tokenSummary: TokenSummary[] = tokens.map((token) => ({
   name: token.name,
   comment: token.comment,
   category: token.category,
@@ -30,4 +37,5 @@ const tokensCatalogResource: McpResource = {
   },
 };
 
-export { tokensCatalogResource, tokens };
+export { tokensCatalogResource, tokens, tokenSummary };
+export type { TokenSummary };

--- a/mcp-server/src/tools/find-docs.ts
+++ b/mcp-server/src/tools/find-docs.ts
@@ -54,7 +54,7 @@ const findDocsTool: McpTool<typeof findDocsInputSchema> = {
   inputSchema: findDocsInputSchema,
   async callback({ kind, query, limit }) {
     if (kind === "migrations") {
-      const results = searchMigrations(query);
+      const results = searchMigrations(query, limit);
 
       if (results.length === 0) {
         return JSON.stringify({

--- a/mcp-server/src/tools/find-docs.ts
+++ b/mcp-server/src/tools/find-docs.ts
@@ -82,7 +82,7 @@ const findDocsTool: McpTool<typeof findDocsInputSchema> = {
         return JSON.stringify({
           kind,
           message: `No tokens found for query: "${query}"`,
-          hint: "Try a broader keyword (e.g. 'danger', 'neutral', 'shadow'), or omit query to browse. Call aksel_get_token_details for a specific token.",
+          hint: "Try a broader keyword (e.g. 'danger', 'neutral', 'shadow', 'space'), or omit query to browse. Call aksel_get_token_details for a specific token.",
         });
       }
 

--- a/mcp-server/src/tools/find-docs.ts
+++ b/mcp-server/src/tools/find-docs.ts
@@ -1,44 +1,142 @@
 import { z } from "zod";
+import pkg from "../../package.json" with { type: "json" };
 import { minMatchCharLength, searchDocs } from "../helpers/fuse-search.js";
+import {
+  getAvailableVersions,
+  searchMigrations,
+} from "../helpers/search-migrations.js";
+import { searchTokens } from "../helpers/search-tokens.js";
 import type { McpTool } from "../types.js";
 
+const CODEMOD_RUN_COMMAND = "npx @navikt/aksel codemod <name>";
+
 const findDocsInputSchema = {
+  kind: z
+    .enum(["docs", "migrations", "tokens"])
+    .optional()
+    .default("docs")
+    .describe(
+      "What to search. 'docs' (default) = documentation pages (components, patterns, guides). 'migrations' = codemods for upgrading between major versions (use for any migration/upgrade/codemod/breaking-change question). 'tokens' = browse design tokens, then call aksel_get_token_details for full metadata.",
+    ),
   query: z
     .string()
     .trim()
-    .min(
-      minMatchCharLength,
-      `query must be at least ${minMatchCharLength} characters`,
-    )
+    .optional()
     .describe(
-      "Keywords describing the page you want. Prefer one or two words; component names work best (e.g. 'button', 'knapp', 'textfield', 'tailwind'). Avoid long sentences.",
+      "Keywords describing what you want. For kind='docs' prefer one or two words; component names work best (e.g. 'button', 'knapp', 'textfield', 'tailwind') and at least 3 characters are required. For kind='migrations' pass a version ('v8', '8', '7->8') or codemod keyword; omit to list all. For kind='tokens' pass a name/category keyword; omit to browse.",
     ),
   limit: z.number().int().min(1).max(20).optional().default(8),
 };
 
+function looksLikeToken(query: string) {
+  const normalized = query.toLowerCase();
+  return (
+    /\b(token|color|colour|farge|farger)\b/.test(normalized) ||
+    /\b(bg|text|border|surface)-/.test(normalized) ||
+    /\b(shadow|skygge)-/.test(normalized) ||
+    /\b(space|spacing|avstand)-/.test(normalized)
+  );
+}
+
+function looksLikeMigration(query: string) {
+  const normalized = query.toLowerCase();
+  return (
+    /\b(migration|migrate|migrering|codemod|upgrade|oppgrader|breaking)\b/.test(
+      normalized,
+    ) || /\bv\d+\b/.test(normalized)
+  );
+}
+
 const findDocsTool: McpTool<typeof findDocsInputSchema> = {
   name: "aksel_find_docs",
   description:
-    "Search Aksel documentation pages (components, patterns, guides) and return matching paths. Accepts multi-word and Norwegian/English queries. Call this before aksel_get_doc / aksel_get_component_info. NOTE: this searches pages — for design tokens use aksel_get_token_details/aksel-tokens://catalog, and for version migrations use aksel_find_migrations/aksel-migrations://catalog. If a query returns no results, retry with a single keyword (e.g. a component name) before falling back.",
+    "Search Aksel documentation pages and return matching paths. Accepts multi-word and Norwegian/English queries. Call this before aksel_get_doc / aksel_get_component_info. Use the 'kind' param to switch what you search: kind='migrations' lists codemods for version upgrades (v6→v7, v7→v8, etc.), and kind='tokens' browses design tokens (then call aksel_get_token_details for full metadata). If a docs query returns no results, retry with a single keyword (e.g. a component name) before falling back.",
   inputSchema: findDocsInputSchema,
-  async callback({ query, limit }) {
+  async callback({ kind, query, limit }) {
+    if (kind === "migrations") {
+      const results = searchMigrations(query);
+
+      if (results.length === 0) {
+        return JSON.stringify({
+          kind,
+          message: query
+            ? `No migrations found for query: "${query}"`
+            : "No migrations available.",
+          availableVersions: getAvailableVersions(),
+          hint: "Pass a version like 'v8' or '7->8', or omit query to list all codemods.",
+        });
+      }
+
+      return JSON.stringify({
+        kind,
+        cliVersion: pkg.version,
+        runCommand: CODEMOD_RUN_COMMAND,
+        results,
+      });
+    }
+
+    if (kind === "tokens") {
+      const results = searchTokens(query, limit);
+
+      if (results.length === 0) {
+        return JSON.stringify({
+          kind,
+          message: `No tokens found for query: "${query}"`,
+          hint: "Try a broader keyword (e.g. 'danger', 'neutral', 'shadow'), or omit query to browse. Call aksel_get_token_details for a specific token.",
+        });
+      }
+
+      return JSON.stringify({
+        kind,
+        results,
+        hint: "Call aksel_get_token_details with a token name for full metadata.",
+      });
+    }
+
+    if (!query || query.length < minMatchCharLength) {
+      return JSON.stringify({
+        kind: "docs",
+        message: `query must be at least ${minMatchCharLength} characters for kind='docs'.`,
+        hint: "Provide a keyword such as a component name or category.",
+      });
+    }
+
     const searchResults = await searchDocs(query, limit);
 
     if (!searchResults) {
       return JSON.stringify({
+        kind: "docs",
         message: `Failed to search docs for query: "${query}"`,
         hint: "Try again later.",
       });
     }
 
     if (searchResults.length === 0) {
+      if (looksLikeToken(query)) {
+        return JSON.stringify({
+          kind: "docs",
+          message: `No documentation pages found for query: "${query}"`,
+          hint: "This looks like a design token. Retry with kind='tokens', or call aksel_get_token_details for a specific token.",
+        });
+      }
+
+      if (looksLikeMigration(query)) {
+        return JSON.stringify({
+          kind: "docs",
+          message: `No documentation pages found for query: "${query}"`,
+          hint: "This looks like a version migration. Retry with kind='migrations'.",
+        });
+      }
+
       return JSON.stringify({
+        kind: "docs",
         message: `No documentation pages found for query: "${query}"`,
         hint: "Try a broader keyword such as a component name or category.",
       });
     }
 
     return JSON.stringify({
+      kind: "docs",
       query,
       results: searchResults,
     });

--- a/mcp-server/src/tools/find-docs.ts
+++ b/mcp-server/src/tools/find-docs.ts
@@ -50,7 +50,7 @@ function looksLikeMigration(query: string) {
 const findDocsTool: McpTool<typeof findDocsInputSchema> = {
   name: "aksel_find_docs",
   description:
-    "Search Aksel documentation pages and return matching paths. Accepts multi-word and Norwegian/English queries. Call this before aksel_get_doc / aksel_get_component_info. Use the 'kind' param to switch what you search: kind='migrations' lists codemods for version upgrades (v6→v7, v7→v8, etc.), and kind='tokens' browses design tokens (then call aksel_get_token_details for full metadata). If a docs query returns no results, retry with a single keyword (e.g. a component name) before falling back.",
+    "Search Aksel documentation pages, design tokens, or version migrations. Accepts multi-word and Norwegian/English queries. Call this before aksel_get_doc / aksel_get_component_info. Use the 'kind' param to switch what you search: kind='migrations' lists codemods for version upgrades (v6→v7, v7→v8, etc.), and kind='tokens' browses design tokens (then call aksel_get_token_details for full metadata). If a docs query returns no results, retry with a single keyword (e.g. a component name) before falling back.",
   inputSchema: findDocsInputSchema,
   async callback({ kind, query, limit }) {
     if (kind === "migrations") {
@@ -94,6 +94,22 @@ const findDocsTool: McpTool<typeof findDocsInputSchema> = {
     }
 
     if (!query || query.length < minMatchCharLength) {
+      if (query && looksLikeMigration(query)) {
+        return JSON.stringify({
+          kind: "docs",
+          message: `query must be at least ${minMatchCharLength} characters for kind='docs'.`,
+          hint: "This looks like a version migration. Retry with kind='migrations'.",
+        });
+      }
+
+      if (query && looksLikeToken(query)) {
+        return JSON.stringify({
+          kind: "docs",
+          message: `query must be at least ${minMatchCharLength} characters for kind='docs'.`,
+          hint: "This looks like a design token. Retry with kind='tokens', or call aksel_get_token_details for a specific token.",
+        });
+      }
+
       return JSON.stringify({
         kind: "docs",
         message: `query must be at least ${minMatchCharLength} characters for kind='docs'.`,

--- a/mcp-server/src/tools/find-icons.ts
+++ b/mcp-server/src/tools/find-icons.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchIcons } from "../helpers/search-icons.js";
 import { metadata } from "../resources/icons-catalog.js";
 import type { McpTool } from "../types.js";
 
@@ -6,16 +7,12 @@ const icons = Object.values(metadata);
 const categories = Array.from(
   new Set(icons.map((icon) => icon.category)),
 ).sort();
-const subcategories = Array.from(
-  new Set(icons.map((icon) => icon.sub_category)),
-).sort();
 const variants = Array.from(
   new Set([...icons.map((icon) => icon.variant), "both"]),
 ).sort();
 
 const findIconsInputSchema = {
   category: z.enum(categories as [string, ...string[]]).optional(),
-  subcategory: z.enum(subcategories as [string, ...string[]]).optional(),
   keyword: z.string().optional(),
   variant: z
     .enum(variants as [string, ...string[]])
@@ -27,9 +24,9 @@ const findIconsInputSchema = {
 const findIconsTool: McpTool<typeof findIconsInputSchema> = {
   name: "aksel_find_icons",
   description:
-    "Find and filter Aksel icons by category, subcategory, keyword, and variant. Use aksel-icons://category-catalog to discover available categories first.",
+    "Find and filter Aksel icons by category, keyword, and variant. Keyword matching is fuzzy (handles typos and synonyms) across icon names and keywords. Use aksel-icons://category-catalog to discover available categories first.",
   inputSchema: findIconsInputSchema,
-  async callback({ category, subcategory, keyword, variant, limit }) {
+  async callback({ category, keyword, variant, limit }) {
     let filtered = icons;
 
     if (category) {
@@ -38,19 +35,13 @@ const findIconsTool: McpTool<typeof findIconsInputSchema> = {
       );
     }
 
-    if (subcategory) {
-      filtered = filtered.filter(
-        (icon) => icon.sub_category.toLowerCase() === subcategory.toLowerCase(),
-      );
-    }
-
     if (keyword) {
-      const searchTerm = keyword.toLowerCase();
-      filtered = filtered.filter(
-        (icon) =>
-          icon.name.toLowerCase().includes(searchTerm) ||
-          icon.keywords.some((kw) => kw.toLowerCase().includes(searchTerm)),
+      const ranking = new Map(
+        searchIcons(keyword).map((icon, index) => [icon.id, index]),
       );
+      filtered = filtered
+        .filter((icon) => ranking.has(icon.id))
+        .sort((a, b) => ranking.get(a.id)! - ranking.get(b.id)!);
     }
 
     if (variant && variant !== "both") {
@@ -72,7 +63,6 @@ const findIconsTool: McpTool<typeof findIconsInputSchema> = {
       icons: results.map((icon) => ({
         name: icon.name,
         category: icon.category,
-        subcategory: icon.sub_category,
         variant: icon.variant,
       })),
     };

--- a/mcp-server/src/tools/find-icons.ts
+++ b/mcp-server/src/tools/find-icons.ts
@@ -39,6 +39,7 @@ const findIconsTool: McpTool<typeof findIconsInputSchema> = {
       const ranking = new Map(
         searchIcons(keyword).map((icon, index) => [icon.id, index]),
       );
+
       filtered = filtered
         .filter((icon) => ranking.has(icon.id))
         .sort((a, b) => ranking.get(a.id)! - ranking.get(b.id)!);

--- a/mcp-server/src/tools/get-token-details.ts
+++ b/mcp-server/src/tools/get-token-details.ts
@@ -11,14 +11,14 @@ const getTokenDetailsInputSchema = {
     .trim()
     .min(1, "tokenName is required")
     .describe(
-      "The token name to fetch details for (e.g., 'bg-neutral-moderate', 'shadow-dialog'). Use the aksel-tokens://catalog resource to browse available tokens.",
+      "Token name, e.g. 'bg-neutral-moderate', 'text-danger', 'shadow-dialog'. Tokens follow '<role>-<tone>-<emphasis>' patterns. To discover names, browse with aksel_find_docs using kind='tokens'.",
     ),
 };
 
 const getTokenDetailsTool: McpTool<typeof getTokenDetailsInputSchema> = {
   name: "aksel_get_token_details",
   description:
-    "Fetch complete details for a specific Aksel design token by name. Returns all metadata including value, rawValue, CSS/SCSS/LESS/JS accessors, semantic information, and usage guidelines.",
+    "Look up an Aksel design token by name and get its value, accessors (CSS/SCSS/LESS/JS), semantics, and usage. THIS is the right tool for any token/color question — do not use aksel_find_docs (kind='docs') for tokens. Unknown or outdated names (e.g. v7 'text-action') return the closest existing tokens. To browse all tokens, call aksel_find_docs with kind='tokens'.",
   inputSchema: getTokenDetailsInputSchema,
   async callback({ tokenName }) {
     const token = tokens.find((t) => t.name === tokenName);
@@ -39,7 +39,7 @@ const getTokenDetailsTool: McpTool<typeof getTokenDetailsInputSchema> = {
 
       return JSON.stringify({
         error: `Token '${tokenName}' not found`,
-        hint: "Use the aksel-tokens://catalog resource to browse available tokens",
+        hint: "Browse available tokens with aksel_find_docs using kind='tokens'.",
       });
     }
 

--- a/mcp-server/src/tools/get-token-details.ts
+++ b/mcp-server/src/tools/get-token-details.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { searchTokens } from "../helpers/search-tokens.js";
 import { tokens } from "../resources/tokens-catalog.js";
 import type { McpTool } from "../types.js";
 
@@ -24,10 +25,7 @@ const getTokenDetailsTool: McpTool<typeof getTokenDetailsInputSchema> = {
     const token = tokens.find((t) => t.name === tokenName);
 
     if (!token) {
-      const similarTokens = tokens
-        .filter((t) => t.name.toLowerCase().includes(tokenName.toLowerCase()))
-        .slice(0, 5)
-        .map((t) => t.name);
+      const similarTokens = searchTokens(tokenName, 5).map((t) => t.name);
 
       if (similarTokens.length > 0) {
         return JSON.stringify({

--- a/mcp-server/src/tools/tools.test.ts
+++ b/mcp-server/src/tools/tools.test.ts
@@ -92,7 +92,7 @@ describe("Tools", () => {
     test("should have proper metadata", () => {
       expect(getTokenDetailsTool.name).toBe("aksel_get_token_details");
       expect(getTokenDetailsTool.description).toContain(
-        "Fetch complete details for a specific Aksel design token",
+        "Look up an Aksel design token by name",
       );
       expect(getTokenDetailsTool.inputSchema).toHaveProperty("tokenName");
     });
@@ -119,15 +119,18 @@ describe("Tools", () => {
   });
 
   describe("findDocsTool", () => {
-    test("should validate query and limit", () => {
+    test("should validate kind and limit", () => {
       const strictSchema = z.object(findDocsTool.inputSchema).strict();
 
       const valid = strictSchema.safeParse({
         query: "button",
         limit: 5,
       });
-      const missingQuery = strictSchema.safeParse({
-        query: "",
+      const validMigrations = strictSchema.safeParse({
+        kind: "migrations",
+      });
+      const invalidKind = strictSchema.safeParse({
+        kind: "everything",
       });
       const invalidLimit = strictSchema.safeParse({
         query: "button",
@@ -135,8 +138,88 @@ describe("Tools", () => {
       });
 
       expect(valid.success).toBe(true);
-      expect(missingQuery.success).toBe(false);
+      expect(validMigrations.success).toBe(true);
+      expect(invalidKind.success).toBe(false);
       expect(invalidLimit.success).toBe(false);
+    });
+
+    test("should default kind to docs", () => {
+      const parsed = z.object(findDocsTool.inputSchema).parse({
+        query: "button",
+      });
+
+      expect(parsed.kind).toBe("docs");
+    });
+
+    test("should reject too-short docs query in callback", async () => {
+      const result = await findDocsTool.callback({
+        kind: "docs",
+        query: "ab",
+        limit: 8,
+      });
+
+      const response = JSON.parse(result);
+      expect(response.kind).toBe("docs");
+      expect(response.message).toContain("at least");
+    });
+
+    test("should list migrations with run command", async () => {
+      const result = await findDocsTool.callback({
+        kind: "migrations",
+        query: undefined,
+        limit: 8,
+      });
+
+      const response = JSON.parse(result);
+      expect(response.kind).toBe("migrations");
+      expect(response).toHaveProperty("cliVersion");
+      expect(response.runCommand).toContain("@navikt/aksel codemod");
+      expect(Array.isArray(response.results)).toBe(true);
+      expect(response.results.length).toBeGreaterThan(0);
+      expect(response.results[0]).toHaveProperty("name");
+      expect(response.results[0]).toHaveProperty("description");
+      expect(response.results[0]).toHaveProperty("version");
+    });
+
+    test("should filter migrations by version", async () => {
+      const result = await findDocsTool.callback({
+        kind: "migrations",
+        query: "v8",
+        limit: 8,
+      });
+
+      const response = JSON.parse(result);
+      expect(response.results.length).toBeGreaterThan(0);
+      expect(response.results.every((m: any) => m.version === "v8")).toBe(true);
+    });
+
+    test("should report available versions for unknown migration query", async () => {
+      const result = await findDocsTool.callback({
+        kind: "migrations",
+        query: "v99",
+        limit: 8,
+      });
+
+      const response = JSON.parse(result);
+      expect(response.kind).toBe("migrations");
+      expect(response).toHaveProperty("message");
+      expect(Array.isArray(response.availableVersions)).toBe(true);
+    });
+
+    test("should browse tokens", async () => {
+      const result = await findDocsTool.callback({
+        kind: "tokens",
+        query: undefined,
+        limit: 5,
+      });
+
+      const response = JSON.parse(result);
+      expect(response.kind).toBe("tokens");
+      expect(Array.isArray(response.results)).toBe(true);
+      expect(response.results.length).toBe(5);
+      expect(response.results[0]).toHaveProperty("name");
+      expect(response.results[0]).toHaveProperty("category");
+      expect(response.results[0]).not.toHaveProperty("rawValue");
     });
   });
 

--- a/mcp-server/src/tools/tools.test.ts
+++ b/mcp-server/src/tools/tools.test.ts
@@ -242,15 +242,11 @@ describe("Tools", () => {
       const invalidCategory = strictSchema.safeParse({
         category: "NotARealCategory",
       });
-      const invalidSubcategory = strictSchema.safeParse({
-        subcategory: "NotARealSubcategory",
-      });
       const invalidVariant = strictSchema.safeParse({
         variant: "outline",
       });
 
       expect(invalidCategory.success).toBe(false);
-      expect(invalidSubcategory.success).toBe(false);
       expect(invalidVariant.success).toBe(false);
     });
 
@@ -263,7 +259,6 @@ describe("Tools", () => {
         keyword: firstKeyword,
         limit: 10,
         category: undefined,
-        subcategory: undefined,
         variant: "both",
       });
 
@@ -280,7 +275,6 @@ describe("Tools", () => {
 
     test("should filter icons by category", async () => {
       const result = await findIconsTool.callback({
-        subcategory: undefined,
         variant: "both",
         keyword: undefined,
         category: "Interface",
@@ -298,7 +292,6 @@ describe("Tools", () => {
     test("should return helpful message when no results", async () => {
       const result = await findIconsTool.callback({
         category: undefined,
-        subcategory: undefined,
         variant: "both",
         limit: 20,
         keyword: "nonexistent-icon-xyz-123",

--- a/mcp-server/src/tools/tools.test.ts
+++ b/mcp-server/src/tools/tools.test.ts
@@ -163,6 +163,18 @@ describe("Tools", () => {
       expect(response.message).toContain("at least");
     });
 
+    test("should route short version-like docs query to migrations", async () => {
+      const result = await findDocsTool.callback({
+        kind: "docs",
+        query: "v8",
+        limit: 8,
+      });
+
+      const response = JSON.parse(result);
+      expect(response.kind).toBe("docs");
+      expect(response.hint).toContain("kind='migrations'");
+    });
+
     test("should list migrations with run command", async () => {
       const result = await findDocsTool.callback({
         kind: "migrations",


### PR DESCRIPTION
### Description

Icons, tokens and migrations are now fuzzy searchable using fuse.js

## Icons
Removed sub-category: Sub-categories are linked to a specific category, causing MCP-calls to fail often since they use mismatching category+sub-category combinations. 

## Migrations
Allows for lookups based on syntax v8, 8 etc 

## find_docs tool
Now has a "kind" param that find the docs for that "kind": tokens, migration or regular docs as before.
- If no docs found, does a simple regex match to see if it might be a token or migration they want.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] Style mappings (`@navikt/core/css/config/_mappings.js`)
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
