### PR TITLE
feat(Sanity): limit length of external link tooltip

### DIFF
--- a/aksel.nav.no/sanity-studio/schema/custom-components/LinkRenderer.tsx
+++ b/aksel.nav.no/sanity-studio/schema/custom-components/LinkRenderer.tsx
@@ -9,13 +9,14 @@ export const ExternalLinkRenderer = (props: FieldProps) => {
     return props.renderDefault(props);
   }
 
+  const content =
+    (props.value as { href: string })?.href || "Ingen lenke definert";
+
   return (
     <Tooltip
-      content={
-        (props.value as { href: string })?.href || "Ingen lenke definert"
-      }
+      content={content.length > 145 ? `${content.substring(0, 140)}…` : content}
       placement="bottom"
-      maxChar={999}
+      maxChar={145}
     >
       {props.renderDefault(props)}
     </Tooltip>


### PR DESCRIPTION
Before:

<img width="1474" height="278" alt="image" src="https://github.com/user-attachments/assets/e0e71d58-b5c8-4aba-a4da-eb15b0faa9a1" />

After:

<img width="1031" height="167" alt="image" src="https://github.com/user-attachments/assets/ca5ba835-ea9f-4e9c-aa3a-c9e99a986734" />
