### PR TITLE
feat(website): added args linter for examples

### DIFF
--- a/@navikt/core/react/tsconfig.sb.json
+++ b/@navikt/core/react/tsconfig.sb.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "noImplicitAny": false,
     "noEmit": true,
-    "types": ["./src/react-css.d.ts"]
+    "types": ["./src/react.d.ts"]
   },
   "include": [
-    "./src/react-css.d.ts",
+    "./src/react.d.ts",
     "./src/**/*.stories.tsx",
     "./src/**/renderStoriesForChromatic.tsx"
   ]

--- a/aksel.nav.no/website/components/react.d.ts
+++ b/aksel.nav.no/website/components/react.d.ts
@@ -15,3 +15,12 @@ declare module "react" {
     [key: `--${string}`]: string | number | undefined;
   }
 }
+
+declare global {
+  type ExampleArgsT = {
+    index: number;
+    desc?: string;
+    sandbox?: boolean;
+    title?: string;
+  };
+}

--- a/aksel.nav.no/website/pages/eksempler/README.md
+++ b/aksel.nav.no/website/pages/eksempler/README.md
@@ -33,7 +33,7 @@ const Example = () => {
 // EXAMPLES DO NOT INCLUDE CONTENT BELOW THIS LINE
 export default withDsExample(Example);
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Primærknapp brukes til xyz",
 };

--- a/aksel.nav.no/website/pages/eksempler/accordion/controlled-state.tsx
+++ b/aksel.nav.no/website/pages/eksempler/accordion/controlled-state.tsx
@@ -42,6 +42,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/accordion/default-open.tsx
+++ b/aksel.nav.no/website/pages/eksempler/accordion/default-open.tsx
@@ -40,6 +40,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/accordion/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/accordion/demo.tsx
@@ -40,6 +40,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/accordion/size.tsx
+++ b/aksel.nav.no/website/pages/eksempler/accordion/size.tsx
@@ -60,6 +60,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/danger.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/danger.tsx
@@ -50,6 +50,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 8,
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/filter.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/filter.tsx
@@ -101,7 +101,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "Med CheckboxItem og RadioItem i ActionMenu er det enkelt å lage et filter for tabeller eller andre komplekse grensesnitt.",
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/groups.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/groups.tsx
@@ -71,7 +71,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Ved å gruppere elementer i ActionMenu vil menyen bli mer oversiktlig og lettere å navigere. Dette vil være ekstra viktig for komplese menyer som inneholder ulike kontekster og funksjonalitet.",
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/header.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/header.tsx
@@ -79,7 +79,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "InternalHeader er implementert med 'dark mode' som standard. For at ActionMenu skal vises riktig kan Theme-komponenten med riktig globalt 'theme' brukes rundt ActionMenu.Content.",
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/indent.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/indent.tsx
@@ -40,7 +40,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 13,
   desc: "Vi anbefaler å bruke innrykk på elementer uten markør som hører sammen hvor minst én av de andre elementene har markør. Dette for å tydeliggjøre at elementet hører til gruppen, og for å skape en visuell sammenheng mellom elementene i gruppen.",
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/items.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/items.tsx
@@ -42,6 +42,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/left-icon-position.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/left-icon-position.tsx
@@ -72,6 +72,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 10,
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/links.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/links.tsx
@@ -60,7 +60,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 7,
   sandbox: false,
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/modal-interaction.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/modal-interaction.tsx
@@ -54,6 +54,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 9,
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/right-icon-position.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/right-icon-position.tsx
@@ -79,6 +79,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 11,
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/shortcuts.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/shortcuts.tsx
@@ -57,7 +57,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Du vil selv måtte legge til funksjonalitet for å lytte til tastatursnarveier, f.eks. med [TanStack Hotkeys](https://tanstack.com/hotkeys/latest).",
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/size.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/size.tsx
@@ -124,7 +124,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 12,
   desc: "Du kan endre størrelsen ved å bruke `size`-prop på `ActionMenu`. Standardstørrelsen er `small`",
 };

--- a/aksel.nav.no/website/pages/eksempler/actionmenu/sub-menu.tsx
+++ b/aksel.nav.no/website/pages/eksempler/actionmenu/sub-menu.tsx
@@ -137,7 +137,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Undermenyer lar deg forenkle komplekse grensesnitt og filter ved å flytte innholdet til en godt strukturert meny. Vi anbefaler maks to nivåer med undermenyer.",
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-global/announcement.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-global/announcement.tsx
@@ -26,6 +26,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-global/centered.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-global/centered.tsx
@@ -40,6 +40,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 8,
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-global/close-button.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-global/close-button.tsx
@@ -27,7 +27,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "Bruk `GlobalAlert.CloseButton` for å legge til en lukkeknapp i alerten. Du må selv håndtere lukke-logikken.",
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-global/error.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-global/error.tsx
@@ -25,6 +25,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-global/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-global/sizes.tsx
@@ -42,7 +42,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "GlobalAlert kommer i to størrelser: medium og small.",
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-global/success.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-global/success.tsx
@@ -24,6 +24,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-global/title-only.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-global/title-only.tsx
@@ -22,7 +22,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 7,
   desc: "For korte meldinger kan man velge å kun vise tittel i alerten. Title er en `h2`-tagg som standard, husk å justere semantikken etter behov.",
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-global/warning.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-global/warning.tsx
@@ -25,6 +25,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-local/announcement.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-local/announcement.tsx
@@ -26,6 +26,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-local/close-button.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-local/close-button.tsx
@@ -27,7 +27,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "Bruk `LocalAlert.CloseButton` for å legge til en lukkeknapp i alerten. Du må selv håndtere lukke-logikken.",
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-local/error.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-local/error.tsx
@@ -25,6 +25,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-local/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-local/sizes.tsx
@@ -42,7 +42,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "LocalAlert kommer i to størrelser: medium og small.",
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-local/success.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-local/success.tsx
@@ -23,6 +23,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-local/title-only.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-local/title-only.tsx
@@ -22,7 +22,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 7,
   desc: "For korte meldinger kan man velge å kun vise tittel i alerten. Title er en `h2`-tagg som standard, husk å justere semantikken etter behov.",
 };

--- a/aksel.nav.no/website/pages/eksempler/alert-local/warning.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert-local/warning.tsx
@@ -25,6 +25,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/alert/fullwidth.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert/fullwidth.tsx
@@ -26,7 +26,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "'fullWidth' fjerner 'border-radius' slik at alerten blir bedre egnet for å vises i full bredde på toppen av en ramme, som et banner.",
 };

--- a/aksel.nav.no/website/pages/eksempler/alert/inline.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert/inline.tsx
@@ -30,7 +30,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "Bruk inline om varselet er en del av annet innhold eller når panelet og bakgrunnsfarge blir støy for brukeren.",
 };

--- a/aksel.nav.no/website/pages/eksempler/alert/med-aria-role.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert/med-aria-role.tsx
@@ -32,7 +32,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "Bruk 'role' dersom alerten vises dynamisk.",
 };

--- a/aksel.nav.no/website/pages/eksempler/alert/med-heading.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert/med-heading.tsx
@@ -22,7 +22,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Husk riktig h-tag ved bruk av heading i Alert.",
 };

--- a/aksel.nav.no/website/pages/eksempler/alert/med-lukkeknapp.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert/med-lukkeknapp.tsx
@@ -47,6 +47,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/alert/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert/sizes.tsx
@@ -22,6 +22,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/alert/variants.tsx
+++ b/aksel.nav.no/website/pages/eksempler/alert/variants.tsx
@@ -27,6 +27,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/bodylong/colors.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodylong/colors.tsx
@@ -43,6 +43,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/bodylong/font-weight.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodylong/font-weight.tsx
@@ -21,6 +21,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/bodylong/override-tag.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodylong/override-tag.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
 };

--- a/aksel.nav.no/website/pages/eksempler/bodylong/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodylong/sizes.tsx
@@ -28,6 +28,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/bodylong/spacing.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodylong/spacing.tsx
@@ -21,7 +21,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Propen 'spacing' legger til mellomrom under avsnittet. Avstanden varierer avhengig av 'size'.",
 };

--- a/aksel.nav.no/website/pages/eksempler/bodylong/text-align.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodylong/text-align.tsx
@@ -28,6 +28,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/bodylong/truncate.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodylong/truncate.tsx
@@ -19,7 +19,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "'truncate' gjør at teksten kuttes ved enden av første linje. Pass på så du ikke gjemmer viktig informasjon som man ikke kan finne andre steder.",
 };

--- a/aksel.nav.no/website/pages/eksempler/bodyshort/colors.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodyshort/colors.tsx
@@ -42,6 +42,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/bodyshort/font-weight.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodyshort/font-weight.tsx
@@ -20,6 +20,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/bodyshort/override-tag.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodyshort/override-tag.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
 };

--- a/aksel.nav.no/website/pages/eksempler/bodyshort/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodyshort/sizes.tsx
@@ -27,6 +27,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/bodyshort/spacing.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodyshort/spacing.tsx
@@ -20,7 +20,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Propen 'spacing' legger til mellomrom under avsnittet. Avstanden varierer avhengig av 'size'.",
 };

--- a/aksel.nav.no/website/pages/eksempler/bodyshort/text-align.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodyshort/text-align.tsx
@@ -27,6 +27,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/bodyshort/truncate.tsx
+++ b/aksel.nav.no/website/pages/eksempler/bodyshort/truncate.tsx
@@ -19,7 +19,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "'truncate' gjør at teksten kuttes ved enden av første linje. Pass på så du ikke gjemmer viktig informasjon som man ikke kan finne andre steder.",
 };

--- a/aksel.nav.no/website/pages/eksempler/button/accent.tsx
+++ b/aksel.nav.no/website/pages/eksempler/button/accent.tsx
@@ -19,7 +19,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Accent-fargen (standard) brukes på handlinger som skal ha oppmerksomhet og er en del av den planlagte flyten.",
 };

--- a/aksel.nav.no/website/pages/eksempler/button/button-as-link.tsx
+++ b/aksel.nav.no/website/pages/eksempler/button/button-as-link.tsx
@@ -36,7 +36,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 10,
   desc: "[OverridableComponent](https://aksel.nav.no/grunnleggende/kode/overridablecomponent) lar deg endre hvilken HTML-tag komponenten rendres med. For vanlige lenker kan dette være en `<a>`-tag, men for f.eks. React Router eller Remix kan det være en `<Link>`-komponent.",
   sandbox: false,

--- a/aksel.nav.no/website/pages/eksempler/button/destructive.tsx
+++ b/aksel.nav.no/website/pages/eksempler/button/destructive.tsx
@@ -25,7 +25,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "For handlinger som kan føre til tap av data eller andre negative konsekvenser for brukeren, bør du bruke en 'destruktiv' knapp.",
 };

--- a/aksel.nav.no/website/pages/eksempler/button/disabled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/button/disabled.tsx
@@ -25,7 +25,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 20,
   desc: "Vi fraråder bruk av disabled state da elementet blir gjemt fra hjelpeteknologier og vil ofte være vanskelig å oppfatte visuelt.",
 };

--- a/aksel.nav.no/website/pages/eksempler/button/icon.tsx
+++ b/aksel.nav.no/website/pages/eksempler/button/icon.tsx
@@ -22,6 +22,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/button/loading.tsx
+++ b/aksel.nav.no/website/pages/eksempler/button/loading.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "[Les mer om loading states i retningslinjene til Loader-komponenten](/komponenter/core/loader#f92383e7d117)",
 };

--- a/aksel.nav.no/website/pages/eksempler/button/neutral.tsx
+++ b/aksel.nav.no/website/pages/eksempler/button/neutral.tsx
@@ -25,7 +25,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "For handlinger som ikke trenger så mye oppmerksomhet, kan du bruke en 'nøytral' knapp.",
 };

--- a/aksel.nav.no/website/pages/eksempler/button/size.tsx
+++ b/aksel.nav.no/website/pages/eksempler/button/size.tsx
@@ -26,7 +26,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Knappene kommer i tre størrelser: medium, small og xsmall. xsmall brukes kun i spesielle tilfeller der det er begrenset plass, for eksempel i tabeller.",
 };

--- a/aksel.nav.no/website/pages/eksempler/chat/avatar.tsx
+++ b/aksel.nav.no/website/pages/eksempler/chat/avatar.tsx
@@ -36,6 +36,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/chat/colors.tsx
+++ b/aksel.nav.no/website/pages/eksempler/chat/colors.tsx
@@ -36,7 +36,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Unngå lik bakgrunnsfarge i komponenten som på flaten bak.",
 };

--- a/aksel.nav.no/website/pages/eksempler/chat/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/chat/demo.tsx
@@ -31,6 +31,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/chat/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/chat/small.tsx
@@ -32,6 +32,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/chat/toptextPosition.tsx
+++ b/aksel.nav.no/website/pages/eksempler/chat/toptextPosition.tsx
@@ -32,7 +32,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Noen ganger ønsker man mer fleksibilitet for plassering av navn + tid i chatboblen.",
 };

--- a/aksel.nav.no/website/pages/eksempler/checkbox/checkbox-description.tsx
+++ b/aksel.nav.no/website/pages/eksempler/checkbox/checkbox-description.tsx
@@ -26,6 +26,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 9,
 };

--- a/aksel.nav.no/website/pages/eksempler/checkbox/controlled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/checkbox/controlled.tsx
@@ -22,6 +22,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 10,
 };

--- a/aksel.nav.no/website/pages/eksempler/checkbox/description.tsx
+++ b/aksel.nav.no/website/pages/eksempler/checkbox/description.tsx
@@ -25,7 +25,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Bruk `description` i tillegg til `legend` når det er behov for mer utfyllende forklaring.",
 };

