### PR TITLE
chore(deps): remove unused dep babel-plugin-preval

### DIFF
--- a/apps/playroom/package.json
+++ b/apps/playroom/package.json
@@ -14,7 +14,6 @@
     "@babel/preset-typescript": "^7.28.5",
     "@types/node": "^24.10.9",
     "babel-loader": "^9.1.3",
-    "babel-plugin-preval": "^5.1.0",
     "playroom": "^1.3.0",
     "style-loader": "^4.0.0",
     "tsx": "^4.23.1",

--- a/apps/playroom/playroom.config.ts
+++ b/apps/playroom/playroom.config.ts
@@ -46,7 +46,6 @@ module.exports = {
                   require.resolve("@babel/preset-react"),
                   require.resolve("@babel/preset-typescript"),
                 ],
-                plugins: [require.resolve("babel-plugin-preval")],
               },
             },
           ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -9152,7 +9152,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__core@npm:^7.1.12, @types/babel__core@npm:^7.20.5":
+"@types/babel__core@npm:^7.20.5":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
   dependencies:
@@ -11627,7 +11627,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-macros@npm:^3.0.1, babel-plugin-macros@npm:^3.1.0":
+"babel-plugin-macros@npm:^3.1.0":
   version: 3.1.0
   resolution: "babel-plugin-macros@npm:3.1.0"
   dependencies:
@@ -11671,18 +11671,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
   checksum: 10/974464353d6f974e97673385aff616a913c0b76039eab8c5317a2d07c661e080f3dcc213e86f3eae40010172a27ab793cda7a290a8a899716f9a22df9b1d92d2
-  languageName: node
-  linkType: hard
-
-"babel-plugin-preval@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "babel-plugin-preval@npm:5.1.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.5"
-    "@types/babel__core": "npm:^7.1.12"
-    babel-plugin-macros: "npm:^3.0.1"
-    require-from-string: "npm:^2.0.2"
-  checksum: 10/d4507d1f134a610b8a2d4de911afe147eba7aab782ea34e7b687e99bdfd2e28d2056e16b7fa4b66acb59bcbd681acc40e851a20f03f7be719ee4cc51fc88eee0
   languageName: node
   linkType: hard
 
@@ -21817,7 +21805,6 @@ __metadata:
     "@navikt/ds-react": "npm:^8.16.1"
     "@types/node": "npm:^24.10.9"
     babel-loader: "npm:^9.1.3"
-    babel-plugin-preval: "npm:^5.1.0"
     playroom: "npm:^1.3.0"
     react: "npm:19.2.8"
     style-loader: "npm:^4.0.0"


### PR DESCRIPTION
`babel-plugin-preval` doesn't seem to be in use. It seems to work without it.