### PR TITLE
fix(core): add asChild guard to overridableComponent API

### DIFF
--- a/.changeset/short-peas-march.md
+++ b/.changeset/short-peas-march.md
@@ -2,4 +2,4 @@
 "@navikt/ds-react": patch
 ---
 
-OverridableComponent: Add built-in guard against using as and asChild at the same time
+OverridableComponent: Add built-in guard against using `as` and `asChild` at the same time

--- a/.changeset/short-peas-march.md
+++ b/.changeset/short-peas-march.md
@@ -1,0 +1,5 @@
+---
+"@navikt/ds-react": patch
+---
+
+OverridableComponent: Add built-in guard against using as and asChild at the same time

--- a/@navikt/core/react/src/utils-external/types/OverridableComponent.ts
+++ b/@navikt/core/react/src/utils-external/types/OverridableComponent.ts
@@ -1,5 +1,11 @@
 import React from "react";
 
+type WithoutAsChild<Component> = Component extends {
+  asChild: true;
+}
+  ? never
+  : Component;
+
 /**
  * This interface represents a component that can be overridden with different props and elements.
  * @template Component The type of the props for the component.
@@ -23,8 +29,11 @@ interface OverridableComponent<Component, Element extends HTMLElement> {
   <As extends React.ElementType>(
     props: {
       as: As;
-    } & Component &
-      Omit<React.ComponentPropsWithRef<As>, keyof Component | "as">,
+    } & WithoutAsChild<Component> &
+      Omit<
+        React.ComponentPropsWithRef<As>,
+        keyof WithoutAsChild<Component> | "as"
+      >,
   ): ReturnType<React.FC>;
 }
 

--- a/@navikt/core/react/src/utils/types/AsChildProps.ts
+++ b/@navikt/core/react/src/utils/types/AsChildProps.ts
@@ -14,12 +14,6 @@ export type AsChildProps =
        * <MergedComponent data-prop data-child />
        */
       asChild: true;
-      /**
-       * Implements [OverridableComponent](https://aksel.nav.no/grunnleggende/kode/overridablecomponent)
-       *
-       * When using asChild, the `as` prop is not allowed as it would have no effect.
-       */
-      as?: never;
     }
   | {
       children?: React.ReactNode;


### PR DESCRIPTION
### Description

Moves check for asChild to overridableComponent-API, allowing us to remove `as` type from`AsChildProps`.

### Component Checklist 📝

- [ ] JSDoc
- [ ] Examples
- [ ] Documentation / Decision Records
- [ ] Storybook
- [ ] CSS class deprecations (`@navikt/aksel-stylelint/src/deprecations.ts`)
- [ ] Exports (`@navikt/core/react/src/index.ts` and `@navikt/core/react/package.json`)
- [ ] New component? CSS import (`@navikt/core/css/index.css`)
- [ ] Breaking change? Update migration guide. Consider codemod.
- [ ] Changeset (Format: `<Component>: <gitmoji?> <Text>` E.g. "Button: :sparkles: Add feature xyz")