--- a/aksel.nav.no/website/pages/eksempler/checkbox/disabled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/checkbox/disabled.tsx
@@ -26,7 +26,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 99,
   desc: "Vi fraråder bruk av disabled state. Vurder om du trenger å vise feltet i det hele tatt, om du heller kan bruke `readOnly`, eller bare kan skrive det ut i ren tekst.",
 };

--- a/aksel.nav.no/website/pages/eksempler/checkbox/group-error.tsx
+++ b/aksel.nav.no/website/pages/eksempler/checkbox/group-error.tsx
@@ -25,6 +25,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
 };

--- a/aksel.nav.no/website/pages/eksempler/checkbox/hide-labels.tsx
+++ b/aksel.nav.no/website/pages/eksempler/checkbox/hide-labels.tsx
@@ -17,7 +17,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Label må være meningsfull selv om den skjules, siden den fortsatt leses av skjermlesere.",
 };

--- a/aksel.nav.no/website/pages/eksempler/checkbox/hide-legend.tsx
+++ b/aksel.nav.no/website/pages/eksempler/checkbox/hide-legend.tsx
@@ -21,7 +21,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Legend må være meningsfull selv om den skjules, siden den fortsatt leses av skjermlesere.",
 };

--- a/aksel.nav.no/website/pages/eksempler/checkbox/indeterminate.tsx
+++ b/aksel.nav.no/website/pages/eksempler/checkbox/indeterminate.tsx
@@ -108,6 +108,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 8,
 };

--- a/aksel.nav.no/website/pages/eksempler/checkbox/medium.tsx
+++ b/aksel.nav.no/website/pages/eksempler/checkbox/medium.tsx
@@ -21,6 +21,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/checkbox/readonly.tsx
+++ b/aksel.nav.no/website/pages/eksempler/checkbox/readonly.tsx
@@ -26,7 +26,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 98,
   desc: "Readonly-attributtet gjør at valgene ikke kan endres, men brukere vil fortsatt kunne markere og kopiere teksten. Til forskjell fra disabled vil brukere også kunne tabbe til det, og feltet vil inkluderes når skjemaet sendes inn.",
 };

--- a/aksel.nav.no/website/pages/eksempler/checkbox/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/checkbox/small.tsx
@@ -25,6 +25,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/chips/color.tsx
+++ b/aksel.nav.no/website/pages/eksempler/chips/color.tsx
@@ -40,7 +40,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "`data-color` kan brukes for å endre farge på chipsene.",
 };

--- a/aksel.nav.no/website/pages/eksempler/chips/removable.tsx
+++ b/aksel.nav.no/website/pages/eksempler/chips/removable.tsx
@@ -40,7 +40,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Removable chips viser valgte verdier som brukeren kan fjerne, for eksempel valgte filter eller verdier som brukeren har skrevet i tekstfelt.",
 };

--- a/aksel.nav.no/website/pages/eksempler/chips/size.tsx
+++ b/aksel.nav.no/website/pages/eksempler/chips/size.tsx
@@ -97,6 +97,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/chips/toggle-no-checkmark.tsx
+++ b/aksel.nav.no/website/pages/eksempler/chips/toggle-no-checkmark.tsx
@@ -40,7 +40,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Hvis du slår av checkmark må det være minst 3 chips, slik at det er mulig å se hvilken som er valgt.",
 };

--- a/aksel.nav.no/website/pages/eksempler/chips/toggle.tsx
+++ b/aksel.nav.no/website/pages/eksempler/chips/toggle.tsx
@@ -43,7 +43,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Toggle chip brukes til filtrering av innhold. Du velger selv om brukeren skal kunne velge én eller flere alternativer om gangen.",
 };

--- a/aksel.nav.no/website/pages/eksempler/combobox/multi-select-controlled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/combobox/multi-select-controlled.tsx
@@ -75,7 +75,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "Du kan overstyre blant annet value, selectedOptions og filteredOptions.",
 };

--- a/aksel.nav.no/website/pages/eksempler/combobox/multi-select-with-new-options.tsx
+++ b/aksel.nav.no/website/pages/eksempler/combobox/multi-select-with-new-options.tsx
@@ -38,7 +38,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "Med `allowNewValues` kan brukeren legge til egne verdier som ikke finnes i listen.",
 };

--- a/aksel.nav.no/website/pages/eksempler/combobox/multi-select.tsx
+++ b/aksel.nav.no/website/pages/eksempler/combobox/multi-select.tsx
@@ -37,7 +37,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Med `isMultiSelect` kan brukeren velge flere alternativer fra nedtrekkslisten.",
 };

--- a/aksel.nav.no/website/pages/eksempler/combobox/react-hook-form.tsx
+++ b/aksel.nav.no/website/pages/eksempler/combobox/react-hook-form.tsx
@@ -77,7 +77,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 9,
   desc: "Eksempel på bruk med react-hook-form.",
   sandbox: false,

--- a/aksel.nav.no/website/pages/eksempler/combobox/read-only.tsx
+++ b/aksel.nav.no/website/pages/eksempler/combobox/read-only.tsx
@@ -40,6 +40,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 9,
 };

--- a/aksel.nav.no/website/pages/eksempler/combobox/single-select-with-autocomplete.tsx
+++ b/aksel.nav.no/website/pages/eksempler/combobox/single-select-with-autocomplete.tsx
@@ -36,7 +36,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Med `shouldAutocomplete` foreslås et valg fra listen som matcher det brukeren skriver.",
 };

--- a/aksel.nav.no/website/pages/eksempler/combobox/single-select.tsx
+++ b/aksel.nav.no/website/pages/eksempler/combobox/single-select.tsx
@@ -34,7 +34,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Ved Single Select velger brukeren kun ett valg fra nedtrekkslisten.",
 };

--- a/aksel.nav.no/website/pages/eksempler/combobox/with-complex-options.tsx
+++ b/aksel.nav.no/website/pages/eksempler/combobox/with-complex-options.tsx
@@ -54,7 +54,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 8,
   desc: "Ved å sende inn options som objekter er det mulig å vise en brukervennlig tekst til brukeren, samtidig som systemet i bakkant kan forholde seg til en ID.",
 };

--- a/aksel.nav.no/website/pages/eksempler/combobox/with-error.tsx
+++ b/aksel.nav.no/website/pages/eksempler/combobox/with-error.tsx
@@ -38,6 +38,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/combobox/with-max-selected-limit.tsx
+++ b/aksel.nav.no/website/pages/eksempler/combobox/with-max-selected-limit.tsx
@@ -49,7 +49,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 7,
   desc: "Ved å sette en grense for maks antall valg vil brukeren få opp en beskjed om at hen ikke kan velge flere når grensen er nådd. Resterende alternativer blir inaktive.",
 };

--- a/aksel.nav.no/website/pages/eksempler/confirmationpanel/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/confirmationpanel/demo.tsx
@@ -25,6 +25,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/confirmationpanel/error.tsx
+++ b/aksel.nav.no/website/pages/eksempler/confirmationpanel/error.tsx
@@ -26,6 +26,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/confirmationpanel/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/confirmationpanel/small.tsx
@@ -26,6 +26,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/copybutton/active-icon.tsx
+++ b/aksel.nav.no/website/pages/eksempler/copybutton/active-icon.tsx
@@ -22,7 +22,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "`activeIcon`-propen lar deg endre ikon i aktivert tilstand.",
 };

--- a/aksel.nav.no/website/pages/eksempler/copybutton/active-text.tsx
+++ b/aksel.nav.no/website/pages/eksempler/copybutton/active-text.tsx
@@ -19,6 +19,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/copybutton/color.tsx
+++ b/aksel.nav.no/website/pages/eksempler/copybutton/color.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/copybutton/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/copybutton/demo.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/copybutton/icon.tsx
+++ b/aksel.nav.no/website/pages/eksempler/copybutton/icon.tsx
@@ -21,7 +21,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "`icon`-propen lar deg bytte ikon i vanlig tilstand.",
 };

--- a/aksel.nav.no/website/pages/eksempler/copybutton/tooltip.tsx
+++ b/aksel.nav.no/website/pages/eksempler/copybutton/tooltip.tsx
@@ -18,7 +18,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 8,
   desc: "Tooltip kan hjelpe med å gi mer kontekst om hva man kopierer. Teksten bør være statisk, blant annet fordi endringer i Tooltip ikke konsekvent blir fanget opp av skjermlesere.",
 };

--- a/aksel.nav.no/website/pages/eksempler/copybutton/used-in-info.tsx
+++ b/aksel.nav.no/website/pages/eksempler/copybutton/used-in-info.tsx
@@ -30,7 +30,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 10,
   desc: "Ved utlisting av mye relevant innhold, kan CopyButton brukes for å enklere kopiere informasjonen.",
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/demo.tsx
@@ -25,7 +25,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "For å sikre statiske ['keys'](https://react.dev/learn/rendering-lists#why-does-react-need-keys) i DataGrid, må hver rad ha en unik identifikator. I dette eksemplet bruker vi 'caseId' som nøkkel for hver rad, og vi spesifiserer dette ved å bruke 'getRowId' prop på DataGrid-komponenten.",
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/detail-panel.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/detail-panel.tsx
@@ -45,6 +45,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 11,
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/empty-state.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/empty-state.tsx
@@ -25,6 +25,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 7,
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/layout-auto.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/layout-auto.tsx
@@ -25,6 +25,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/loading-content.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/loading-content.tsx
@@ -33,6 +33,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 10,
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/loading-overlay.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/loading-overlay.tsx
@@ -33,6 +33,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 8,
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/loading-skeleton.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/loading-skeleton.tsx
@@ -33,6 +33,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 9,
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/multi-select.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/multi-select.tsx
@@ -30,6 +30,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/nested-rows.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/nested-rows.tsx
@@ -223,6 +223,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 12,
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/row-click.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/row-click.tsx
@@ -27,7 +27,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 13,
   desc: "`onRowAction`-callbacken gir tilgang til raden som ble klikket på, og kan brukes til å utføre en handling basert på denne raden.",
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/settings.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/settings.tsx
@@ -130,6 +130,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/single-select.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/single-select.tsx
@@ -30,6 +30,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/sorting.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/sorting.tsx
@@ -83,7 +83,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "I tilfeller der data endres dynamisk, bør du bruke `getRowId` for å beholde ytelsen.",
 };

--- a/aksel.nav.no/website/pages/eksempler/data-grid/sticky-columns.tsx
+++ b/aksel.nav.no/website/pages/eksempler/data-grid/sticky-columns.tsx
@@ -38,6 +38,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/anchor.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/anchor.tsx
@@ -36,6 +36,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 8,
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/disable-weekends.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/disable-weekends.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/disabled-days.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/disabled-days.tsx
@@ -29,6 +29,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/dropdown.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/dropdown.tsx
@@ -22,6 +22,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/input-range-with-error.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/input-range-with-error.tsx
@@ -57,7 +57,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 11,
   desc: "Eksempel på hvordan du legger inn feilmelding som gjelder for begge feltene.",
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/input-range.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/input-range.tsx
@@ -42,7 +42,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 7,
   desc: "Før du velger å bruke range mode, vurder om to separate datepickere i single mode er bedre. Range fungerer best for korte perioder innenfor en måned.",
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/input-single.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/input-single.tsx
@@ -29,7 +29,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "Vi anbefaler å bruke `useDatepicker`-hooken hvis du har et input-felt.",
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/multiple.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/multiple.tsx
@@ -20,6 +20,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/range.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/range.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/readonly.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/readonly.tsx
@@ -23,7 +23,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 99,
   desc: "Readonly-attributtet gjør at verdien ikke kan endres, men brukere vil fortsatt kunne markere og kopiere fra feltet. Til forskjell fra disabled-felter vil brukere også kunne tabbe til det, og feltet vil inkluderes når skjemaet sendes inn.",
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/standalone.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/standalone.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/two-digit-year.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/two-digit-year.tsx
@@ -30,7 +30,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 10,
   desc: "Propen `allowTwoDigitYear` gjør det mulig å skrive årstallet på 'yy'-format. Mulige årstall vil være 80 år bakover og 19 år framover. I 2025 tilsvarer det 1945-2044.",
 };

--- a/aksel.nav.no/website/pages/eksempler/datepicker/validation.tsx
+++ b/aksel.nav.no/website/pages/eksempler/datepicker/validation.tsx
@@ -47,7 +47,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 9,
   desc: "Bruk `onValidate`-callback for å håndtere validering. Se også [Mønster for skjemavalidering](/monster-maler/soknadsdialog/monster-for-skjemavalidering).",
 };

--- a/aksel.nav.no/website/pages/eksempler/detail/colors.tsx
+++ b/aksel.nav.no/website/pages/eksempler/detail/colors.tsx
@@ -42,6 +42,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/detail/font-weight.tsx
+++ b/aksel.nav.no/website/pages/eksempler/detail/font-weight.tsx
@@ -20,6 +20,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/detail/override-tag.tsx
+++ b/aksel.nav.no/website/pages/eksempler/detail/override-tag.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
 };

--- a/aksel.nav.no/website/pages/eksempler/detail/spacing.tsx
+++ b/aksel.nav.no/website/pages/eksempler/detail/spacing.tsx
@@ -20,7 +20,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Propen 'spacing' legger til mellomrom under teksten. Avstanden varierer avhengig av 'size'.",
 };

