### PR TITLE
fix(css): browserslist was bringing in old browsers

### DIFF
--- a/.changeset/orange-meals-beg.md
+++ b/.changeset/orange-meals-beg.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-css": patch
+---
+
+Browserlist: Updated browser-support.

--- a/@navikt/core/css/config/bundle.ts
+++ b/@navikt/core/css/config/bundle.ts
@@ -55,9 +55,8 @@ async function bundle() {
       drafts: {
         customMedia: false,
       },
-      targets: browserslistToTargets(
-        browserslist(">= 0.5% in NO, safari >= 15.4, iOS >= 15.4, not dead"),
-      ),
+      /* Uses the "browserslist" field in package.json as the single source of truth. */
+      targets: browserslistToTargets(browserslist(packageJSON.browserslist)),
       resolver: {
         read(filePath) {
           const file = fs.readFileSync(filePath, "utf8");

--- a/@navikt/core/css/package.json
+++ b/@navikt/core/css/package.json
@@ -40,10 +40,10 @@
     "tsx": "^4.23.1"
   },
   "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not ie <= 11",
-    "not op_mini all"
+    ">= 0.2% in NO",
+    "not safari < 15.4",
+    "not ios_saf < 15.4",
+    "not dead"
   ],
   "main": "./dist/index.css",
   "exports": {


### PR DESCRIPTION
### Description

- Browserslist was specified in two places - `package.json` and `bundle.ts`
- The browserslist spec was a union, meaning it was doing ">= 0.5% in NO `OR` safari >= 15.4 `OR` iOS >= 15.4 `OR` not dead"

This unioning had the effect of syntax-lowering the built CSS to ~Safari 12 - an extra 33kb raw in `index.min.css` and ~1k gzip.

The browserslist set here is likely only temporary, it now correctly sets a floor of Safari 15.4 - but other browsers are impacted a bit too sharply (I will message in Slack with a link to show the impact).

You can validate the bug by looking for `webkit-any` in [the published 8.16.1 CSS](https://cdn.nav.no/aksel/@navikt/ds-css/8.16.1/index.min.css)

artifact | count | needed by
-- | -- | --
:-webkit-any(...) (dupe of :is()) | 50 | Safari <14
position:-webkit-sticky | 3 | Safari <13
-webkit-fit-content | 20 | old intrinsic sizing
-webkit-max/min-content | 3 | old
-webkit-user-select / -webkit-hyphens | 3 | old

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
