### PR TITLE
fix(website): adjust validation error messages for feedback form

### DIFF
--- a/aksel.nav.no/website/app/(routes)/(god-praksis)/_ui/feedback/actions.zod.ts
+++ b/aksel.nav.no/website/app/(routes)/(god-praksis)/_ui/feedback/actions.zod.ts
@@ -8,12 +8,9 @@ const zodFormDataSchema = z.object({
           ? "Tilbakemelding er påkrevd"
           : "Tilbakemelding må være en tekststreng",
     })
-    .min(1, "Kan ikke send en tom tilbakemelding")
+    .min(1, "Du kan ikke sende en tom tilbakemelding")
     .max(500, "Tilbakemeldingen må være under 500 tegn"),
-  docId: z.string({
-    error: (issue) =>
-      issue.input === undefined ? "Ugyldig dokument id" : "Ugyldig dokument id",
-  }),
+  docId: z.string("Dokument-ID mangler"),
 });
 
 export { zodFormDataSchema };


### PR DESCRIPTION
This is validation of the feedback form in the bottom of God praksis-articles:

<img width="928" height="436" alt="image" src="https://github.com/user-attachments/assets/a507f15e-3419-4e20-b432-2ee7672250e2" />

Afaics, "min" and "max" are the only errors that can be triggered by users. The two others will only be triggered if there's a bug on our end.