--- a/aksel.nav.no/website/pages/eksempler/detail/text-align.tsx
+++ b/aksel.nav.no/website/pages/eksempler/detail/text-align.tsx
@@ -21,6 +21,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/detail/truncate.tsx
+++ b/aksel.nav.no/website/pages/eksempler/detail/truncate.tsx
@@ -19,6 +19,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/detail/uppercase.tsx
+++ b/aksel.nav.no/website/pages/eksempler/detail/uppercase.tsx
@@ -17,6 +17,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/dialog/alertdialog.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/alertdialog.tsx
@@ -44,7 +44,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: 'Bruk gjerne role="alertdialog" på Dialog.Popup når dialogen formidler viktig informasjon. [Les mer og alertdialog-rollen](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alertdialog_role)',
 };

--- a/aksel.nav.no/website/pages/eksempler/dialog/conditional-render.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/conditional-render.tsx
@@ -68,7 +68,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 15,
   desc: "Vi anbefaler å alltid rendre dialog-elementet, siden Dialog.Popup returnerer null så lenge dialogen er lukket. Dette sikrer at animasjoner for åpning og lukking av dialogen fungerer som forventet.",
 };

--- a/aksel.nav.no/website/pages/eksempler/dialog/controlled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/controlled.tsx
@@ -51,7 +51,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Du kan kontrollere åpen-tilstanden ved å bruke `open`- og `onOpenChange`-props på Dialog-komponenten. Dette er nyttig når du må åpne dialogen programmatisk eller reagere på tilstandsendringer.",
 };

--- a/aksel.nav.no/website/pages/eksempler/dialog/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/demo.tsx
@@ -39,6 +39,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/dialog/form.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/form.tsx
@@ -62,6 +62,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/dialog/initial-focus.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/initial-focus.tsx
@@ -40,7 +40,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 10,
   desc: "Ved å bruke `initialFocusTo` kan du angi hvilket element som skal få fokus når dialogen åpnes. Dette er nyttig for skjemaer der du vil at brukeren skal kunne begynne å skrive med en gang.",
 };

--- a/aksel.nav.no/website/pages/eksempler/dialog/position.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/position.tsx
@@ -85,6 +85,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/dialog/prevent-close.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/prevent-close.tsx
@@ -65,7 +65,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 9,
   desc: "Ved `onOpenChange` kan du forhindre at dialogen lukkes basert på logikk.",
 };

--- a/aksel.nav.no/website/pages/eksempler/dialog/return-focus.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/return-focus.tsx
@@ -45,6 +45,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 11,
 };

--- a/aksel.nav.no/website/pages/eksempler/dialog/size.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/size.tsx
@@ -58,6 +58,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/dialog/trap-focus.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/trap-focus.tsx
@@ -220,7 +220,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 12,
   desc: '`modal="trap-focus"` lar brukeren interagere med innholdet utenfor dialogen med pointer/touch, mens fokus forblir innenfor dialogen. Tastatur og skjermlesere vil ikke ha tilgang til innholdet bak dialogen, slik at dette bør bare implementeres i ekspertsystemer!',
 };

--- a/aksel.nav.no/website/pages/eksempler/dialog/width.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/width.tsx
@@ -75,6 +75,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/dialog/with-actionmenu.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dialog/with-actionmenu.tsx
@@ -60,7 +60,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 16,
   desc: "Merk at fokus returneres til menyknappen når dialogen lukkes, selv om dialogen ble åpnet fra en ActionMenu.",
 };

--- a/aksel.nav.no/website/pages/eksempler/dropdown/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/dropdown/demo.tsx
@@ -46,7 +46,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   sandbox: false,
 };

--- a/aksel.nav.no/website/pages/eksempler/errormessage/show-icon.tsx
+++ b/aksel.nav.no/website/pages/eksempler/errormessage/show-icon.tsx
@@ -22,6 +22,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/errormessage/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/errormessage/sizes.tsx
@@ -20,6 +20,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/errorsummary/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/errorsummary/demo.tsx
@@ -22,6 +22,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/errorsummary/heading-tag.tsx
+++ b/aksel.nav.no/website/pages/eksempler/errorsummary/heading-tag.tsx
@@ -25,7 +25,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Ved behov kan overskriftsnivået endres med `headingTag`-propen.",
 };

--- a/aksel.nav.no/website/pages/eksempler/errorsummary/setting-focus.tsx
+++ b/aksel.nav.no/website/pages/eksempler/errorsummary/setting-focus.tsx
@@ -43,7 +43,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Eksempel på hvordan du kan sette fokus på ErrorSummary ved submit. Hvis du gjør en ny sidelasting kan du også sette en `id` og referere til den i URLens hash. Se [Mønster for skjemavalidering](/monster-maler/soknadsdialog/monster-for-skjemavalidering) for et mer fullstendig eksempel.",
 };

--- a/aksel.nav.no/website/pages/eksempler/errorsummary/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/errorsummary/small.tsx
@@ -22,6 +22,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/expansioncard/color.tsx
+++ b/aksel.nav.no/website/pages/eksempler/expansioncard/color.tsx
@@ -106,7 +106,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Obs! Dette fungerer bare med nytt 'darkside' tema.",
 };

--- a/aksel.nav.no/website/pages/eksempler/expansioncard/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/expansioncard/demo.tsx
@@ -100,6 +100,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/expansioncard/description.tsx
+++ b/aksel.nav.no/website/pages/eksempler/expansioncard/description.tsx
@@ -103,6 +103,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/expansioncard/heading-sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/expansioncard/heading-sizes.tsx
@@ -124,6 +124,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/expansioncard/icon.tsx
+++ b/aksel.nav.no/website/pages/eksempler/expansioncard/icon.tsx
@@ -111,7 +111,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "Man kan manuelt legge til ikoner eller illustrasjoner vha. HStack.",
 };

--- a/aksel.nav.no/website/pages/eksempler/expansioncard/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/expansioncard/small.tsx
@@ -113,6 +113,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/fieldset/address.tsx
+++ b/aksel.nav.no/website/pages/eksempler/fieldset/address.tsx
@@ -41,7 +41,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Fieldset kan brukes for å legge til ledetekst på felter som opptrer flere ganger. (Her har vi justert opp størrelsen på legend-teksten for å skape et tydeligere hierarki.)",
 };

--- a/aksel.nav.no/website/pages/eksempler/fieldset/agepicker.tsx
+++ b/aksel.nav.no/website/pages/eksempler/fieldset/agepicker.tsx
@@ -32,7 +32,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Bruk av Fieldset her gjør at man unngår å gjenta konteksten i hver Select. (Her har vi justert ned font-vekten på labelen til hvert felt for å skape et tydeligere hierarki.)",
 };

--- a/aksel.nav.no/website/pages/eksempler/fieldset/heading-as-legend.tsx
+++ b/aksel.nav.no/website/pages/eksempler/fieldset/heading-as-legend.tsx
@@ -26,7 +26,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Selv om du har en overskrift som fungerer som ledetekst, kan det likevel være nyttig å bruke fieldset mht. skjermleser-brukere. For å unngå duplisert tekst kan du putte overskriften rett i legend.",
 };

--- a/aksel.nav.no/website/pages/eksempler/fieldset/hide-legend.tsx
+++ b/aksel.nav.no/website/pages/eksempler/fieldset/hide-legend.tsx
@@ -29,7 +29,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "En annen variant av 'Heading as legend'-eksempelet der overskriften er utenfor og vi i stedet skjuler legend visuelt med `hideLegend` for å unngå duplisert tekst for seende.",
 };

--- a/aksel.nav.no/website/pages/eksempler/fieldset/phone-input.tsx
+++ b/aksel.nav.no/website/pages/eksempler/fieldset/phone-input.tsx
@@ -35,6 +35,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/fieldset/switch-group.tsx
+++ b/aksel.nav.no/website/pages/eksempler/fieldset/switch-group.tsx
@@ -22,7 +22,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "OBS 1: Switch skal ikke brukes i skjemaer ([se dokumentasjon](/komponenter/core/switch)). OBS 2: Ved bruk av `error`-propen på Fieldset må feilmeldingen knyttes til Switch-ene manuelt med `aria-describedby`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/file-upload/default.tsx
+++ b/aksel.nav.no/website/pages/eksempler/file-upload/default.tsx
@@ -98,6 +98,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/file-upload/dropzone-disabled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/file-upload/dropzone-disabled.tsx
@@ -25,6 +25,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/file-upload/error.tsx
+++ b/aksel.nav.no/website/pages/eksempler/file-upload/error.tsx
@@ -24,6 +24,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/file-upload/item-actions.tsx
+++ b/aksel.nav.no/website/pages/eksempler/file-upload/item-actions.tsx
@@ -50,6 +50,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/file-upload/single-file.tsx
+++ b/aksel.nav.no/website/pages/eksempler/file-upload/single-file.tsx
@@ -35,6 +35,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/file-upload/too-many-files.tsx
+++ b/aksel.nav.no/website/pages/eksempler/file-upload/too-many-files.tsx
@@ -63,6 +63,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/file-upload/translation.tsx
+++ b/aksel.nav.no/website/pages/eksempler/file-upload/translation.tsx
@@ -45,7 +45,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 99,
   desc: "Med translations API-et kan du endre tekstene i komponentene. **OBS:** `dragAndDrop`, `dragAndDropMultiple` og `or` er usynlige for skjermlesere. Ikke legg viktig info her.",
 };

--- a/aksel.nav.no/website/pages/eksempler/file-upload/trigger-button.tsx
+++ b/aksel.nav.no/website/pages/eksempler/file-upload/trigger-button.tsx
@@ -44,7 +44,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "Enkel knapp uten dropzone. Label og ev. beskrivelse kobles opp med `aria-describedby`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/formprogress/links.tsx
+++ b/aksel.nav.no/website/pages/eksempler/formprogress/links.tsx
@@ -45,7 +45,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Hvis hvert steg har sin egen URL, kan du bruke href på FormProgress.Step i stedet for onStepChange.",
 };

--- a/aksel.nav.no/website/pages/eksempler/formprogress/state.tsx
+++ b/aksel.nav.no/website/pages/eksempler/formprogress/state.tsx
@@ -33,6 +33,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/formsummary/custom-editlink.tsx
+++ b/aksel.nav.no/website/pages/eksempler/formsummary/custom-editlink.tsx
@@ -30,6 +30,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/formsummary/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/formsummary/demo.tsx
@@ -77,6 +77,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/formsummary/grouped-answers.tsx
+++ b/aksel.nav.no/website/pages/eksempler/formsummary/grouped-answers.tsx
@@ -64,7 +64,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Man kan gruppere svar ved å neste `FormSummary.Answers` innenfor `FormSummary.Answer`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/guidepanel/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/guidepanel/demo.tsx
@@ -19,7 +19,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "På mobil (brekkpunkt sm) blir komponenten mer kompakt og avataren flyttes til toppen. Avatar-plasseringen kan låses med propen 'poster'.",
 };

--- a/aksel.nav.no/website/pages/eksempler/guidepanel/poster.tsx
+++ b/aksel.nav.no/website/pages/eksempler/guidepanel/poster.tsx
@@ -19,7 +19,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "I poster-varianten er avataren plassert øverst i midten.",
 };

--- a/aksel.nav.no/website/pages/eksempler/h-grid/align.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-grid/align.tsx
@@ -45,7 +45,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Propen `align` endrer `align-items` (vertikal justering).",
 };

--- a/aksel.nav.no/website/pages/eksempler/h-grid/columns-variants.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-grid/columns-variants.tsx
@@ -30,7 +30,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Prop-en `columns` styrer CSS-attributtet `grid-template-columns`. Hvis du bruker tall blir det automatisk omgjort til `repeat(<number>, minmax(0, 1fr))`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/h-grid/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-grid/demo.tsx
@@ -26,6 +26,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/h-grid/responsive-columns.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-grid/responsive-columns.tsx
@@ -27,7 +27,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Med responsive kolonner kan du dynamisk tilpasse dem basert på brekkpunktene våre.",
 };

--- a/aksel.nav.no/website/pages/eksempler/h-grid/responsive-gap.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-grid/responsive-gap.tsx
@@ -27,7 +27,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Med responsiv gap kan du dynamisk tilpasse spacing basert på brekkpunktene våre.",
 };

--- a/aksel.nav.no/website/pages/eksempler/h-stack/align.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-stack/align.tsx
@@ -72,7 +72,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Propen `align` endrer `align-items`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/h-stack/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-stack/demo.tsx
@@ -21,7 +21,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "HStack er en enkel layout-komponent for flexbox.",
 };

--- a/aksel.nav.no/website/pages/eksempler/h-stack/justify.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-stack/justify.tsx
@@ -69,7 +69,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Propen `justify` endrer `justify-content`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/h-stack/responsive-direction.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-stack/responsive-direction.tsx
@@ -36,7 +36,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 7,
   desc: "Ønsker du å endre fra 'row' til 'column' ved et brekkpunkt kan du bruke Stack-komponenten. Husk også å oppdatere `align` og `justify` samtidig.",
 };

--- a/aksel.nav.no/website/pages/eksempler/h-stack/responsive-gap.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-stack/responsive-gap.tsx
@@ -29,7 +29,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "På noen props, f.eks. gap, kan du sette ulike verdier per brekkpunkt. Implementasjonen er mobile-first, slik at 'sm: 8' vil også gjelde for 'md', 'lg' og 'xl'.",
 };

--- a/aksel.nav.no/website/pages/eksempler/h-stack/spacer.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-stack/spacer.tsx
@@ -33,7 +33,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 99,
   desc: "Spacer lar deg lett legge inn automatisk stretch mellom elementer. Dette kan være nyttig når man f.eks. skal plassere knapper i 'InternalHeader'.",
 };

