### PR TITLE
build(aksel-icons): fix prettier script

### DIFF
--- a/@navikt/aksel-icons/package.json
+++ b/@navikt/aksel-icons/package.json
@@ -59,7 +59,8 @@
     "!**/*.tsbuildinfo"
   ],
   "scripts": {
-    "create-icons": "svgr --no-prettier --silent --index-template config/index-template.js --out-dir src icons && yarn prettier --write ./src",
+    "create-icons": "svgr --no-prettier --silent --index-template config/index-template.js --out-dir src icons && yarn prettify-icons",
+    "prettify-icons": "yarn prettier ./src --write --ignore-path nonexisting-path --log-level silent --no-config",
     "parse-svg": "node -e 'require(\"./config/parse-svg.js\").main()'",
     "copy": "copyfiles util/* src",
     "update-metadata": "node config/metadata.js",


### PR DESCRIPTION
`--ignore-path nonexisting-path` overrides the default `ignore-path`, which is `./.gitignore` and `./.prettierignore`. This is needed because the folder we are prettifying is listed in `.gitignore`.

`--no-config` makes the script use less time since it skips config lookup.