--- a/aksel.nav.no/website/pages/eksempler/h-stack/wrap.tsx
+++ b/aksel.nav.no/website/pages/eksempler/h-stack/wrap.tsx
@@ -46,7 +46,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Som standard er `wrap` satt til `true`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/header/app-switcher.tsx
+++ b/aksel.nav.no/website/pages/eksempler/header/app-switcher.tsx
@@ -80,7 +80,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   title: "App-meny",
   desc: "App-menyen inneholder lenker til andre interne systemer.",

--- a/aksel.nav.no/website/pages/eksempler/header/brukermeny.tsx
+++ b/aksel.nav.no/website/pages/eksempler/header/brukermeny.tsx
@@ -56,7 +56,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Brukernavnet kan være en ActionMenu som inneholder logg ut-lenke og info om brukeren (fullt navn, identnummer og eventuelt annen relevant info).",
   sandbox: false,

--- a/aksel.nav.no/website/pages/eksempler/header/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/header/demo.tsx
@@ -19,6 +19,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/header/description.tsx
+++ b/aksel.nav.no/website/pages/eksempler/header/description.tsx
@@ -19,6 +19,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/header/home.tsx
+++ b/aksel.nav.no/website/pages/eksempler/header/home.tsx
@@ -19,7 +19,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   title: "Hjem-lenke",
 };

--- a/aksel.nav.no/website/pages/eksempler/header/search.tsx
+++ b/aksel.nav.no/website/pages/eksempler/header/search.tsx
@@ -35,7 +35,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   title: "Søk",
   desc: "Husk å ta høyde for mobilvisning.",

--- a/aksel.nav.no/website/pages/eksempler/heading/align.tsx
+++ b/aksel.nav.no/website/pages/eksempler/heading/align.tsx
@@ -50,6 +50,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/heading/colors.tsx
+++ b/aksel.nav.no/website/pages/eksempler/heading/colors.tsx
@@ -75,6 +75,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/heading/level.tsx
+++ b/aksel.nav.no/website/pages/eksempler/heading/level.tsx
@@ -19,7 +19,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Propen 'level' bestemmer hvilken h-tagg som brukes. Du kan sette 'size' uavhengig av dette, men størrelsen bør samsvare med nivået.",
 };

--- a/aksel.nav.no/website/pages/eksempler/heading/override-tag.tsx
+++ b/aksel.nav.no/website/pages/eksempler/heading/override-tag.tsx
@@ -17,6 +17,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/heading/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/heading/sizes.tsx
@@ -25,6 +25,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/heading/spacing.tsx
+++ b/aksel.nav.no/website/pages/eksempler/heading/spacing.tsx
@@ -20,7 +20,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Propen 'spacing' legger til mellomrom under overskriften. Avstanden varierer avhengig av 'size'.",
 };

--- a/aksel.nav.no/website/pages/eksempler/helptext/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/helptext/demo.tsx
@@ -17,6 +17,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/helptext/placement.tsx
+++ b/aksel.nav.no/website/pages/eksempler/helptext/placement.tsx
@@ -28,6 +28,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/info-card/as-section.tsx
+++ b/aksel.nav.no/website/pages/eksempler/info-card/as-section.tsx
@@ -28,7 +28,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Bruk `as='section'` + aria-label/aria-labelledby for å gjøre InfoCard til en semantisk seksjon på siden. Dette 'rammer inn' InfoCard for skjermlesere og gjør det lettere å forstå hvor den starter og slutter.",
 };

--- a/aksel.nav.no/website/pages/eksempler/info-card/colors.tsx
+++ b/aksel.nav.no/website/pages/eksempler/info-card/colors.tsx
@@ -46,7 +46,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "InfoCard støtter flere fargevalg for ulike kontekster.",
 };

--- a/aksel.nav.no/website/pages/eksempler/info-card/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/info-card/demo.tsx
@@ -23,6 +23,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/info-card/icon.tsx
+++ b/aksel.nav.no/website/pages/eksempler/info-card/icon.tsx
@@ -24,6 +24,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/info-card/message.tsx
+++ b/aksel.nav.no/website/pages/eksempler/info-card/message.tsx
@@ -21,7 +21,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "For korte meldinger kan man velge å bruke InfoCard.Message. Dette er en enklere variant av InfoCard som kun inneholder en melding og et ikon. Denne skal ikke inneholde tittel eller knapper, men lenker er ok.",
 };

--- a/aksel.nav.no/website/pages/eksempler/info-card/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/info-card/sizes.tsx
@@ -34,7 +34,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "InfoCard kommer i to størrelser: medium og small.",
 };

--- a/aksel.nav.no/website/pages/eksempler/info-card/use-cases.tsx
+++ b/aksel.nav.no/website/pages/eksempler/info-card/use-cases.tsx
@@ -75,6 +75,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/inline-message/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/inline-message/demo.tsx
@@ -28,7 +28,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Bruk InlineMessage for å gi brukeren viktig informasjon i en tekstflyt uten at det tar for mye plass visuelt.",
 };

--- a/aksel.nav.no/website/pages/eksempler/inline-message/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/inline-message/sizes.tsx
@@ -22,6 +22,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/label/colors.tsx
+++ b/aksel.nav.no/website/pages/eksempler/label/colors.tsx
@@ -43,6 +43,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/label/override-tag.tsx
+++ b/aksel.nav.no/website/pages/eksempler/label/override-tag.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/label/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/label/sizes.tsx
@@ -21,6 +21,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/label/spacing.tsx
+++ b/aksel.nav.no/website/pages/eksempler/label/spacing.tsx
@@ -26,7 +26,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Propen 'spacing' legger til margin-bottom. Avstanden varierer avhengig av 'size'.",
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/demo.tsx
@@ -37,7 +37,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "LinkCard er bygget for å kunne settes sammen på ulike måter.",
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/description.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/description.tsx
@@ -23,6 +23,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/footer.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/footer.tsx
@@ -29,6 +29,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/frameworks.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/frameworks.tsx
@@ -37,7 +37,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 7,
   desc: "Bruk `asChild`-propen hvis du bruker et rammeverk som har sin egen link-komponent. Du legger da komponenten du ønsker å bruke som child i `LinkCard.Anchor`.",
   sandbox: false,

--- a/aksel.nav.no/website/pages/eksempler/link-card/grid-demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/grid-demo.tsx
@@ -47,7 +47,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 11,
   desc: "Vi anbefaler å samle kortene i en liste (`<ul>`), med mindre du rendrer titlene som overskrifter.",
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/icon.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/icon.tsx
@@ -23,6 +23,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/image.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/image.tsx
@@ -36,6 +36,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/next-image.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/next-image.tsx
@@ -37,7 +37,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   sandbox: false,
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/picture.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/picture.tsx
@@ -43,6 +43,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/size-small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/size-small.tsx
@@ -26,6 +26,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 8,
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/title-as-heading.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/title-as-heading.tsx
@@ -28,7 +28,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 10,
   desc: "For viktige lenker kan det gi mening å bruker heading-elementer for å fremheve dem for skjermlesere og andre hjelpemidler. I dette eksempelet er tittelen på LinkCard satt til et h2-element.",
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/title.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/title.tsx
@@ -19,6 +19,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/umami-logging.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/umami-logging.tsx
@@ -29,6 +29,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 10,
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/use-cases.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/use-cases.tsx
@@ -278,7 +278,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 15,
   desc: "Dette er replikasjoner av eksempler funnet i Navs løsninger.",
 };

--- a/aksel.nav.no/website/pages/eksempler/link-card/vstack-demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link-card/vstack-demo.tsx
@@ -47,7 +47,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 12,
   desc: "Vi anbefaler å samle kortene i en liste (`<ul>`), med mindre du rendrer titlene som overskrifter.",
 };

--- a/aksel.nav.no/website/pages/eksempler/link/anchor.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link/anchor.tsx
@@ -25,6 +25,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
 };

--- a/aksel.nav.no/website/pages/eksempler/link/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link/demo.tsx
@@ -18,6 +18,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/link/frameworks.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link/frameworks.tsx
@@ -34,7 +34,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "Bruk 'as'-propen hvis du bruker et rammeverk som har sin egen link-komponent.",
   sandbox: false,

--- a/aksel.nav.no/website/pages/eksempler/link/icon.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link/icon.tsx
@@ -23,6 +23,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/link/inline.tsx
+++ b/aksel.nav.no/website/pages/eksempler/link/inline.tsx
@@ -26,7 +26,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Prop-en 'inlineText' gjør at teksten wrapper.",
 };

--- a/aksel.nav.no/website/pages/eksempler/linkpanel/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/linkpanel/demo.tsx
@@ -17,6 +17,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/linkpanel/description.tsx
+++ b/aksel.nav.no/website/pages/eksempler/linkpanel/description.tsx
@@ -20,6 +20,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/linkpanel/nextjs-link.tsx
+++ b/aksel.nav.no/website/pages/eksempler/linkpanel/nextjs-link.tsx
@@ -18,7 +18,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   sandbox: false,
 };

--- a/aksel.nav.no/website/pages/eksempler/linkpanel/no-border.tsx
+++ b/aksel.nav.no/website/pages/eksempler/linkpanel/no-border.tsx
@@ -17,6 +17,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/list/icons.tsx
+++ b/aksel.nav.no/website/pages/eksempler/list/icons.tsx
@@ -38,7 +38,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "Husk å sette `aria-hidden` på dekorative ikoner.",
 };

--- a/aksel.nav.no/website/pages/eksempler/list/item-title.tsx
+++ b/aksel.nav.no/website/pages/eksempler/list/item-title.tsx
@@ -32,7 +32,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "Du kan sette en tittel på hvert element i listen. Dette er kun visuelt og får ingen semantisk betydning.",
 };

--- a/aksel.nav.no/website/pages/eksempler/list/large.tsx
+++ b/aksel.nav.no/website/pages/eksempler/list/large.tsx
@@ -28,6 +28,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/list/ordered.tsx
+++ b/aksel.nav.no/website/pages/eksempler/list/ordered.tsx
@@ -25,7 +25,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: 'Du kan sette `as="ol"` for å få en nummerert liste.',
 };

--- a/aksel.nav.no/website/pages/eksempler/list/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/list/small.tsx
@@ -28,6 +28,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/list/unordered.tsx
+++ b/aksel.nav.no/website/pages/eksempler/list/unordered.tsx
@@ -28,7 +28,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "<List> rendrer en <ul> og <List.Item> rendrer en <li>.",
 };

--- a/aksel.nav.no/website/pages/eksempler/loader/button.tsx
+++ b/aksel.nav.no/website/pages/eksempler/loader/button.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/loader/interaction.tsx
+++ b/aksel.nav.no/website/pages/eksempler/loader/interaction.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Interaction-varianten er ment for interaktive elementer.",
 };

--- a/aksel.nav.no/website/pages/eksempler/loader/inverted.tsx
+++ b/aksel.nav.no/website/pages/eksempler/loader/inverted.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Inverted-varianten passer bedre på mørkere flater.",
 };

--- a/aksel.nav.no/website/pages/eksempler/loader/neutral.tsx
+++ b/aksel.nav.no/website/pages/eksempler/loader/neutral.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Neutral-varianten blir ofte brukt for innholdslasting.",
 };

--- a/aksel.nav.no/website/pages/eksempler/loader/size.tsx
+++ b/aksel.nav.no/website/pages/eksempler/loader/size.tsx
@@ -23,6 +23,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/loader/transparent.tsx
+++ b/aksel.nav.no/website/pages/eksempler/loader/transparent.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Prop-en `transparent` skjuler bakgrunnselementet på Loader.",
 };

--- a/aksel.nav.no/website/pages/eksempler/lookup/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/lookup/demo.tsx
@@ -26,7 +26,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Lookup kan brukes inne i løpende tekst for å forklare et enkelt ord eller begrep.",
 };

--- a/aksel.nav.no/website/pages/eksempler/lookup/rich-content.tsx
+++ b/aksel.nav.no/website/pages/eksempler/lookup/rich-content.tsx
@@ -31,7 +31,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Popoveren som åpnes kan inneholde rikt innhold, for eksempel flere avsnitt, lenker eller en liste.",
 };

--- a/aksel.nav.no/website/pages/eksempler/modal/close-on-backdrop-click.tsx
+++ b/aksel.nav.no/website/pages/eksempler/modal/close-on-backdrop-click.tsx
@@ -33,7 +33,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "Husk at det er lett å klikke utenfor ved et uhell. Ikke bruk 'closeOnBackdropClick' hvis det kan føre til at brukeren mister data eller går glipp av viktig informasjon.",
 };

--- a/aksel.nav.no/website/pages/eksempler/modal/custom-header.tsx
+++ b/aksel.nav.no/website/pages/eksempler/modal/custom-header.tsx
@@ -42,7 +42,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Headeren tilbys som en egen komponent for de tilfellene du trenger mer fleksiblitet enn header-propen gir deg. Begge varianter har mulighet for å skjule lukkeknappen.",
 };

--- a/aksel.nav.no/website/pages/eksempler/modal/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/modal/demo.tsx
@@ -52,6 +52,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/modal/form.tsx
+++ b/aksel.nav.no/website/pages/eksempler/modal/form.tsx
@@ -38,7 +38,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: 'Det er ikke støtte for å ha <form> som direkte barn av <Modal>. Legg <form> enten rundt hele modalen eller inni <Modal.Body>. Sistnevnte gjør det mulig å sette method="dialog", som gjør at modalen lukkes ved submit.',
 };

--- a/aksel.nav.no/website/pages/eksempler/modal/no-closebutton.tsx
+++ b/aksel.nav.no/website/pages/eksempler/modal/no-closebutton.tsx
@@ -55,7 +55,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Lukkeknappen i headeren kan skjules, men da må du ha en annen knapp som lukker modalen.",
 };

--- a/aksel.nav.no/website/pages/eksempler/modal/placement-top.tsx
+++ b/aksel.nav.no/website/pages/eksempler/modal/placement-top.tsx
@@ -37,7 +37,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "Bruk placement='top' hvis høyden kan endre seg (dynamisk innhold).",
 };

--- a/aksel.nav.no/website/pages/eksempler/modal/with-label-and-icon.tsx
+++ b/aksel.nav.no/website/pages/eksempler/modal/with-label-and-icon.tsx
@@ -60,6 +60,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/monthpicker/anchor.tsx
+++ b/aksel.nav.no/website/pages/eksempler/monthpicker/anchor.tsx
@@ -31,6 +31,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/monthpicker/disabled-months.tsx
+++ b/aksel.nav.no/website/pages/eksempler/monthpicker/disabled-months.tsx
@@ -28,6 +28,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/monthpicker/dropdown.tsx
+++ b/aksel.nav.no/website/pages/eksempler/monthpicker/dropdown.tsx
@@ -22,6 +22,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/monthpicker/input.tsx
+++ b/aksel.nav.no/website/pages/eksempler/monthpicker/input.tsx
@@ -31,7 +31,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Vi anbefaler å bruke `useMonthpicker`-hooken hvis du har et input-felt.",
 };

--- a/aksel.nav.no/website/pages/eksempler/monthpicker/readonly.tsx
+++ b/aksel.nav.no/website/pages/eksempler/monthpicker/readonly.tsx
@@ -24,7 +24,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 99,
   desc: "Readonly-attributtet gjør at verdien ikke kan endres, men brukere vil fortsatt kunne markere og kopiere fra feltet. Til forskjell fra disabled-felter vil brukere også kunne tabbe til det, og feltet vil inkluderes når skjemaet sendes inn.",
 };

--- a/aksel.nav.no/website/pages/eksempler/monthpicker/standalone.tsx
+++ b/aksel.nav.no/website/pages/eksempler/monthpicker/standalone.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/monthpicker/validation.tsx
+++ b/aksel.nav.no/website/pages/eksempler/monthpicker/validation.tsx
@@ -45,7 +45,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "Bruk `onValidate`-callback for å håndtere validering. Se også [Mønster for skjemavalidering](/monster-maler/soknadsdialog/monster-for-skjemavalidering).",
 };

--- a/aksel.nav.no/website/pages/eksempler/pagination/labeling.tsx
+++ b/aksel.nav.no/website/pages/eksempler/pagination/labeling.tsx
@@ -29,7 +29,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "For å gjøre det lettere for skjermlesere å navigere til Pagination, anbefaler vi å bruke `srHeading`-prop for å legge til en skjult heading. Husk å bruke riktig h-tag.",
 };

--- a/aksel.nav.no/website/pages/eksempler/pagination/prev-next-texts.tsx
+++ b/aksel.nav.no/website/pages/eksempler/pagination/prev-next-texts.tsx
@@ -24,7 +24,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Ved å skru på propen 'prevNextTexts' får forrige- og neste-knappene synlig tekst i tillegg til chevron.",
 };

--- a/aksel.nav.no/website/pages/eksempler/pagination/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/pagination/sizes.tsx
@@ -41,7 +41,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Komponenten finnes i størrelsene medium, small og xsmall.",
 };

--- a/aksel.nav.no/website/pages/eksempler/panel/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/panel/demo.tsx
@@ -26,6 +26,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/panel/no-border.tsx
+++ b/aksel.nav.no/website/pages/eksempler/panel/no-border.tsx
@@ -26,6 +26,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/popover/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/popover/demo.tsx
@@ -38,7 +38,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Popover kan kobles til de fleste typer elementer med bruk av `ref`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/popover/no-offset.tsx
+++ b/aksel.nav.no/website/pages/eksempler/popover/no-offset.tsx
@@ -40,7 +40,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Offset er avstanden mellom elementet og popoveren, og kan overstyres.",
 };

--- a/aksel.nav.no/website/pages/eksempler/popover/no-padding.tsx
+++ b/aksel.nav.no/website/pages/eksempler/popover/no-padding.tsx
@@ -38,7 +38,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "`Popover.Content` legger bare på litt padding, så den kan utelates.",
 };

--- a/aksel.nav.no/website/pages/eksempler/popover/placement.tsx
+++ b/aksel.nav.no/website/pages/eksempler/popover/placement.tsx
@@ -67,7 +67,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Her kan du teste ulike 'placement'-verdier. Popover styrer selv plassering hvis det ikke er plass i valgt retning.",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/as-child.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/as-child.tsx
@@ -31,7 +31,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "Vi anbefaler å bruke `asChild`-propen der mulig. Dette reduserer antall DOM-noder og forenkler output. [Les mer om asChild her](https://aksel.nav.no/grunnleggende/kode/komponent-api#613715c234c8).",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/demo.tsx
@@ -31,6 +31,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/directions.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/directions.tsx
@@ -54,6 +54,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/full.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/full.tsx
@@ -37,7 +37,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: 'Med `marginInline="full"` kan du få enkeltelementer til å dekke hele skjermbredden mens resten av innholdet følger bredden satt av parent-container som vanlig. OBS: Du må kanskje sette `overflow-x: hidden` på body for å unngå horisontal scrollbar.',
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/optical-alignment.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/optical-alignment.tsx
@@ -41,7 +41,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "Noen ganger er det den ene pixelen som skal til for å optisk sentrere elementer. Les mer om [optiske effekter](https://medium.com/design-bridges/optical-effects-9fca82b4cd9a).",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/reflective-padding.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/reflective-padding.tsx
@@ -35,6 +35,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-bleed/responsive.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-bleed/responsive.tsx
@@ -43,7 +43,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Både `marginBlock` og `marginInline` er responsive, slik at du kan sette negativ margin dynamisk basert på brekkpunkter.",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/as-child.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/as-child.tsx
@@ -20,7 +20,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 8,
   desc: "Vi anbefaler å bruke `asChild`-propen der mulig. Dette reduserer antall DOM-noder og forenkler output. [Les mer om asChild her](https://aksel.nav.no/grunnleggende/kode/komponent-api#613715c234c8).",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/background.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/background.tsx
@@ -25,7 +25,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Propen `background` lar deg sette bakgrunnsfarge basert på tokens.",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/border-color.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/border-color.tsx
@@ -40,7 +40,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "Propen `borderColor` lar deg endre border-color basert på tokens.",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/border-radius.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/border-radius.tsx
@@ -45,7 +45,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "Propen `borderRadius` lar deg sette border-radius basert på tokens. Du kan også enkelt endre border-radius basert på brekkpunkt.",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/border-width.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/border-width.tsx
@@ -22,7 +22,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Propen `borderWidth` lar deg kontrollere tykkelsen på border.",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/padding-block.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/padding-block.tsx
@@ -36,7 +36,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Propen `paddingBlock` gir deg kontroll over vertikal padding.",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/padding-inline.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/padding-inline.tsx
@@ -36,7 +36,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Propen `paddingInline` gir deg kontroll over horisontal padding.",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/padding.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/padding.tsx
@@ -31,7 +31,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Propen `padding` lar deg sette padding responsivt basert på brekkpunkt. Verdien mapper til tokens, så f.eks. `space-4` tilsvarer `--ax-space-4` som er 0.25rem (4px).",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/panel.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/panel.tsx
@@ -37,7 +37,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 9,
   desc: "Box erstatter den avviklede komponenten Panel.",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-box/shadow.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-box/shadow.tsx
@@ -24,7 +24,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 7,
   desc: "Propen `shadow` lar deg sette box-shadow basert på tokens.",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-hide/hide.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-hide/hide.tsx
@@ -21,7 +21,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Endre størrelsen på eksempelvinduet for å se komponenten i aksjon. [Les mer om asChild her](https://aksel.nav.no/grunnleggende/kode/komponent-api#613715c234c8).",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-hide/mix.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-hide/mix.tsx
@@ -24,7 +24,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Vi anbefaler konsistent bruk av `above` og `below` for bedre lesbarhet i koden.",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-page/below-fold.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-page/below-fold.tsx
@@ -38,7 +38,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   title: "Footer belowFold",
   desc: '`footerPosition="belowFold"` sikrer at footer aldri vil vises før man begynner å scrolle. Dette hjelper med å redusere layout-shifts ved navigering mellom sider.',

--- a/aksel.nav.no/website/pages/eksempler/primitive-page/content-block-padding.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-page/content-block-padding.tsx
@@ -38,7 +38,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   title: "Content Padding",
   desc: "Propen `contentBlockPadding` på Page sikrer at det alltid vil være en minimumspadding mellom innhold og footer. Dette vil være en god fallback, men mange layouts vil trenge ekstra padding top/bottom.",

--- a/aksel.nav.no/website/pages/eksempler/primitive-page/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-page/demo.tsx
@@ -39,7 +39,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   title: "Standard",
   desc: "`Page.Block` kan også brukes i header og footer for å sikre at innholdet er sentrert og har samme maksbredde som resten av innholdet.",

--- a/aksel.nav.no/website/pages/eksempler/primitive-page/gutters.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-page/gutters.tsx
@@ -47,7 +47,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   title: "Gutters",
   desc: "Propen `gutters` på Page.Block setter responsive gutters (padding-inline).",

--- a/aksel.nav.no/website/pages/eksempler/primitive-page/width.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-page/width.tsx
@@ -40,7 +40,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   title: "Maksbredde",
   desc: "Propen `width` på `Page.Block` sentrerer innhold og legger på maksbredde.",

--- a/aksel.nav.no/website/pages/eksempler/primitive-show/mix.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-show/mix.tsx
@@ -24,7 +24,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Vi anbefaler konsistent bruk av `above` og `below` for bedre lesbarhet i koden.",
 };

--- a/aksel.nav.no/website/pages/eksempler/primitive-show/show.tsx
+++ b/aksel.nav.no/website/pages/eksempler/primitive-show/show.tsx
@@ -21,7 +21,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Endre størrelsen på eksempelvinduet for å se komponenten i aksjon. [Les mer om asChild her](https://aksel.nav.no/grunnleggende/kode/komponent-api#613715c234c8).",
 };

--- a/aksel.nav.no/website/pages/eksempler/process/checkmark.tsx
+++ b/aksel.nav.no/website/pages/eksempler/process/checkmark.tsx
@@ -48,7 +48,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "Hvis du ønsker å ha en hake på fullførte steg så kan du bruke `<CheckmarkHeavyIcon />`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/process/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/process/demo.tsx
@@ -76,6 +76,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/process/numbers.tsx
+++ b/aksel.nav.no/website/pages/eksempler/process/numbers.tsx
@@ -31,7 +31,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "Du kan bruke `bullet` for å vise et nummer i hver 'event'. Dette kan være nyttig for å vise rekkefølgen på stegene i en allerede kjent prosess.",
 };

--- a/aksel.nav.no/website/pages/eksempler/process/simple-events.tsx
+++ b/aksel.nav.no/website/pages/eksempler/process/simple-events.tsx
@@ -31,6 +31,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/process/sub-events.tsx
+++ b/aksel.nav.no/website/pages/eksempler/process/sub-events.tsx
@@ -52,6 +52,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/process/truncated.tsx
+++ b/aksel.nav.no/website/pages/eksempler/process/truncated.tsx
@@ -31,7 +31,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "`isTruncated` legger til en linje før første og/eller etter siste hendelse. Dette brukes for å illustrere at prosessen har flere hendelser før/etter enn det som vises.",
 };

--- a/aksel.nav.no/website/pages/eksempler/progress-bar/indeterminate.tsx
+++ b/aksel.nav.no/website/pages/eksempler/progress-bar/indeterminate.tsx
@@ -30,7 +30,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Med simulated-propen kan man legge inn et anslag i sekunder, så simulerer komponenten progresjon.",
 };

--- a/aksel.nav.no/website/pages/eksempler/progress-bar/interactive.tsx
+++ b/aksel.nav.no/website/pages/eksempler/progress-bar/interactive.tsx
@@ -63,7 +63,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "ProgressBar kan brukes til å vise hvor i en flyt brukeren er",
 };

--- a/aksel.nav.no/website/pages/eksempler/progress-bar/loading.tsx
+++ b/aksel.nav.no/website/pages/eksempler/progress-bar/loading.tsx
@@ -40,6 +40,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/progress-bar/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/progress-bar/sizes.tsx
@@ -37,6 +37,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/progress-bar/status-change.tsx
+++ b/aksel.nav.no/website/pages/eksempler/progress-bar/status-change.tsx
@@ -25,7 +25,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Du kan bruke `data-color` for å endre farge på ProgressBar basert på status.",
 };

--- a/aksel.nav.no/website/pages/eksempler/radio-horizontal/horizontal.tsx
+++ b/aksel.nav.no/website/pages/eksempler/radio-horizontal/horizontal.tsx
@@ -24,6 +24,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/radio/controlled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/radio/controlled.tsx
@@ -22,6 +22,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 9,
 };

--- a/aksel.nav.no/website/pages/eksempler/radio/description.tsx
+++ b/aksel.nav.no/website/pages/eksempler/radio/description.tsx
@@ -25,7 +25,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Bruk `description` i tillegg til `legend` når det er behov for mer utfyllende forklaring.",
 };

--- a/aksel.nav.no/website/pages/eksempler/radio/disabled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/radio/disabled.tsx
@@ -25,7 +25,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 99,
   desc: "Vi fraråder bruk av disabled state. Vurder om du trenger å vise feltet i det hele tatt, om du heller kan bruke `readOnly`, eller bare kan skrive det ut i ren tekst.",
 };

--- a/aksel.nav.no/website/pages/eksempler/radio/error.tsx
+++ b/aksel.nav.no/website/pages/eksempler/radio/error.tsx
@@ -32,6 +32,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
 };

--- a/aksel.nav.no/website/pages/eksempler/radio/hide-legend.tsx
+++ b/aksel.nav.no/website/pages/eksempler/radio/hide-legend.tsx
@@ -25,7 +25,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Legend må være meningsfull selv om den skjules, siden den fortsatt leses av skjermlesere.",
 };

--- a/aksel.nav.no/website/pages/eksempler/radio/medium.tsx
+++ b/aksel.nav.no/website/pages/eksempler/radio/medium.tsx
@@ -21,6 +21,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/radio/radio-description.tsx
+++ b/aksel.nav.no/website/pages/eksempler/radio/radio-description.tsx
@@ -23,6 +23,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 8,
 };

--- a/aksel.nav.no/website/pages/eksempler/radio/readonly.tsx
+++ b/aksel.nav.no/website/pages/eksempler/radio/readonly.tsx
@@ -26,7 +26,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 98,
   desc: "Readonly-attributtet gjør at valget ikke kan endres, men brukere vil fortsatt kunne markere og kopiere teksten. Til forskjell fra disabled vil brukere også kunne tabbe til det, og feltet vil inkluderes når skjemaet sendes inn.",
 };

--- a/aksel.nav.no/website/pages/eksempler/radio/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/radio/small.tsx
@@ -25,6 +25,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/readmore/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/readmore/demo.tsx
@@ -29,6 +29,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/readmore/variant-ghost.tsx
+++ b/aksel.nav.no/website/pages/eksempler/readmore/variant-ghost.tsx
@@ -43,7 +43,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Ghost er en nedtonet variant av ReadMore som skal brukes når innholdet er koblet til en annen kontekst, for eksempel et skjema.",
 };

--- a/aksel.nav.no/website/pages/eksempler/readmore/variant-moderate.tsx
+++ b/aksel.nav.no/website/pages/eksempler/readmore/variant-moderate.tsx
@@ -46,7 +46,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Moderate er en mer fremhevet variant av ReadMore, som bør brukes når innholdet en en viktig del av siden og ofte står for seg selv.",
 };

--- a/aksel.nav.no/website/pages/eksempler/search/custom-button.tsx
+++ b/aksel.nav.no/website/pages/eksempler/search/custom-button.tsx
@@ -19,7 +19,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 8,
   desc: "Children kan erstatte knapp hvis man f.eks. trenger eget ikon eller 'type'-prop.",
 };

--- a/aksel.nav.no/website/pages/eksempler/search/error.tsx
+++ b/aksel.nav.no/website/pages/eksempler/search/error.tsx
@@ -21,6 +21,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
 };

--- a/aksel.nav.no/website/pages/eksempler/search/input-size.tsx
+++ b/aksel.nav.no/website/pages/eksempler/search/input-size.tsx
@@ -21,6 +21,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/search/primary.tsx
+++ b/aksel.nav.no/website/pages/eksempler/search/primary.tsx
@@ -17,7 +17,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Primary brukes der søk er hovedfunksjon, f.eks. ved globalt søk. Merk at det som regel bare skal finnes ett primary søk på en og samme side.",
 };

--- a/aksel.nav.no/website/pages/eksempler/search/secondary.tsx
+++ b/aksel.nav.no/website/pages/eksempler/search/secondary.tsx
@@ -17,7 +17,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Hvis du er i tvil om hvilken variant du skal bruke, er det sikkert denne som er riktig.",
 };

--- a/aksel.nav.no/website/pages/eksempler/search/simple.tsx
+++ b/aksel.nav.no/website/pages/eksempler/search/simple.tsx
@@ -17,7 +17,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Simple er en forenklet variant av søkefeltet uten søkeknapp. Den brukes særlig på input-felter der innholdet blir oppdatert fortløpende eller ved autocomplete med dropdown.",
 };

--- a/aksel.nav.no/website/pages/eksempler/search/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/search/small.tsx
@@ -21,6 +21,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/search/vis-label.tsx
+++ b/aksel.nav.no/website/pages/eksempler/search/vis-label.tsx
@@ -22,7 +22,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Vi har valgt å skjule label som standard. Dette kan lett endres på med prop `hideLabel`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/select/description.tsx
+++ b/aksel.nav.no/website/pages/eksempler/select/description.tsx
@@ -23,7 +23,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Bruk `description` i tillegg til `label` når det er behov for mer utfyllende forklaring.",
 };

--- a/aksel.nav.no/website/pages/eksempler/select/disabled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/select/disabled.tsx
@@ -20,7 +20,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 99,
   desc: "Vi fraråder bruk av disabled state. Vurder om du trenger å vise feltet i det hele tatt, om du heller kan bruke `readOnly`, eller bare kan skrive det ut i ren tekst.",
 };

--- a/aksel.nav.no/website/pages/eksempler/select/error.tsx
+++ b/aksel.nav.no/website/pages/eksempler/select/error.tsx
@@ -20,6 +20,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/select/hide-label.tsx
+++ b/aksel.nav.no/website/pages/eksempler/select/hide-label.tsx
@@ -20,7 +20,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Label må være meningsfull selv om den skjules, siden den fortsatt leses av skjermlesere.",
 };

--- a/aksel.nav.no/website/pages/eksempler/select/readonly.tsx
+++ b/aksel.nav.no/website/pages/eksempler/select/readonly.tsx
@@ -20,7 +20,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 98,
   desc: "Readonly-attributtet gjør at verdien ikke kan endres. Til forskjell fra disabled-felter vil brukere fortsatt kunne tabbe til det, og feltet vil inkluderes når skjemaet sendes inn.",
 };

--- a/aksel.nav.no/website/pages/eksempler/select/size.tsx
+++ b/aksel.nav.no/website/pages/eksempler/select/size.tsx
@@ -29,6 +29,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/skeleton/children.tsx
+++ b/aksel.nav.no/website/pages/eksempler/skeleton/children.tsx
@@ -16,7 +16,7 @@ export default withDsExample(Example);
 /* Storybook story */
 export const Demo = { render: Example };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Bruk av `children` med flere elementer vil gi en grå blokk som ofte ikke ligner på det faktiske innholdet. Derfor anbefaler vi å manuelt bygge elementet ved hjelp av flere skeletons og `height` + `width`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/skeleton/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/skeleton/demo.tsx
@@ -29,7 +29,7 @@ export default withDsExample(Example);
 /* Storybook story */
 export const Demo = { render: Example };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Du kan enten wrappe elementet som skal emuleres, eller sette størrelsen manuelt med prop-ene `width` og `height`. Width og height settes rett på style, slik at px, rem eller f.eks. '100%' fungerer.",
 };

--- a/aksel.nav.no/website/pages/eksempler/skeleton/link-card.tsx
+++ b/aksel.nav.no/website/pages/eksempler/skeleton/link-card.tsx
@@ -46,6 +46,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/skeleton/text-size.tsx
+++ b/aksel.nav.no/website/pages/eksempler/skeleton/text-size.tsx
@@ -22,7 +22,7 @@ export default withDsExample(Example);
 /* Storybook story */
 export const Demo = { render: Example };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Med `variant='text'` følger høyden skriftstørrelsen.",
 };

--- a/aksel.nav.no/website/pages/eksempler/skeleton/variants.tsx
+++ b/aksel.nav.no/website/pages/eksempler/skeleton/variants.tsx
@@ -20,7 +20,7 @@ export default withDsExample(Example);
 /* Storybook story */
 export const Demo = { render: Example };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Varianten 'text' (standard) representerer en enkel linje med tekst. Variantene 'circle', 'rectangle' og 'rounded' gir forskjellig visuell representasjon av elementet.",
 };

--- a/aksel.nav.no/website/pages/eksempler/stepper/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/stepper/demo.tsx
@@ -33,6 +33,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/stepper/horizontal.tsx
+++ b/aksel.nav.no/website/pages/eksempler/stepper/horizontal.tsx
@@ -34,7 +34,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "Vi anbefaler å ikke bruke horisontal stepper, da den fungerer dårlig på mindre skjermer.",
 };

--- a/aksel.nav.no/website/pages/eksempler/stepper/wizard.tsx
+++ b/aksel.nav.no/website/pages/eksempler/stepper/wizard.tsx
@@ -41,7 +41,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Ved hjelp av propene `interactive` og `completed` kan man bygge opp wizard-lignende løsninger, der fullførte steg er merket med checkmark og fremtidige steg er låst.",
 };

--- a/aksel.nav.no/website/pages/eksempler/switch/controlled-boolean.tsx
+++ b/aksel.nav.no/website/pages/eksempler/switch/controlled-boolean.tsx
@@ -20,6 +20,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 7,
 };

--- a/aksel.nav.no/website/pages/eksempler/switch/controlled-value.tsx
+++ b/aksel.nav.no/website/pages/eksempler/switch/controlled-value.tsx
@@ -24,6 +24,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
 };

--- a/aksel.nav.no/website/pages/eksempler/switch/description.tsx
+++ b/aksel.nav.no/website/pages/eksempler/switch/description.tsx
@@ -17,6 +17,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/switch/disabled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/switch/disabled.tsx
@@ -20,7 +20,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 99,
   desc: "Vi fraråder bruk av disabled state. Vurder om du trenger å vise feltet i det hele tatt, om du heller kan bruke `readOnly`, eller bare kan skrive det ut i ren tekst.",
 };

--- a/aksel.nav.no/website/pages/eksempler/switch/hide-label.tsx
+++ b/aksel.nav.no/website/pages/eksempler/switch/hide-label.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Label må være meningsfull selv om den skjules, siden den fortsatt leses av skjermlesere.",
 };

--- a/aksel.nav.no/website/pages/eksempler/switch/loading.tsx
+++ b/aksel.nav.no/website/pages/eksempler/switch/loading.tsx
@@ -20,7 +20,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 8,
   desc: "`loading`-prop bør bare brukes for korte lastetider. Ved lengre lastetid bør brukeren [informeres om hva som foregår](https://aksel.nav.no/komponenter/core/loader#ba471ad4389c).",
 };

--- a/aksel.nav.no/website/pages/eksempler/switch/medium.tsx
+++ b/aksel.nav.no/website/pages/eksempler/switch/medium.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/switch/position.tsx
+++ b/aksel.nav.no/website/pages/eksempler/switch/position.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/switch/readonly.tsx
+++ b/aksel.nav.no/website/pages/eksempler/switch/readonly.tsx
@@ -20,7 +20,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 98,
   desc: "Readonly-attributtet gjør at tilstanden ikke kan endres. Til forskjell fra `disabled` vil brukere fortsatt kunne tabbe til feltet, og verdien vil inkluderes når skjemaet sendes inn.",
 };

--- a/aksel.nav.no/website/pages/eksempler/switch/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/switch/small.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Small bør brukes sparsomt på sider som brukes fra mobil, da det er viktig at touch-flaten er stor nok.",
 };

--- a/aksel.nav.no/website/pages/eksempler/table-menu/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table-menu/demo.tsx
@@ -80,6 +80,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/table-numbers/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table-numbers/demo.tsx
@@ -71,6 +71,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/table/expandable.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/expandable.tsx
@@ -73,7 +73,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
   desc: "Rader kan utvides for å vise ekstra informasjon. Man kan velge om knappen for å utvide/lukke vises i starten eller enden av raden.",
 };

--- a/aksel.nav.no/website/pages/eksempler/table/medium.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/medium.tsx
@@ -69,7 +69,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Medium er standardstørrelsen på både eksterne og interne flater.",
 };

--- a/aksel.nav.no/website/pages/eksempler/table/pagination.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/pagination.tsx
@@ -109,6 +109,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/table/selectable.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/selectable.tsx
@@ -108,6 +108,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/table/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/small.tsx
@@ -69,6 +69,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/table/sortable.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/sortable.tsx
@@ -118,6 +118,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/table/with-input.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/with-input.tsx
@@ -84,6 +84,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 7,
 };

--- a/aksel.nav.no/website/pages/eksempler/table/zebraStripes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/table/zebraStripes.tsx
@@ -69,6 +69,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/tabs/controlled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tabs/controlled.tsx
@@ -56,6 +56,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/tabs/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tabs/demo.tsx
@@ -53,6 +53,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/tabs/fill.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tabs/fill.tsx
@@ -36,6 +36,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/tabs/follow-focus.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tabs/follow-focus.tsx
@@ -53,7 +53,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "'selectionFollowsFocus' gjør at valgt tab følger fokus ved bruk av piltaster.",
 };

--- a/aksel.nav.no/website/pages/eksempler/tabs/icon-top.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tabs/icon-top.tsx
@@ -53,6 +53,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/tabs/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tabs/small.tsx
@@ -53,6 +53,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/tag/ikon.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tag/ikon.tsx
@@ -30,7 +30,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Husk å legge til 'aria-hidden' hvis ikonet bare er illustrativt.",
 };

--- a/aksel.nav.no/website/pages/eksempler/tag/moderate.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tag/moderate.tsx
@@ -49,6 +49,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/tag/outline.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tag/outline.tsx
@@ -49,6 +49,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/tag/sizes.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tag/sizes.tsx
@@ -49,6 +49,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/tag/strong.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tag/strong.tsx
@@ -49,6 +49,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/textarea/auto-scrollbar.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textarea/auto-scrollbar.tsx
@@ -20,7 +20,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 7,
   desc: "Den ekspermentelle prop-en `UNSAFE_autoScrollbar` gjør at tekstfeltet får en scrollbar når det ikke er mer plass i høyden. Krever `display:flex` på parent.",
 };

--- a/aksel.nav.no/website/pages/eksempler/textarea/description.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textarea/description.tsx
@@ -18,7 +18,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Bruk `description` i tillegg til `label` når det er behov for mer utfyllende forklaring.",
 };

--- a/aksel.nav.no/website/pages/eksempler/textarea/disabled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textarea/disabled.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 99,
   desc: "Vi fraråder bruk av disabled state. Vurder om du trenger å vise feltet i det hele tatt, om du heller kan bruke `readOnly`, eller bare kan skrive det ut i ren tekst.",
 };

--- a/aksel.nav.no/website/pages/eksempler/textarea/error.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textarea/error.tsx
@@ -18,6 +18,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/textarea/hide-label.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textarea/hide-label.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Label må være meningsfull selv om den skjules, siden den fortsatt leses av skjermlesere.",
 };

--- a/aksel.nav.no/website/pages/eksempler/textarea/max-length.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textarea/max-length.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   desc: "Textarea kan vise antall gjenværende tegn som er tillatt å skrive inn. Tallet oppdateres mens brukeren skriver eller fjerner innhold. NB! Dette er bare en visuell indikator. Faktisk begrensning og validering må håndteres i kode.",
 };

--- a/aksel.nav.no/website/pages/eksempler/textarea/medium.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textarea/medium.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/textarea/readonly.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textarea/readonly.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 98,
   desc: "Readonly-attributtet gjør at verdien ikke kan endres, men brukere vil fortsatt kunne markere og kopiere fra feltet. Til forskjell fra disabled-felter vil brukere også kunne tabbe til det, og feltet vil inkluderes når skjemaet sendes inn.",
 };

--- a/aksel.nav.no/website/pages/eksempler/textarea/resizable.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textarea/resizable.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
 };

--- a/aksel.nav.no/website/pages/eksempler/textarea/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textarea/small.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/textfield/description.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textfield/description.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Bruk `description` i tillegg til `label` når det er behov for mer utfyllende forklaring.",
 };

--- a/aksel.nav.no/website/pages/eksempler/textfield/disabled.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textfield/disabled.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 99,
   desc: "Vi fraråder bruk av disabled state. Vurder om du trenger å vise feltet i det hele tatt, om du heller kan bruke `readOnly`, eller bare kan skrive det ut i ren tekst.",
 };

--- a/aksel.nav.no/website/pages/eksempler/textfield/error.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textfield/error.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
 };

--- a/aksel.nav.no/website/pages/eksempler/textfield/hide-label.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textfield/hide-label.tsx
@@ -13,7 +13,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Label må være meningsfull selv om den skjules, siden den fortsatt leses av skjermlesere.",
 };

--- a/aksel.nav.no/website/pages/eksempler/textfield/medium.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textfield/medium.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/textfield/readonly.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textfield/readonly.tsx
@@ -20,7 +20,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 98,
   desc: "Readonly-attributtet gjør at verdien ikke kan endres, men brukere vil fortsatt kunne markere og kopiere fra feltet. Til forskjell fra disabled-felter vil brukere også kunne tabbe til det, og feltet vil inkluderes når skjemaet sendes inn.",
 };

--- a/aksel.nav.no/website/pages/eksempler/textfield/small.tsx
+++ b/aksel.nav.no/website/pages/eksempler/textfield/small.tsx
@@ -13,6 +13,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/timeline-intern/active-periods.tsx
+++ b/aksel.nav.no/website/pages/eksempler/timeline-intern/active-periods.tsx
@@ -141,6 +141,6 @@ export const Demo = {
   desc: "'onSelectPeriod' og 'isActive' lar deg velge aktive perioder for visning av ekstra informasjon en annen plass i UI.",
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/timeline-intern/aria-controls.tsx
+++ b/aksel.nav.no/website/pages/eksempler/timeline-intern/aria-controls.tsx
@@ -151,7 +151,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Vi anbefaler å bruke `aria-controls` begge veier mellom aktive perioder og panelet det refererer til. Dette gir brukere av enkelte skjermlesere hurtigtaster for å hoppe mellom perioder og panelet.",
 };

--- a/aksel.nav.no/website/pages/eksempler/timeline-intern/dynamic.tsx
+++ b/aksel.nav.no/website/pages/eksempler/timeline-intern/dynamic.tsx
@@ -274,7 +274,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "Vi anbefaler å la bruker velge tidsperioder som er relevante for dem, og ikke vise alle perioder samtidig.",
 };

--- a/aksel.nav.no/website/pages/eksempler/timeline-intern/pins.tsx
+++ b/aksel.nav.no/website/pages/eksempler/timeline-intern/pins.tsx
@@ -139,6 +139,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/timeline-intern/timeline.tsx
+++ b/aksel.nav.no/website/pages/eksempler/timeline-intern/timeline.tsx
@@ -132,6 +132,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/togglegroup/colors.tsx
+++ b/aksel.nav.no/website/pages/eksempler/togglegroup/colors.tsx
@@ -40,7 +40,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Bruk `data-color`-attributtet for å endre farge på ToggleGroup.",
 };

--- a/aksel.nav.no/website/pages/eksempler/togglegroup/fill.tsx
+++ b/aksel.nav.no/website/pages/eksempler/togglegroup/fill.tsx
@@ -19,6 +19,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
 };

--- a/aksel.nav.no/website/pages/eksempler/togglegroup/group-label.tsx
+++ b/aksel.nav.no/website/pages/eksempler/togglegroup/group-label.tsx
@@ -19,6 +19,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/togglegroup/ikon-med-tooltip.tsx
+++ b/aksel.nav.no/website/pages/eksempler/togglegroup/ikon-med-tooltip.tsx
@@ -36,6 +36,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 6,
 };

--- a/aksel.nav.no/website/pages/eksempler/togglegroup/item-label.tsx
+++ b/aksel.nav.no/website/pages/eksempler/togglegroup/item-label.tsx
@@ -19,6 +19,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/togglegroup/size.tsx
+++ b/aksel.nav.no/website/pages/eksempler/togglegroup/size.tsx
@@ -56,6 +56,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/tooltip/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tooltip/demo.tsx
@@ -18,6 +18,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/eksempler/tooltip/labeling.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tooltip/labeling.tsx
@@ -23,7 +23,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   desc: "Hvis elementet allerede har en tilgjengelig tekst, kan du sette `describesChild` til `true`. Tooltipen blir da satt som `title` når lukket og `aria-describedby` når åpen, slik at skjermleser får med seg begge tekstene.",
 };

--- a/aksel.nav.no/website/pages/eksempler/tooltip/no-arrow.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tooltip/no-arrow.tsx
@@ -18,6 +18,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
 };

--- a/aksel.nav.no/website/pages/eksempler/tooltip/placement.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tooltip/placement.tsx
@@ -34,6 +34,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
 };

--- a/aksel.nav.no/website/pages/eksempler/tooltip/with-shortcuts.tsx
+++ b/aksel.nav.no/website/pages/eksempler/tooltip/with-shortcuts.tsx
@@ -18,6 +18,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/eksempler/v-stack/align.tsx
+++ b/aksel.nav.no/website/pages/eksempler/v-stack/align.tsx
@@ -74,7 +74,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   desc: "Propen `align` endrer `align-items`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/v-stack/demo.tsx
+++ b/aksel.nav.no/website/pages/eksempler/v-stack/demo.tsx
@@ -21,7 +21,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "VStack er en enkel layout-komponent for flexbox med `flex-direction: column`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/v-stack/justify.tsx
+++ b/aksel.nav.no/website/pages/eksempler/v-stack/justify.tsx
@@ -74,7 +74,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   desc: "Propen `justify` endrer `justify-content`.",
 };

--- a/aksel.nav.no/website/pages/eksempler/v-stack/responsive-gap.tsx
+++ b/aksel.nav.no/website/pages/eksempler/v-stack/responsive-gap.tsx
@@ -29,7 +29,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   desc: "På noen props, f.eks. gap, kan du sette ulike verdier per brekkpunkt. Implementasjonen er mobile-first, slik at 'sm: 8' vil også gjelde for 'md', 'lg' og 'xl'.",
 };

--- a/aksel.nav.no/website/pages/templates/404/enkel.tsx
+++ b/aksel.nav.no/website/pages/templates/404/enkel.tsx
@@ -60,7 +60,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   title: "Enkel",
   desc: "I sin enkleste form skal 404-side inneholde en tittel, feilmelding, løsningsforslag og illustrasjon.",

--- a/aksel.nav.no/website/pages/templates/404/komplett.tsx
+++ b/aksel.nav.no/website/pages/templates/404/komplett.tsx
@@ -86,7 +86,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   title: "Komplett",
   desc: "I sin fullstendige form kan en 404-side inneholde tittel, feilmelding, løsningsforslag, CTA, tilbakemeldingsfunksjon, flere språk og illustrasjon.",

--- a/aksel.nav.no/website/pages/templates/404/med-cta.tsx
+++ b/aksel.nav.no/website/pages/templates/404/med-cta.tsx
@@ -66,7 +66,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   title: "Med CTA til side",
   desc: "En 404-side kan inneholde en CTA som leder til et relevant område eller side, avhengig av konteksten.",

--- a/aksel.nav.no/website/pages/templates/404/med-feedback.tsx
+++ b/aksel.nav.no/website/pages/templates/404/med-feedback.tsx
@@ -67,7 +67,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 3,
   title: "Med tilbakemeldingsfunksjon",
   desc: "Hvis løsningen din støtter det, kan du vurdere å gi brukerne muligheten til å rapportere avvik.",

--- a/aksel.nav.no/website/pages/templates/404/med-lang-en.tsx
+++ b/aksel.nav.no/website/pages/templates/404/med-lang-en.tsx
@@ -75,7 +75,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   title: "Flerspråk",
   desc: "En 404-feil kan være frustrerende, spesielt hvis den er på et ukjent språk. En melding på engelsk kan gjøre det lettere å forstå problemet og hva du skal gjøre videre",

--- a/aksel.nav.no/website/pages/templates/500/enkel.tsx
+++ b/aksel.nav.no/website/pages/templates/500/enkel.tsx
@@ -89,7 +89,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   title: "Enkel",
   desc: "I sin enkleste form skal 500-side inneholde en tittel, feilmelding, tilbakemeldingsfunksjon og løsningsforslag",

--- a/aksel.nav.no/website/pages/templates/500/komplett.tsx
+++ b/aksel.nav.no/website/pages/templates/500/komplett.tsx
@@ -118,7 +118,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   title: "Komplett",
   desc: "I sin fullstendige form kan en 500-side inneholde tittel, feilmelding, løsningsforslag, tilbakemeldingsfunksjon, feil-id, CTA og flere språk.",

--- a/aksel.nav.no/website/pages/templates/500/med-cta.tsx
+++ b/aksel.nav.no/website/pages/templates/500/med-cta.tsx
@@ -96,7 +96,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   title: "Med CTA til side",
   desc: "En 500-side kan inneholde en CTA som leder til et relevant område eller side, avhengig av konteksten.",

--- a/aksel.nav.no/website/pages/templates/500/med-feil-id.tsx
+++ b/aksel.nav.no/website/pages/templates/500/med-feil-id.tsx
@@ -96,7 +96,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 4,
   title: "Med feil-id",
   desc: "Ved å legge til en feil-id kan man enklere feilsøke mot logger hvis man får skjermbilde av feilmelding fra bruker.",

--- a/aksel.nav.no/website/pages/templates/500/med-lang-en.tsx
+++ b/aksel.nav.no/website/pages/templates/500/med-lang-en.tsx
@@ -109,7 +109,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 5,
   title: "Flerspråk",
   desc: "Ved å legge til flere språk kan man være sikrere på at flere forstår hva som gikk feil.",

--- a/aksel.nav.no/website/pages/templates/skjemavalidering/demo.tsx
+++ b/aksel.nav.no/website/pages/templates/skjemavalidering/demo.tsx
@@ -145,6 +145,6 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
 };

--- a/aksel.nav.no/website/pages/templates/skjemavalidering/react-hook-form.tsx
+++ b/aksel.nav.no/website/pages/templates/skjemavalidering/react-hook-form.tsx
@@ -123,7 +123,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   sandbox: false,
 };

--- a/aksel.nav.no/website/pages/templates/soknad-introside-real-examples/soknad-introside-aap.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside-real-examples/soknad-introside-aap.tsx
@@ -175,7 +175,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   title: "AAP",
 };

--- a/aksel.nav.no/website/pages/templates/soknad-introside-real-examples/soknad-introside-alderspensjon.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside-real-examples/soknad-introside-alderspensjon.tsx
@@ -229,7 +229,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   title: "Alderspensjon",
 };

--- a/aksel.nav.no/website/pages/templates/soknad-introside-real-examples/soknad-introside-foreldrepenger.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside-real-examples/soknad-introside-foreldrepenger.tsx
@@ -168,7 +168,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   title: "Foreldrepenger",
 };

--- a/aksel.nav.no/website/pages/templates/soknad-introside-real-examples/soknad-introside-pass-av-barn.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside-real-examples/soknad-introside-pass-av-barn.tsx
@@ -194,7 +194,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   title: "Pass av barn",
 };

--- a/aksel.nav.no/website/pages/templates/soknad-introside/intro-med-alternativ-soknad.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside/intro-med-alternativ-soknad.tsx
@@ -242,7 +242,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 2,
   title: "Alternativ søknad",
   desc: "For å redusere sjansen for at brukere søker på feil ytelse, kan du inkludere en seksjon som sier hva du kan søke på i denne søknaden, og eventuelt hva du må bruke en annen søknad for.",

--- a/aksel.nav.no/website/pages/templates/soknad-introside/intro-med-fremhevet-info.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside/intro-med-fremhevet-info.tsx
@@ -235,7 +235,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 1,
   title: "Med InfoCard",
   desc: "I noen tilfeller oppstår det akutte eller tidsbestemte forhold rundt søknaden som brukeren må vite om før de starter søknaden. Dette kan være frister, situasjonsbestemte forhold eller annen viktig informasjon som brukeren bør ha før de starter søknaden. [InfoCard](https://aksel.nav.no/komponenter/core/infocard) skal være informativ og kortfattet.",

--- a/aksel.nav.no/website/pages/templates/soknad-introside/intro.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-introside/intro.tsx
@@ -245,7 +245,7 @@ export const Demo = {
   },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   title: "Standard",
 };

--- a/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside-real-examples/aap.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside-real-examples/aap.tsx
@@ -323,7 +323,7 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   title: "AAP",
 };

--- a/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside-real-examples/dagpenger.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside-real-examples/dagpenger.tsx
@@ -505,6 +505,6 @@ export const Demo = {
   parameters: { layout: "fullscreen" },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside/standard.tsx
+++ b/aksel.nav.no/website/pages/templates/soknad-oppsummeringsside/standard.tsx
@@ -205,6 +205,6 @@ export const Demo = {
   },
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
 };

--- a/aksel.nav.no/website/pages/templates/theme-switch/bare-ikon.tsx
+++ b/aksel.nav.no/website/pages/templates/theme-switch/bare-ikon.tsx
@@ -85,5 +85,5 @@ export const Demo = {
 
 export const args = {
   index: 0,
-  sandboxEnabled: false,
+  sandbox: false,
 };

--- a/aksel.nav.no/website/pages/templates/theme-switch/bare-ikon.tsx
+++ b/aksel.nav.no/website/pages/templates/theme-switch/bare-ikon.tsx
@@ -83,7 +83,7 @@ export const Demo = {
   desc: "Bruk Tooltip hvis du bruker en knapp med kun ikon.",
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   sandbox: false,
 };

--- a/aksel.nav.no/website/pages/templates/theme-switch/tekst.tsx
+++ b/aksel.nav.no/website/pages/templates/theme-switch/tekst.tsx
@@ -82,7 +82,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   sandbox: false,
 };

--- a/aksel.nav.no/website/pages/templates/theme-switch/tekst.tsx
+++ b/aksel.nav.no/website/pages/templates/theme-switch/tekst.tsx
@@ -84,5 +84,5 @@ export const Demo = {
 
 export const args = {
   index: 0,
-  sandboxEnabled: false,
+  sandbox: false,
 };

--- a/aksel.nav.no/website/pages/templates/theme-switch/uten-system-bare-ikon.tsx
+++ b/aksel.nav.no/website/pages/templates/theme-switch/uten-system-bare-ikon.tsx
@@ -40,5 +40,5 @@ export const Demo = {
 export const args = {
   index: 0,
   desc: "Undermeny trengs ikke hvis man bare skal kunne bytte mellom lyst og mørkt tema.",
-  sandboxEnabled: false,
+  sandbox: false,
 };

--- a/aksel.nav.no/website/pages/templates/theme-switch/uten-system-bare-ikon.tsx
+++ b/aksel.nav.no/website/pages/templates/theme-switch/uten-system-bare-ikon.tsx
@@ -37,7 +37,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Undermeny trengs ikke hvis man bare skal kunne bytte mellom lyst og mørkt tema.",
   sandbox: false,

--- a/aksel.nav.no/website/pages/templates/theme-switch/uten-system.tsx
+++ b/aksel.nav.no/website/pages/templates/theme-switch/uten-system.tsx
@@ -35,5 +35,5 @@ export const Demo = {
 export const args = {
   index: 0,
   desc: "Undermeny trengs ikke hvis man bare skal kunne bytte mellom lyst og mørkt tema.",
-  sandboxEnabled: false,
+  sandbox: false,
 };

--- a/aksel.nav.no/website/pages/templates/theme-switch/uten-system.tsx
+++ b/aksel.nav.no/website/pages/templates/theme-switch/uten-system.tsx
@@ -32,7 +32,7 @@ export const Demo = {
   render: Example,
 };
 
-export const args = {
+export const args: ExampleArgsT = {
   index: 0,
   desc: "Undermeny trengs ikke hvis man bare skal kunne bytte mellom lyst og mørkt tema.",
   sandbox: false,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -159,6 +159,7 @@ module.exports = defineConfig([
       "aksel-local": akselLocal,
     },
     rules: {
+      "aksel-local/args-check": ["error"],
       "aksel-local/comment-check": ["error"],
     },
   },

--- a/scripts/eslint/args-check.js
+++ b/scripts/eslint/args-check.js
@@ -1,9 +1,10 @@
 module.exports = {
   meta: {
     type: "problem",
+    fixable: "code",
     docs: {
       description:
-        "Checks that each example exports const args with shape { index: number, desc?: string, sandbox?: boolean, title?: string }",
+        "Checks that each example exports const args with type ExampleArgsT",
     },
     schema: [],
   },
@@ -34,100 +35,40 @@ module.exports = {
 
             hasArgsExport = true;
 
-            const init = declaration.init;
-            if (!init || init.type !== "ObjectExpression") {
+            let typeAnnotation = null;
+            let typeName = null;
+
+            if (declaration.id.typeAnnotation) {
+              typeAnnotation = declaration.id.typeAnnotation.typeAnnotation;
+            }
+
+            if (typeAnnotation) {
+              typeName = typeAnnotation.typeName;
+            }
+
+            if (
+              !typeAnnotation ||
+              typeAnnotation.type !== "TSTypeReference" ||
+              !typeName ||
+              typeName.type !== "Identifier" ||
+              typeName.name !== "ExampleArgsT"
+            ) {
               context.report({
                 node: declaration,
-                message:
-                  "'args' must be exported as an object with shape { index: number, desc?: string, sandbox?: boolean, title?: string }.",
-              });
-              continue;
-            }
+                message: "'args' must have type 'ExampleArgsT'.",
+                fix(fixer) {
+                  if (declaration.id.typeAnnotation) {
+                    return fixer.replaceText(
+                      declaration.id.typeAnnotation,
+                      ": ExampleArgsT",
+                    );
+                  }
 
-            const allowedKeys = new Set(["index", "desc", "sandbox", "title"]);
-            let hasIndex = false;
-
-            for (const property of init.properties) {
-              if (property.type !== "Property" || property.computed) {
-                context.report({
-                  node: property,
-                  message:
-                    "'args' can only contain static properties 'index', optional 'desc', optional 'sandbox', and optional 'title'.",
-                });
-                continue;
-              }
-
-              const key =
-                property.key.type === "Identifier"
-                  ? property.key.name
-                  : property.key.type === "Literal"
-                    ? property.key.value
-                    : null;
-
-              if (typeof key !== "string" || !allowedKeys.has(key)) {
-                context.report({
-                  node: property,
-                  message:
-                    "'args' only supports keys 'index', optional 'desc', optional 'sandbox', and optional 'title'.",
-                });
-                continue;
-              }
-
-              if (key === "index") {
-                hasIndex = true;
-                if (
-                  property.value.type !== "Literal" ||
-                  typeof property.value.value !== "number"
-                ) {
-                  context.report({
-                    node: property,
-                    message: "'args.index' must be a number.",
-                  });
-                }
-              }
-
-              if (key === "desc") {
-                if (
-                  property.value.type !== "Literal" ||
-                  typeof property.value.value !== "string"
-                ) {
-                  context.report({
-                    node: property,
-                    message: "'args.desc' must be a string when provided.",
-                  });
-                }
-              }
-
-              if (key === "sandbox") {
-                if (
-                  property.value.type !== "Literal" ||
-                  typeof property.value.value !== "boolean"
-                ) {
-                  context.report({
-                    node: property,
-                    message: "'args.sandbox' must be a boolean when provided.",
-                  });
-                }
-              }
-
-              if (key === "title") {
-                if (
-                  property.value.type !== "Literal" ||
-                  typeof property.value.value !== "string"
-                ) {
-                  context.report({
-                    node: property,
-                    message: "'args.title' must be a string when provided.",
-                  });
-                }
-              }
-            }
-
-            if (!hasIndex) {
-              context.report({
-                node: init,
-                message:
-                  "'args' must include required key 'index' as a number.",
+                  return fixer.insertTextAfter(
+                    declaration.id,
+                    ": ExampleArgsT",
+                  );
+                },
               });
             }
           }
@@ -137,7 +78,7 @@ module.exports = {
           context.report({
             node: programNode,
             message:
-              "Each example must export 'const args = { index: number, desc?: string, sandbox?: boolean, title?: string }'.",
+              "Each example must export 'const args: ExampleArgsT = ...'.",
           });
         }
       },

--- a/scripts/eslint/args-check.js
+++ b/scripts/eslint/args-check.js
@@ -1,0 +1,146 @@
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Checks that each example exports const args with shape { index: number, desc?: string, sandbox?: boolean, title?: string }",
+    },
+    schema: [],
+  },
+  create(context) {
+    let hasArgsExport = false;
+
+    return {
+      Program(programNode) {
+        const body = programNode.body;
+
+        for (const node of body) {
+          if (node.type !== "ExportNamedDeclaration" || !node.declaration) {
+            continue;
+          }
+
+          if (node.declaration.type !== "VariableDeclaration") {
+            continue;
+          }
+
+          for (const declaration of node.declaration.declarations) {
+            if (
+              !declaration.id ||
+              declaration.id.type !== "Identifier" ||
+              declaration.id.name !== "args"
+            ) {
+              continue;
+            }
+
+            hasArgsExport = true;
+
+            const init = declaration.init;
+            if (!init || init.type !== "ObjectExpression") {
+              context.report({
+                node: declaration,
+                message:
+                  "'args' must be exported as an object with shape { index: number, desc?: string, sandbox?: boolean, title?: string  }.",
+              });
+              continue;
+            }
+
+            const allowedKeys = new Set(["index", "desc", "sandbox", "title"]);
+            let hasIndex = false;
+
+            for (const property of init.properties) {
+              if (property.type !== "Property" || property.computed) {
+                context.report({
+                  node: property,
+                  message:
+                    "'args' can only contain static properties 'index', optional 'desc', optional 'sandbox', and optional 'title'.",
+                });
+                continue;
+              }
+
+              const key =
+                property.key.type === "Identifier"
+                  ? property.key.name
+                  : property.key.type === "Literal"
+                    ? property.key.value
+                    : null;
+
+              if (typeof key !== "string" || !allowedKeys.has(key)) {
+                context.report({
+                  node: property,
+                  message:
+                    "'args' only supports keys 'index', optional 'desc', optional 'sandbox', and optional 'title'.",
+                });
+                continue;
+              }
+
+              if (key === "index") {
+                hasIndex = true;
+                if (
+                  property.value.type !== "Literal" ||
+                  typeof property.value.value !== "number"
+                ) {
+                  context.report({
+                    node: property,
+                    message: "'args.index' must be a number.",
+                  });
+                }
+              }
+
+              if (key === "desc") {
+                if (
+                  property.value.type !== "Literal" ||
+                  typeof property.value.value !== "string"
+                ) {
+                  context.report({
+                    node: property,
+                    message: "'args.desc' must be a string when provided.",
+                  });
+                }
+              }
+
+              if (key === "sandbox") {
+                if (
+                  property.value.type !== "Literal" ||
+                  typeof property.value.value !== "boolean"
+                ) {
+                  context.report({
+                    node: property,
+                    message: "'args.sandbox' must be a boolean when provided.",
+                  });
+                }
+              }
+
+              if (key === "title") {
+                if (
+                  property.value.type !== "Literal" ||
+                  typeof property.value.value !== "string"
+                ) {
+                  context.report({
+                    node: property,
+                    message: "'args.title' must be a string when provided.",
+                  });
+                }
+              }
+            }
+
+            if (!hasIndex) {
+              context.report({
+                node: init,
+                message:
+                  "'args' must include required key 'index' as a number.",
+              });
+            }
+          }
+        }
+
+        if (!hasArgsExport) {
+          context.report({
+            node: programNode,
+            message:
+              "Each example must export 'const args = { index: number, desc?: string, sandbox?: boolean, title?: string }'.",
+          });
+        }
+      },
+    };
+  },
+};

--- a/scripts/eslint/args-check.js
+++ b/scripts/eslint/args-check.js
@@ -39,7 +39,7 @@ module.exports = {
               context.report({
                 node: declaration,
                 message:
-                  "'args' must be exported as an object with shape { index: number, desc?: string, sandbox?: boolean, title?: string  }.",
+                  "'args' must be exported as an object with shape { index: number, desc?: string, sandbox?: boolean, title?: string }.",
               });
               continue;
             }

--- a/scripts/eslint/index.js
+++ b/scripts/eslint/index.js
@@ -1,6 +1,11 @@
 const commentCheck = require("./comment-check");
 const importCheck = require("./import-check");
+const argsCheck = require("./args-check");
 
 module.exports = {
-  rules: { "comment-check": commentCheck, "import-check": importCheck },
+  rules: {
+    "args-check": argsCheck,
+    "comment-check": commentCheck,
+    "import-check": importCheck,
+  },
 };


### PR DESCRIPTION
### Description

Custom eslint-rule to validate args-field in examples and templates.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
